### PR TITLE
update nodeport proxy version

### DIFF
--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -1,5 +1,5 @@
 nodePortPoxy:
   image:
     repository: "kubermatic/nodeport-proxy"
-    tag: "v1.0"
+    tag: "v1.1"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The old version could not handle changes of the target port. This one can.

**Release note**:
```release-note
Updated nodeport-proxy to `v1.1`
```