### PR TITLE
Fix apiserver openvpn connection

### DIFF
--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn
+        - openvpn-server
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn
+        - openvpn-server
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn
+        - openvpn-server
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn
+        - openvpn-server
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn
+        - openvpn-server
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn
+        - openvpn-server
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn
+        - openvpn-server
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn
+        - openvpn-server
         - "1194"
         - --nobind
         - --connect-timeout

--- a/config/kubermatic/static/master/apiserver-dep.yaml
+++ b/config/kubermatic/static/master/apiserver-dep.yaml
@@ -52,7 +52,7 @@ spec:
           "--proto", "tcp",
           "--dev", "tun",
           "--auth-nocache",
-          "--remote", "openvpn", "1194",
+          "--remote", "openvpn-server", "1194",
           "--nobind",
           "--connect-timeout", "5",
           "--connect-retry", "1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes all new apiservers coming up. The apiserver deployments points to a wrong service

**Release note**:
```release-note
NONE
```