### PR TITLE
add kubernetes 1.9.4

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -35,14 +35,7 @@ updates:
   visible: true
   promote: true
 - from: 1.9.x
-  to: 1.9.1
-  automatic: false
-  rollbackAllowed: false
-  enabled: true
-  visible: true
-  promote: true
-- from: 1.9.x
-  to: 1.9.2
+  to: 1.9.4
   automatic: false
   rollbackAllowed: false
   enabled: true

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -175,7 +175,7 @@ versions:
     kube-state-metrics-version: latest
 - name: 1.8.7
   id: 1.8.7
-  default: true
+  default: false
   allowedNodeVersions: [1.4.0]
   etcdOperatorDeploymentYaml: etcd-operator-dep.yaml
   etcdClusterYaml: etcd-cluster.yaml
@@ -254,6 +254,50 @@ versions:
   kubeStateMetricsDeploymentYaml: kube-state-metrics-dep.yaml
   values:
     k8s-version: v1.9.2
+    etcd-operator-version: v0.6.0
+    etcd-cluster-version: 3.2.7
+    kube-machine-version: v0.2.3
+    addon-manager-version: v1.9.1
+    pod-network-bridge: v0.2
+    machine-controller-version: v0.2.1
+    kube-state-metrics-version: latest
+- name: 1.9.3
+  id: 1.9.3
+  default: false
+  allowedNodeVersions: [1.4.0]
+  etcdOperatorDeploymentYaml: etcd-operator-dep.yaml
+  etcdClusterYaml: etcd-cluster.yaml
+  apiserverDeploymentYaml: apiserver-dep.yaml
+  controllerDeploymentYaml: controller-manager-dep.yaml
+  schedulerDeploymentYaml: scheduler-dep.yaml
+  nodeControllerDeploymentYaml: node-controller-dep.yaml
+  addonManagerDeploymentYaml: addon-manager-dep.yaml
+  machineControllerDeploymentYaml: machine-controller-dep.yaml
+  kubeStateMetricsDeploymentYaml: kube-state-metrics-dep.yaml
+  values:
+    k8s-version: v1.9.3
+    etcd-operator-version: v0.6.0
+    etcd-cluster-version: 3.2.7
+    kube-machine-version: v0.2.3
+    addon-manager-version: v1.9.1
+    pod-network-bridge: v0.2
+    machine-controller-version: v0.2.1
+    kube-state-metrics-version: latest
+- name: 1.9.4
+  id: 1.9.4
+  default: true
+  allowedNodeVersions: [1.4.0]
+  etcdOperatorDeploymentYaml: etcd-operator-dep.yaml
+  etcdClusterYaml: etcd-cluster.yaml
+  apiserverDeploymentYaml: apiserver-dep.yaml
+  controllerDeploymentYaml: controller-manager-dep.yaml
+  schedulerDeploymentYaml: scheduler-dep.yaml
+  nodeControllerDeploymentYaml: node-controller-dep.yaml
+  addonManagerDeploymentYaml: addon-manager-dep.yaml
+  machineControllerDeploymentYaml: machine-controller-dep.yaml
+  kubeStateMetricsDeploymentYaml: kube-state-metrics-dep.yaml
+  values:
+    k8s-version: v1.9.4
     etcd-operator-version: v0.6.0
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes 1.9.4 was a security fix release. We need to add it asap & make it default

Fixed #809