### PR TITLE
Increase scrape interval and timeout for kube-state-metrics

### DIFF
--- a/config/monitoring/kube-state-metrics/templates/service-monitor.yaml
+++ b/config/monitoring/kube-state-metrics/templates/service-monitor.yaml
@@ -15,14 +15,16 @@ spec:
   endpoints:
   - port: https-main
     scheme: https
-    interval: 30s
+    interval: 1m
+    scrapeTimeout: 30
     honorLabels: true
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       insecureSkipVerify: true
   - port: https-self
     scheme: https
-    interval: 30s
+    interval: 1m
+    scrapeTimeout: 30
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       insecureSkipVerify: true


### PR DESCRIPTION
With an increase workload on the cluster we have more objects returned by the apiserver that need to be converted to metrics by kube-state-metrics.
This takes some times and sometimes doesn't finish within 10s.

**Release note**:
```release-note
NONE
```