### PR TITLE
Add config checksums to deployments

### DIFF
--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -9,6 +9,12 @@ spec:
       labels:
         role: kubermatic-api
         version: v1
+      annotations:
+        checksum/master-files: {{ include (print $.Template.BasePath "/master-files-secret.yaml") . | sha256sum }}
+        checksum/datacenter-secretes: {{ include (print $.Template.BasePath "/datacenter-secrets.yaml") . | sha256sum }}
+        checksum/datecenters: {{ include (print $.Template.BasePath "/datacenter-yaml-secret.yaml") . | sha256sum }}
+        checksum/kubeconfig: {{ include (print $.Template.BasePath "/kubeconfig-secret.yaml") . | sha256sum }}
+        checksum/node-files: {{ include (print $.Template.BasePath "/node-files-secret.yaml") . | sha256sum }}
     spec:
       serviceAccountName: kubermatic
       containers:

--- a/config/kubermatic/templates/kubermatic-cluster-controller-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-cluster-controller-dep.yaml
@@ -9,6 +9,12 @@ spec:
       labels:
         role: cluster-controller
         version: v1
+      annotations:
+        checksum/master-files: {{ include (print $.Template.BasePath "/master-files-secret.yaml") . | sha256sum }}
+        checksum/datacenter-secretes: {{ include (print $.Template.BasePath "/datacenter-secrets.yaml") . | sha256sum }}
+        checksum/datecenters: {{ include (print $.Template.BasePath "/datacenter-yaml-secret.yaml") . | sha256sum }}
+        checksum/kubeconfig: {{ include (print $.Template.BasePath "/kubeconfig-secret.yaml") . | sha256sum }}
+        checksum/node-files: {{ include (print $.Template.BasePath "/node-files-secret.yaml") . | sha256sum }}
     spec:
       serviceAccountName: kubermatic
       containers:

--- a/config/oauth/templates/dex-dep.yaml
+++ b/config/oauth/templates/dex-dep.yaml
@@ -10,6 +10,9 @@ spec:
     metadata:
       labels:
         app: dex
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/dex-config.yaml") . | sha256sum }}
+        checksum/themes: {{ include (print $.Template.BasePath "/themes-secret.yaml") . | sha256sum }}
     spec:
       serviceAccountName: dex
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Automatically rolls all pods of a kubermatic/dex deployment when a relevant configmap/secret changes during a helm upgrade
