### PR TITLE
Fixes learned from AWS setup

### DIFF
--- a/api/pkg/resources/fixtures/deployment-aws-1.8.0-addon-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-aws-1.8.0-addon-manager.yaml
@@ -33,6 +33,8 @@ spec:
       - env:
         - name: KUBECTL_OPTS
           value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"
         image: kubermatic/addon-manager:v1.8.2
         imagePullPolicy: Always
         name: addon-manager

--- a/api/pkg/resources/fixtures/deployment-aws-1.9.0-addon-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-aws-1.9.0-addon-manager.yaml
@@ -33,6 +33,8 @@ spec:
       - env:
         - name: KUBECTL_OPTS
           value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"
         image: kubermatic/addon-manager:v1.9.0
         imagePullPolicy: Always
         name: addon-manager

--- a/api/pkg/resources/fixtures/deployment-bringyourown-1.8.0-addon-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-bringyourown-1.8.0-addon-manager.yaml
@@ -33,6 +33,8 @@ spec:
       - env:
         - name: KUBECTL_OPTS
           value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"
         image: kubermatic/addon-manager:v1.8.2
         imagePullPolicy: Always
         name: addon-manager

--- a/api/pkg/resources/fixtures/deployment-bringyourown-1.9.0-addon-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-bringyourown-1.9.0-addon-manager.yaml
@@ -33,6 +33,8 @@ spec:
       - env:
         - name: KUBECTL_OPTS
           value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"
         image: kubermatic/addon-manager:v1.9.0
         imagePullPolicy: Always
         name: addon-manager

--- a/api/pkg/resources/fixtures/deployment-digitalocean-1.8.0-addon-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-digitalocean-1.8.0-addon-manager.yaml
@@ -33,6 +33,8 @@ spec:
       - env:
         - name: KUBECTL_OPTS
           value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"
         image: kubermatic/addon-manager:v1.8.2
         imagePullPolicy: Always
         name: addon-manager

--- a/api/pkg/resources/fixtures/deployment-digitalocean-1.9.0-addon-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-digitalocean-1.9.0-addon-manager.yaml
@@ -33,6 +33,8 @@ spec:
       - env:
         - name: KUBECTL_OPTS
           value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"
         image: kubermatic/addon-manager:v1.9.0
         imagePullPolicy: Always
         name: addon-manager

--- a/api/pkg/resources/fixtures/deployment-openstack-1.8.0-addon-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-openstack-1.8.0-addon-manager.yaml
@@ -33,6 +33,8 @@ spec:
       - env:
         - name: KUBECTL_OPTS
           value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"
         image: kubermatic/addon-manager:v1.8.2
         imagePullPolicy: Always
         name: addon-manager

--- a/api/pkg/resources/fixtures/deployment-openstack-1.9.0-addon-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-openstack-1.9.0-addon-manager.yaml
@@ -33,6 +33,8 @@ spec:
       - env:
         - name: KUBECTL_OPTS
           value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"
         image: kubermatic/addon-manager:v1.9.0
         imagePullPolicy: Always
         name: addon-manager

--- a/api/pkg/resources/fixtures/service-aws-1.8.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-aws-1.8.0-apiserver-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   name: apiserver-external
   ownerReferences:

--- a/api/pkg/resources/fixtures/service-aws-1.9.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-aws-1.9.0-apiserver-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   name: apiserver-external
   ownerReferences:

--- a/api/pkg/resources/fixtures/service-bringyourown-1.8.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-bringyourown-1.8.0-apiserver-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   name: apiserver-external
   ownerReferences:

--- a/api/pkg/resources/fixtures/service-bringyourown-1.9.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-bringyourown-1.9.0-apiserver-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   name: apiserver-external
   ownerReferences:

--- a/api/pkg/resources/fixtures/service-digitalocean-1.8.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-digitalocean-1.8.0-apiserver-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   name: apiserver-external
   ownerReferences:

--- a/api/pkg/resources/fixtures/service-digitalocean-1.9.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-digitalocean-1.9.0-apiserver-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   name: apiserver-external
   ownerReferences:

--- a/api/pkg/resources/fixtures/service-openstack-1.8.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-openstack-1.8.0-apiserver-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   name: apiserver-external
   ownerReferences:

--- a/api/pkg/resources/fixtures/service-openstack-1.9.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-openstack-1.9.0-apiserver-external.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   name: apiserver-external
   ownerReferences:

