### PR TITLE
Fix descriptions in kube-state-metrics alerts

### DIFF
--- a/config/monitoring/prometheus/rules/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/kube-state-metrics.yaml
@@ -7,7 +7,7 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: "Observed deployment generation does not match expected one for deployment {{$labels.namespaces}}/{{$labels.deployment}}"
+      description: "Observed deployment generation does not match expected one for deployment {{$labels.exported_namespace}}/{{$labels.deployment}}"
       summary: "Deployment is outdated"
   - alert: KubernetesDeploymentReplicasNotUpdated
     expr: ((kube_deployment_status_replicas_updated != kube_deployment_spec_replicas) or (kube_deployment_status_replicas_available != kube_deployment_spec_replicas)) unless (kube_deployment_spec_paused == 1)
@@ -15,7 +15,7 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: "Replicas are not updated and available for deployment {{$labels.namespaces}}/{{$labels.deployment}}"
+      description: "Replicas are not updated and available for deployment {{$labels.exported_namespace}}/{{$labels.deployment}}"
       summary: "Deployment replicas are outdated"
   - alert: KubernetesDaemonSetRolloutStuck
     expr: kube_daemonset_status_number_ready / kube_daemonset_status_desired_number_scheduled * 100 < 100
@@ -23,7 +23,7 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: "Only {{$value}}% of desired pods scheduled and ready for daemon set {{$labels.namespaces}}/{{$labels.daemonset}}"
+      description: "Only {{$value}}% of desired pods scheduled and ready for daemon set {{$labels.exported_namespace}}/{{$labels.daemonset}}"
       summary: "DaemonSet is missing pods"
   - alert: KubernetesDaemonSetsNotScheduled
     expr: kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_current_number_scheduled > 0
@@ -47,5 +47,5 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: "Pod {{$labels.namespaces}}/{{$labels.pod}} is was restarted {{$value}} times within the last hour"
+      description: "Pod {{$labels.exported_namespace}}/{{$labels.exported_pod}} is was restarted {{$value}} times within the last hour"
       summary: "Pod is restarting frequently"


### PR DESCRIPTION
**What this PR does / why we need it**:
The current alert descriptions for kube-state-metrics don't use the correct labels and thus the messages in Slack are broken.
