### PR TITLE
Add Federation to Cluster Prometheus

### DIFF
--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -348,6 +348,7 @@ func (cc *Controller) ensureServices(c *kubermaticv1.Cluster) error {
 		controllerresources.ControllerManagerServiceName: controllerresources.LoadServiceFile,
 		controllerresources.KubeStateMetricsServiceName:  controllerresources.LoadServiceFile,
 		controllerresources.MachineControllerServiceName: controllerresources.LoadServiceFile,
+		controllerresources.PrometheusServiceName:        controllerresources.LoadServiceFile,
 		controllerresources.SchedulerServiceName:         controllerresources.LoadServiceFile,
 	}
 

--- a/api/pkg/controller/resources/load_files.go
+++ b/api/pkg/controller/resources/load_files.go
@@ -47,6 +47,8 @@ const (
 	KubeStateMetricsServiceName = "kube-state-metrics"
 	//MachineControllerServiceName is the name for the machine controller service
 	MachineControllerServiceName = "machine-controller"
+	//PrometheusServiceName is the name for the prometheus service
+	PrometheusServiceName = "prometheus"
 	//SchedulerServiceName is the name for the scheduler service
 	SchedulerServiceName = "scheduler"
 

--- a/config/kubermatic/static/master/prometheus-service.yaml
+++ b/config/kubermatic/static/master/prometheus-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     prometheus: {{ .Cluster.Name }}
+    cluster: user
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -12,11 +13,11 @@ metadata:
     name: {{ .Cluster.Name }}
     uid: "{{ .Cluster.ObjectMeta.UID }}"
 spec:
-  type: ClusterIP
+  clusterIP: None
   ports:
   - name: web
     port: 9090
     protocol: TCP
     targetPort: web
   selector:
-    prometheus: {{ .Cluster.Name }}
+    app: prometheus

--- a/config/monitoring/prometheus/templates/prometheus.yaml
+++ b/config/monitoring/prometheus/templates/prometheus.yaml
@@ -10,6 +10,7 @@ spec:
   version: {{ .Values.prometheus.version }}
   retention: 360h
   serviceAccountName: prometheus
+  externalUrl: {{ .Values.prometheus.host | trim }}
   serviceMonitorSelector:
     matchLabels:
       team: kubermatic

--- a/config/monitoring/prometheus/templates/service-monitor-clusters.yaml
+++ b/config/monitoring/prometheus/templates/service-monitor-clusters.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusters
+  namespace: monitoring
+  labels:
+    team: kubermatic
+spec:
+  selector:
+    matchLabels:
+      cluster: user
+  namespaceSelector:
+    any: true
+  endpoints:
+  - port: web
+    interval: 30s
+    path: /federate
+    honorLabels: true
+    params:
+      'match[]':
+        - '{__name__="up"}'
+        - '{__name__=~"machine_controller.*"}'


### PR DESCRIPTION
**What this PR does / why we need it**:
This configures our seed cluster Prometheuses to scrape all Prometheus in all clusters. 

**Which issue(s) this PR fixes**

**Special notes for your reviewer**:
