### PR TITLE
update master readiness and liveness checks

### DIFF
--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.7.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.7.0-apiserver.yaml
@@ -75,8 +75,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -86,8 +86,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.7.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.7.0-controller-manager.yaml
@@ -49,17 +49,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.7.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.7.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -80,8 +80,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -91,8 +91,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -51,17 +51,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -80,8 +80,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -91,8 +91,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -50,17 +50,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.7.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.7.0-apiserver.yaml
@@ -73,8 +73,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -84,8 +84,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.7.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.7.0-controller-manager.yaml
@@ -38,17 +38,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.7.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.7.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -78,8 +78,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -89,8 +89,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -40,17 +40,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -78,8 +78,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -89,8 +89,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -39,17 +39,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.7.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.7.0-apiserver.yaml
@@ -73,8 +73,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -84,8 +84,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.7.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.7.0-controller-manager.yaml
@@ -38,17 +38,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.7.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.7.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -78,8 +78,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -89,8 +89,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -40,17 +40,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -78,8 +78,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -89,8 +89,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -39,17 +39,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.7.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.7.0-apiserver.yaml
@@ -75,8 +75,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -86,8 +86,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.7.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.7.0-controller-manager.yaml
@@ -40,17 +40,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.7.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.7.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -80,8 +80,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -91,8 +91,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -42,17 +42,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -80,8 +80,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: apiserver
         ports:
         - containerPort: 30000
@@ -91,8 +91,8 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/apiserver

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -41,17 +41,17 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: controller-manager
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
         volumeMounts:
         - mountPath: /var/run/kubernetes/auth

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -32,16 +32,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         name: scheduler
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         resources: {}
 status: {}

--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -97,15 +97,15 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 60
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         ports:
         - containerPort: {{ .Cluster.Address.ExternalPort }}
         - containerPort: 8080

--- a/config/kubermatic/static/master/controller-manager-dep.yaml
+++ b/config/kubermatic/static/master/controller-manager-dep.yaml
@@ -51,16 +51,16 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10252
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30
         env:
         {{ if eq .CloudProvider "aws" }}
         - name: AWS_ACCESS_KEY_ID

--- a/config/kubermatic/static/master/scheduler-dep.yaml
+++ b/config/kubermatic/static/master/scheduler-dep.yaml
@@ -29,13 +29,13 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 60
         readinessProbe:
           httpGet:
             path: /healthz
             port: 10251
           initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 30


### PR DESCRIPTION
**What this PR does / why we need it**:
The current liveness checks caused a lot of restarts. Increasing the timeout and reducing the check-period should make it a bit more smooth.