### PR TITLE
use seed cluster for cluster provider in api

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -124,7 +124,7 @@ func main() {
 
 		glog.V(2).Infof("adding %s as seed", ctx)
 
-		kubeClient := kubernetes.NewForConfigOrDie(config)
+		kubeClient := kubernetes.NewForConfigOrDie(cfg)
 		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, informerResyncPeriod)
 
 		kubermaticSeedClient := kubermaticclientset.NewForConfigOrDie(cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes kubeconfig error for non-master seed clusters

**Release note**:
```release-note
NONE
```