### PR TITLE
lowers alert value of unhandled errors metric

### DIFF
--- a/config/monitoring/prometheus/rules/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic.yaml
@@ -2,12 +2,12 @@ groups:
 - name: kubermatic
   rules:
   - alert: KubermaticUnhandledErrorsTotal
-    expr: sum(rate(kubermatic_cluster_controller_unhandled_errors_total[5m])) > 50
+    expr: sum(rate(kubermatic_cluster_controller_unhandled_errors_total[5m])) > 0.25
     for: 10m
     labels:
       severity: warning
     annotations:
-      description: "Received more than 50 errors that were not handled in the controller sync loop. The metric has been collected over 5min duration."
+      description: "Average increase of unhandled errors in the controller sync loop is greater than 0.25. The metric has been collected over 5min duration."
       summary: "Too many unhandled errors"
   - alert: KubermaticClusterPhase
     expr: kubermatic_cluster_controller_cluster_status_phase{phase="running"} == 0 and


### PR DESCRIPTION
**What this PR does / why we need it**: simply lowers alert value of `unhandled_errors_total` metric

