### PR TITLE
Delete the apiserver latencty alert

### DIFF
--- a/config/monitoring/prometheus/rules/kube-apiserver.yaml
+++ b/config/monitoring/prometheus/rules/kube-apiserver.yaml
@@ -9,11 +9,3 @@ groups:
     annotations:
       summary: Kubernetes API Server unreachable
       description: Prometheus fails to scrape API Server(s), or all API servers have disappeared from service discovery.
-  - alert: KubernetesApiServerLatency
-    expr: histogram_quantile(0.95, sum(apiserver_request_latencies_bucket{subresource!="log",verb!~"^(?:CONNECT|WATCHLIST|WATCH|PROXY)$"}) WITHOUT (instance, resource)) / 1e+06 > 1
-    for: 10m
-    labels:
-      severity: warning
-    annotations:
-      summary: Kubernetes API Server latency is high
-      description: 95th percentile Latency for {{ $labels.verb }} requests to the kube-apiserver is higher than 1s.


### PR DESCRIPTION
**What this PR does / why we need it**:
This alert is very noisy even after tuning it down already.
We don't really care that much about the lantency and thus we delete it now.
