### PR TITLE
add optional 1.8.7 update

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -14,8 +14,8 @@ updates:
   visible: true
   promote: true
 - from: 1.8.x
-  to: 1.8.5
-  automatic: true
+  to: 1.8.7
+  automatic: false
   rollbackAllowed: false
   enabled: true
   visible: true

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -123,3 +123,21 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.2
     pod-network-bridge: v0.2
+- name: 1.8.7
+  id: 1.8.7
+  default: false
+  allowedNodeVersions: [1.4.0]
+  etcdOperatorDeploymentYaml: etcd-operator-dep.yaml
+  etcdClusterYaml: etcd-cluster.yaml
+  apiserverDeploymentYaml: apiserver-dep.yaml
+  controllerDeploymentYaml: controller-manager-dep.yaml
+  schedulerDeploymentYaml: scheduler-dep.yaml
+  nodeControllerDeploymentYaml: node-controller-dep.yaml
+  addonManagerDeploymentYaml: addon-manager-dep.yaml
+  values:
+    k8s-version: v1.8.7
+    etcd-operator-version: v0.6.0
+    etcd-cluster-version: 3.2.7
+    kube-machine-version: v0.2.3
+    addon-manager-version: v1.8.2
+    pod-network-bridge: v0.2


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds an optional update for kubernetes v1..8.7.
v1.8.5 stays default for now, as we need to have a optional update for the dashboard work
