### PR TITLE
fix npe and patch creation logic to keep backwards compatible

### DIFF
--- a/api/pkg/controller/cluster/controller.go
+++ b/api/pkg/controller/cluster/controller.go
@@ -222,7 +222,7 @@ func (cc *controller) syncCluster(key string) error {
 		cluster.Status.Phase = kubermaticv1.ValidatingClusterStatusPhase
 	}
 	var updateErr error
-	if cluster, err = cc.validateCluster(cluster); err != nil {
+	if err = cc.validateCluster(cluster); err != nil {
 		updateErr = cc.updateClusterError(cluster, kubermaticv1.InvalidConfigurationClusterError, err.Error(), originalData)
 		if updateErr != nil {
 			return fmt.Errorf("failed to set the cluster error: %v", updateErr)

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -287,7 +287,7 @@ func getPatch(currentObj, updateObj metav1.Object) ([]byte, error) {
 
 	originalData, exists := currentObj.GetAnnotations()[lastAppliedConfigAnnotation]
 	if !exists {
-		return nil, fmt.Errorf("no annotation found")
+		glog.V(2).Infof("no last applied found in annotation %s for %s/%s", lastAppliedConfigAnnotation, currentObj.GetNamespace(), currentObj.GetName())
 	}
 
 	return jsonmergepatch.CreateThreeWayJSONMergePatch([]byte(originalData), modifiedData, currentData)

--- a/api/pkg/controller/cluster/validating.go
+++ b/api/pkg/controller/cluster/validating.go
@@ -7,16 +7,16 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 )
 
-func (cc *controller) validateCluster(c *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
+func (cc *controller) validateCluster(c *kubermaticv1.Cluster) error {
 	if err := cc.validateDatacenter(c); err != nil {
-		return nil, fmt.Errorf("failed to validate datacenter: %v", err)
+		return fmt.Errorf("failed to validate datacenter: %v", err)
 	}
 
 	if err := cc.validateCloudSpec(c); err != nil {
-		return nil, fmt.Errorf("failed to validate cloud spec: %v", err)
+		return fmt.Errorf("failed to validate cloud spec: %v", err)
 	}
 
-	return c, nil
+	return nil
 }
 
 func (cc *controller) validateCloudSpec(c *kubermaticv1.Cluster) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix NPE during update of a cluste rerror.
Also fix patch creation for old clusters
