### PR TITLE
add flag to disable tls verification for token issuer

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -61,6 +61,8 @@ var (
 	updatesFile     string
 	tokenIssuer     string
 	clientID        string
+
+	tokenIssuerSkipTLSVerify bool
 )
 
 const (
@@ -77,6 +79,7 @@ func main() {
 	flag.StringVar(&versionsFile, "versions", "versions.yaml", "The versions.yaml file path")
 	flag.StringVar(&updatesFile, "updates", "updates.yaml", "The updates.yaml file path")
 	flag.StringVar(&tokenIssuer, "token-issuer", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
+	flag.BoolVar(&tokenIssuerSkipTLSVerify, "token-issuer-skip-tls-verify", false, "SKip TLS verification for the token issuer")
 	flag.StringVar(&clientID, "client-id", "", "OpenID client ID")
 	flag.Parse()
 
@@ -147,6 +150,7 @@ func main() {
 			handler.NewHeaderBearerTokenExtractor("Authorization"),
 			handler.NewQueryParamBearerTokenExtractor("token"),
 		),
+		tokenIssuerSkipTLSVerify,
 	)
 	if err != nil {
 		glog.Fatalf("failed to create a openid authenticator for issuer %s (clientID=%s): %v", tokenIssuer, clientID, err)

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -30,6 +30,7 @@ spec:
           - -prometheus-address=0.0.0.0:8085
           - -kubeconfig=/opt/.kube/kubeconfig
           - -master-resources=/opt/master-files
+          - -token-issuer-skip-tls-verify={{ default false .Values.kubermatic.auth.skipTokenIssuerTLSVerify }}
           image: '{{ .Values.kubermatic.api.image.repository }}:{{.Values.kubermatic.api.image.tag}}'
           imagePullPolicy: {{.Values.kubermatic.api.image.pullPolicy}}
           ports:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -5,8 +5,10 @@ kubermatic:
   auth:
     # the full path to the openid connect token issuer. For example 'https://dev.kubermatic.io/dex'
     tokenIssuer: ""
-    # die client id for openid connect
+    # the client id for openid connect
     clientID: ""
+    # skip tls verification on the token issuer
+    skipTokenIssuerTLSVerify: "false"
   # base64 encoded datacenters.yaml
   datacenters: ""
   # external domain for the kubermatic installation. For example 'dev.kubermatic.io'


### PR DESCRIPTION
**What this PR does / why we need it**:
add flag to disable tls verification for token issuer.
Needed for offline environment where no valid certificates can get created.

**Release note**:
```release-note
Allow disabling TLS verification in offline environments
```