--- a/config/deploy_master_helm_charts.sh
+++ b/config/deploy_master_helm_charts.sh
@@ -70,4 +70,4 @@ helm ${HELM_OPTS} upgrade -i cert-manager --namespace cert-manager -f ${VALUESFI
 helm ${HELM_OPTS} upgrade -i certs --namespace default -f ${VALUESFILE} ${CHARTS_PATH}/certs/
 helm ${HELM_OPTS} upgrade -i nodeport-proxy --namespace nodeport-proxy -f ${VALUESFILE} ${CHARTS_PATH}/nodeport-proxy/
 
-helm ${HELM_OPTS} delete --purge nodeport-exposer
+helm ${HELM_OPTS} delete --purge nodeport-exposer || true

--- a/config/deploy_master_helm_charts.sh
+++ b/config/deploy_master_helm_charts.sh
@@ -68,4 +68,6 @@ helm ${HELM_OPTS} upgrade -i oauth --namespace oauth -f ${VALUESFILE} ${CHARTS_P
 helm ${HELM_OPTS} upgrade -i kubermatic --namespace kubermatic -f ${VALUESFILE} ${CHARTS_PATH}/kubermatic/
 helm ${HELM_OPTS} upgrade -i cert-manager --namespace cert-manager -f ${VALUESFILE} ${CHARTS_PATH}/cert-manager/
 helm ${HELM_OPTS} upgrade -i certs --namespace default -f ${VALUESFILE} ${CHARTS_PATH}/certs/
-helm ${HELM_OPTS} upgrade -i nodeport-exposer --namespace nodeport-exposer -f ${VALUESFILE} ${CHARTS_PATH}/nodeport-exposer/
+helm ${HELM_OPTS} upgrade -i nodeport-proxy --namespace nodeport-proxy -f ${VALUESFILE} ${CHARTS_PATH}/nodeport-proxy/
+
+helm ${HELM_OPTS} delete --purge nodeport-exposer

--- a/config/deploy_seed_helm_charts.sh
+++ b/config/deploy_seed_helm_charts.sh
@@ -65,4 +65,6 @@ sleep 30
 ############# Kubermatic #############
 helm ${HELM_OPTS} upgrade -i storage --namespace default -f ${VALUESFILE} ${CHARTS_PATH}/storage/
 helm ${HELM_OPTS} upgrade -i kubermatic --namespace kubermatic -f ${VALUESFILE} ${CHARTS_PATH}/kubermatic/
-helm ${HELM_OPTS} upgrade -i nodeport-exposer --namespace nodeport-exposer -f ${VALUESFILE} ${CHARTS_PATH}/nodeport-exposer/
+helm ${HELM_OPTS} upgrade -i nodeport-proxy --namespace nodeport-proxy -f ${VALUESFILE} ${CHARTS_PATH}/nodeport-proxy/
+
+helm ${HELM_OPTS} delete --purge nodeport-exposer

--- a/config/deploy_seed_helm_charts.sh
+++ b/config/deploy_seed_helm_charts.sh
@@ -67,4 +67,4 @@ helm ${HELM_OPTS} upgrade -i storage --namespace default -f ${VALUESFILE} ${CHAR
 helm ${HELM_OPTS} upgrade -i kubermatic --namespace kubermatic -f ${VALUESFILE} ${CHARTS_PATH}/kubermatic/
 helm ${HELM_OPTS} upgrade -i nodeport-proxy --namespace nodeport-proxy -f ${VALUESFILE} ${CHARTS_PATH}/nodeport-proxy/
 
-helm ${HELM_OPTS} delete --purge nodeport-exposer
+helm ${HELM_OPTS} delete --purge nodeport-exposer || true

--- a/config/kubermatic/static/master/addon-manager-dep.yaml
+++ b/config/kubermatic/static/master/addon-manager-dep.yaml
@@ -40,4 +40,6 @@ spec:
         imagePullPolicy: Always
         env:
         - name: KUBECTL_OPTS
-          value: "--server=http://apiserver:8080"
+          value: --server=http://apiserver:8080
+        - name: ADDON_MANAGER_LEADER_ELECTION
+          value: "false"

--- a/config/kubermatic/static/master/apiserver-external-service.yaml
+++ b/config/kubermatic/static/master/apiserver-external-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: apiserver-external
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
     blockOwnerDeletion: true

--- a/config/kubermatic/static/master/openvpn-server-service.yaml
+++ b/config/kubermatic/static/master/openvpn-server-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: openvpn-server
   annotations:
-    nodeport-exposer.k8s.io/expose: "true"
+    nodeport-proxy.k8s.io/expose: "true"
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
     blockOwnerDeletion: true

--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,0 +1,13 @@
+name: nodeport-proxy
+version: 1.0.0
+description: Kubermatic nodeport-proxy
+keywords:
+  - k8s
+  - kubermatic
+  - nodeport-proxy
+home: http://www.kubermatic.io/
+sources:
+  - https://github.com/kubermatic/nodeport-proxy
+maintainers:
+  - name: Henrik Schmidt
+    email: henrik@loodse.com

--- a/config/nodeport-proxy/templates/clusterrole.yaml
+++ b/config/nodeport-proxy/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nodeport-proxy
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs: ["get", "list", "watch", "update"]

--- a/config/nodeport-proxy/templates/clusterrolebinding.yaml
+++ b/config/nodeport-proxy/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nodeport-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nodeport-proxy
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: nodeport-proxy

--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodeport-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nodeport-proxy
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: nodeport-proxy
+    spec:
+      serviceAccountName: nodeport-proxy
+      containers:
+      - name: nodeport-proxy
+        image: {{ .Values.nodePortPoxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag }}
+        command:
+        - "/nodeport-proxy"
+        args: [
+          "-listen-address", "0.0.0.0",
+          "-lb-namespace", "nodeport-proxy",
+          "-lb-name", "nodeport-lb",
+          "-logtostderr",
+          "-v","6"
+        ]

--- a/config/nodeport-proxy/templates/lb.yaml
+++ b/config/nodeport-proxy/templates/lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodeport-lb
+spec:
+  selector:
+    app: nodeport-proxy
+  ports:
+  - name: keepalive
+    port: 1337
+    protocol: TCP
+  type: LoadBalancer

--- a/config/nodeport-proxy/templates/serviceaccount.yaml
+++ b/config/nodeport-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodeport-proxy

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -1,0 +1,5 @@
+nodePortPoxy:
+  image:
+    repository: "kubermatic/nodeport-proxy"
+    tag: "v1.0"
+


### PR DESCRIPTION
**What this PR does / why we need it**:
- Disables addon-manager leader-election as it stores lock in master and not user cluster
- Switches from nodeport exposer to nodeport proxy
- Implements sorting to handle multiple IP's coming from DNS

**Release note**:
```release-note
NONE
```