### PR TITLE
Update kube-state-metrics to 1.3.1

### DIFF
--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.2.0
+    tag: v1.3.1
   resizer:
     image:
       repository: gcr.io/google_containers/addon-resizer


### PR DESCRIPTION
Closes #876 

**Release note**:
```release-note
Updated kube-state-metrics to `v1.3.1`
```