### PR TITLE
don't use machine.Spec.Name in displayName

### DIFF
--- a/api/pkg/handler/node_v2.go
+++ b/api/pkg/handler/node_v2.go
@@ -158,7 +158,7 @@ func outputMachine(machine *v1alpha1.Machine, node *corev1.Node, hideInitialNode
 
 	if node != nil {
 		if node.Name != machine.Spec.Name {
-			displayName = fmt.Sprintf("%s (%s)", node.Name, machine.Spec.Name)
+			displayName = node.Name
 		}
 
 		labels = node.Labels


### PR DESCRIPTION
**What this PR does / why we need it**:
don't use machine.Spec.Name in displayName if node.Name != machine.Spec.Name, because of conversation in this pr https://github.com/kubermatic/dashboard-v2/pull/592

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```