### PR TITLE
Remove apiserver health check as it causes panics

### DIFF
--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -53,12 +53,6 @@ spec:
             "--ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa",
             "--ssh-user=apiserver",
             "--v=4" ]
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
         ports:
         - containerPort: {{ .Cluster.Address.ExternalPort }}
         - containerPort: 8080

--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -53,6 +53,13 @@ spec:
             "--ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa",
             "--ssh-user=apiserver",
             "--v=4" ]
+#TODO: Investigate reason why this causes a panic: https://github.com/kubermatic/kubermatic/issues/406
+#        livenessProbe:
+#          httpGet:
+#            path: /healthz
+#            port: 8080
+#          initialDelaySeconds: 15
+#          timeoutSeconds: 1
         ports:
         - containerPort: {{ .Cluster.Address.ExternalPort }}
         - containerPort: 8080


### PR DESCRIPTION
```
I0822 11:51:21.586402       1 wrap.go:75] GET /healthz: (221.232µs) 500
goroutine 17622 [running]:
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/httplog.(*respLogger).recordStatus(0xc423276d20, 0x1f4)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/httplog/log.go:219 +0xbb
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/httplog.(*respLogger).WriteHeader(0xc423276d20, 0x1f4)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/httplog/log.go:198 +0x35
net/http.Error(0x6ccc9e0, 0xc423276d20, 0xc421dfe900, 0xf6, 0x1f4)
	/usr/local/go/src/net/http/server.go:1738 +0xda
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/healthz.handleRootHealthz.func1(0x6ccc9e0, 0xc423276d20, 0xc4232e5c20)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/healthz/healthz.go:110 +0x41a
net/http.HandlerFunc.ServeHTTP(0xc422188c00, 0x6ccc9e0, 0xc423276d20, 0xc4232e5c20)
	/usr/local/go/src/net/http/server.go:1726 +0x44
net/http.(*ServeMux).ServeHTTP(0xc42099d4a0, 0x6ccc9e0, 0xc423276d20, 0xc4232e5c20)
	/usr/local/go/src/net/http/server.go:2022 +0x7f
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.WithPanicRecovery.func1(0x6ccc9e0, 0xc423276d20, 0xc4232e5c20)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x24a
net/http.HandlerFunc.ServeHTTP(0xc420fd2090, 0x7febb1e0bf88, 0xc4234c3060, 0xc4232e5c20)
	/usr/local/go/src/net/http/server.go:1726 +0x44
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1(0xc420ff8540, 0x6cd7ee0, 0xc4234c3060, 0xc4232e5c20, 0xc42334b380)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:91 +0x8d
created by k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:93 +0x1d1

logging error output: "[+]ping ok\n[+]poststarthook/bootstrap-controller ok\n[+]poststarthook/extensions/third-party-resources ok\n[+]poststarthook/rbac/bootstrap-roles ok\n[-]SSH Tunnel Check failed: reason withheld\n[+]poststarthook/ca-registration ok\nhealthz check failed\n"
 [[Go-http-client/1.1] 10.244.5.1:37958]

```