### PR TITLE
Use addon-manager 1.9.3 with openvpn for 1.10

### DIFF
--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -259,7 +259,7 @@ versions:
     etcd-operator-version: v0.6.0
     etcd-cluster-version: 3.2.7
     kube-machine-version: v0.2.3
-    addon-manager-version: v1.9.2
+    addon-manager-version: v1.9.3
     pod-network-bridge: v0.4
     machine-controller-version: v0.3.1
     kube-state-metrics-version: latest


### PR DESCRIPTION
**What this PR does / why we need it**:

If you upgrade to 1.10 the wrong add-on manager is used. 

