### PR TITLE
add tags to openstack machines

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3124,6 +3124,14 @@
           "description": "image to use",
           "type": "string",
           "x-go-name": "Image"
+        },
+        "tags": {
+          "description": "Additional metadata to set",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Tags"
         }
       },
       "x-go-name": "OpenstackNodeSpec",

--- a/api/pkg/api/v2/node.go
+++ b/api/pkg/api/v2/node.go
@@ -111,6 +111,9 @@ type OpenstackNodeSpec struct {
 	// image to use
 	// required: true
 	Image string `json:"image"`
+	// Additional metadata to set
+	// required: false
+	Tags map[string]string `json:"tags"`
 }
 
 // AWSNodeSpec aws specific node settings

--- a/api/pkg/api/v2/node.go
+++ b/api/pkg/api/v2/node.go
@@ -113,7 +113,7 @@ type OpenstackNodeSpec struct {
 	Image string `json:"image"`
 	// Additional metadata to set
 	// required: false
-	Tags map[string]string `json:"tags"`
+	Tags map[string]string `json:"tags,omitempty"`
 }
 
 // AWSNodeSpec aws specific node settings

--- a/api/pkg/machine/convert.go
+++ b/api/pkg/machine/convert.go
@@ -89,6 +89,7 @@ func GetAPIV2NodeCloudSpec(machine *v1alpha1.Machine) (*apiv2.NodeCloudSpec, err
 		cloudSpec.Openstack = &apiv2.OpenstackNodeSpec{
 			Flavor: config.Flavor.Value,
 			Image:  config.Image.Value,
+			Tags:   config.Tags,
 		}
 	} else if decodedProviderConfig.CloudProvider == providerconfig.CloudProviderHetzner {
 		config := &hetzner.RawConfig{}

--- a/api/pkg/resources/fixtures/machine-openstack.yaml
+++ b/api/pkg/resources/fixtures/machine-openstack.yaml
@@ -18,6 +18,9 @@ spec:
       region: os-region
       securityGroups:
       - os-security-groups
+      tags:
+        foo: bar
+        kubermatic-cluster: openstackcluster-1a2b3c4d5e
     operatingSystem: ubuntu
     operatingSystemSpec:
       distUpgradeOnBoot: false

--- a/api/pkg/resources/load_files_test.go
+++ b/api/pkg/resources/load_files_test.go
@@ -561,6 +561,9 @@ func TestExecute(t *testing.T) {
 							Openstack: &apiv2.OpenstackNodeSpec{
 								Flavor: "os-flavor",
 								Image:  "os-image",
+								Tags: map[string]string{
+									"foo": "bar",
+								},
 							},
 						},
 						OperatingSystem: apiv2.OperatingSystemSpec{

--- a/config/kubermatic/static/master/machine.yaml
+++ b/config/kubermatic/static/master/machine.yaml
@@ -40,6 +40,11 @@ spec:
       floatingIpPool: {{ .Cluster.Spec.Cloud.Openstack.FloatingIPPool | quote }}
       availabilityZone: {{ .Datacenter.Spec.Openstack.AvailabilityZone | quote }}
       network: {{ .Cluster.Spec.Cloud.Openstack.Network | quote }}
+      tags:
+        "kubermatic-cluster": {{ .Cluster.Name }}
+        {{- range $key, $value := .Node.Spec.Cloud.Openstack.Tags }}
+        {{$key | quote }}: {{$value | quote }}
+        {{- end }}
     {{- end }}
     {{- if .Node.Spec.Cloud.Digitalocean }}
     cloudProvider: digitalocean


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows setting additional instance tags for Openstack nodes.
Additional a dedicated `kubermatic-cluster` tag will always be added to simplify matching instances on Openstack and kubermatic clusters

Fixes #970

**Release note**:
```release-note
NONE
```