### PR TITLE
Retry starting setup-network-environment and kubelet on DigitalOcean

### DIFF
--- a/config/kubermatic/static/nodes/aws.yaml
+++ b/config/kubermatic/static/nodes/aws.yaml
@@ -31,7 +31,7 @@ config:
           - "{{ .Cluster.Status.ApiserverSSHKey.PublicKey | apiBytesToString }} apiserver@{{ .Cluster.Address.ExternalName }}"
         sudo: true
     commands:
-      - "sudo /usr/bin/bash /opt/bin/bootstrap.sh"
+      - "sudo chmod +x /opt/bin/bootstrap.sh && sudo /opt/bin/bootstrap.sh"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
       - path: "/etc/kubernetes/bootstrap.kubeconfig"
@@ -75,7 +75,7 @@ config:
           StartLimitInterval=600
           StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
-          ExecStartPre=/usr/bin/bash /opt/bin/bootstrap.sh
+          ExecStartPre=/opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \

--- a/config/kubermatic/static/nodes/aws.yaml
+++ b/config/kubermatic/static/nodes/aws.yaml
@@ -31,7 +31,6 @@ config:
           - "{{ .Cluster.Status.ApiserverSSHKey.PublicKey | apiBytesToString }} apiserver@{{ .Cluster.Address.ExternalName }}"
         sudo: true
     commands:
-      - "sudo systemctl start download-kubelet.service"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
       - path: "/etc/kubernetes/bootstrap.kubeconfig"
@@ -39,25 +38,26 @@ config:
         owner: "root"
         content: |-
 {{ .Kubeconfig | indent 10 }}
-      - path: "/etc/systemd/system/download-kubelet.service"
+      - path: "/opt/bin/bootstrap.sh"
         permissions: "0640"
         owner: "root"
         content: |-
-          [Unit]
-          Description=Download Kubelet and requirements
-          After=network.target
+          #!/bin/bash
 
-          [Service]
-          Type=oneshot
-          ExecStartPre=/usr/bin/mkdir -p /opt/bin /opt/cni/bin /etc/cni/net.d /var/run/kubernetes /var/lib/kubelet /etc/kubernetes/manifests /var/log/containers
-          ExecStartPre=/usr/bin/curl -L -o /opt/bin/socat https://s3-eu-west-1.amazonaws.com/kubermatic/coreos/socat
-          ExecStartPre=/usr/bin/chmod +x /opt/bin/socat
-          ExecStart=/usr/bin/curl -L -o /opt/bin/kubelet https://storage.googleapis.com/kubelet/kubelet.{{index .Version.Values "k8s-version"}}
-          ExecStartPost=/usr/bin/chmod +x /opt/bin/kubelet
-          RemainAfterExit=true
+          set -xeuo pipefail
 
-          [Install]
-          WantedBy=multi-user.target
+          mkdir -p /opt/bin /opt/cni/bin /etc/cni/net.d /var/run/kubernetes /var/lib/kubelet /etc/kubernetes/manifests /var/log/containers
+
+          if [ ! -f /opt/bin/socat ]; then
+            curl -L -o /opt/bin/socat https://s3-eu-west-1.amazonaws.com/kubermatic/coreos/socat
+            chmod +x /opt/bin/socat
+          fi
+
+          if [ ! -f /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} ]; then
+            curl -L -o /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} https://storage.googleapis.com/kubelet/kubelet.{{index .Version.Values "k8s-version"}}
+            cp /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} /opt/bin/kubelet
+            chmod +x /opt/bin/kubelet
+          fi
 
       - path: "/etc/systemd/system/kubelet.service"
         permissions: "0640"
@@ -71,7 +71,10 @@ config:
           [Service]
           Restart=always
           RestartSec=10
+          StartLimitInterval=600
+          StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
+          PreExecStart=/usr/bin/bash /opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \

--- a/config/kubermatic/static/nodes/aws.yaml
+++ b/config/kubermatic/static/nodes/aws.yaml
@@ -31,6 +31,7 @@ config:
           - "{{ .Cluster.Status.ApiserverSSHKey.PublicKey | apiBytesToString }} apiserver@{{ .Cluster.Address.ExternalName }}"
         sudo: true
     commands:
+      - "sudo /usr/bin/bash /opt/bin/bootstrap.sh"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
       - path: "/etc/kubernetes/bootstrap.kubeconfig"
@@ -74,7 +75,7 @@ config:
           StartLimitInterval=600
           StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
