### PR TITLE
use gcr instead of own docker hub hyperkube image

### DIFF
--- a/addon-manager/addons/kube-proxy/kube-proxy.yaml
+++ b/addon-manager/addons/kube-proxy/kube-proxy.yaml
@@ -32,7 +32,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: kube-proxy
-        image: "kubermatic/hyperkube-amd64:v1.9.2"
+        image: "gcr.io/google_containers/hyperkube-amd64:v1.9.2"
         command: [
           "/hyperkube",
           "proxy",

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -85,7 +85,7 @@ spec:
         - --cloud-provider=aws
         - --kubelet-preferred-address-types=InternalIP
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
           value: aws-vpn-id
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -34,7 +34,7 @@ spec:
         - scheduler
         - --master=http://apiserver:8080
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -85,7 +85,7 @@ spec:
         - --cloud-provider=aws
         - --kubelet-preferred-address-types=InternalIP
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -54,7 +54,7 @@ spec:
           value: aws-vpn-id
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -34,7 +34,7 @@ spec:
         - scheduler
         - --master=http://apiserver:8080
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -83,7 +83,7 @@ spec:
         - --kubelet-client-key=/var/run/kubernetes/apiserver/kubelet-client.key
         - --kubelet-preferred-address-types=InternalIP
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -44,7 +44,7 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers=*,tokencleaner,bootstrapsigner
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -34,7 +34,7 @@ spec:
         - scheduler
         - --master=http://apiserver:8080
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -83,7 +83,7 @@ spec:
         - --kubelet-client-key=/var/run/kubernetes/apiserver/kubelet-client.key
         - --kubelet-preferred-address-types=InternalIP
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -43,7 +43,7 @@ spec:
         - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -34,7 +34,7 @@ spec:
         - scheduler
         - --master=http://apiserver:8080
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -83,7 +83,7 @@ spec:
         - --kubelet-client-key=/var/run/kubernetes/apiserver/kubelet-client.key
         - --kubelet-preferred-address-types=InternalIP
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -44,7 +44,7 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers=*,tokencleaner,bootstrapsigner
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -34,7 +34,7 @@ spec:
         - scheduler
         - --master=http://apiserver:8080
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -83,7 +83,7 @@ spec:
         - --kubelet-client-key=/var/run/kubernetes/apiserver/kubelet-client.key
         - --kubelet-preferred-address-types=InternalIP
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -43,7 +43,7 @@ spec:
         - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -34,7 +34,7 @@ spec:
         - scheduler
         - --master=http://apiserver:8080
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -85,7 +85,7 @@ spec:
         - --cloud-provider=openstack
         - --kubelet-preferred-address-types=InternalIP
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -46,7 +46,7 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers=*,tokencleaner,bootstrapsigner
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -34,7 +34,7 @@ spec:
         - scheduler
         - --master=http://apiserver:8080
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.8.5
+        image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -85,7 +85,7 @@ spec:
         - --cloud-provider=openstack
         - --kubelet-preferred-address-types=InternalIP
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -45,7 +45,7 @@ spec:
         - --cloud-provider=openstack
         - --allocate-node-cidrs=true
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -34,7 +34,7 @@ spec:
         - scheduler
         - --master=http://apiserver:8080
         - --v=4
-        image: kubermatic/hyperkube-amd64:v1.9.0
+        image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -57,7 +57,7 @@ spec:
           name: apiserver
           readOnly: true
       - name: apiserver
-        image: kubermatic/hyperkube-amd64:{{index .Version.Values "k8s-version"}}
+        image: gcr.io/google_containers/hyperkube-amd64:{{index .Version.Values "k8s-version"}}
         command: [ "/hyperkube", "apiserver",
             "--advertise-address={{ .Cluster.Address.IP }}",
             "--secure-port={{ .Cluster.Address.ExternalPort }}",

--- a/config/kubermatic/static/master/controller-manager-dep.yaml
+++ b/config/kubermatic/static/master/controller-manager-dep.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: controller-manager
-        image: kubermatic/hyperkube-amd64:{{index .Version.Values "k8s-version"}}
+        image: gcr.io/google_containers/hyperkube-amd64:{{index .Version.Values "k8s-version"}}
         command: [
           "/hyperkube", "controller-manager",
           "--master=http://apiserver:8080",

--- a/config/kubermatic/static/master/scheduler-dep.yaml
+++ b/config/kubermatic/static/master/scheduler-dep.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: scheduler
-        image: kubermatic/hyperkube-amd64:{{index .Version.Values "k8s-version"}}
+        image: gcr.io/google_containers/hyperkube-amd64:{{index .Version.Values "k8s-version"}}
         command: [ "/hyperkube", "scheduler",
             "--master=http://apiserver:8080",
             "--v=4"


### PR DESCRIPTION
**What this PR does / why we need it**:
Use GCR instead of our own hyperkube docker repo