### PR TITLE
accept not found errors during cleanup of openstack resources

### DIFF
--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -136,19 +136,19 @@ func (os *Provider) CleanUpCloudProvider(cloud *kubermaticv1.CloudSpec) error {
 
 	if cloud.Openstack.NetworkCreated {
 		if _, err = detachSubnetFromRouter(netClient, cloud.Openstack.SubnetID, cloud.Openstack.RouterID); err != nil {
-			if err.Error() != "Resource not found" {
+			if _, ok := err.(gophercloud.Err404er); !ok {
 				return fmt.Errorf("failed to detach subnet from router: %v", err)
 			}
 		}
 
 		if err = deleteNetworkByName(netClient, cloud.Openstack.Network); err != nil {
-			if err.Error() != "Resource not found" {
+			if _, ok := err.(gophercloud.Err404er); !ok {
 				return fmt.Errorf("failed delete network %q: %v", cloud.Openstack.Network, err)
 			}
 		}
 
 		if err = deleteRouter(netClient, cloud.Openstack.RouterID); err != nil {
-			if err.Error() != "Resource not found" {
+			if _, ok := err.(gophercloud.Err404er); !ok {
 				return fmt.Errorf("failed delete router %q: %v", cloud.Openstack.RouterID, err)
 			}
 		}

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -135,17 +135,22 @@ func (os *Provider) CleanUpCloudProvider(cloud *kubermaticv1.CloudSpec) error {
 	}
 
 	if cloud.Openstack.NetworkCreated {
-
 		if _, err = detachSubnetFromRouter(netClient, cloud.Openstack.SubnetID, cloud.Openstack.RouterID); err != nil {
-			return fmt.Errorf("failed to detach subnet from router: %v", err)
+			if err.Error() != "Resource not found" {
+				return fmt.Errorf("failed to detach subnet from router: %v", err)
+			}
 		}
 
 		if err = deleteNetworkByName(netClient, cloud.Openstack.Network); err != nil {
-			return fmt.Errorf("failed delete network %q: %v", cloud.Openstack.Network, err)
+			if err.Error() != "Resource not found" {
+				return fmt.Errorf("failed delete network %q: %v", cloud.Openstack.Network, err)
+			}
 		}
 
 		if err = deleteRouter(netClient, cloud.Openstack.RouterID); err != nil {
-			return fmt.Errorf("failed delete router %q: %v", cloud.Openstack.RouterID, err)
+			if err.Error() != "Resource not found" {
+				return fmt.Errorf("failed delete router %q: %v", cloud.Openstack.RouterID, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
accept not found errors during cleanup of openstack resources

**Release note**:
```release-note cloud provider
Openstack: made cluster resource cleanup idempotent
```