### PR TITLE
fix machine.yaml for operating system containerLinux

### DIFF
--- a/config/kubermatic/static/master/machine.yaml
+++ b/config/kubermatic/static/master/machine.yaml
@@ -85,7 +85,7 @@ spec:
     {{- if .Node.Spec.OperatingSystem.ContainerLinux }}
     operatingSystem: coreos
     operatingSystemSpec:
-      disableAutoUpdate: {{ .Node.Spec.OperatingSystem.DisableAutoUpdate }}
+      disableAutoUpdate: {{ .Node.Spec.OperatingSystem.ContainerLinux.DisableAutoUpdate }}
     {{- end }}
     {{- if .Node.Spec.OperatingSystem.Ubuntu }}
     operatingSystem: ubuntu


### PR DESCRIPTION
**What this PR does / why we need it**:
options for operating system containerLinux weren't correct in machine.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
