### PR TITLE
remove until loop in installer

### DIFF
--- a/config/deploy_master_helm_charts.sh
+++ b/config/deploy_master_helm_charts.sh
@@ -48,13 +48,8 @@ kubectl apply -f ${CHARTS_PATH}/installer/tiller-serviceaccount.yaml
 kubectl delete -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml || true
 kubectl create -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml
 
-helm ${HELM_OPTS} reset --force
-sleep 10
-helm ${HELM_OPTS} init --history-max 5 --service-account tiller
-until helm ${HELM_OPTS} version
-do
-   sleep 5
-done
+helm ${HELM_OPTS} init --history-max 5 --service-account tiller --upgrade
+sleep 30
 
 ############# MONITORING #############
 # All monitoring charts require the monitoring ns.

--- a/config/deploy_seed_helm_charts.sh
+++ b/config/deploy_seed_helm_charts.sh
@@ -48,11 +48,8 @@ kubectl apply -f ${CHARTS_PATH}/installer/tiller-serviceaccount.yaml
 kubectl delete -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml || true
 kubectl create -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml
 
-helm ${HELM_OPTS} init --service-account tiller --upgrade
-until helm ${HELM_OPTS} version
-do
-   sleep 5
-done
+helm ${HELM_OPTS} init --history-max 5 --service-account tiller --upgrade
+sleep 30
 
 #TODO: Add federation
 ############# MONITORING #############


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the until loop as `helm version` runs into a timeout which seems extremely high (more than 10min)