### PR TITLE
use `buf.String()` instead of `string(buf.Bytes())`

### DIFF
--- a/provider/cloud/aws/provider.go
+++ b/provider/cloud/aws/provider.go
@@ -605,7 +605,7 @@ func (a *aws) CreateNodes(ctx context.Context, cluster *api.Cluster, node *api.N
 			return createdNodes, fmt.Errorf("failed to execute template: %v", err)
 		}
 
-		glog.V(2).Infof("User-Data:\n\n%s", string(buf.Bytes()))
+		glog.V(2).Infof("User-Data:\n\n%s", buf.String())
 
 		netSpec := []*ec2.InstanceNetworkInterfaceSpecification{
 			{

--- a/provider/cloud/digitalocean/provider.go
+++ b/provider/cloud/digitalocean/provider.go
@@ -144,7 +144,7 @@ func (do *digitalocean) CreateNodes(ctx context.Context, cluster *api.Cluster, s
 			return created, fmt.Errorf("failed to execute template: %v", err)
 		}
 
-		glog.V(2).Infof("User-Data:\n\n%s", string(buf.Bytes()))
+		glog.V(2).Infof("User-Data:\n\n%s", buf.String())
 
 		t := token(cSpec.GetToken())
 		client := godo.NewClient(oauth2.NewClient(ctx, t))


### PR DESCRIPTION
To get rid of these annoying linter warnings

```
provider/cloud/aws/provider.go:608:39: should use buf.String() instead of string(buf.Bytes()) (S1030)                                                                                                              
provider/cloud/digitalocean/provider.go:147:39: should use buf.String() instead of string(buf.Bytes()) (S1030) 
```