### PR TITLE
Alert on the 95th percentile, as the 99th is to noisy

### DIFF
--- a/config/monitoring/prometheus/rules/kube-apiserver.yaml
+++ b/config/monitoring/prometheus/rules/kube-apiserver.yaml
@@ -10,10 +10,10 @@ groups:
       summary: Kubernetes API Server unreachable
       description: Prometheus fails to scrape API Server(s), or all API servers have disappeared from service discovery.
   - alert: KubernetesApiServerLatency
-    expr: histogram_quantile(0.99, sum(apiserver_request_latencies_bucket{subresource!="log",verb!~"^(?:CONNECT|WATCHLIST|WATCH|PROXY)$"}) WITHOUT (instance, resource)) / 1e+06 > 1
+    expr: histogram_quantile(0.95, sum(apiserver_request_latencies_bucket{subresource!="log",verb!~"^(?:CONNECT|WATCHLIST|WATCH|PROXY)$"}) WITHOUT (instance, resource)) / 1e+06 > 1
     for: 10m
     labels:
       severity: warning
     annotations:
       summary: Kubernetes API Server latency is high
-      description: 99th percentile Latency for {{ $labels.verb }} requests to the kube-apiserver is higher than 1s.
+      description: 95th percentile Latency for {{ $labels.verb }} requests to the kube-apiserver is higher than 1s.


### PR DESCRIPTION
**What this PR does / why we need it**:
The SysEleven cluster is pretty noisy when it comes to this alert. Something going on there is rather slow. So far the 95th percentile looks quite good. That should be good enough for us still.
