### PR TITLE
Move Prometheus annotations on etcd statefulset to pod level

### DIFF
--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -36,11 +36,6 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 
 	set.Name = resources.EtcdStatefulSetName
 	set.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	set.Annotations = map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/path":   "/metrics",
-		"prometheus.io/port":   "2379",
-	}
 
 	set.Spec.Replicas = resources.Int32(3)
 	set.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
@@ -58,6 +53,11 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 		Labels: map[string]string{
 			resources.AppLabelKey: name,
 			"cluster":             data.Cluster.Name,
+		},
+		Annotations: map[string]string{
+			"prometheus.io/scrape": "true",
+			"prometheus.io/path":   "/metrics",
+			"prometheus.io/port":   "2379",
 		},
 	}
 


### PR DESCRIPTION
I think on this level the annotations should be added to the pods. That's where we need them to find those pod via Prometheus' ServiceDiscovery.

**Release note**:
```release-note
NONE
```