-          PreExecStart=/usr/bin/bash /opt/bin/bootstrap.sh
+          ExecStartPre=/usr/bin/bash /opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \

--- a/config/kubermatic/static/nodes/digitalocean.yaml
+++ b/config/kubermatic/static/nodes/digitalocean.yaml
@@ -31,48 +31,32 @@ config:
         owner: "root"
         content: |-
 {{ .Kubeconfig | indent 10 }}
-      - path: "/etc/systemd/system/download-kubelet.service"
+      - path: "/opt/bin/bootstrap.sh"
         permissions: "0640"
         owner: "root"
         content: |-
-          [Unit]
-          Description=Download Kubelet and requirements
-          After=network.target
+          #!/bin/bash
 
-          [Service]
-          Type=oneshot
-          ExecStartPre=/usr/bin/mkdir -p /opt/bin /opt/cni/bin /etc/cni/net.d /var/run/kubernetes /var/lib/kubelet /etc/kubernetes/manifests /var/log/containers
-          ExecStartPre=/usr/bin/curl -L -o /opt/bin/socat https://s3-eu-west-1.amazonaws.com/kubermatic/coreos/socat
-          ExecStartPre=/usr/bin/chmod +x /opt/bin/socat
-          ExecStart=/usr/bin/curl -L -o /opt/bin/kubelet https://storage.googleapis.com/kubelet/kubelet.{{index .Version.Values "k8s-version"}}
-          ExecStartPost=/usr/bin/chmod +x /opt/bin/kubelet
-          RemainAfterExit=true
+          set -xeuo pipefail
 
-          [Install]
-          WantedBy=multi-user.target
+          mkdir -p /opt/bin /opt/cni/bin /etc/cni/net.d /var/run/kubernetes /var/lib/kubelet /etc/kubernetes/manifests /var/log/containers
 
-      - path: "/etc/systemd/system/setup-network-environment.service"
-        permissions: "0640"
-        owner: "root"
-        content: |-
-          [Unit]
-          Description=Setup Network Environment
-          Documentation=https://github.com/kelseyhightower/setup-network-environment
-          Requires=network.target
-          After=network.target
+          if [ ! -f /opt/bin/socat ]; then
+            curl -L -o /opt/bin/socat https://s3-eu-west-1.amazonaws.com/kubermatic/coreos/socat
+            chmod +x /opt/bin/socat
+          fi
 
-          [Service]
-          ExecStartPre=-/usr/bin/mkdir -p /opt/bin
-          ExecStartPre=/usr/bin/wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
+          if [ ! -f /opt/bin/kubelet ]; then
+            curl -L -o /opt/bin/kubelet https://storage.googleapis.com/kubelet/kubelet.{{index .Version.Values "k8s-version"}}
+            chmod +x /opt/bin/kubelet
+          fi
 
-          ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
-          ExecStart=/opt/bin/setup-network-environment
-          RemainAfterExit=yes
+          if [ ! -f /opt/bin/setup-network-environment ]; then
+            wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
+            chmod +x /opt/bin/setup-network-environment
+          fi
 
-          Restart=on-failure
-          RestartSec=10
-          StartLimitInterval=60
-          StartLimitBurst=5
+          /opt/bin/setup-network-environment
 
       - path: "/etc/systemd/system/kubelet.service"
         permissions: "0640"
@@ -80,15 +64,18 @@ config:
         content: |-
           [Unit]
           Description=Kubelet
-          Requires=network.target setup-network-environment.service
-          After=network.target setup-network-environment.service
-          PartOf=network.target setup-network-environment.service
+          Requires=network.target
+          After=network.target
+          PartOf=network.target
 
           [Service]
           Restart=always
           RestartSec=10
+          StartLimitInterval=600
+          StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
           EnvironmentFile=/etc/network-environment
+          PreExecStart=/usr/bin/bash /opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \

--- a/config/kubermatic/static/nodes/digitalocean.yaml
+++ b/config/kubermatic/static/nodes/digitalocean.yaml
@@ -22,6 +22,7 @@ config:
           - "{{ .Cluster.Status.ApiserverSSHKey.PublicKey | apiBytesToString }} apiserver@{{ .Cluster.Address.ExternalName }}"
         sudo: true
     commands:
+      - "sudo /usr/bin/bash /opt/bin/bootstrap.sh"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
       - path: "/etc/kubernetes/bootstrap.kubeconfig"
@@ -30,7 +31,7 @@ config:
         content: |-
 {{ .Kubeconfig | indent 10 }}
       - path: "/opt/bin/bootstrap.sh"
