### PR TITLE
Use kubeciio/kubectl to deploy jobs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -161,23 +161,27 @@ pipeline:
 
   deploy-dev:
     group: deploy
-    image: kubeciio/kubectl
+    image: kubeciio/kubectl:0.1
+    pull: true
     kubectl: create
-    files:
+    templates:
       - config/installer/install-job.template.yaml
-    secrets: [ kubeconfig_dev ]
-    kubeconfig_secret: kubeconfig_dev
+    secrets:
+      - source: kubeconfig_dev
+        target: kubeconfig
     when:
       branch: master
 
   deploy-cloud-master:
     group: deploy
-    image: kubeciio/kubectl
+    image: kubeciio/kubectl:0.1
+    pull: true
     kubectl: create
-    files:
+    templates:
       - config/installer/install-job.template.yaml
-    secrets: [ kubeconfig_cloud ]
-    kubeconfig_secret: kubeconfig_cloud
+    secrets:
+      - source: kubeconfig_cloud
+        target: kubeconfig
     when:
       branch: master
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -161,27 +161,23 @@ pipeline:
 
   deploy-dev:
     group: deploy
-    image: gcr.io/google_containers/hyperkube-amd64:v1.8.3
-    commands:
-      - echo $KUBECONFIG_DEV | base64 -d > /kubeconfig
-      - cp config/installer/install-job.template.yaml install-job-dev.yaml
-      - sed -i s/{INSTALLER_TAG}/${DRONE_COMMIT}/g install-job-dev.yaml
-      - /hyperkube kubectl --kubeconfig /kubeconfig create -f install-job-dev.yaml
-      - rm install-job-dev.yaml
+    image: kubeciio/kubectl
+    kubectl: create
+    files:
+      - config/installer/install-job.template.yaml
     secrets: [ kubeconfig_dev ]
+    kubeconfig_secret: kubeconfig_dev
     when:
       branch: master
 
   deploy-cloud-master:
     group: deploy
-    image: gcr.io/google_containers/hyperkube-amd64:v1.8.3
-    commands:
-      - echo $KUBECONFIG_CLOUD | base64 -d > /kubeconfig
-      - cp config/installer/install-job.template.yaml install-job-cloud.yaml
-      - sed -i s/{INSTALLER_TAG}/${DRONE_COMMIT}/g install-job-cloud.yaml
-      - /hyperkube kubectl --kubeconfig /kubeconfig create -f install-job-cloud.yaml
-      - rm install-job-cloud.yaml
+    image: kubeciio/kubectl
+    kubectl: create
+    files:
+      - config/installer/install-job.template.yaml
     secrets: [ kubeconfig_cloud ]
+    kubeconfig_secret: kubeconfig_cloud
     when:
       branch: master
 

--- a/config/installer/install-job.template.yaml
+++ b/config/installer/install-job.template.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: kubermatic-installer
       containers:
       - name: kubermatic-installer
-        image: kubermatic/installer:{INSTALLER_TAG}
+        image: kubermatic/installer:{{ .DroneCommit }}
         command:
         - /kubermatic/deploy_helm_charts.sh
         args:


### PR DESCRIPTION
Now that kubeciio/kubectl:0.1 is tagged we should make use if it.
Rather then doing some `sed` making we can simply use the tiny templating features of the kubectl plugin.