### PR TITLE
remove dex docker secret

### DIFF
--- a/config/oauth/templates/dex-dep.yaml
+++ b/config/oauth/templates/dex-dep.yaml
@@ -28,8 +28,6 @@ spec:
         - name: themes
           mountPath: /web/themes/coreos
           readOnly: true
-      imagePullSecrets:
-      - name: dockercfg
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the docker secret from dex.
We don't need it and it causes warning logs in the kubelet
