### PR TITLE
Monitoring pvcs

### DIFF
--- a/config/monitoring/alertmanager/templates/alertmanager.yaml
+++ b/config/monitoring/alertmanager/templates/alertmanager.yaml
@@ -9,3 +9,12 @@ spec:
   replicas: 3
   version: {{ .Values.alertmanager.version }}
   externalUrl: {{ .Values.alertmanager.host | trim }}
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi
+        storageClassName: kubermatic-fast

--- a/config/monitoring/prometheus/templates/prometheus.yaml
+++ b/config/monitoring/prometheus/templates/prometheus.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   replicas: 2
   version: {{ .Values.prometheus.version }}
+  retention: 360h
   serviceAccountName: prometheus
   serviceMonitorSelector:
     matchLabels:

--- a/config/monitoring/prometheus/templates/prometheus.yaml
+++ b/config/monitoring/prometheus/templates/prometheus.yaml
@@ -24,3 +24,12 @@ spec:
   resources:
     requests:
       memory: 1G
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+        storageClassName: kubermatic-fast


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we still don't save metrics beyond 24h on our kubermatic Prometheus. This sets the retention to 360h (15d). This is perfect, mostly for Dashboards 👍

Also Prometheus & Alertmanager did not have any PVCs so far. Rescheduling deleted their data. Numerous times, this resulted in vanished silences.
