### PR TITLE
make kubernetes allocate nodeport

### DIFF
--- a/api/pkg/resources/fixtures/service-aws-1.8.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-aws-1.8.0-apiserver-external.yaml
@@ -18,7 +18,7 @@ spec:
     nodePort: 30000
     port: 30000
     protocol: TCP
-    targetPort: 0
+    targetPort: 30000
   selector:
     role: apiserver
   type: NodePort

--- a/api/pkg/resources/fixtures/service-aws-1.9.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-aws-1.9.0-apiserver-external.yaml
@@ -18,7 +18,7 @@ spec:
     nodePort: 30000
     port: 30000
     protocol: TCP
-    targetPort: 0
+    targetPort: 30000
   selector:
     role: apiserver
   type: NodePort

--- a/api/pkg/resources/fixtures/service-bringyourown-1.8.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-bringyourown-1.8.0-apiserver-external.yaml
@@ -18,7 +18,7 @@ spec:
     nodePort: 30000
     port: 30000
     protocol: TCP
-    targetPort: 0
+    targetPort: 30000
   selector:
     role: apiserver
   type: NodePort

--- a/api/pkg/resources/fixtures/service-bringyourown-1.9.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-bringyourown-1.9.0-apiserver-external.yaml
@@ -18,7 +18,7 @@ spec:
     nodePort: 30000
     port: 30000
     protocol: TCP
-    targetPort: 0
+    targetPort: 30000
   selector:
     role: apiserver
   type: NodePort

--- a/api/pkg/resources/fixtures/service-digitalocean-1.8.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-digitalocean-1.8.0-apiserver-external.yaml
@@ -18,7 +18,7 @@ spec:
     nodePort: 30000
     port: 30000
     protocol: TCP
-    targetPort: 0
+    targetPort: 30000
   selector:
     role: apiserver
   type: NodePort

--- a/api/pkg/resources/fixtures/service-digitalocean-1.9.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-digitalocean-1.9.0-apiserver-external.yaml
@@ -18,7 +18,7 @@ spec:
     nodePort: 30000
     port: 30000
     protocol: TCP
-    targetPort: 0
+    targetPort: 30000
   selector:
     role: apiserver
   type: NodePort

--- a/api/pkg/resources/fixtures/service-openstack-1.8.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-openstack-1.8.0-apiserver-external.yaml
@@ -18,7 +18,7 @@ spec:
     nodePort: 30000
     port: 30000
     protocol: TCP
-    targetPort: 0
+    targetPort: 30000
   selector:
     role: apiserver
   type: NodePort

--- a/api/pkg/resources/fixtures/service-openstack-1.9.0-apiserver-external.yaml
+++ b/api/pkg/resources/fixtures/service-openstack-1.9.0-apiserver-external.yaml
@@ -18,7 +18,7 @@ spec:
     nodePort: 30000
     port: 30000
     protocol: TCP
-    targetPort: 0
+    targetPort: 30000
   selector:
     role: apiserver
   type: NodePort

--- a/config/kubermatic/static/master/apiserver-external-service.yaml
+++ b/config/kubermatic/static/master/apiserver-external-service.yaml
@@ -15,8 +15,9 @@ spec:
   type: NodePort
   ports:
     - name: secure
-      port: {{ .GetApiserverExternalNodePortOrGetFree }}
-      nodePort: {{ .GetApiserverExternalNodePortOrGetFree }}
+      port: {{ default 443 .GetApiserverExternalNodePort }}
+      nodePort: {{ .GetApiserverExternalNodePort }}
       protocol: TCP
+      targetPort: {{ default 443 .GetApiserverExternalNodePort }}
   selector:
     role: apiserver


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of self allocating a NodePort, we'll let kubernetes allocate one for us.

How it works:
- Create a service of type NodePort. Let it point to port 443
- Update service to adjust Port -> NodePort

This fixes environments which do not use the default 30000 NodePort range.

**Release note**:
```release-note
Kubernetes can now automatically allocate a nodeport if the default nodeport range is unavailable
```