### PR TITLE
Add ingress-nginx servicemonitor and a nginx grafana dashboard

### DIFF
--- a/config/monitoring/grafana/dashboards/nginx-dashboard.json
+++ b/config/monitoring/grafana/dashboards/nginx-dashboard.json
@@ -1,0 +1,347 @@
+{
+  "meta": {
+    "type": "db",
+    "canSave": true,
+    "canEdit": true,
+    "canStar": true,
+    "slug": "nginx",
+    "expires": "0001-01-01T00:00:00Z",
+    "created": "2017-12-14T10:19:07Z",
+    "updated": "2017-12-14T10:19:07Z",
+    "updatedBy": "admin",
+    "createdBy": "admin",
+    "version": 1
+  },
+  "dashboard": {
+    "__requires": [
+      {
+        "id": "grafana",
+        "name": "Grafana",
+        "type": "grafana",
+        "version": "4.5.2"
+      },
+      {
+        "id": "graph",
+        "name": "Graph",
+        "type": "panel",
+        "version": ""
+      },
+      {
+        "id": "prometheus",
+        "name": "Prometheus",
+        "type": "datasource",
+        "version": "1.0.0"
+      },
+      {
+        "id": "singlestat",
+        "name": "Singlestat",
+        "type": "panel",
+        "version": ""
+      }
+    ],
+    "annotations": {
+      "list": []
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": true,
+    "id": null,
+    "links": [],
+    "rows": [
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "id": 1,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(rate(nginx_total_requests[5m])) by (instance)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}}",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Rate of total nginx requests per 5min",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "decimals": null,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 3,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(nginx_active_connections)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 1800
+              }
+            ],
+            "thresholds": "",
+            "title": "Current Active Connections",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "id": 2,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 9,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(nginx_active_connections) by (instance)",
+                "format": "time_series",
+                "intervalFactor": 5,
+                "legendFormat": "{{ instance }}",
+                "refId": "A",
+                "step": 300
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Active Connections",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-24h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Nginx",
+    "version": 1
+  },
+  "overwrite": true
+}

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -15,9 +15,6 @@ spec:
     metadata:
       labels:
         app: ingress-nginx
-      annotations:
-        prometheus.io/port: {{ .Values.nginx.prometheus.port | quote }}
-        prometheus.io/scrape: {{ .Values.nginx.prometheus.scrape | quote }}
     spec:
     {{ if .Values.nginx.hostNetwork }}
       hostNetwork: true
@@ -42,8 +39,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{ if not .Values.nginx.hostNetwork }}
           ports:
+          - name: metrics
+            containerPort: 10254
+          {{ if not .Values.nginx.hostNetwork }}
           - name: http
             containerPort: 80
           - name: https

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -42,12 +42,10 @@ spec:
           ports:
           - name: metrics
             containerPort: 10254
-          {{ if not .Values.nginx.hostNetwork }}
           - name: http
             containerPort: 80
           - name: https
             containerPort: 443
-          {{ end }}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/config/nginx-ingress-controller/templates/service.yaml
+++ b/config/nginx-ingress-controller/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app: ingress-nginx
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 10254
+    protocol: TCP
+  selector:
+    app: ingress-nginx

--- a/config/nginx-ingress-controller/templates/servicemonitor.yaml
+++ b/config/nginx-ingress-controller/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx
+  namespace: monitoring
+  labels:
+    team: kubermatic
+spec:
+  selector:
+    matchLabels:
+      app: ingress-nginx
+  namespaceSelector:
+    matchNames:
+    - ingress-nginx
+  endpoints:
+  - port: metrics
+    interval: 15s


### PR DESCRIPTION
For now this is only used by the grafana dashboard.

<img width="1429" alt="screen shot 2017-12-21 at 2 19 41 pm" src="https://user-images.githubusercontent.com/872251/34257408-05bde3ac-e65a-11e7-8255-7afd0c0c90c1.png">
