### PR TITLE
update machine-controller to v0.2.1

### DIFF
--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -18,7 +18,7 @@ versions:
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.2
     addon-manager-version: v1.7.1
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.7.7
   id: 1.7.7
   default: false
@@ -37,7 +37,7 @@ versions:
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.2
     addon-manager-version: v1.7.2
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.7.9
   id: 1.7.9
   default: false
@@ -56,7 +56,7 @@ versions:
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.2
     addon-manager-version: v1.7.3
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.7.10
   id: 1.7.10
   default: false
@@ -76,7 +76,7 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.7.4
     pod-network-bridge: v0.1
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.7.11
   id: 1.7.11
   default: false
@@ -96,7 +96,7 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.7.6
     pod-network-bridge: v0.1
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.8.4
   id: 1.8.4
   default: false
@@ -116,7 +116,7 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.1
     pod-network-bridge: v0.2
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.8.5
   id: 1.8.5
   default: false
@@ -136,7 +136,7 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.2
     pod-network-bridge: v0.2
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.8.6
   id: 1.8.6
   default: false
@@ -156,7 +156,7 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.2
     pod-network-bridge: v0.2
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.8.7
   id: 1.8.7
   default: true
@@ -176,7 +176,7 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.2
     pod-network-bridge: v0.2
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.9.0
   id: 1.9.0
   default: false
@@ -196,7 +196,7 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.9.1
     pod-network-bridge: v0.2
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.9.1
   id: 1.9.1
   default: false
@@ -216,7 +216,7 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.9.1
     pod-network-bridge: v0.2
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1
 - name: 1.9.2
   id: 1.9.2
   default: false
@@ -236,4 +236,4 @@ versions:
     kube-machine-version: v0.2.3
     addon-manager-version: v1.9.1
     pod-network-bridge: v0.2
-    machine-controller-version: v0.2.0
+    machine-controller-version: v0.2.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the machine-controller to 0.2.1 (latest)
