### PR TITLE
from "github.com/hashicorp/go-version" to "github.com/blang/semver"

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -43,6 +43,12 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  name = "github.com/blang/semver"
+  packages = ["."]
+  revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
+  version = "v3.5.1"
+
+[[projects]]
   branch = "master"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
@@ -324,6 +330,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9736b4c460f867e292f2043c90418bd80d52875c3a43113e7aa65024d63957bc"
+  inputs-digest = "dacc118ecec7cc4239796ddf78243a8531a27789f54eead4b40feaa783e6ff4e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/handler/upgrade.go
+++ b/api/handler/upgrade.go
@@ -9,9 +9,9 @@ import (
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/blang/semver"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
-	version "github.com/hashicorp/go-version"
 	"github.com/kubermatic/kubermatic/api"
 	"github.com/kubermatic/kubermatic/api/provider"
 )
@@ -40,7 +40,7 @@ func getClusterUpgrades(
 			return nil, err
 		}
 
-		current, err := version.NewVersion(c.Spec.MasterVersion)
+		current, err := semver.Parse(c.Spec.MasterVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -48,17 +48,17 @@ func getClusterUpgrades(
 		s := kversion.
 			NewUpdatePathSearch(versions, updates, kversion.EqualityMatcher{})
 
-		possibleUpdates := make(version.Collection, 0)
+		possibleUpdates := make(semver.Versions, 0)
 		for _, ver := range versions {
 			if _, err := s.Search(c.Spec.MasterVersion, ver.ID); err != nil {
 				continue
 			}
-			v, err := version.NewVersion(ver.ID)
+			v, err := semver.Parse(ver.ID)
 			if err != nil {
 				continue
 			}
 
-			if current.LessThan(v) {
+			if current.LT(v) {
 				possibleUpdates = append(possibleUpdates, v)
 			}
 		}

--- a/api/handler/upgrade_test.go
+++ b/api/handler/upgrade_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	version "github.com/hashicorp/go-version"
+	"github.com/blang/semver"
 	"github.com/kubermatic/kubermatic/api"
 	"github.com/kubermatic/kubermatic/api/provider"
 	"github.com/kubermatic/kubermatic/api/provider/kubernetes"
@@ -189,11 +189,11 @@ func generateMasterVersions(versions []string) map[string]*api.MasterVersion {
 	return vs
 }
 
-func generateSemVerSlice(versions []string) version.Collection {
-	vs := make(version.Collection, 0)
+func generateSemVerSlice(versions []string) semver.Versions {
+	vs := make(semver.Versions, 0)
 
 	for _, v := range versions {
-		ver, err := version.NewVersion(v)
+		ver, err := semver.Parse(v)
 		if err != nil {
 			continue
 		}
@@ -284,7 +284,7 @@ func Test_getClusterUpgrades(t *testing.T) {
 						ctx:  context.Background(),
 						req:  generateClusterReq("234jkh24234g", "base", "anom"),
 						want: want{
-							val: version.Collection{},
+							val: semver.Versions{},
 							err: nil,
 						},
 					},


### PR DESCRIPTION
because 'go-version' doesn't support JSON marshalling