### PR TITLE
Use kube-state-metrics v1.2.0

### DIFF
--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.2.0-rc.0
+    tag: v1.2.0
   resizer:
     image:
       repository: gcr.io/google_containers/addon-resizer


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now we're running v1.2.0-rc0 but v1.2.0 is now out.
