### PR TITLE
Add node os validation

### DIFF
--- a/api/pkg/handler/node_v2.go
+++ b/api/pkg/handler/node_v2.go
@@ -239,6 +239,9 @@ func createNodeEndpointV2(dcs map[string]provider.DatacenterMeta, kp provider.Cl
 		if node.Spec.OperatingSystem.ContainerLinux != nil && node.Spec.Versions.ContainerRuntime.Name != string(containerruntime.Docker) {
 			return nil, fmt.Errorf("only docker is allowd when using container linux")
 		}
+		if node.Spec.OperatingSystem.ContainerLinux == nil && node.Spec.OperatingSystem.Ubuntu == nil {
+			return nil, fmt.Errorf("no operating system specified")
+		}
 
 		//TODO(mrIncompetent): We need to make the kubelet version configurable but restrict it to master version
 		if node.Spec.Versions.Kubelet != "" {

--- a/config/kubermatic/static/nodes/machine.yaml
+++ b/config/kubermatic/static/nodes/machine.yaml
@@ -66,7 +66,7 @@ spec:
     operatingSystemSpec:
       disableAutoUpdate: {{ .Node.Spec.OperatingSystem.DisableAutoUpdate }}
     {{- end }}
-    {{- if .Node.Spec.OperatingSystem.Ubuntu.DistUpgradeOnBoot }}
+    {{- if .Node.Spec.OperatingSystem.Ubuntu }}
     operatingSystem: "ubuntu"
     operatingSystemSpec:
       distUpgradeOnBoot: {{ .Node.Spec.OperatingSystem.Ubuntu.DistUpgradeOnBoot }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes machine creation when using ubuntu and distUpgrade=false

Also it adds a validation to check if a os was specified