### PR TITLE
Create etcd.rules for alerting on etcd metrics

### DIFF
--- a/config/monitoring/prometheus/rules/etcd.yaml
+++ b/config/monitoring/prometheus/rules/etcd.yaml
@@ -1,0 +1,82 @@
+groups:
+- name: etcd.rules
+  rules:
+  - alert: EtcdInsufficientMembers
+    expr: count(up{job="etcd-cluster"} == 0) > (count(up{job="etcd-cluster"}) by (namespace) / 2 - 1)
+    for: 3m
+    labels:
+      severity: critical
+    annotations:
+      description: If one more etcd member goes down {{ $labels.namespace }} will be unavailable
+      summary: etcd cluster insufficient members
+  - alert: EtcdNoLeader
+    expr: etcd_server_has_leader{job="etcd-cluster"} == 0
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      description: etcd cluster {{ $labels.namespace }} has no leader
+      summary: etcd member has no leader
+  - alert: HighNumberOfLeaderChanges
+    expr: increase(etcd_server_leader_changes_seen_total{job="etcd-cluster"}[1h]) > 5
+    labels:
+      severity: warning
+    annotations:
+      description: etcd in namespace {{ $labels.namespace }} has seen {{ $value }} leader changes within the last hour
+      summary: a high number of leader changes within the etcd cluster are happening
+  # TODO: Move alerting to namespace prometheus as we don't federate grpc_.* metrics.
+  # - alert: HighNumberOfFailedGRPCRequests
+  #   expr: 100 * (sum(rate(grpc_server_handled_total{grpc_code!="OK",job="etcd-cluster"}[5m])) BY (grpc_service, grpc_method) / sum(rate(grpc_server_handled_total{job="etcd-cluster"}[5m])) BY (grpc_service, grpc_method)) > 1
+  #   for: 10m
+  #   labels:
+  #     severity: warning
+  #   annotations:
+  #     description: '{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}'
+  #     summary: a high number of gRPC requests are failing
+  # - alert: HighNumberOfFailedGRPCRequests
+  #   expr: 100 * (sum(rate(grpc_server_handled_total{grpc_code!="OK",job="etcd-cluster"}[5m])) BY (grpc_service, grpc_method) / sum(rate(grpc_server_handled_total{job="etcd-cluster"}[5m])) BY (grpc_service, grpc_method)) > 5
+  #   for: 5m
+  #   labels:
+  #     severity: critical
+  #   annotations:
+  #     description: '{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}'
+  #     summary: a high number of gRPC requests are failing
+  # - alert: GRPCRequestsSlow
+  #   expr: histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd",grpc_type="unary"}[5m])) by (grpc_service, grpc_method, le)) > 0.15
+  #   for: 10m
+  #   labels:
+  #     severity: critical
+  #   annotations:
+  #     description: on etcd instance {{ $labels.instance }} gRPC requests to {{ $labels.grpc_method }} are slow
+  #     summary: slow gRPC requests
+  - alert: EtcdMemberCommunicationSlow
+    expr:  histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket[5m])) by (namespace, le)) > 0.15
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: etcd in namespace {{ $labels.namespace }} member communication is slow
+      summary: etcd member communication is slow
+  - alert: HighNumberOfFailedProposals
+    expr: increase(etcd_server_proposals_failed_total{job="etcd-cluster"}[1h]) > 5
+    labels:
+      severity: warning
+    annotations:
+      description: etcd in namespace {{ $labels.namespace }} has seen {{ $value }} proposal failures within the last hour
+      summary: a high number of proposals within the etcd cluster are failing
+  - alert: HighFsyncDurations
+    expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: etcd in namespace {{ $labels.namespace }} fync durations are high
+      summary: high fsync durations
+  - alert: HighCommitDurations
+    expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.25
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: etcd in namespace {{ $labels.namespace }} commit durations are high
+      summary: high commit durations


### PR DESCRIPTION
This is rather a quick work around than a proper setup.
In the future I want to alert on etcd from within the namespace, but for now we federate all etcd metrics one level up to the kubermatic prometheus.
Thus a few alerts don't work as we don't federate `grpc_.*`.

So we should rather work on alerting in the namespace then federate even more metrics.

**Release note**:
```release-note
NONE
```