### PR TITLE
use custom ingress for acme challenge to solve force-https redirect issue

### DIFF
--- a/config/certs/templates/acme-challenge-ingress.yaml
+++ b/config/certs/templates/acme-challenge-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  name: cert-manager-acme-challenge-kubermatic-all
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /.really-not-used
+        backend:
+          serviceName: does-not-exist
+          servicePort: does-not-exist

--- a/config/certs/templates/certificates.yaml
+++ b/config/certs/templates/certificates.yaml
@@ -24,4 +24,4 @@ spec:
       - {{ $val }}
       {{- end }}
       http01:
-        ingressClass: nginx
+        ingress: cert-manager-acme-challenge-kubermatic-all


### PR DESCRIPTION
**What this PR does / why we need it**:
The acme-challenge ingresses created from the cert-manager were redirected to https by the nginx.
When there is no valid https certificate, the acme-challenge will never succeed.
This pr introduces a custom ingress, which will be used by the cert-manager, which disables the https redirect via annotation.