### PR TITLE
fix duplicate user creation

### DIFF
--- a/api/pkg/provider/kubernetes/user.go
+++ b/api/pkg/provider/kubernetes/user.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
-
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -34,11 +32,7 @@ type UserProvider struct {
 
 // UserByEmail returns a user by the given email
 func (p *UserProvider) UserByEmail(email string) (*kubermaticv1.User, error) {
-	selector, err := labels.Parse(fmt.Sprintf("%s=%s", userEmailLabelKey, kubernetes.ToLabelValue(email)))
-	if err != nil {
-		return nil, err
-	}
-
+	selector := labels.SelectorFromSet(map[string]string{userEmailLabelKey: kubernetes.ToLabelValue(email)})
 	users, err := p.userLister.List(selector)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
As base64 enoded strings have a high potential to container `=` characters, we need to create a selector from set to prevent broken selectors.

**Release note**:
```release-note bugfix
Fixed an issue with duplicate users being sometimes created
```