### PR TITLE
Enable bootstrap token handling

### DIFF
--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -82,6 +82,9 @@ spec:
             "--cloud-provider=aws",
             {{ end }}
             "--kubelet-preferred-address-types=InternalIP",
+            {{ if contains "v1.8" (index .Version.Values "k8s-version") }}
+            "--enable-bootstrap-token-auth",
+            {{ end }}
             "--v=4" ]
         livenessProbe:
           httpGet:

--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -83,6 +83,7 @@ spec:
             {{ end }}
             "--kubelet-preferred-address-types=InternalIP",
             {{ if contains "v1.8" (index .Version.Values "k8s-version") }}
+            #TODO: Remove when we drop 1.8 support
             "--enable-bootstrap-token-auth",
             {{ end }}
             "--v=4" ]

--- a/config/kubermatic/static/master/controller-manager-dep.yaml
+++ b/config/kubermatic/static/master/controller-manager-dep.yaml
@@ -41,6 +41,9 @@ spec:
           {{ if contains "v1.6" (index .Version.Values "k8s-version") }}
           "--insecure-experimental-approve-all-kubelet-csrs-for-group=system:bootstrappers",
           {{ end }}
+          {{ if contains "v1.8" (index .Version.Values "k8s-version") }}
+          "--controllers=*,tokencleaner,bootstrapsigner",
+          {{ end }}
           "--v=4"
         ]
         livenessProbe:

--- a/config/kubermatic/static/master/controller-manager-dep.yaml
+++ b/config/kubermatic/static/master/controller-manager-dep.yaml
@@ -38,10 +38,8 @@ spec:
           "--cloud-provider=openstack",
           {{ end }}
           "--allocate-node-cidrs=true",
-          {{ if contains "v1.6" (index .Version.Values "k8s-version") }}
-          "--insecure-experimental-approve-all-kubelet-csrs-for-group=system:bootstrappers",
-          {{ end }}
           {{ if contains "v1.8" (index .Version.Values "k8s-version") }}
+          #TODO: Remove when we drop 1.8 support
           "--controllers=*,tokencleaner,bootstrapsigner",
           {{ end }}
           "--v=4"


### PR DESCRIPTION
Enables bootstrap tokens which should be used for node authentication in the future.
See: https://kubernetes.io/docs/admin/bootstrap-tokens/