### PR TITLE
Use kube-state-metrics 1.2-rc0 and enable its alerting rules

### DIFF
--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.1.0
+    tag: v1.2.0-rc.0
   resizer:
     image:
       repository: gcr.io/google_containers/addon-resizer

--- a/config/monitoring/prometheus/rules/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/kube-state-metrics.yaml
@@ -1,0 +1,51 @@
+groups:
+- name: kube-state-metrics
+  rules:
+  - alert: KubernetesDeploymentGenerationMismatch
+    expr: kube_deployment_status_observed_generation != kube_deployment_metadata_generation
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: "Observed deployment generation does not match expected one for deployment {{$labels.namespaces}}/{{$labels.deployment}}"
+      summary: "Deployment is outdated"
+  - alert: KubernetesDeploymentReplicasNotUpdated
+    expr: ((kube_deployment_status_replicas_updated != kube_deployment_spec_replicas) or (kube_deployment_status_replicas_available != kube_deployment_spec_replicas)) unless (kube_deployment_spec_paused == 1)
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: "Replicas are not updated and available for deployment {{$labels.namespaces}}/{{$labels.deployment}}"
+      summary: "Deployment replicas are outdated"
+  - alert: KubernetesDaemonSetRolloutStuck
+    expr: kube_daemonset_status_number_ready / kube_daemonset_status_desired_number_scheduled * 100 < 100
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: "Only {{$value}}% of desired pods scheduled and ready for daemon set {{$labels.namespaces}}/{{$labels.daemonset}}"
+      summary: "DaemonSet is missing pods"
+  - alert: KubernetesDaemonSetsNotScheduled
+    expr: kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_current_number_scheduled > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "A number of daemonsets are not scheduled."
+      summary: "Daemonsets are not scheduled correctly"
+  - alert: KubernetesDaemonSetsMissScheduled
+    expr: kube_daemonset_status_number_misscheduled > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Daemonsets are not scheduled correctly"
+      description: "A number of daemonsets are running where they are not supposed to run."
+  - alert: KubernetesPodFrequentlyRestarting
+    expr: increase(kube_pod_container_status_restarts_total[1h]) > 5
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "Pod {{$labels.namespaces}}/{{$labels.pod}} is was restarted {{$value}} times within the last hour"
+      summary: "Pod is restarting frequently"


### PR DESCRIPTION
**What this PR does / why we need it**:
We are already running kube-state-metrics. But I bumped the version to the latest 1.2-rc0 to test it. CoreOS didn't receive any bad feedback for a week now, so I think we can do that.

I finally added and thus enabled kube-state-metrics alerting rules which are updated for 1.2-rc0. 
I've also updated this upstream: https://github.com/coreos/prometheus-operator/pull/884

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Nope.

**Special notes for your reviewer**:
I like you?