### PR TITLE
Use datacenter name, not cloud specific region for url

### DIFF
--- a/accessors.go
+++ b/accessors.go
@@ -15,17 +15,3 @@ func (spec *CloudSpec) GetDigitalocean() *DigitaloceanCloudSpec {
 	}
 	return spec.Digitalocean
 }
-
-// GetRegion returns the region for the active cloud spec or empty string.
-func (spec *CloudSpec) GetRegion() string {
-	switch {
-	case spec.Digitalocean != nil:
-		return spec.Digitalocean.Region
-	case spec.Fake != nil:
-		return spec.Fake.Region
-	case spec.Linode != nil:
-		return "linode"
-	}
-
-	return ""
-}

--- a/controller/cluster/pending.go
+++ b/controller/cluster/pending.go
@@ -193,11 +193,10 @@ func (cc *clusterController) pendingCheckReplicationController(c *api.Cluster) e
 	}
 
 	loadApiserver := func(s string) (*kapi.ReplicationController, error) {
-		u, err := url.Parse(fmt.Sprintf(cc.urlPattern, c.Spec.Cloud.GetRegion()))
+		u, err := url.Parse(c.Address.URL)
 		if err != nil {
 			return nil, err
 		}
-
 		addrs, err := net.LookupHost(u.Host)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We have the dc name already as part of the cluster controller (e.g. do-ams2). This
is supposed to be used in the customer cluster url.
