### PR TITLE
Fix addon manager deployment

### DIFF
--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-addon-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.8.0-addon-manager.yaml
@@ -17,7 +17,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null

--- a/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-addon-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-aws-1.9.0-addon-manager.yaml
@@ -17,7 +17,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-addon-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.8.0-addon-manager.yaml
@@ -17,7 +17,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null

--- a/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-addon-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-bringyourown-1.9.0-addon-manager.yaml
@@ -17,7 +17,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-addon-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.8.0-addon-manager.yaml
@@ -17,7 +17,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null

--- a/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-addon-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-digitalocean-1.9.0-addon-manager.yaml
@@ -17,7 +17,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-addon-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.8.0-addon-manager.yaml
@@ -17,7 +17,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null

--- a/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-addon-manager.yaml
+++ b/api/pkg/controller/resources/fixtures/deployment-openstack-1.9.0-addon-manager.yaml
@@ -17,7 +17,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null

--- a/config/kubermatic/static/master/addon-manager-dep.yaml
+++ b/config/kubermatic/static/master/addon-manager-dep.yaml
@@ -16,7 +16,10 @@ spec:
       role: addon-manager
       version: v1
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts the change of the update strategy for the addon-manager

**Release note**:
```release-note
NONE
```