### PR TITLE
Allow Prometheus Operator to watch Namespaces via ClusterRole

### DIFF
--- a/config/monitoring/prometheus-operator/templates/clusterrole.yaml
+++ b/config/monitoring/prometheus-operator/templates/clusterrole.yaml
@@ -49,4 +49,4 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
-  verbs: ["list"]
+  verbs: ["list","watch"]


### PR DESCRIPTION
**What this PR does / why we need it**:
While looking at the logs of the Prometheus Operator in the last days I could see this log line happening a lot:
```
E0513 13:07:34.592619       1 reflector.go:322] github.com/coreos/prometheus-operator/pkg/prometheus/operator.go:300: Failed to watch *v1.Namespace: unknown (get namespaces)
```
Today I looked at all notifications on GitHub for the Prometheus Operator and found this issue which exactly describes our problem:
https://github.com/coreos/prometheus-operator/issues/1324

We simply need to allow the Prometheus Operator to not only list but also watch namespaces.

**Release note**:
```release-note
NONE
```