-        permissions: "0640"
+        permissions: "0750"
         owner: "root"
         content: |-
           #!/bin/bash
@@ -74,7 +75,7 @@ config:
           StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
           EnvironmentFile=/etc/network-environment
-          PreExecStart=/usr/bin/bash /opt/bin/bootstrap.sh
+          ExecStartPre=/usr/bin/bash /opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \

--- a/config/kubermatic/static/nodes/digitalocean.yaml
+++ b/config/kubermatic/static/nodes/digitalocean.yaml
@@ -68,7 +68,11 @@ config:
           ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
           ExecStart=/opt/bin/setup-network-environment
           RemainAfterExit=yes
-          Type=oneshot
+
+          Restart=on-failure
+          RestartSec=10
+          StartLimitInterval=60
+          StartLimitBurst=5
 
       - path: "/etc/systemd/system/kubelet.service"
         permissions: "0640"
@@ -78,6 +82,7 @@ config:
           Description=Kubelet
           Requires=network.target setup-network-environment.service
           After=network.target setup-network-environment.service
+          PartOf=network.target setup-network-environment.service
 
           [Service]
           Restart=always

--- a/config/kubermatic/static/nodes/digitalocean.yaml
+++ b/config/kubermatic/static/nodes/digitalocean.yaml
@@ -22,8 +22,6 @@ config:
           - "{{ .Cluster.Status.ApiserverSSHKey.PublicKey | apiBytesToString }} apiserver@{{ .Cluster.Address.ExternalName }}"
         sudo: true
     commands:
-      - "sudo systemctl start download-kubelet.service"
-      - "sudo systemctl start setup-network-environment.service"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
       - path: "/etc/kubernetes/bootstrap.kubeconfig"
@@ -46,13 +44,15 @@ config:
             chmod +x /opt/bin/socat
           fi
 
-          if [ ! -f /opt/bin/kubelet ]; then
-            curl -L -o /opt/bin/kubelet https://storage.googleapis.com/kubelet/kubelet.{{index .Version.Values "k8s-version"}}
+          if [ ! -f /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} ]; then
+            curl -L -o /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} https://storage.googleapis.com/kubelet/kubelet.{{index .Version.Values "k8s-version"}}
+            cp /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} /opt/bin/kubelet
             chmod +x /opt/bin/kubelet
           fi
 
-          if [ ! -f /opt/bin/setup-network-environment ]; then
-            wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
+          if [ ! -f /opt/bin/setup-network-environment.v1.0.0 ]; then
+            curl -L -o /opt/bin/setup-network-environment.v1.0.0 https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
+            cp /opt/bin/setup-network-environment.v1.0.0 /opt/bin/setup-network-environment
             chmod +x /opt/bin/setup-network-environment
           fi
 
@@ -66,7 +66,6 @@ config:
           Description=Kubelet
           Requires=network.target
           After=network.target
-          PartOf=network.target
 
           [Service]
           Restart=always

--- a/config/kubermatic/static/nodes/digitalocean.yaml
+++ b/config/kubermatic/static/nodes/digitalocean.yaml
@@ -22,7 +22,7 @@ config:
           - "{{ .Cluster.Status.ApiserverSSHKey.PublicKey | apiBytesToString }} apiserver@{{ .Cluster.Address.ExternalName }}"
         sudo: true
     commands:
-      - "sudo /usr/bin/bash /opt/bin/bootstrap.sh"
+      - "sudo chmod +x /opt/bin/bootstrap.sh && sudo /opt/bin/bootstrap.sh"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
       - path: "/etc/kubernetes/bootstrap.kubeconfig"
@@ -75,7 +75,7 @@ config:
           StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
           EnvironmentFile=/etc/network-environment
-          ExecStartPre=/usr/bin/bash /opt/bin/bootstrap.sh
+          ExecStartPre=/opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \

--- a/config/kubermatic/static/nodes/digitalocean.yaml
+++ b/config/kubermatic/static/nodes/digitalocean.yaml
@@ -88,5 +88,6 @@ config:
             --bootstrap-kubeconfig=/etc/kubernetes/bootstrap.kubeconfig \
             --require-kubeconfig \
             --cert-dir=/etc/kubernetes/
+
           [Install]
           WantedBy=multi-user.target

--- a/config/kubermatic/static/nodes/openstack.yaml
+++ b/config/kubermatic/static/nodes/openstack.yaml
@@ -29,7 +29,6 @@ config:
         sudo: true
     commands:
       - "sudo apt-get update && sudo apt-get install -y socat"
