### PR TITLE
Remove ssh flag on machine controller

### DIFF
--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.7.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.7.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.7.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.7.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.7.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.7.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.7.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.7.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
         - -v=4
         - -cluster-dns=10.10.10.10
         - -internal-listen-address=0.0.0.0:8085
-        - -ssh-key-name=kubermatic-cluster-de-test-01
         image: kubermatic/machine-controller:v0.1.2
         livenessProbe:
           httpGet:

--- a/config/kubermatic/static/master/machine-controller.yaml
+++ b/config/kubermatic/static/master/machine-controller.yaml
@@ -24,7 +24,6 @@ spec:
             - -v=4
             - -cluster-dns=10.10.10.10
             - -internal-listen-address=0.0.0.0:8085
-            - -ssh-key-name=kubermatic-cluster-{{ .Cluster.Name }}
           livenessProbe:
             httpGet:
               path: /live


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes a deprecated flag on the machine-controller deployment