### PR TITLE
use coreos_production_vmware_ova instead of container-linux-template

### DIFF
--- a/config/kubermatic/static/master/machine.yaml
+++ b/config/kubermatic/static/master/machine.yaml
@@ -70,7 +70,7 @@ spec:
       templateVMName: {{ default "ubuntu-template" .Node.Spec.Cloud.VSphere.Template | quote }}
     {{- end }}
     {{- if .Node.Spec.OperatingSystem.ContainerLinux }}
-      templateVMName: {{ default "container-linux-template" .Node.Spec.Cloud.VSphere.Template | quote }}
+      templateVMName: {{ default "coreos_production_vmware_ova" .Node.Spec.Cloud.VSphere.Template | quote }}
     {{- end }}
       username: {{ .Cluster.Spec.Cloud.VSphere.Username | quote }}
       password: {{ .Cluster.Spec.Cloud.VSphere.Password | quote }}


### PR DESCRIPTION
**What this PR does / why we need it**:
use coreos_production_vmware_ova instead of container-linux-template for vsphere container linux template

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```