### PR TITLE
update kubermatic-installer components

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.6
 
 ARG HELM_VER
 ARG KUBECTL_VER
-ENV HELM_VER ${HELM_VER:-v2.8.1}
-ENV KUBECTL_VER ${KUBECTL_VER:-v1.9.3}
+ENV HELM_VER ${HELM_VER:-v2.8.2}
+ENV KUBECTL_VER ${KUBECTL_VER:-v1.9.4}
 
 RUN apk add -U bash ca-certificates --no-cache
 

--- a/config/deploy_master_helm_charts.sh
+++ b/config/deploy_master_helm_charts.sh
@@ -48,7 +48,9 @@ kubectl apply -f ${CHARTS_PATH}/installer/tiller-serviceaccount.yaml
 kubectl delete -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml || true
 kubectl create -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml
 
-helm ${HELM_OPTS} init --service-account tiller --upgrade
+helm ${HELM_OPTS} reset
+sleep 10
+helm ${HELM_OPTS} init --history-max 5 --service-account tiller
 until helm ${HELM_OPTS} version
 do
    sleep 5


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates helm & kubectl in the installer.
Also sets the maximum of tiller release-configmaps to 5