### PR TITLE
remove hard coded monitoring namespace from charts

### DIFF
--- a/config/deploy_master_helm_charts.sh
+++ b/config/deploy_master_helm_charts.sh
@@ -54,12 +54,12 @@ sleep 30
 ############# MONITORING #############
 # All monitoring charts require the monitoring ns.
 kubectl create namespace monitoring || true
-helm ${HELM_OPTS} upgrade -i prometheus-operator -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/prometheus-operator/
-helm ${HELM_OPTS} upgrade -i node-exporter -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/node-exporter/
-helm ${HELM_OPTS} upgrade -i kube-state-metrics -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/kube-state-metrics/
-helm ${HELM_OPTS} upgrade -i grafana -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/grafana/
-helm ${HELM_OPTS} upgrade -i alertmanager -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/alertmanager/
-helm ${HELM_OPTS} upgrade -i prometheus -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/prometheus/
+helm ${HELM_OPTS} upgrade -i prometheus-operator --namespace monitoring -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/prometheus-operator/
+helm ${HELM_OPTS} upgrade -i node-exporter --namespace monitoring -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/node-exporter/
+helm ${HELM_OPTS} upgrade -i kube-state-metrics --namespace monitoring -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/kube-state-metrics/
+helm ${HELM_OPTS} upgrade -i grafana --namespace monitoring -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/grafana/
+helm ${HELM_OPTS} upgrade -i alertmanager --namespace monitoring -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/alertmanager/
+helm ${HELM_OPTS} upgrade -i prometheus --namespace monitoring -f ${VALUESFILE} ${CHARTS_PATH}/monitoring/prometheus/
 
 ############# Kubermatic #############
 helm ${HELM_OPTS} upgrade -i storage --namespace default -f ${VALUESFILE} ${CHARTS_PATH}/storage/

--- a/config/monitoring/alertmanager/templates/alertmanager-secret.yaml
+++ b/config/monitoring/alertmanager/templates/alertmanager-secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: alertmanager-alertmanager
-  namespace: monitoring
 type: Opaque
 data:
   alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}

--- a/config/monitoring/alertmanager/templates/alertmanager.yaml
+++ b/config/monitoring/alertmanager/templates/alertmanager.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   name: alertmanager
-  namespace: monitoring
   labels:
     app: alertmanager
 spec:

--- a/config/monitoring/alertmanager/templates/auth-secret.yaml
+++ b/config/monitoring/alertmanager/templates/auth-secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: alertmanager-auth
-  namespace: monitoring
 type: Opaque
 data:
   auth: {{ .Values.alertmanager.auth }}

--- a/config/monitoring/alertmanager/templates/ingress.yaml
+++ b/config/monitoring/alertmanager/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: alertmanager
-  namespace: monitoring
   annotations:
     kubernetes.io/ingress.class: "nginx"
     # type of authentication

--- a/config/monitoring/alertmanager/templates/service-monitor.yaml
+++ b/config/monitoring/alertmanager/templates/service-monitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: alertmanager
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/alertmanager/templates/service.yaml
+++ b/config/monitoring/alertmanager/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: alertmanager
-  namespace: monitoring
   labels:
     app: alertmanager
 spec:

--- a/config/monitoring/grafana/templates/credentials.yaml
+++ b/config/monitoring/grafana/templates/credentials.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: grafana-credentials
-  namespace: monitoring
 data:
   user: {{ .Values.grafana.user }}
   password: {{ .Values.grafana.password }}

--- a/config/monitoring/grafana/templates/dashboards.yaml
+++ b/config/monitoring/grafana/templates/dashboards.yaml
@@ -2,6 +2,5 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboards-0
-  namespace: monitoring
 data:
 {{ (.Files.Glob "dashboards/*").AsConfig | indent 2 }}

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: grafana
-  namespace: monitoring
   labels:
     app: grafana
 spec:

--- a/config/monitoring/grafana/templates/ingress.yaml
+++ b/config/monitoring/grafana/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: grafana
-  namespace: monitoring
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/config/monitoring/grafana/templates/service-monitor.yaml
+++ b/config/monitoring/grafana/templates/service-monitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: grafana
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/grafana/templates/service.yaml
+++ b/config/monitoring/grafana/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: monitoring
   labels:
     app: grafana
 spec:

--- a/config/monitoring/kube-state-metrics/templates/cluster-role-binding.yaml
+++ b/config/monitoring/kube-state-metrics/templates/cluster-role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
-  namespace: monitoring
+  namespace: {{ .Release.Namespace }}

--- a/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
 rules:
 - apiGroups: [""]
   resources:

--- a/config/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/config/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
 spec:
   replicas: 1
   template:

--- a/config/monitoring/kube-state-metrics/templates/role-binding.yaml
+++ b/config/monitoring/kube-state-metrics/templates/role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/monitoring/kube-state-metrics/templates/role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: kube-state-metrics-resizer
-  namespace: monitoring
 rules:
 - apiGroups: [""]
   resources:

--- a/config/monitoring/kube-state-metrics/templates/service-account.yaml
+++ b/config/monitoring/kube-state-metrics/templates/service-account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-state-metrics
-  namespace: monitoring

--- a/config/monitoring/kube-state-metrics/templates/service-monitor.yaml
+++ b/config/monitoring/kube-state-metrics/templates/service-monitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/kube-state-metrics/templates/service.yaml
+++ b/config/monitoring/kube-state-metrics/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
   labels:
     app: kube-state-metrics
 spec:

