### PR TITLE
fix aws nodeclass

### DIFF
--- a/config/kubermatic/static/nodes/aws.yaml
+++ b/config/kubermatic/static/nodes/aws.yaml
@@ -14,7 +14,7 @@ config:
     amazonec2-subnet-id: "{{ .Cluster.Spec.Cloud.AWS.SubnetID }}"
     amazonec2-vpc-id: "{{ .Cluster.Spec.Cloud.AWS.VPCID }}"
     amazonec2-open-port: "22,10250"
-    amazonec2-ssh-user: "{{ default .NodeSpec.OperatingSystem.SSHUser "core" }}"
+    amazonec2-ssh-user: "core"
     amazonec2-root-size: "{{ .NodeSpec.AWS.RootSize }}"
     amazonec2-volume-type: "{{ default .NodeSpec.AWS.VolumeType "gp2" }}"
     amazonec2-device-name: "/dev/xvda"


### PR DESCRIPTION
**What this PR does / why we need it**:
We removed a struct which was referenced in the aws nodeclass template.
This pr removes the reference to the removed struct
