### PR TITLE
Remove download require

### DIFF
--- a/config/kubermatic/static/nodes/aws.yaml
+++ b/config/kubermatic/static/nodes/aws.yaml
@@ -65,8 +65,8 @@ config:
         content: |-
           [Unit]
           Description=Kubelet
-          Requires=network.target download-kubelet.service
-          After=network.target download-kubelet.service
+          Requires=network.target
+          After=network.target
 
           [Service]
           Restart=always

--- a/config/kubermatic/static/nodes/digitalocean.yaml
+++ b/config/kubermatic/static/nodes/digitalocean.yaml
@@ -74,8 +74,8 @@ config:
         content: |-
           [Unit]
           Description=Kubelet
-          Requires=network.target download-kubelet.service setup-network-environment.service
-          After=network.target download-kubelet.service setup-network-environment.service
+          Requires=network.target setup-network-environment.service
+          After=network.target setup-network-environment.service
 
           [Service]
           Restart=always

--- a/config/kubermatic/static/nodes/openstack.yaml
+++ b/config/kubermatic/static/nodes/openstack.yaml
@@ -61,8 +61,8 @@ config:
         content: |-
           [Unit]
           Description=Kubelet
-          Requires=network.target download-kubelet.service
-          After=network.target download-kubelet.service
+          Requires=network.target
+          After=network.target
 
           [Service]
           Restart=always


### PR DESCRIPTION
We are already starting the service on the initial provisioning of the node. So theres no need to have the download unit as required