### PR TITLE
Add additional selector to prometheus service

### DIFF
--- a/config/monitoring/prometheus/templates/prometheus-service.yaml
+++ b/config/monitoring/prometheus/templates/prometheus-service.yaml
@@ -14,3 +14,5 @@ spec:
     targetPort: 9090
   selector:
     app: prometheus
+    prometheus: prometheus
+


### PR DESCRIPTION
We need to select the prometheus called prometheus (I am going to rename the prometheus to kubermatic in the future) to not randomly balance between our kubermatic and loodse prometheus.

Right now at https://prometheus.dev.kubermatic.io/targets you can see that you sometimes get the one and then the other.