### PR TITLE
Change alertmanager’s service port name to web for service discovery

### DIFF
--- a/config/monitoring/alertmanager/templates/ingress.yaml
+++ b/config/monitoring/alertmanager/templates/ingress.yaml
@@ -25,4 +25,4 @@ spec:
       - path: /
         backend:
           serviceName: alertmanager
-          servicePort: http
+          servicePort: web

--- a/config/monitoring/alertmanager/templates/service.yaml
+++ b/config/monitoring/alertmanager/templates/service.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: http
+  - name: web
     port: 9093
     protocol: TCP
-    targetPort: http
+    targetPort: 9093
   selector:
     app: alertmanager

--- a/config/monitoring/prometheus/templates/ingress.yaml
+++ b/config/monitoring/prometheus/templates/ingress.yaml
@@ -25,4 +25,4 @@ spec:
       - path: /
         backend:
           serviceName: prometheus
-          servicePort: http
+          servicePort: web

--- a/config/monitoring/prometheus/templates/prometheus-service.yaml
+++ b/config/monitoring/prometheus/templates/prometheus-service.yaml
@@ -11,6 +11,6 @@ spec:
   - name: web
     protocol: TCP
     port: 9090
-    targetPort: web
+    targetPort: 9090
   selector:
     app: prometheus


### PR DESCRIPTION
The Prometheus Operator's Prometheus uses Service Discovery to find its alertmanagers. It's looking for a service called `alertmanager` with a port called `web`...