### PR TITLE
update the pod network bridge to version v0.3

### DIFF
--- a/addon-manager/Dockerfile
+++ b/addon-manager/Dockerfile
@@ -17,7 +17,7 @@ FROM debian:jessie
 RUN apt-get update
 RUN apt-get install -y jq
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.9.2/bin/linux/amd64/kubectl /usr/local/bin/
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl /usr/local/bin/
 RUN chmod 755 /usr/local/bin/kubectl
 
 ADD kube-addons.sh /opt/

--- a/addon-manager/addons/apiserver-bridge/deployment.yaml
+++ b/addon-manager/addons/apiserver-bridge/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: apiserver-server
+  name: pod-network-bridge
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
@@ -18,7 +18,8 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: kubermatic/pod-network-bridge
+      - name: server
+        image: kubermatic/pod-network-bridge:v0.3
         command:
         - /server
         args:
@@ -29,5 +30,16 @@ spec:
         securityContext:
           privileged: true
         imagePullPolicy: Always
-        name: server
+      - name: sshd
+        image: kubermatic/sshd:latest
+        volumeMounts:
+        - mountPath: /home/apiserver/.ssh/
+          name: authorized-keys
       restartPolicy: Always
+      volumes:
+        - name: authorized-keys
+          secret:
+            secretName: apiserver-bridge-server-authorized-keys
+            items:
+            - key: authorized_keys
+              path:  authorized_keys

--- a/addon-manager/migrate.sh
+++ b/addon-manager/migrate.sh
@@ -6,3 +6,5 @@
 /etc/kubermatic/migrations/fix-node-label.sh
 # We switched from externalName for NodePort, so we need to delete the service so the apiserver recreates it
 /etc/kubermatic/migrations/delete-kubernetes-service.sh
+# We changed the name of the pod network bridge server deployment. Therefore we need to delete the old one
+/etc/kubermatic/migrations/rename-pod-network-bridge.sh

--- a/addon-manager/migrations/rename-pod-network-bridge.sh
+++ b/addon-manager/migrations/rename-pod-network-bridge.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+KUBECTL=${KUBECTL_BIN:-/usr/local/bin/kubectl}
+KUBECTL_OPTS=${KUBECTL_OPTS:-}
+
+${KUBECTL} ${KUBECTL_OPTS} -n kube-system delete deployment apiserver-server

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -150,6 +150,10 @@ func (cc *Controller) reconcileCluster(cluster *kubermaticv1.Cluster) error {
 		return err
 	}
 
+	if err := cc.launchingCreateApiserverBridgePublicKeySecret(cluster); err != nil {
+		return err
+	}
+
 	if cluster.Status.Phase == kubermaticv1.LaunchingClusterStatusPhase {
 		cluster.Status.Phase = kubermaticv1.RunningClusterStatusPhase
 	}

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         - -ssh-preferred-address-types=ExternalIP

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         - -ssh-preferred-address-types=ExternalIP

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         - -ssh-preferred-address-types=InternalIP

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         - -ssh-preferred-address-types=InternalIP

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         - -ssh-preferred-address-types=InternalIP

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         - -ssh-preferred-address-types=InternalIP

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         - -ssh-preferred-address-types=ExternalIP

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         - -ssh-preferred-address-types=ExternalIP

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -217,6 +217,18 @@ func addSecurityGroup(client *ec2.EC2, vpc *ec2.Vpc, name string) (string, error
 		return "", fmt.Errorf("failed to authorize security group ingress for ssh: %v", err)
 	}
 
+	// Allow SSH for the network bridge from everywhere
+	_, err = client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		CidrIp:     aws.String("0.0.0.0/0"),
+		FromPort:   aws.Int64(provider.PodNetworkBridgeSSHPort),
+		ToPort:     aws.Int64(provider.PodNetworkBridgeSSHPort),
+		GroupId:    csgOut.GroupId,
+		IpProtocol: aws.String("tcp"),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to authorize security group ingress for pod network bridge ssh: %v", err)
+	}
+
 	// Allow kubelet 10250 from everywhere
 	_, err = client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
 		CidrIp:     aws.String("0.0.0.0/0"),

