### PR TITLE
Fix node alerts

### DIFF
--- a/config/monitoring/prometheus/rules/node.yml
+++ b/config/monitoring/prometheus/rules/node.yml
@@ -6,26 +6,32 @@ groups:
     for: 15m
     labels:
       severity: page
+    annotations:
+      description: "Device {{ $labels.device }} of instance {{ $labels.instance }} is filling quickly."
+      summary: "Disk will fill in 4 hours"
   - alert: NodeDiskWillFillIn8Hours
     expr: predict_linear(node_filesystem_free{job="node-exporter"}[1h], 8 * 3600) < 0
     for: 15m
     labels:
       severity: notify
+    annotations:
+      description: "Device {{ $labels.device }} of instance {{ $labels.instance }} is filling quickly."
+      summary: "Disk will fill in 4 hours"
   - alert: NodeExporterDown
     expr: absent(up{job="node-exporter"} == 1)
     for: 10m
     labels:
       severity: warning
     annotations:
-      summary: node-exporter cannot be scraped
-      description: Prometheus could not scrape a node-exporter for more than 10m, or node-exporters have disappeared from discovery.
+      summary: "node-exporter cannot be scraped"
+      description: "Prometheus could not scrape a node-exporter for more than 10m, or node-exporters have disappeared from discovery."
   - alert: KubernetesNodeOutOfDisk
     expr: kube_node_status_condition{condition="OutOfDisk",status="true"} == 1
     labels:
       service: k8s
       severity: critical
     annotations:
-      summary: Node ran out of disk space.
+      summary: "Node ran out of disk space"
       description: '{{ $labels.node }} has run out of disk space.'
   - alert: KubernetesNodeMemoryPressure
     expr: kube_node_status_condition{condition="MemoryPressure",status="true"} == 1
@@ -33,7 +39,7 @@ groups:
       service: k8s
       severity: warning
     annotations:
-      summary: Node is under memory pressure.
+      summary: "Node is under memory pressure"
       description: '{{ $labels.node }} is under memory pressure.'
   - alert: KubernetesNodeDiskPressure
     expr: kube_node_status_condition{condition="DiskPressure",status="true"} == 1
@@ -41,5 +47,5 @@ groups:
       service: k8s
       severity: warning
     annotations:
-      summary: Node is under disk pressure.
+      summary: "Node is under disk pressure"
       description: '{{ $labels.node }} is under disk pressure.'


### PR DESCRIPTION
The NodeDiskWillFillInXHours alerts were missing summary and description, resulting in empty alert messages on Slack.