### PR TITLE
fix nodes endpoint

### DIFF
--- a/api/pkg/handler/node.go
+++ b/api/pkg/handler/node.go
@@ -51,7 +51,11 @@ func nodesEndpoint(kp provider.ClusterProvider) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return client.CoreV1().Nodes().List(metav1.ListOptions{})
+		nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return nodes.Items, err
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the nodes endpoint response.
We returned the NodeList instead of an array of nodes