-      - "sudo systemctl start download-kubelet.service"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
       - path: "/etc/kubernetes/bootstrap.kubeconfig"
@@ -37,23 +36,21 @@ config:
         owner: "root"
         content: |-
 {{ .Kubeconfig | indent 10 }}
-      - path: "/etc/systemd/system/download-kubelet.service"
+      - path: "/opt/bin/bootstrap.sh"
         permissions: "0640"
         owner: "root"
         content: |-
-          [Unit]
-          Description=Download Kubelet and requirements
-          After=network.target
+          #!/bin/bash
 
-          [Service]
-          Type=oneshot
-          ExecStartPre=/bin/mkdir -p /opt/bin /opt/cni/bin /etc/cni/net.d /var/run/kubernetes /var/lib/kubelet /etc/kubernetes/manifests /var/log/containers
-          ExecStart=/usr/bin/curl -L -o /opt/bin/kubelet https://storage.googleapis.com/kubelet/kubelet.{{index .Version.Values "k8s-version"}}
-          ExecStartPost=/bin/chmod +x /opt/bin/kubelet
-          RemainAfterExit=true
+          set -xeuo pipefail
 
-          [Install]
-          WantedBy=multi-user.target
+          mkdir -p /opt/bin /opt/cni/bin /etc/cni/net.d /var/run/kubernetes /var/lib/kubelet /etc/kubernetes/manifests /var/log/containers
+
+          if [ ! -f /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} ]; then
+            curl -L -o /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} https://storage.googleapis.com/kubelet/kubelet.{{index .Version.Values "k8s-version"}}
+            cp /opt/bin/kubelet.{{index .Version.Values "k8s-version"}} /opt/bin/kubelet
+            chmod +x /opt/bin/kubelet
+          fi
 
       - path: "/etc/systemd/system/kubelet.service"
         permissions: "0640"
@@ -67,7 +64,10 @@ config:
           [Service]
           Restart=always
           RestartSec=10
+          StartLimitInterval=600
+          StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
+          PreExecStart=/usr/bin/bash /opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \

--- a/config/kubermatic/static/nodes/openstack.yaml
+++ b/config/kubermatic/static/nodes/openstack.yaml
@@ -28,8 +28,8 @@ config:
           - "{{ .Cluster.Status.ApiserverSSHKey.PublicKey | apiBytesToString }} apiserver@{{ .Cluster.Address.ExternalName }}"
         sudo: true
     commands:
-      - "sudo /usr/bin/bash /opt/bin/bootstrap.sh"
       - "sudo apt-get update && sudo apt-get install -y socat"
+      - "sudo chmod +x /opt/bin/bootstrap.sh && sudo /opt/bin/bootstrap.sh"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
       - path: "/etc/kubernetes/bootstrap.kubeconfig"
@@ -68,7 +68,7 @@ config:
           StartLimitInterval=600
           StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
-          ExecStartPre=/usr/bin/bash /opt/bin/bootstrap.sh
+          ExecStartPre=/opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \

--- a/config/kubermatic/static/nodes/openstack.yaml
+++ b/config/kubermatic/static/nodes/openstack.yaml
@@ -28,6 +28,7 @@ config:
           - "{{ .Cluster.Status.ApiserverSSHKey.PublicKey | apiBytesToString }} apiserver@{{ .Cluster.Address.ExternalName }}"
         sudo: true
     commands:
+      - "sudo /usr/bin/bash /opt/bin/bootstrap.sh"
       - "sudo apt-get update && sudo apt-get install -y socat"
       - "sudo systemctl enable kubelet && sudo systemctl start kubelet"
     files:
@@ -67,7 +68,7 @@ config:
           StartLimitInterval=600
           StartLimitBurst=50
           Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin:/opt/bin"
-          PreExecStart=/usr/bin/bash /opt/bin/bootstrap.sh
+          ExecStartPre=/usr/bin/bash /opt/bin/bootstrap.sh
           ExecStart=/opt/bin/kubelet \
             --container-runtime=docker \
             --allow-privileged=true \


### PR DESCRIPTION
This is still WIP...

Restarting setup-network-environment on failure works fine for me on my nodes. But sadly ones the setup-network-environment is up after a few retries the kubelet isn't started automatically and says it's dependencies aren't started, because it seems to doesn't know that the setup-network-environment was retried and now is up and running. 😕 

Any ideas on how to trigger kubelet restart after setup-network-environment is up at a 2 or 3 retry?
I've tried WantedBy & PartOf (as you can see below)

@mrIncompetent @realfake 