### PR TITLE
disable the creation of network routes on cloud provider

### DIFF
--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt
         - --cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key
         - --cluster-cidr=172.25.0.0/16
+        - --configure-cloud-routes=false
         - --cloud-config=/etc/kubernetes/cloud/config
         - --cloud-provider=aws
         - --allocate-node-cidrs=true

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt
         - --cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key
         - --cluster-cidr=172.25.0.0/16
+        - --configure-cloud-routes=false
         - --cloud-config=/etc/kubernetes/cloud/config
         - --cloud-provider=aws
         - --allocate-node-cidrs=true

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt
         - --cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key
         - --cluster-cidr=172.25.0.0/16
+        - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
         - --controllers=*,tokencleaner,bootstrapsigner
         - --v=4

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt
         - --cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key
         - --cluster-cidr=172.25.0.0/16
+        - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
         - --v=4
         image: kubermatic/hyperkube-amd64:v1.9.0

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt
         - --cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key
         - --cluster-cidr=172.25.0.0/16
+        - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
         - --controllers=*,tokencleaner,bootstrapsigner
         - --v=4

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt
         - --cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key
         - --cluster-cidr=172.25.0.0/16
+        - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
         - --v=4
         image: kubermatic/hyperkube-amd64:v1.9.0

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt
         - --cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key
         - --cluster-cidr=172.25.0.0/16
+        - --configure-cloud-routes=false
         - --cloud-config=/etc/kubernetes/cloud/config
         - --cloud-provider=openstack
         - --allocate-node-cidrs=true

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt
         - --cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key
         - --cluster-cidr=172.25.0.0/16
+        - --configure-cloud-routes=false
         - --cloud-config=/etc/kubernetes/cloud/config
         - --cloud-provider=openstack
         - --allocate-node-cidrs=true

--- a/config/kubermatic/static/master/controller-manager-dep.yaml
+++ b/config/kubermatic/static/master/controller-manager-dep.yaml
@@ -29,7 +29,9 @@ spec:
           "--cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt",
           "--cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key",
           "--cluster-cidr=172.25.0.0/16",
+          {{ if not (contains "v1.7" (index .Version.Values "k8s-version")) }}
           "--configure-cloud-routes=false",
+          {{ end }}
           {{ if eq .CloudProvider "aws" }}
           "--cloud-config=/etc/kubernetes/cloud/config",
           "--cloud-provider=aws",

--- a/config/kubermatic/static/master/controller-manager-dep.yaml
+++ b/config/kubermatic/static/master/controller-manager-dep.yaml
@@ -29,6 +29,7 @@ spec:
           "--cluster-signing-cert-file=/var/run/kubernetes/auth/root-ca.crt",
           "--cluster-signing-key-file=/var/run/kubernetes/auth/root-ca.key",
           "--cluster-cidr=172.25.0.0/16",
+          "--configure-cloud-routes=false",
           {{ if eq .CloudProvider "aws" }}
           "--cloud-config=/etc/kubernetes/cloud/config",
           "--cloud-provider=aws",


### PR DESCRIPTION
**What this PR does / why we need it**:
We should not create network routes for the pod network on cloud-provider side. As we manage the pod network with canal its not needed.
