### PR TITLE
Fix installer

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -23,7 +23,7 @@ kubectl create -f installer/clusterrolebinding.yaml
 # values.yaml is the file you created during the step above
 kubectl -n kubermatic-installer create secret generic values --from-file=values.yaml
 #Create the docker secret - needs to have read access to kubermatic/installer 
-kubectl -n kubermatic-installer create secret dockercfg regsecret --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>
+kubectl  -n kubermatic-installer create secret docker-registry dockercfg --docker-username='' --docker-password='' --docker-email=''
 # Create and run the installer job
 # Replace the version in the installer job template
 cp installer/install-job.template.yaml install-job.yaml

--- a/config/deploy_helm_charts.sh
+++ b/config/deploy_helm_charts.sh
@@ -45,7 +45,7 @@ kubectl apply -f ${CHARTS_PATH}/installer/namespace.yaml
 kubectl apply -f ${CHARTS_PATH}/installer/tiller-serviceaccount.yaml
 
 # You cannot update clusterrolebindings so we recreate them
-kubectl delete -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml
+kubectl delete -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml || true
 kubectl create -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml
 
 helm ${HELM_OPTS} init --service-account tiller --upgrade
@@ -54,15 +54,8 @@ do
    sleep 5
 done
 
-############# Kubermatic #############
-helm ${HELM_OPTS} upgrade -i storage --namespace default -f ${VALUESFILE} ${CHARTS_PATH}/storage/
-helm ${HELM_OPTS} upgrade -i nginx --namespace ingress-nginx -f ${VALUESFILE} ${CHARTS_PATH}/nginx-ingress-controller/
-helm ${HELM_OPTS} upgrade -i oauth --namespace oauth -f ${VALUESFILE} ${CHARTS_PATH}/oauth/
-helm ${HELM_OPTS} upgrade -i kubermatic --namespace kubermatic -f ${VALUESFILE} ${CHARTS_PATH}/kubermatic/
-helm ${HELM_OPTS} upgrade -i cert-manager --namespace cert-manager -f ${VALUESFILE} ${CHARTS_PATH}/cert-manager/
-helm ${HELM_OPTS} upgrade -i certs --namespace default -f ${VALUESFILE} ${CHARTS_PATH}/certs/
-helm ${HELM_OPTS} upgrade -i nodeport-exposer --namespace nodeport-exposer -f ${VALUESFILE} ${CHARTS_PATH}/nodeport-exposer/
-
+# We need to install the monitoring charts first, as the other charts include ServiceMonitors - which is
+# a CRD created by prometheus
 ############# MONITORING #############
 # All monitoring charts require the monitoring ns.
 kubectl create namespace monitoring || true
@@ -72,6 +65,15 @@ helm ${HELM_OPTS} upgrade -i kube-state-metrics -f ${VALUESFILE} ${CHARTS_PATH}/
 helm ${HELM_OPTS} upgrade -i grafana -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/grafana/
 helm ${HELM_OPTS} upgrade -i alertmanager -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/alertmanager/
 helm ${HELM_OPTS} upgrade -i prometheus -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/prometheus/
+
+############# Kubermatic #############
+helm ${HELM_OPTS} upgrade -i storage --namespace default -f ${VALUESFILE} ${CHARTS_PATH}/storage/
+helm ${HELM_OPTS} upgrade -i nginx --namespace ingress-nginx -f ${VALUESFILE} ${CHARTS_PATH}/nginx-ingress-controller/
+helm ${HELM_OPTS} upgrade -i oauth --namespace oauth -f ${VALUESFILE} ${CHARTS_PATH}/oauth/
+helm ${HELM_OPTS} upgrade -i kubermatic --namespace kubermatic -f ${VALUESFILE} ${CHARTS_PATH}/kubermatic/
+helm ${HELM_OPTS} upgrade -i cert-manager --namespace cert-manager -f ${VALUESFILE} ${CHARTS_PATH}/cert-manager/
+helm ${HELM_OPTS} upgrade -i certs --namespace default -f ${VALUESFILE} ${CHARTS_PATH}/certs/
+helm ${HELM_OPTS} upgrade -i nodeport-exposer --namespace nodeport-exposer -f ${VALUESFILE} ${CHARTS_PATH}/nodeport-exposer/
 
 #TODO: Update
 #helm ${HELM_OPTS} upgrade -i efk-logging -f ${VALUESFILE} ${PATH}/efk-logging/


### PR DESCRIPTION
**What this PR does / why we need it**:
We had 3 bugs in the installer:
- The install order of the charts was wrong. First we need to install the prometheus chart as prometheus creates a crd which is beeing used by other charts
- the installer tries to recreated the tiller clusterrolebinding on start but failes if none existed 
- the docker secret creation changed in kubernetes

