### PR TITLE
Deploy Prometheus and ServiceMonitors per cluster

### DIFF
--- a/api/cmd/kubermatic-cluster-controller/main.go
+++ b/api/cmd/kubermatic-cluster-controller/main.go
@@ -255,6 +255,7 @@ func startController(stop <-chan struct{}, kubeClient kubernetes.Interface, kube
 		kubeInformerFactory.Rbac().V1beta1().RoleBindings(),
 		kubeInformerFactory.Rbac().V1beta1().ClusterRoleBindings(),
 		kubermaticInformerFactory.Monitoring().V1().Prometheuses(),
+		kubermaticInformerFactory.Monitoring().V1().ServiceMonitors(),
 	)
 	if err != nil {
 		return err

--- a/api/cmd/kubermatic-cluster-controller/main.go
+++ b/api/cmd/kubermatic-cluster-controller/main.go
@@ -254,6 +254,7 @@ func startController(stop <-chan struct{}, kubeClient kubernetes.Interface, kube
 		kubeInformerFactory.Rbac().V1beta1().Roles(),
 		kubeInformerFactory.Rbac().V1beta1().RoleBindings(),
 		kubeInformerFactory.Rbac().V1beta1().ClusterRoleBindings(),
+		kubermaticInformerFactory.Monitoring().V1().Prometheuses(),
 	)
 	if err != nil {
 		return err

--- a/api/pkg/controller/cluster/controller.go
+++ b/api/pkg/controller/cluster/controller.go
@@ -81,6 +81,7 @@ type Controller struct {
 	RoleBindingLister        rbacv1beta1lister.RoleBindingLister
 	ClusterRoleBindingLister rbacv1beta1lister.ClusterRoleBindingLister
 	PrometheusLister         prometheusv1lister.PrometheusLister
+	ServiceMonitorLister     prometheusv1lister.ServiceMonitorLister
 }
 
 // ControllerMetrics contains metrics about the clusters & workers
@@ -118,6 +119,7 @@ func NewController(
 	RoleBindingInformer rbacv1beta1informers.RoleBindingInformer,
 	ClusterRoleBindingInformer rbacv1beta1informers.ClusterRoleBindingInformer,
 	PrometheusInformer prometheusv1informers.PrometheusInformer,
+	ServiceMonitorInformer prometheusv1informers.ServiceMonitorInformer,
 ) (*Controller, error) {
 	cc := &Controller{
 		kubermaticClient: kubermaticClient,
@@ -228,6 +230,11 @@ func NewController(
 		UpdateFunc: func(old, cur interface{}) { cc.handleChildObject(cur) },
 		DeleteFunc: func(obj interface{}) { cc.handleChildObject(obj) },
 	})
+	ServiceMonitorInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { cc.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { cc.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { cc.handleChildObject(obj) },
+	})
 
 	cc.ClusterLister = ClusterInformer.Lister()
 	cc.EtcdClusterLister = EtcdClusterInformer.Lister()
@@ -243,6 +250,7 @@ func NewController(
 	cc.RoleBindingLister = RoleBindingInformer.Lister()
 	cc.ClusterRoleBindingLister = ClusterRoleBindingInformer.Lister()
 	cc.PrometheusLister = PrometheusInformer.Lister()
+	cc.ServiceMonitorLister = ServiceMonitorInformer.Lister()
 
 	var err error
 	cc.defaultMasterVersion, err = version.DefaultMasterVersion(versions)

--- a/api/pkg/controller/cluster/controller.go
+++ b/api/pkg/controller/cluster/controller.go
@@ -12,8 +12,10 @@ import (
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	etcdoperatorv1beta2informers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions/etcdoperator/v1beta2"
 	kubermaticv1informers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions/kubermatic/v1"
+	prometheusv1informers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions/prometheus/v1"
 	etcdoperatorv1beta2lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/etcdoperator/v1beta2"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	prometheusv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/prometheus/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
@@ -78,6 +80,7 @@ type Controller struct {
 	RoleLister               rbacv1beta1lister.RoleLister
 	RoleBindingLister        rbacv1beta1lister.RoleBindingLister
 	ClusterRoleBindingLister rbacv1beta1lister.ClusterRoleBindingLister
+	PrometheusLister         prometheusv1lister.PrometheusLister
 }
 
 // ControllerMetrics contains metrics about the clusters & workers
@@ -114,6 +117,7 @@ func NewController(
 	RoleInformer rbacv1beta1informers.RoleInformer,
 	RoleBindingInformer rbacv1beta1informers.RoleBindingInformer,
 	ClusterRoleBindingInformer rbacv1beta1informers.ClusterRoleBindingInformer,
+	PrometheusInformer prometheusv1informers.PrometheusInformer,
 ) (*Controller, error) {
 	cc := &Controller{
 		kubermaticClient: kubermaticClient,
@@ -219,6 +223,11 @@ func NewController(
 		UpdateFunc: func(old, cur interface{}) { cc.handleChildObject(cur) },
 		DeleteFunc: func(obj interface{}) { cc.handleChildObject(obj) },
 	})
+	PrometheusInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { cc.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { cc.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { cc.handleChildObject(obj) },
+	})
 
 	cc.ClusterLister = ClusterInformer.Lister()
 	cc.EtcdClusterLister = EtcdClusterInformer.Lister()
@@ -233,6 +242,7 @@ func NewController(
 	cc.RoleLister = RoleInformer.Lister()
 	cc.RoleBindingLister = RoleBindingInformer.Lister()
 	cc.ClusterRoleBindingLister = ClusterRoleBindingInformer.Lister()
+	cc.PrometheusLister = PrometheusInformer.Lister()
 
 	var err error
 	cc.defaultMasterVersion, err = version.DefaultMasterVersion(versions)

--- a/api/pkg/controller/cluster/controller_test.go
+++ b/api/pkg/controller/cluster/controller_test.go
@@ -60,6 +60,8 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		kubeInformerFactory.Rbac().V1beta1().Roles(),
 		kubeInformerFactory.Rbac().V1beta1().RoleBindings(),
 		kubeInformerFactory.Rbac().V1beta1().ClusterRoleBindings(),
+		kubermaticInformerFactory.Monitoring().V1().Prometheuses(),
+		kubermaticInformerFactory.Monitoring().V1().ServiceMonitors(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -702,7 +702,7 @@ func (cc *Controller) ensureEtcdCluster(c *kubermaticv1.Cluster) error {
 
 func (cc *Controller) ensurePrometheus(c *kubermaticv1.Cluster) error {
 	proms := map[string]func(data *controllerresources.TemplateData, app, masterResourcesPath string) (*prometheusv1.Prometheus, string, error){
-		"prometheus": controllerresources.LoadPrometheusFile,
+		controllerresources.PrometheusName: controllerresources.LoadPrometheusFile,
 	}
 
 	data, err := cc.getClusterTemplateData(c)
@@ -730,11 +730,11 @@ func (cc *Controller) ensurePrometheus(c *kubermaticv1.Cluster) error {
 			return err
 		}
 		if prometheus.Annotations[lastAppliedConfigAnnotation] != lastApplied {
-			path, err := getPatch(prometheus, generatedPrometheus)
+			patch, err := getPatch(prometheus, generatedPrometheus)
 			if err != nil {
 				return err
 			}
-			if _, err := cc.kubermaticClient.MonitoringV1().Prometheuses(c.Status.NamespaceName).Patch(generatedPrometheus.Name, types.MergePatchType, path); err != nil {
+			if _, err := cc.kubermaticClient.MonitoringV1().Prometheuses(c.Status.NamespaceName).Patch(generatedPrometheus.Name, types.MergePatchType, patch); err != nil {
 				return fmt.Errorf("failed to create patch for prometheus resource: %v", err)
 			}
 		}
@@ -744,12 +744,12 @@ func (cc *Controller) ensurePrometheus(c *kubermaticv1.Cluster) error {
 
 func (cc *Controller) ensureServiceMonitors(c *kubermaticv1.Cluster) error {
 	sms := map[string]func(data *controllerresources.TemplateData, app, masterResourcesPath string) (*prometheusv1.ServiceMonitor, string, error){
-		"apiserver":          controllerresources.LoadServiceMonitorFile,
-		"controller-manager": controllerresources.LoadServiceMonitorFile,
-		"etcd":               controllerresources.LoadServiceMonitorFile,
-		"kube-state-metrics": controllerresources.LoadServiceMonitorFile,
-		"machine-controller": controllerresources.LoadServiceMonitorFile,
-		"scheduler":          controllerresources.LoadServiceMonitorFile,
+		controllerresources.ApiserverServiceMonitorName:         controllerresources.LoadServiceMonitorFile,
+		controllerresources.ControllerManagerServiceMonitorName: controllerresources.LoadServiceMonitorFile,
+		controllerresources.EtcdServiceMonitorName:              controllerresources.LoadServiceMonitorFile,
+		controllerresources.KubeStateMetricsServiceMonitorName:  controllerresources.LoadServiceMonitorFile,
+		controllerresources.MachineControllerServiceMonitorName: controllerresources.LoadServiceMonitorFile,
+		controllerresources.SchedulerServiceMonitorName:         controllerresources.LoadServiceMonitorFile,
 	}
 
 	data, err := cc.getClusterTemplateData(c)
@@ -777,11 +777,11 @@ func (cc *Controller) ensureServiceMonitors(c *kubermaticv1.Cluster) error {
 			return err
 		}
 		if serviceMonitor.Annotations[lastApplied] != lastApplied {
-			path, err := getPatch(serviceMonitor, generatedServiceMonitor)
+			patch, err := getPatch(serviceMonitor, generatedServiceMonitor)
 			if err != nil {
 				return err
 			}
-			if _, err := cc.kubermaticClient.MonitoringV1().ServiceMonitors(c.Status.NamespaceName).Patch(serviceMonitor.Name, types.MergePatchType, path); err != nil {
+			if _, err := cc.kubermaticClient.MonitoringV1().ServiceMonitors(c.Status.NamespaceName).Patch(serviceMonitor.Name, types.MergePatchType, patch); err != nil {
 				return fmt.Errorf("failed to create patch for service monitor resource: %v", err)
 			}
 		}

--- a/api/pkg/controller/resources/load_files.go
+++ b/api/pkg/controller/resources/load_files.go
@@ -66,6 +66,9 @@ const (
 	PrometheusServiceAccountName = "prometheus"
 
 	//PrometheusRoleName is the name for the Prometheus role
+	PrometheusName = "prometheus"
+
+	//PrometheusRoleName is the name for the Prometheus role
 	PrometheusRoleName = "prometheus"
 
 	//PrometheusRoleBindingName is the name for the Prometheus rolebinding
@@ -73,6 +76,13 @@ const (
 
 	//EtcdOperatorClusterRoleBindingName is the name for the etcd-operator clusterrolebinding
 	EtcdOperatorClusterRoleBindingName = "etcd-operator"
+
+	ApiserverServiceMonitorName         = "apiserver"
+	ControllerManagerServiceMonitorName = "controller-manager"
+	EtcdServiceMonitorName              = "etcd"
+	KubeStateMetricsServiceMonitorName  = "kube-state-metrics"
+	MachineControllerServiceMonitorName = "machine-controller"
+	SchedulerServiceMonitorName         = "scheduler"
 )
 
 // TemplateData is a group of data required for template generation

--- a/api/pkg/controller/resources/load_files.go
+++ b/api/pkg/controller/resources/load_files.go
@@ -65,7 +65,7 @@ const (
 	//PrometheusServiceAccountName is the name for the Prometheus serviceaccount
 	PrometheusServiceAccountName = "prometheus"
 
-	//PrometheusRoleName is the name for the Prometheus role
+	//PrometheusName is the name for the Prometheus role
 	PrometheusName = "prometheus"
 
 	//PrometheusRoleName is the name for the Prometheus role
@@ -77,12 +77,18 @@ const (
 	//EtcdOperatorClusterRoleBindingName is the name for the etcd-operator clusterrolebinding
 	EtcdOperatorClusterRoleBindingName = "etcd-operator"
 
-	ApiserverServiceMonitorName         = "apiserver"
+	//ApiserverServiceMonitorName is the name for the apiserver servicemonitor
+	ApiserverServiceMonitorName = "apiserver"
+	//ControllerManagerServiceMonitorName is the name for the controller manager servicemonitor
 	ControllerManagerServiceMonitorName = "controller-manager"
-	EtcdServiceMonitorName              = "etcd"
-	KubeStateMetricsServiceMonitorName  = "kube-state-metrics"
+	//EtcdServiceMonitorName is the name for the etcd servicemonitor
+	EtcdServiceMonitorName = "etcd"
+	//KubeStateMetricsServiceMonitorName is the name for the kube state metrics servicemonitor
+	KubeStateMetricsServiceMonitorName = "kube-state-metrics"
+	//MachineControllerServiceMonitorName is the name for the machine controller servicemonitor
 	MachineControllerServiceMonitorName = "machine-controller"
-	SchedulerServiceMonitorName         = "scheduler"
+	//SchedulerServiceMonitorName is the name for the scheduler servicemonitor
+	SchedulerServiceMonitorName = "scheduler"
 )
 
 // TemplateData is a group of data required for template generation

--- a/api/pkg/controller/resources/load_files.go
+++ b/api/pkg/controller/resources/load_files.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/golang/glog"
@@ -259,7 +260,7 @@ func LoadClusterRoleBindingFile(data *TemplateData, app, masterResourcesPath str
 	return &r, json, err
 }
 
-// LoadPrometheusFile loads a etcd-operator crd from disk and returns a Cluster crd struct
+// LoadPrometheusFile loads a prometheus crd from disk and returns a Cluster crd struct
 func LoadPrometheusFile(data *TemplateData, app, masterResourcesPath string) (*prometheusv1.Prometheus, string, error) {
 	t, err := k8stemplate.ParseFile(path.Join(masterResourcesPath, "prometheus.yaml"))
 	if err != nil {
@@ -269,4 +270,17 @@ func LoadPrometheusFile(data *TemplateData, app, masterResourcesPath string) (*p
 	var p prometheusv1.Prometheus
 	json, err := t.Execute(data, &p)
 	return &p, json, err
+}
+
+// LoadServiceMonitorFile loads a service monitor crd from disk and returns a Cluster crd struct
+func LoadServiceMonitorFile(data *TemplateData, app, masterResourcesPath string) (*prometheusv1.ServiceMonitor, string, error) {
+	filename := fmt.Sprintf("prometheus-service-monitor-%s.yaml", app)
+	t, err := k8stemplate.ParseFile(path.Join(masterResourcesPath, filename))
+	if err != nil {
+		return nil, "", err
+	}
+
+	var sm prometheusv1.ServiceMonitor
+	json, err := t.Execute(data, &sm)
+	return &sm, json, err
 }

--- a/api/pkg/controller/resources/load_files.go
+++ b/api/pkg/controller/resources/load_files.go
@@ -7,6 +7,7 @@ import (
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	etcdoperatorv1beta2 "github.com/kubermatic/kubermatic/api/pkg/crd/etcdoperator/v1beta2"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	prometheusv1 "github.com/kubermatic/kubermatic/api/pkg/crd/prometheus/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	k8stemplate "github.com/kubermatic/kubermatic/api/pkg/template/kubernetes"
 
@@ -256,4 +257,16 @@ func LoadClusterRoleBindingFile(data *TemplateData, app, masterResourcesPath str
 	var r rbacv1beta1.ClusterRoleBinding
 	json, err := t.Execute(data, &r)
 	return &r, json, err
+}
+
+// LoadPrometheusFile loads a etcd-operator crd from disk and returns a Cluster crd struct
+func LoadPrometheusFile(data *TemplateData, app, masterResourcesPath string) (*prometheusv1.Prometheus, string, error) {
+	t, err := k8stemplate.ParseFile(path.Join(masterResourcesPath, "prometheus.yaml"))
+	if err != nil {
+		return nil, "", err
+	}
+
+	var p prometheusv1.Prometheus
+	json, err := t.Execute(data, &p)
+	return &p, json, err
 }

--- a/api/pkg/controller/resources/load_files.go
+++ b/api/pkg/controller/resources/load_files.go
@@ -65,7 +65,7 @@ const (
 	//PrometheusServiceAccountName is the name for the Prometheus serviceaccount
 	PrometheusServiceAccountName = "prometheus"
 
-	//PrometheusName is the name for the Prometheus role
+	//PrometheusName is the name for the Prometheus
 	PrometheusName = "prometheus"
 
 	//PrometheusRoleName is the name for the Prometheus role

--- a/config/kubermatic/static/master/machine-controller-service.yaml
+++ b/config/kubermatic/static/master/machine-controller-service.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: scheduler
+    name: machine-controller
     prometheus: {{ .Cluster.Name }}
-  name: scheduler
+  name: machine-controller
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
     blockOwnerDeletion: true
@@ -18,4 +18,4 @@ spec:
   - name: http-metrics
     port: 8085
   selector:
-    role: scheduler
+    app: machine-controller

--- a/config/kubermatic/static/master/prometheus-service-monitor-machine-controller.yaml
+++ b/config/kubermatic/static/master/prometheus-service-monitor-machine-controller.yaml
@@ -19,7 +19,7 @@ spec:
     interval: 30s
   selector:
     matchLabels:
-      app: machine-controller
+      name: machine-controller
   namespaceSelector:
     matchNames:
     - cluster-{{ .Cluster.Name }}

--- a/config/kubermatic/static/master/prometheus.yaml
+++ b/config/kubermatic/static/master/prometheus.yaml
@@ -13,7 +13,7 @@ metadata:
     uid: "{{ .Cluster.ObjectMeta.UID }}"
 spec:
   replicas: 1
-  version: v2.1.0
+  version: v2.2.0
   serviceAccountName: prometheus
   serviceMonitorSelector:
     matchLabels:


### PR DESCRIPTION
**What this PR does / why we need it**:
So far we only deployed all the things necessary to start Prometheus. With these changes a Prometheus CRD and a CRD for each ServiceMonitor are now deploy with all clusters.

The Prometheus Operator in the monitoring namespace will immediately see that Prometheus CRD and starts scheduling a Prometheus statefulset/pod. Additonally it generates a configmap from all ServiceMonitors for that Prometheus.
That cluster Prometheus then starts scraping its targets right away.

**Which issue(s) this PR fixes** 
Continues #770 

**Special notes for your reviewer**:
:tada: 