### PR TITLE
only accept ipv4 addresses when choosing the advertise address

### DIFF
--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -251,7 +251,9 @@ func (cc *Controller) ensureAddress(c *kubermaticv1.Cluster) error {
 	}
 	ipList := sets.NewString()
 	for _, ip := range resolvedIPs {
-		ipList.Insert(ip.String())
+		if ip.To4() != nil {
+			ipList.Insert(ip.String())
+		}
 	}
 	ips := ipList.List()
 	sort.Strings(ips)


### PR DESCRIPTION
**What this PR does / why we need it**:
On some systems we get a ipv4 and ipv6 address when doing the lookup.
But kubernetes is not yet ipv6 compatible, therefore we need to only accept ipv4 addresses.

**Release note**:
```release-note bugfix
Cluster IPv6 addresses will be ignored on systems on which they are available
```