### PR TITLE
Alerts for waiting and terminating pods

### DIFF
--- a/config/monitoring/prometheus/rules/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/kube-state-metrics.yaml
@@ -49,3 +49,19 @@ groups:
     annotations:
       description: "Pod {{$labels.exported_namespace}}/{{$labels.exported_pod}} is was restarted {{$value}} times within the last hour"
       summary: "Pod is restarting frequently"
+  - alert: KubernetesPodTerminating
+    expr: kube_pod_container_status_terminated == 1
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      description: "Container {{$labels.exported_namespace}}/{{$labels.exported_pod}}/{{$labels.container}} is terminating for {{$value}}min."
+      summary: "Pod is terminating too long"
+  - alert: KubernetesPodWaiting
+    expr: kube_pod_container_status_waiting == 1
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      description: "Container {{$labels.exported_namespace}}/{{$labels.exported_pod}}/{{$labels.container}} is waiting for {{$value}}min."
+      summary: "Pod is waiting too long"


### PR DESCRIPTION
With these two new rules we can alert on pods that are terminating or waiting for more then 30 min.