### PR TITLE
Honor kube-state-metric labels

### DIFF
--- a/config/monitoring/grafana/dashboards/deployment-dashboard.json
+++ b/config/monitoring/grafana/dashboards/deployment-dashboard.json
@@ -333,7 +333,7 @@
             "tableColumn": "",
             "targets": [
               {
-                "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "metric": "kube_deployment_spec_replicas",
@@ -412,7 +412,7 @@
             "tableColumn": "",
             "targets": [
               {
-                "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "refId": "A",
@@ -490,7 +490,7 @@
             "tableColumn": "",
             "targets": [
               {
-                "expr": "max(kube_deployment_status_observed_generation{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "max(kube_deployment_status_observed_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "",
@@ -569,7 +569,7 @@
             "tableColumn": "",
             "targets": [
               {
-                "expr": "max(kube_deployment_metadata_generation{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "max(kube_deployment_metadata_generation{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "",
@@ -638,7 +638,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "expr": "max(kube_deployment_status_replicas{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "max(kube_deployment_status_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "current replicas",
@@ -646,7 +646,7 @@
                 "step": 120
               },
               {
-                "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "available",
@@ -654,7 +654,7 @@
                 "step": 120
               },
               {
-                "expr": "max(kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "max(kube_deployment_status_replicas_unavailable{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "unavailable",
@@ -662,7 +662,7 @@
                 "step": 120
               },
               {
-                "expr": "min(kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "min(kube_deployment_status_replicas_updated{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "updated",
@@ -670,7 +670,7 @@
                 "step": 120
               },
               {
-                "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",exported_namespace=\"$deployment_namespace\"}) without (instance, pod)",
+                "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\",namespace=\"$deployment_namespace\"}) without (instance, pod)",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "desired",
@@ -743,7 +743,7 @@
           "multi": false,
           "name": "deployment_namespace",
           "options": [],
-          "query": "label_values(kube_deployment_metadata_generation, exported_namespace)",
+          "query": "label_values(kube_deployment_metadata_generation, namespace)",
           "refresh": 1,
           "regex": "",
           "sort": 1,
@@ -766,7 +766,7 @@
           "multi": false,
           "name": "deployment_name",
           "options": [],
-          "query": "label_values(kube_deployment_metadata_generation{exported_namespace=\"$deployment_namespace\"}, deployment)",
+          "query": "label_values(kube_deployment_metadata_generation{namespace=\"$deployment_namespace\"}, deployment)",
           "refresh": 1,
           "regex": "",
           "sort": 1,

--- a/config/monitoring/grafana/dashboards/pods-dashboard.json
+++ b/config/monitoring/grafana/dashboards/pods-dashboard.json
@@ -112,7 +112,7 @@
                 "step": 10
               },
               {
-                "expr": "sum by(container) (kube_pod_container_resource_requests_memory_bytes{exported_pod=\"$pod\", container=~\"$container\", container!=\"POD\"})",
+                "expr": "sum by(container) (kube_pod_container_resource_requests_memory_bytes{pod=\"$pod\", container=~\"$container\", container!=\"POD\"})",
                 "format": "time_series",
                 "interval": "10s",
                 "intervalFactor": 2,
@@ -122,7 +122,7 @@
                 "step": 20
               },
               {
-                "expr": "sum by(container) (kube_pod_container_resource_limits_memory_bytes{exported_pod=\"$pod\", container=~\"$container\", container!=\"POD\"})",
+                "expr": "sum by(container) (kube_pod_container_resource_limits_memory_bytes{pod=\"$pod\", container=~\"$container\", container!=\"POD\"})",
                 "format": "time_series",
                 "hide": false,
                 "interval": "",
@@ -382,7 +382,7 @@
           "multi": false,
           "name": "namespace",
           "options": [],
-          "query": "label_values(kube_pod_info, exported_namespace)",
+          "query": "label_values(kube_pod_info, namespace)",
           "refresh": 1,
           "regex": "",
           "sort": 1,
@@ -406,7 +406,7 @@
           "multi": false,
           "name": "pod",
           "options": [],
-          "query": "label_values(kube_pod_info{exported_namespace=~\"$namespace\"}, exported_pod)",
+          "query": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
           "refresh": 1,
           "regex": "",
           "sort": 1,
@@ -429,7 +429,7 @@
           "multi": false,
           "name": "container",
           "options": [],
-          "query": "label_values(kube_pod_container_info{exported_namespace=\"$namespace\", exported_pod=\"$pod\"}, container)",
+          "query": "label_values(kube_pod_container_info{namespace=\"$namespace\", pod=\"$pod\"}, container)",
           "refresh": 1,
           "regex": "",
           "sort": 1,

--- a/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -12,6 +12,9 @@ rules:
   - replicationcontrollers
   - limitranges
   - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:
@@ -28,3 +31,15 @@ rules:
   - cronjobs
   - jobs
   verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]

--- a/config/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/config/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -10,28 +10,47 @@ spec:
         app: kube-state-metrics
     spec:
       serviceAccountName: kube-state-metrics
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       containers:
+      - name: kube-rbac-proxy-main
+        image: quay.io/brancz/kube-rbac-proxy:v0.2.0
+        args:
+        - "--secure-listen-address=:8443"
+        - "--upstream=http://127.0.0.1:8081/"
+        ports:
+        - name: https-main
+          containerPort: 8443
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+          limits:
+            memory: 40Mi
+            cpu: 20m
+      - name: kube-rbac-proxy-self
+        image: quay.io/brancz/kube-rbac-proxy:v0.2.0
+        args:
+        - "--secure-listen-address=:9443"
+        - "--upstream=http://127.0.0.1:8082/"
+        ports:
+        - name: https-self
+          containerPort: 9443
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+          limits:
+            memory: 40Mi
+            cpu: 20m
       - name: kube-state-metrics
         image: {{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}
         args:
-        - '--collectors'
-        - 'daemonsets,deployments,jobs,limitranges,nodes,pods,replicasets,replicationcontrollers,resourcequotas,services,statefulsets,persistentvolumeclaims'
-        ports:
-        - name: metrics
-          containerPort: 8080
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
-        resources:
-          requests:
-            memory: 100Mi
-            cpu: 100m
-          limits:
-            memory: 200Mi
-            cpu: 200m
+        - "--host=127.0.0.1"
+        - "--port=8081"
+        - "--telemetry-host=127.0.0.1"
+        - "--telemetry-port=8082"
       - name: addon-resizer
         image: {{ .Values.kubeStateMetrics.resizer.image.repository }}:{{ .Values.kubeStateMetrics.resizer.image.tag }}
         resources:
@@ -54,8 +73,8 @@ spec:
           - /pod_nanny
           - --container=kube-state-metrics
           - --cpu=100m
-          - --extra-cpu=1m
-          - --memory=100Mi
-          - --extra-memory=2Mi
+          - --extra-cpu=2m
+          - --memory=150Mi
+          - --extra-memory=30Mi
           - --threshold=5
           - --deployment=kube-state-metrics

--- a/config/monitoring/kube-state-metrics/templates/service-monitor.yaml
+++ b/config/monitoring/kube-state-metrics/templates/service-monitor.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     team: kubermatic
 spec:
+  jobLabel: app
   selector:
     matchLabels:
       app: kube-state-metrics
@@ -12,5 +13,16 @@ spec:
     matchNames:
     - monitoring
   endpoints:
-  - port: http
+  - port: https-main
+    scheme: https
     interval: 30s
+    honorLabels: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      insecureSkipVerify: true
+  - port: https-self
+    scheme: https
+    interval: 30s
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      insecureSkipVerify: true

--- a/config/monitoring/kube-state-metrics/templates/service.yaml
+++ b/config/monitoring/kube-state-metrics/templates/service.yaml
@@ -5,10 +5,16 @@ metadata:
   labels:
     app: kube-state-metrics
 spec:
+  clusterIP: None
   ports:
-  - name: http
-    port: 8080
-    targetPort: metrics
+  - name: https-main
+    port: 8443
+    targetPort: https-main
+    protocol: TCP
+  - name: https-self
+    port: 9443
+    targetPort: https-self
     protocol: TCP
   selector:
     app: kube-state-metrics
+

--- a/config/monitoring/prometheus/rules/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/kube-state-metrics.yaml
@@ -7,7 +7,7 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: "Observed deployment generation does not match expected one for deployment {{$labels.exported_namespace}}/{{$labels.deployment}}"
+      description: "Observed deployment generation does not match expected one for deployment {{$labels.namespace}}/{{$labels.deployment}}"
       summary: "Deployment is outdated"
   - alert: KubernetesDeploymentReplicasNotUpdated
     expr: ((kube_deployment_status_replicas_updated != kube_deployment_spec_replicas) or (kube_deployment_status_replicas_available != kube_deployment_spec_replicas)) unless (kube_deployment_spec_paused == 1)
@@ -15,7 +15,7 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: "Replicas are not updated and available for deployment {{$labels.exported_namespace}}/{{$labels.deployment}}"
+      description: "Replicas are not updated and available for deployment {{$labels.namespace}}/{{$labels.deployment}}"
       summary: "Deployment replicas are outdated"
   - alert: KubernetesDaemonSetRolloutStuck
     expr: kube_daemonset_status_number_ready / kube_daemonset_status_desired_number_scheduled * 100 < 100
@@ -23,7 +23,7 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: "Only {{$value}}% of desired pods scheduled and ready for daemon set {{$labels.exported_namespace}}/{{$labels.daemonset}}"
+      description: "Only {{$value}}% of desired pods scheduled and ready for daemon set {{$labels.namespace}}/{{$labels.daemonset}}"
       summary: "DaemonSet is missing pods"
   - alert: KubernetesDaemonSetsNotScheduled
     expr: kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_current_number_scheduled > 0
@@ -47,21 +47,21 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: "Pod {{$labels.exported_namespace}}/{{$labels.exported_pod}} is was restarted {{$value}} times within the last hour."
+      description: "Pod {{$labels.namespace}}/{{$labels.pod}} is was restarted {{$value}} times within the last hour."
       summary: "Pod is restarting frequently"
   - alert: KubernetesPodTerminating
-    expr: kube_pod_container_status_terminated{exported_namespace!="kubermatic-installer"} == 1
+    expr: kube_pod_container_status_terminated{namespace!="kubermatic-installer"} == 1
     for: 30m
     labels:
       severity: warning
     annotations:
-      description: "Container {{$labels.exported_namespace}}/{{$labels.exported_pod}}/{{$labels.container}} is terminating too long."
+      description: "Container {{$labels.namespace}}/{{$labels.pod}}/{{$labels.container}} is terminating too long."
       summary: "Pod is terminating too long"
   - alert: KubernetesPodWaiting
-    expr: kube_pod_container_status_waiting{exported_namespace!="kubermatic-installer"} == 1
+    expr: kube_pod_container_status_waiting{namespace!="kubermatic-installer"} == 1
     for: 30m
     labels:
       severity: warning
     annotations:
-      description: "Container {{$labels.exported_namespace}}/{{$labels.exported_pod}}/{{$labels.container}} is waiting too long."
+      description: "Container {{$labels.namespace}}/{{$labels.pod}}/{{$labels.container}} is waiting too long."
       summary: "Pod is waiting too long"


### PR DESCRIPTION
**What this PR does / why we need it**:
We are currently running kube-state-metrics and simply ingest its data into Prometheus.
The kube-state-metric metrics expose metrics with labels `namespace="cluster-1234"` and `pod="foo-bar-123"`. But when kube-state-metrics is scraped by Prometheus we scrape with the following labels: `namespace="monitoring"` and `pod="kube-state-metrics-123-123"`.

That's why Prometheus prefixes the `namespace` and `pod` labels exposed my kube-state-metrics with `exported_` resulting in `exported_namespace` and `exported_pod`.

```diff
-kube_deployment_spec_replicas{deployment="nodeport-exposer",exported_namespace="nodeport-exposer",namespace="monitoring"}
+kube_deployment_spec_replicas{deployment="nodeport-exposer",namespace="nodeport-exposer"}
```
