### PR TITLE
add minreadyseconds to apiserver deployment

### DIFF
--- a/api/pkg/resources/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/api/pkg/resources/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/api/pkg/resources/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/api/pkg/resources/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/api/pkg/resources/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/api/pkg/resources/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/api/pkg/resources/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/api/pkg/resources/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -11,6 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  minReadySeconds: 10
   replicas: 1
   selector:
     matchLabels:

--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -20,6 +20,7 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+  minReadySeconds: 10
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add minreadyseconds to apiserver deployment.

**Release note**:
```release-note
NONE
```