### PR TITLE
Increase pod restarts alert to 10 per hour

### DIFF
--- a/config/monitoring/prometheus/rules/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/kube-state-metrics.yaml
@@ -42,7 +42,7 @@ groups:
       summary: "Daemonsets are not scheduled correctly"
       description: "A number of daemonsets are running where they are not supposed to run."
   - alert: KubernetesPodFrequentlyRestarting
-    expr: increase(kube_pod_container_status_restarts_total[1h]) > 5
+    expr: increase(kube_pod_container_status_restarts_total[1h]) > 10
     for: 10m
     labels:
       severity: warning


### PR DESCRIPTION
**What this PR does / why we need it**:
I don't think it's that bad when things restart 5 times every hour.
To reduce some noise I want to increase the number to 10. Most of our alerts are for pods restart 5 - 7 times an hour.
