### PR TITLE
make volume zone validation configurable for openstack

### DIFF
--- a/api/pkg/controller/resources/fixtures/loadopenstackcloudconfigconfigmap-result.yaml
+++ b/api/pkg/controller/resources/fixtures/loadopenstackcloudconfigconfigmap-result.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  config: |
+    [Global]
+    auth-url = "https://my.openstack.foo/v3"
+    username = "openstack-username"
+    password = "openstack-password"
+    domain-name= "openstack-domain"
+    tenant-name = "openstack-tenant"
+
+    [BlockStorage]
+    trust-device-path = false
+    bs-version = "v2"
+    ignore-volume-az = true
+metadata:
+  creationTimestamp: null
+  name: cloud-config

--- a/api/pkg/controller/resources/load_files_test.go
+++ b/api/pkg/controller/resources/load_files_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghodss/yaml"
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/pmezard/go-difflib/difflib"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -284,7 +285,7 @@ func TestLoadAwsCloudConfigConfigMap(t *testing.T) {
 		},
 	}
 
-	res, err := LoadAwsCloudConfigConfigMap(c, nil)
+	res, err := LoadAwsCloudConfigConfigMap(c, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,4 +321,72 @@ func TestLoadClusterRoleBindingFile(t *testing.T) {
 
 		checkTestResult(t, r, res)
 	}
+}
+
+func TestLoadOpenstackCloudConfigConfigMap(t *testing.T) {
+	c := &kubermaticv1.Cluster{
+		Spec: kubermaticv1.ClusterSpec{
+			Cloud: &kubermaticv1.CloudSpec{
+				Openstack: &kubermaticv1.OpenstackCloudSpec{
+					SubnetID:       "openstack-subnetid",
+					Username:       "openstack-username",
+					Tenant:         "openstack-tenant",
+					SecurityGroups: "openstack-security-groups",
+					RouterID:       "openstack-router-id",
+					Password:       "openstack-password",
+					Network:        "openstack-network",
+					Domain:         "openstack-domain",
+					FloatingIPPool: "openstack-floating-ip-pool",
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "de-test-01",
+		},
+		Address: &kubermaticv1.ClusterAddress{
+			URL:          "https://jh8j81chn.europe-west3-c.dev.kubermatic.io:8443",
+			ExternalName: "jh8j81chn.europe-west3-c.dev.kubermatic.io",
+			ExternalPort: 8002,
+		},
+	}
+
+	dc := &provider.DatacenterMeta{
+		Spec: provider.DatacenterSpec{
+			Openstack: &provider.OpenstackSpec{
+				AvailabilityZone: "az1",
+				AuthURL:          "https://my.openstack.foo/v3",
+				DNSServers:       []string{"8.8.8.8", "8.8.4.4"},
+				IgnoreVolumeAZ:   true,
+			},
+		},
+	}
+
+	version := &apiv1.MasterVersion{
+		Name:                         "1.9.0",
+		ID:                           "1.9.0",
+		Default:                      true,
+		AllowedNodeVersions:          []string{"1.3.0"},
+		EtcdOperatorDeploymentYaml:   "etcd-operator-dep.yaml",
+		ApiserverDeploymentYaml:      "apiserver-dep.yaml",
+		ControllerDeploymentYaml:     "controller-manager-dep.yaml",
+		SchedulerDeploymentYaml:      "scheduler-dep.yaml",
+		AddonManagerDeploymentYaml:   "addon-manager-dep.yaml",
+		NodeControllerDeploymentYaml: "node-controller-dep.yaml",
+		Values: map[string]string{
+			"k8s-version":           "v1.9.0",
+			"etcd-operator-version": "v0.6.0",
+			"etcd-cluster-version":  "3.2.7",
+			"kube-machine-version":  "v0.2.3",
+			"addon-manager-version": "v1.9.0",
+			"pod-network-bridge":    "v0.2",
+		},
+	}
+
+	res, err := LoadOpenstackCloudConfigConfigMap(c, dc, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkTestResult(t, "loadopenstackcloudconfigconfigmap-result", res)
+
 }

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -17,6 +17,7 @@ type DigitaloceanSpec struct {
 type OpenstackSpec struct {
 	AuthURL          string `yaml:"auth_url"`
 	AvailabilityZone string `yaml:"availability_zone"`
+	IgnoreVolumeAZ   bool   `yaml:"ignore_volume_az"`
 	// Used for automatic network creation
 	DNSServers []string `yaml:"dns_servers"`
 }

--- a/config/kubermatic/static/nodes/openstack.yaml
+++ b/config/kubermatic/static/nodes/openstack.yaml
@@ -105,5 +105,5 @@ config:
           [BlockStorage]
           trust-device-path = false
           {{- if eq (substr 0 4 (index .Version.Values "k8s-version")) "v1.9" }}
-          ignore-volume-az = {{ .DC.Spec.Openstack.IgnoreVolumeAZ }}
+          ignore-volume-az = {{ .Datacenter.Spec.Openstack.IgnoreVolumeAZ }}
           {{- end }}

--- a/config/kubermatic/static/nodes/openstack.yaml
+++ b/config/kubermatic/static/nodes/openstack.yaml
@@ -104,3 +104,6 @@ config:
           tenant-name = "{{ .Cluster.Spec.Cloud.Openstack.Tenant }}"
           [BlockStorage]
           trust-device-path = false
+          {{- if eq (substr 0 4 (index .Version.Values "k8s-version")) "v1.9" }}
+          ignore-volume-az = {{ .DC.Spec.Openstack.IgnoreVolumeAZ }}
+          {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
In Openstack the volume zone often differes from the zone of the machines.
That's because it became habit to have only one zone for storage but multiple for compute instances.
Currently volumes get created with  a zone label and as long as the nodes dont have the same zone label, they wont be able to mount the volumes.
Since kubernetes 1.9 this validation can be disabled.

