### PR TITLE
add missing api flag

### DIFF
--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -29,6 +29,7 @@ spec:
           - -versions=/opt/master-files/versions.yaml
           - -updates=/opt/master-files/updates.yaml
           - -prometheus-address=0.0.0.0:8085
+          - -kubeconfig=/opt/.kube/kubeconfig
           image: '{{ .Values.kubermatic.api.image.repository }}:{{.Values.kubermatic.api.image.tag}}'
           imagePullPolicy: {{.Values.kubermatic.api.image.pullPolicy}}
           ports:

--- a/config/kubermatic/templates/kubermatic-cluster-controller-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-cluster-controller-dep.yaml
@@ -27,7 +27,6 @@ spec:
           - -datacenters=/opt/datacenter/datacenters.yaml
           - -versions=/opt/master-files/versions.yaml
           - -updates=/opt/master-files/updates.yaml
-          - -apiserver-external-port={{ .Values.kubermatic.externalApiserverPort }}
           - -prometheus-address=0.0.0.0:8085
           image: '{{.Values.kubermatic.controller.image.repository}}:{{.Values.kubermatic.controller.image.tag}}'
           imagePullPolicy: {{.Values.kubermatic.controller.image.pullPolicy}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing kubeconfig flag to the kubermatic api