### PR TITLE
remove apiserver bridge port

### DIFF
--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -228,18 +228,6 @@ func addSecurityGroup(client *ec2.EC2, vpc *ec2.Vpc, name string) (string, error
 		return "", fmt.Errorf("failed to authorize security group ingress for ssh: %v", err)
 	}
 
-	// Allow SSH for the network bridge from everywhere
-	_, err = client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
-		CidrIp:     aws.String("0.0.0.0/0"),
-		FromPort:   aws.Int64(provider.PodNetworkBridgeSSHPort),
-		ToPort:     aws.Int64(provider.PodNetworkBridgeSSHPort),
-		GroupId:    csgOut.GroupId,
-		IpProtocol: aws.String("tcp"),
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to authorize security group ingress for pod network bridge ssh: %v", err)
-	}
-
 	// Allow kubelet 10250 from everywhere
 	_, err = client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
 		CidrIp:     aws.String("0.0.0.0/0"),

--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -177,15 +177,6 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 			PortRangeMax: provider.DefaultSSHPort,
 			Protocol:     osecruritygrouprules.ProtocolTCP,
 		},
-		{
-			// Allows ssh for the pod network bridge from external
-			Direction:    osecruritygrouprules.DirIngress,
-			EtherType:    osecruritygrouprules.EtherType4,
-			SecGroupID:   g.ID,
-			PortRangeMin: provider.PodNetworkBridgeSSHPort,
-			PortRangeMax: provider.PodNetworkBridgeSSHPort,
-			Protocol:     osecruritygrouprules.ProtocolTCP,
-		},
 	}
 
 	for _, opts := range rules {

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -29,9 +29,8 @@ const (
 	HetznerCloudProvider      = "hetzner"
 	VSphereCloudProvider      = "vsphere"
 
-	DefaultSSHPort          = 22
-	PodNetworkBridgeSSHPort = 2222
-	DefaultKubeletPort      = 10250
+	DefaultSSHPort     = 22
+	DefaultKubeletPort = 10250
 )
 
 // CloudProvider declares a set of methods for interacting with a cloud provider


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes port 2222 from new security groups.
Port 2222 was used before we had openvpn

**Release note**:
```release-note
NONE
```