--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -177,6 +177,15 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 			PortRangeMax: provider.DefaultSSHPort,
 			Protocol:     osecruritygrouprules.ProtocolTCP,
 		},
+		{
+			// Allows ssh for the pod network bridge from external
+			Direction:    osecruritygrouprules.DirIngress,
+			EtherType:    osecruritygrouprules.EtherType4,
+			SecGroupID:   g.ID,
+			PortRangeMin: provider.PodNetworkBridgeSSHPort,
+			PortRangeMax: provider.PodNetworkBridgeSSHPort,
+			Protocol:     osecruritygrouprules.ProtocolTCP,
+		},
 	}
 
 	for _, opts := range rules {

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -25,8 +25,9 @@ const (
 	OpenstackCloudProvider    = "openstack"
 	HetznerCloudProvider      = "hetzner"
 
-	DefaultSSHPort     = 22
-	DefaultKubeletPort = 10250
+	DefaultSSHPort          = 22
+	PodNetworkBridgeSSHPort = 2222
+	DefaultKubeletPort      = 10250
 )
 
 // CloudProvider declares a set of methods for interacting with a cloud provider

--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -35,6 +35,7 @@ spec:
         - -v=4
         - -logtostderr
         - -ssh-user=apiserver
+        - -ssh-port=2222
         - -ssh-keyfile=/var/run/kubernetes/apiserver/id-rsa
         - -master=127.0.0.1:8080
         {{ if or (eq .ProviderName "digitalocean") (eq .ProviderName "bringyourown") }}
@@ -42,12 +43,10 @@ spec:
         {{ else }}
         - -ssh-preferred-address-types=ExternalIP
         {{ end }}
-        {{ if eq (index .Version.Values "pod-network-bridge") "v0.2" }}
         - -interface-address=10.250.0.2/24
         - -pod-network-cidr=172.25.0.0/16
         - -service-network-cidr=10.10.10.0/24
         - -block-ports=8080
-        {{ end }}
         imagePullPolicy: Always
         name: bridge-client
         securityContext:

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -19,7 +19,7 @@ versions:
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.1
-    pod-network-bridge: v0.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest
 - name: 1.8.5
@@ -41,7 +41,7 @@ versions:
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.2
-    pod-network-bridge: v0.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest
 - name: 1.8.6
@@ -63,7 +63,7 @@ versions:
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.2
-    pod-network-bridge: v0.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest
 - name: 1.8.7
@@ -85,7 +85,7 @@ versions:
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
     addon-manager-version: v1.8.2
-    pod-network-bridge: v0.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest
 - name: 1.9.0
@@ -106,8 +106,8 @@ versions:
     etcd-operator-version: v0.6.0
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
-    addon-manager-version: v1.9.1
-    pod-network-bridge: v0.2
+    addon-manager-version: v1.9.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest
 - name: 1.9.1
@@ -128,8 +128,8 @@ versions:
     etcd-operator-version: v0.6.0
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
-    addon-manager-version: v1.9.1
-    pod-network-bridge: v0.2
+    addon-manager-version: v1.9.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest
 - name: 1.9.2
@@ -150,8 +150,8 @@ versions:
     etcd-operator-version: v0.6.0
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
-    addon-manager-version: v1.9.1
-    pod-network-bridge: v0.2
+    addon-manager-version: v1.9.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest
 - name: 1.9.3
@@ -172,8 +172,8 @@ versions:
     etcd-operator-version: v0.6.0
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
-    addon-manager-version: v1.9.1
-    pod-network-bridge: v0.2
+    addon-manager-version: v1.9.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest
 - name: 1.9.4
@@ -194,7 +194,7 @@ versions:
     etcd-operator-version: v0.6.0
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
-    addon-manager-version: v1.9.1
-    pod-network-bridge: v0.2
+    addon-manager-version: v1.9.2
+    pod-network-bridge: v0.3
     machine-controller-version: v0.2.1
     kube-state-metrics-version: latest


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the pod network bridge to version v0.3.
This version includes an integrated ssh-daemon which mounts the authorized key via configmap.
The configmap will be created by the controller.

Fixes #826

