### PR TITLE
Always forward to same Prometheus based on the IP

### DIFF
--- a/config/monitoring/prometheus/templates/ingress.yaml
+++ b/config/monitoring/prometheus/templates/ingress.yaml
@@ -10,6 +10,8 @@ metadata:
     ingress.kubernetes.io/auth-secret: prometheus-auth
     # message to display with an appropiate context why the authentication is required
     ingress.kubernetes.io/auth-realm: "Authentication Required"
+    # always load balance to the same prometheus based on a IP, this is needed for Prometheus Federation.
+    ingress.kubernetes.io/upstream-hash-by: "ip_hash"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
**What this PR does / why we need it**:
For Prometheus Federation to work we need to always scrape the same Prometheus, even if there are multiple Prometheuses running behind a reverse proxy.

That's why I want to add this annotation so the federate requests always get forwarded to the same Prometheus. This is already tested on dev. :+1: 
