### PR TITLE
update dex & set replicas to 1 due to key loading/refreshing issues

### DIFF
--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -2,8 +2,8 @@
 dex:
   image:
     repository: "quay.io/coreos/dex"
-    tag: "v2.9.0"
-  replicas: 3
+    tag: "v2.10.0"
+  replicas: 1
   ingress:
     host: ""
     path: "/dex"


### PR DESCRIPTION
**What this PR does / why we need it**:
We encountered issues on Sys11 where the refreshing of the keys only worked on one of the 3 replicas therefore the change.

**Release note**:
```release-note
Updated dex to `v2.10.0`
```