### PR TITLE
Increase Kubermatic's cluster controller memory limits to 256Mi

### DIFF
--- a/config/kubermatic/templates/kubermatic-cluster-controller-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-cluster-controller-dep.yaml
@@ -46,7 +46,7 @@ spec:
               memory: "64Mi"
               cpu: "100m"
             limits:
-              memory: "128Mi"
+              memory: "256Mi"
               cpu: "200m"
       imagePullSecrets:
         - name: dockercfg


### PR DESCRIPTION
On Cloud the cluster-controller takes around 130MB to run, thus it was OOM killed a bunch of times.