### PR TITLE
Fix bug in ServiceMonitor lastAppliedConfigAnnotation matching

### DIFF
--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -776,7 +776,7 @@ func (cc *Controller) ensureServiceMonitors(c *kubermaticv1.Cluster) error {
 			}
 			return err
 		}
-		if serviceMonitor.Annotations[lastApplied] != lastApplied {
+		if serviceMonitor.Annotations[lastAppliedConfigAnnotation] != lastApplied {
 			patch, err := getPatch(serviceMonitor, generatedServiceMonitor)
 			if err != nil {
 				return err


### PR DESCRIPTION
This seems like a small regression from last Friday's merge for ServiceMonitors per cluster.