### PR TITLE
Increase apiserver count to 2 & add liveness check

### DIFF
--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -7,7 +7,7 @@ spec:
     matchLabels:
       role: apiserver
       version: v1
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -28,6 +28,7 @@ spec:
             "--apiserver-service-port={{ .Cluster.Address.ExternalPort }}",
             "--insecure-bind-address=0.0.0.0",
             "--insecure-port=8080",
+            "--apiserver-count=2",
             "--external-hostname=apiserver",
             "--etcd-servers=http://etcd-cluster-client:2379",
             "--storage-backend=etcd3",
@@ -57,13 +58,13 @@ spec:
             "--ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa",
             "--ssh-user=apiserver",
             "--v=4" ]
-#TODO: Investigate reason why this causes a panic: https://github.com/kubermatic/kubermatic/issues/406
-#        livenessProbe:
-#          httpGet:
-#            path: /healthz
-#            port: 8080
-#          initialDelaySeconds: 15
-#          timeoutSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5
         ports:
         - containerPort: {{ .Cluster.Address.ExternalPort }}
         - containerPort: 8080

--- a/config/kubermatic/static/master/controller-manager-dep.yaml
+++ b/config/kubermatic/static/master/controller-manager-dep.yaml
@@ -44,8 +44,9 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5
         env:
         {{ if eq .CloudProvider "aws" }}
         - name: AWS_ACCESS_KEY_ID

--- a/config/kubermatic/static/master/node-controller-dep.yaml
+++ b/config/kubermatic/static/master/node-controller-dep.yaml
@@ -21,6 +21,16 @@ spec:
         imagePullPolicy: Always
         command: [ "/node-controller",
             "--master=http://apiserver:8080",
+            "--health-listen-address=:8081",
             "--v=4",
             "--logtostderr",
         ]
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8081

--- a/config/kubermatic/static/master/scheduler-dep.yaml
+++ b/config/kubermatic/static/master/scheduler-dep.yaml
@@ -29,5 +29,6 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -22,8 +22,8 @@ updates:
   promote: true
 - from: 1.6.x
   to: 1.6.9
-  automatic: false
-  rollbackAllowed: true
+  automatic: true
+  rollbackAllowed: false
   enabled: true
   visible: true
   promote: true

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -15,11 +15,11 @@ versions:
     k8s-version: v1.6.7
     etcd-operator-version: v0.2.4fix
     etcd-cluster-version: 3.1.5
-    kube-machine-version: v0.1
+    kube-machine-version: v0.1.1
     addon-manager-version: v1.6.0
 - name: 1.6.8
   id: 1.6.8
-  default: true
+  default: false
   allowedNodeVersions: [1.4.0]
   etcdOperatorDeploymentYaml: etcd-operator-dep.yaml
   etcdClusterYaml: etcd-cluster.yaml
@@ -32,11 +32,11 @@ versions:
     k8s-version: v1.6.8
     etcd-operator-version: v0.2.4fix
     etcd-cluster-version: 3.1.5
-    kube-machine-version: v0.1
+    kube-machine-version: v0.1.1
     addon-manager-version: v1.6.0
 - name: 1.6.9
   id: 1.6.9
-  default: false
+  default: true
   allowedNodeVersions: [1.4.0]
   etcdOperatorDeploymentYaml: etcd-operator-dep.yaml
   etcdClusterYaml: etcd-cluster.yaml
@@ -49,5 +49,5 @@ versions:
     k8s-version: v1.6.9
     etcd-operator-version: v0.2.4fix
     etcd-cluster-version: 3.1.5
-    kube-machine-version: v0.1
+    kube-machine-version: v0.1.1
     addon-manager-version: v1.6.0


### PR DESCRIPTION
We initially deleted the liveness check on the apiserver, but it actually restarts the apiserver when it really needs to be restarted.
As a restart causes a downtime, i increased the apiserver count to 2.
Also i added a liveness check to the node-controller.