### PR TITLE
allow machine & node matching by equal name

### DIFF
--- a/api/pkg/handler/node_v2.go
+++ b/api/pkg/handler/node_v2.go
@@ -287,7 +287,7 @@ func getNodeForMachine(machine *v1alpha1.Machine, nodes []corev1.Node) *corev1.N
 		return nil
 	}
 	for _, node := range nodes {
-		if node.UID == machine.Status.NodeRef.UID {
+		if node.UID == machine.Status.NodeRef.UID || node.Name == machine.Name {
 			return &node
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow matching of machines&nodes by name to fix the issue when a machine&node exist but the node controller has not set the owner-ref & node-ref on the machine & node.