### PR TITLE
setting read/write http timeouts

### DIFF
--- a/api/cmd/kubermatic-cluster-controller/main.go
+++ b/api/cmd/kubermatic-cluster-controller/main.go
@@ -121,8 +121,10 @@ func main() {
 		m.Handle(*prometheusPath, promhttp.Handler())
 
 		s := http.Server{
-			Addr:    *prometheusAddr,
-			Handler: m,
+			Addr:         *prometheusAddr,
+			Handler:      m,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 10 * time.Second,
 		}
 
 		g.Add(func() error {


### PR DESCRIPTION
**What this PR does / why we need it**: this pr sets read and write http timeouts. As by default these timeouts are off, it means that clients can hold up connections indefinitely this in turn can potentially use up all available connections in a pool.