--- a/config/monitoring/node-exporter/templates/daemonset.yaml
+++ b/config/monitoring/node-exporter/templates/daemonset.yaml
@@ -2,12 +2,10 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: node-exporter
-  namespace: monitoring
 spec:
   template:
     metadata:
       name: node-exporter
-      namespace: monitoring
       labels:
         app: node-exporter
     spec:

--- a/config/monitoring/node-exporter/templates/service-monitor.yaml
+++ b/config/monitoring/node-exporter/templates/service-monitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: node-exporter
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/node-exporter/templates/service.yaml
+++ b/config/monitoring/node-exporter/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: node-exporter
-  namespace: monitoring
   labels:
     app: node-exporter
 spec:

--- a/config/monitoring/prometheus-operator/templates/clusterrole.yaml
+++ b/config/monitoring/prometheus-operator/templates/clusterrole.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus-operator
-  namespace: monitoring
 rules:
 - apiGroups:
   - extensions

--- a/config/monitoring/prometheus-operator/templates/clusterrolebinding.yaml
+++ b/config/monitoring/prometheus-operator/templates/clusterrolebinding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-operator
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: monitoring
+  namespace: {{ .Release.Namespace }}

--- a/config/monitoring/prometheus-operator/templates/deployment.yaml
+++ b/config/monitoring/prometheus-operator/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: prometheus-operator
   name: prometheus-operator
-  namespace: monitoring
 spec:
   replicas: 1
   template:

--- a/config/monitoring/prometheus-operator/templates/service.yaml
+++ b/config/monitoring/prometheus-operator/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-operator
-  namespace: monitoring
   labels:
     app: prometheus-operator
 spec:

--- a/config/monitoring/prometheus-operator/templates/serviceaccount.yaml
+++ b/config/monitoring/prometheus-operator/templates/serviceaccount.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-operator
-  namespace: monitoring

--- a/config/monitoring/prometheus/templates/auth-secret.yaml
+++ b/config/monitoring/prometheus/templates/auth-secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: prometheus-auth
-  namespace: monitoring
 type: Opaque
 data:
   auth: {{ .Values.prometheus.auth }}

--- a/config/monitoring/prometheus/templates/configmap.yaml
+++ b/config/monitoring/prometheus/templates/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-kubermatic-rules
-  namespace: monitoring
   labels:
     role: prometheus-rulefiles
     prometheus: prometheus

--- a/config/monitoring/prometheus/templates/ingress.yaml
+++ b/config/monitoring/prometheus/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: prometheus
-  namespace: monitoring
   annotations:
     kubernetes.io/ingress.class: "nginx"
     # type of authentication

--- a/config/monitoring/prometheus/templates/prometheus-cluster-role-binding.yaml
+++ b/config/monitoring/prometheus/templates/prometheus-cluster-role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: monitoring
+  namespace: {{ .Release.Namespace }}

--- a/config/monitoring/prometheus/templates/prometheus-cluster-role.yaml
+++ b/config/monitoring/prometheus/templates/prometheus-cluster-role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
-  namespace: monitoring
 rules:
 - apiGroups: [""]
   resources:

--- a/config/monitoring/prometheus/templates/prometheus-service-account.yaml
+++ b/config/monitoring/prometheus/templates/prometheus-service-account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
-  namespace: monitoring

--- a/config/monitoring/prometheus/templates/prometheus-service-monitor.yaml
+++ b/config/monitoring/prometheus/templates/prometheus-service-monitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: prometheus
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/prometheus/templates/prometheus-service.yaml
+++ b/config/monitoring/prometheus/templates/prometheus-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
-  namespace: monitoring
   labels:
     app: prometheus
 spec:

--- a/config/monitoring/prometheus/templates/prometheus.yaml
+++ b/config/monitoring/prometheus/templates/prometheus.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: prometheus
-  namespace: monitoring
   labels:
     app: prometheus
 spec:
@@ -16,7 +15,7 @@ spec:
       team: kubermatic
   alerting:
     alertmanagers:
-    - namespace: monitoring
+    - namespace: {{ .Release.Namespace }}
       name: alertmanager
       port: web
   ruleSelector:

--- a/config/monitoring/prometheus/templates/service-monitor-apiserver.yaml
+++ b/config/monitoring/prometheus/templates/service-monitor-apiserver.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: apiserver
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/prometheus/templates/service-monitor-clusters.yaml
+++ b/config/monitoring/prometheus/templates/service-monitor-clusters.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: clusters
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/prometheus/templates/service-monitor-kubelet.yaml
+++ b/config/monitoring/prometheus/templates/service-monitor-kubelet.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kubelet
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/prometheus/templates/service-monitor-kubermatic-api.yaml
+++ b/config/monitoring/prometheus/templates/service-monitor-kubermatic-api.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kubermatic-api
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/prometheus/templates/service-monitor-kubermatic-cluster-controller.yaml
+++ b/config/monitoring/prometheus/templates/service-monitor-kubermatic-cluster-controller.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kubermatic-cluster-controller
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/prometheus/templates/service-monitor-nginx-ingress.yaml
+++ b/config/monitoring/prometheus/templates/service-monitor-nginx-ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: nginx
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:

--- a/config/monitoring/prometheus/templates/service-monitor-operator.yaml
+++ b/config/monitoring/prometheus/templates/service-monitor-operator.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: prometheus-operator
-  namespace: monitoring
   labels:
     team: kubermatic
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the hardcoded namespace from the monitoring templates