### PR TITLE
Add missing token controllers

### DIFF
--- a/api/pkg/resources/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -47,7 +47,7 @@ spec:
         - --cloud-config=/etc/kubernetes/cloud/config
         - --cloud-provider=aws
         - --allocate-node-cidrs=true
-        - --controllers=*,tokencleaner,bootstrapsigner
+        - --controllers=*,bootstrapsigner,tokencleaner
         - --v=4
         env:
         - name: AWS_ACCESS_KEY_ID

--- a/api/pkg/resources/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -47,6 +47,7 @@ spec:
         - --cloud-config=/etc/kubernetes/cloud/config
         - --cloud-provider=aws
         - --allocate-node-cidrs=true
+        - --controllers=*,bootstrapsigner,tokencleaner
         - --v=4
         env:
         - name: AWS_ACCESS_KEY_ID

--- a/api/pkg/resources/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -45,7 +45,7 @@ spec:
         - --cluster-cidr=172.25.0.0/16
         - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
-        - --controllers=*,tokencleaner,bootstrapsigner
+        - --controllers=*,bootstrapsigner,tokencleaner
         - --v=4
         image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:

--- a/api/pkg/resources/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -45,6 +45,7 @@ spec:
         - --cluster-cidr=172.25.0.0/16
         - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
+        - --controllers=*,bootstrapsigner,tokencleaner
         - --v=4
         image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:

--- a/api/pkg/resources/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -45,7 +45,7 @@ spec:
         - --cluster-cidr=172.25.0.0/16
         - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
-        - --controllers=*,tokencleaner,bootstrapsigner
+        - --controllers=*,bootstrapsigner,tokencleaner
         - --v=4
         image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:

--- a/api/pkg/resources/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -45,6 +45,7 @@ spec:
         - --cluster-cidr=172.25.0.0/16
         - --configure-cloud-routes=false
         - --allocate-node-cidrs=true
+        - --controllers=*,bootstrapsigner,tokencleaner
         - --v=4
         image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:

--- a/api/pkg/resources/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -47,7 +47,7 @@ spec:
         - --cloud-config=/etc/kubernetes/cloud/config
         - --cloud-provider=openstack
         - --allocate-node-cidrs=true
-        - --controllers=*,tokencleaner,bootstrapsigner
+        - --controllers=*,bootstrapsigner,tokencleaner
         - --v=4
         image: gcr.io/google_containers/hyperkube-amd64:v1.8.5
         livenessProbe:

--- a/api/pkg/resources/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -47,6 +47,7 @@ spec:
         - --cloud-config=/etc/kubernetes/cloud/config
         - --cloud-provider=openstack
         - --allocate-node-cidrs=true
+        - --controllers=*,bootstrapsigner,tokencleaner
         - --v=4
         image: gcr.io/google_containers/hyperkube-amd64:v1.9.0
         livenessProbe:

--- a/config/kubermatic/static/master/controller-manager-dep.yaml
+++ b/config/kubermatic/static/master/controller-manager-dep.yaml
@@ -59,10 +59,7 @@ spec:
           "--cloud-provider=openstack",
           {{ end }}
           "--allocate-node-cidrs=true",
-          {{ if contains "v1.8" (index .Version.Values "k8s-version") }}
-          #TODO: Remove when we drop 1.8 support
-          "--controllers=*,tokencleaner,bootstrapsigner",
-          {{ end }}
+          "--controllers=*,bootstrapsigner,tokencleaner",
           "--v=4"
         ]
         readinessProbe:


### PR DESCRIPTION
**What this PR does / why we need it**:
Otherwise the new version of the machine-controller wont work as we use kubeadm now, which validates actually the bootstrap tokens.

**Release note**:
```release-note
NONE
```