### PR TITLE
Overwrite host address

### DIFF
--- a/cmd/kubermatic-cluster-controller/cmd/root.go
+++ b/cmd/kubermatic-cluster-controller/cmd/root.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
-var cfgFile, kubeConfig, masterResources, externalURL, dcFile string
+var cfgFile, kubeConfig, masterResources, externalURL, dcFile, overwriteHost string
 var dev bool
 
 var viperWhiteList = []string{
@@ -90,7 +90,7 @@ var RootCmd = &cobra.Command{
 			// start controller
 			cps := cloud.Providers(dcs)
 			ctrl, err := cluster.NewController(
-				ctx, client, cps, masterResources, externalURL, dev,
+				ctx, client, cps, masterResources, externalURL, dev, overwriteHost,
 			)
 			if err != nil {
 				log.Fatal(err)
@@ -120,6 +120,8 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&externalURL, "external-url", "", "The external url for the apiserver host and the the dc.(Required)")
 	RootCmd.PersistentFlags().StringVar(&dcFile, "datacenters", "datacenters.yaml", "The datacenters.yaml file path")
 	RootCmd.PersistentFlags().BoolVar(&dev, "dev", false, "Create dev-mode clusters only processed by dev-mode cluster controller")
+	RootCmd.PersistentFlags().StringVar(&overwriteHost, "overwrite-host", "", "If set it will not do a hostlookup and will force the given host")
+
 	err := viper.BindPFlags(RootCmd.PersistentFlags())
 	if err != nil {
 		log.Fatalf("Unable to bind Command Line flags: %s\n", err)

--- a/cmd/kubermatic-cluster-controller/cmd/root.go
+++ b/cmd/kubermatic-cluster-controller/cmd/root.go
@@ -120,7 +120,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&externalURL, "external-url", "", "The external url for the apiserver host and the the dc.(Required)")
 	RootCmd.PersistentFlags().StringVar(&dcFile, "datacenters", "datacenters.yaml", "The datacenters.yaml file path")
 	RootCmd.PersistentFlags().BoolVar(&dev, "dev", false, "Create dev-mode clusters only processed by dev-mode cluster controller")
-	RootCmd.PersistentFlags().StringVar(&overwriteHost, "overwrite-host", "", "If set it will not do a hostlookup and will force the given host")
+	RootCmd.PersistentFlags().StringVar(&overwriteHost, "overwrite-host", "", "If set it will not do a hostlookup and will force the given host on all clustes. This is mostly used to run one static cluster.")
 
 	err := viper.BindPFlags(RootCmd.PersistentFlags())
 	if err != nil {

--- a/controller/cluster/controller.go
+++ b/controller/cluster/controller.go
@@ -49,6 +49,7 @@ type clusterController struct {
 	masterResourcesPath string
 	externalURL         string
 	etcdURL             string
+	overwriteHost       string
 	// store namespaces with the role=kubermatic-cluster label
 	nsController *framework.Controller
 	nsStore      cache.Store
@@ -83,6 +84,7 @@ func NewController(
 	masterResourcesPath string,
 	externalURL string,
 	dev bool,
+	overwriteHost string,
 ) (controller.Controller, error) {
 	cc := &clusterController{
 		dc:                  dc,
@@ -94,6 +96,7 @@ func NewController(
 		externalURL:         externalURL,
 		etcdURL:             fmt.Sprintf(etcdURLFormat, externalURL),
 		dev:                 dev,
+		overwriteHost:       overwriteHost,
 	}
 
 	eventBroadcaster := record.NewBroadcaster()

--- a/controller/cluster/pending.go
+++ b/controller/cluster/pending.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
-func (cc *clusterController) syncPendingCluster(c *api.Cluster) (*api.Cluster, error) {
-	changedC, err := cc.checkTimeout(c)
+func (cc *clusterController) syncPendingCluster(c *api.Cluster) (changedC *api.Cluster, err error) {
+	_, err = cc.checkTimeout(c)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/cluster/pending.go
+++ b/controller/cluster/pending.go
@@ -449,19 +449,19 @@ func (cc *clusterController) launchingCheckDeployments(c *api.Cluster) error {
 	}
 
 	loadApiserver := func(s string) (*extensions.Deployment, error) {
-		u, err := url.Parse(c.Address.URL)
-		if err != nil {
-			return nil, err
-		}
-		addrs, err := net.LookupHost(u.Host)
-		if err != nil {
-			return nil, err
-		}
-
-		data := struct {
-			AdvertiseAddress string
-		}{
-			AdvertiseAddress: addrs[0],
+		var data struct{ AdvertiseAddress string }
+		if cc.overwriteHost == "" {
+			u, err := url.Parse(c.Address.URL)
+			if err != nil {
+				return nil, err
+			}
+			addrs, err := net.LookupHost(u.Host)
+			if err != nil {
+				return nil, err
+			}
+			data.AdvertiseAddress = addrs[0]
+		} else {
+			data.AdvertiseAddress = cc.overwriteHost
 		}
 
 		t, err := template.ParseFiles(path.Join(cc.masterResourcesPath, s+"-dep.yaml"))

--- a/handler/kubeconfig.go
+++ b/handler/kubeconfig.go
@@ -91,6 +91,9 @@ func encodeKubeconfig(w http.ResponseWriter, response interface{}) (err error) {
 	}
 
 	ycfg, err := yaml.JSONToYAML(jcfg)
+	if err != nil {
+		return err
+	}
 	_, err = w.Write(ycfg)
 	return err
 }


### PR DESCRIPTION
This will enforce a hostAddress. If the flag `--overwrite-host` is set it will use this address instead of doing a host lookup.