### PR TITLE
add machine-controller health check

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1505,6 +1505,10 @@
         "lastTransitionTime": {
           "$ref": "#/definitions/Time"
         },
+        "machineController": {
+          "type": "boolean",
+          "x-go-name": "MachineController"
+        },
         "nodeController": {
           "type": "boolean",
           "x-go-name": "NodeController"

--- a/api/pkg/controller/cluster/launching.go
+++ b/api/pkg/controller/cluster/launching.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/resources"
+	controllerresources "github.com/kubermatic/kubermatic/api/pkg/controller/resources"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
@@ -29,10 +30,11 @@ func (cc *Controller) clusterHealth(c *kubermaticv1.Cluster) (bool, *kubermaticv
 	}
 
 	healthMapping := map[string]*depInfo{
-		"apiserver":          {healthy: &health.Apiserver, minReady: 1},
-		"controller-manager": {healthy: &health.Controller, minReady: 1},
-		"scheduler":          {healthy: &health.Scheduler, minReady: 1},
-		"node-controller":    {healthy: &health.NodeController, minReady: 1},
+		controllerresources.ApiserverDeploymenName:          {healthy: &health.Apiserver, minReady: 1},
+		controllerresources.ControllerManagerDeploymentName: {healthy: &health.Controller, minReady: 1},
+		controllerresources.SchedulerDeploymentName:         {healthy: &health.Scheduler, minReady: 1},
+		controllerresources.NodeControllerDeploymentName:    {healthy: &health.NodeController, minReady: 1},
+		controllerresources.MachineControllerDeploymentName: {healthy: &health.MachineController, minReady: 1},
 	}
 
 	for name := range healthMapping {

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -251,11 +251,12 @@ type OpenstackCloudSpec struct {
 
 // ClusterHealthStatus stores health information of the components of a cluster.
 type ClusterHealthStatus struct {
-	Apiserver      bool `json:"apiserver"`
-	Scheduler      bool `json:"scheduler"`
-	Controller     bool `json:"controller"`
-	NodeController bool `json:"nodeController"`
-	Etcd           bool `json:"etcd"`
+	Apiserver         bool `json:"apiserver"`
+	Scheduler         bool `json:"scheduler"`
+	Controller        bool `json:"controller"`
+	NodeController    bool `json:"nodeController"`
+	MachineController bool `json:"machineController"`
+	Etcd              bool `json:"etcd"`
 }
 
 // AllHealthy returns if all components are healthy


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds the missing check for the machine-controller health.
Otherwise the cluster gets displayed as running even when the machine-controller is not running.
The dashboard would try to create nodes, which would fail as the machine-crd has not been created yet...
