### PR TITLE
use group ID when deleting security group

### DIFF
--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -497,12 +497,12 @@ func (a *amazonEc2) CleanUpCloudProvider(cloud *kubermaticv1.CloudSpec) error {
 
 	if cloud.AWS.SecurityGroup != "" {
 		_, err = ec2client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
-			GroupName: aws.String(cloud.AWS.SecurityGroup),
+			GroupId: aws.String(cloud.AWS.SecurityGroupID),
 		})
 
 		if err != nil {
 			if err.(awserr.Error).Code() != "InvalidGroup.NotFound" {
-				return fmt.Errorf("failed to delete security group %s: %s", cloud.AWS.SecurityGroup, err.(awserr.Error).Message())
+				return fmt.Errorf("failed to delete security group %s(%s): %s", cloud.AWS.SecurityGroup, cloud.AWS.SecurityGroupID, err.(awserr.Error).Message())
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:uses security group ID to delete security group.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
