### PR TITLE
Fixed wrong certificat name

### DIFF
--- a/provider/cloud/digitalocean/provider.go
+++ b/provider/cloud/digitalocean/provider.go
@@ -122,7 +122,7 @@ func (do *digitalocean) CreateNodes(
 
 		glog.V(2).Infof("dropletName %q", dropletName)
 
-		clientKC, err := cluster.CreateKeyCert("dropletName")
+		clientKC, err := cluster.CreateKeyCert(dropletName)
 		if err != nil {
 			return created, err
 		}


### PR DESCRIPTION
The cert name will always be `"dropletName"` not the value of the var `dropletName`.
