### PR TITLE
Cluster Prometheus uses app name as job label

### DIFF
--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -51,7 +51,7 @@ global:
 rule_files:
 - "/etc/prometheus/config/rules.yaml"
 scrape_configs:
-- job_name: 'pods-0'
+- job_name: 'pods'
   kubernetes_sd_configs:
   - role: pod
     namespaces:
@@ -73,16 +73,14 @@ scrape_configs:
     target_label: __address__
   - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
     action: replace
-    target_label: role
-  - source_labels: [__meta_kubernetes_pod_label_release]
-    action: replace
-    target_label: release
+    target_label: job
+    separator: ''
   - source_labels: [__meta_kubernetes_namespace]
     action: replace
-    target_label: kubernetes_namespace
+    target_label: namespace
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
-    target_label: kubernetes_pod_name
+    target_label: pod
 alerting:
   alertmanagers: []
 `

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-prometheus.yaml
@@ -9,7 +9,7 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
-    - job_name: 'pods-0'
+    - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -31,16 +31,14 @@ data:
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
         action: replace
-        target_label: role
-      - source_labels: [__meta_kubernetes_pod_label_release]
-        action: replace
-        target_label: release
+        target_label: job
+        separator: ''
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
     alerting:
       alertmanagers: []
   rules.yaml: ""

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-prometheus.yaml
@@ -9,7 +9,7 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
-    - job_name: 'pods-0'
+    - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -31,16 +31,14 @@ data:
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
         action: replace
-        target_label: role
-      - source_labels: [__meta_kubernetes_pod_label_release]
-        action: replace
-        target_label: release
+        target_label: job
+        separator: ''
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
     alerting:
       alertmanagers: []
   rules.yaml: ""

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-prometheus.yaml
@@ -9,7 +9,7 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
-    - job_name: 'pods-0'
+    - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -31,16 +31,14 @@ data:
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
         action: replace
-        target_label: role
-      - source_labels: [__meta_kubernetes_pod_label_release]
-        action: replace
-        target_label: release
+        target_label: job
+        separator: ''
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
     alerting:
       alertmanagers: []
   rules.yaml: ""

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-prometheus.yaml
@@ -9,7 +9,7 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
-    - job_name: 'pods-0'
+    - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -31,16 +31,14 @@ data:
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
         action: replace
-        target_label: role
-      - source_labels: [__meta_kubernetes_pod_label_release]
-        action: replace
-        target_label: release
+        target_label: job
+        separator: ''
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
     alerting:
       alertmanagers: []
   rules.yaml: ""

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-prometheus.yaml
@@ -9,7 +9,7 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
-    - job_name: 'pods-0'
+    - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -31,16 +31,14 @@ data:
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
         action: replace
-        target_label: role
-      - source_labels: [__meta_kubernetes_pod_label_release]
-        action: replace
-        target_label: release
+        target_label: job
+        separator: ''
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
     alerting:
       alertmanagers: []
   rules.yaml: ""

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-prometheus.yaml
@@ -9,7 +9,7 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
-    - job_name: 'pods-0'
+    - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -31,16 +31,14 @@ data:
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
         action: replace
-        target_label: role
-      - source_labels: [__meta_kubernetes_pod_label_release]
-        action: replace
-        target_label: release
+        target_label: job
+        separator: ''
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
     alerting:
       alertmanagers: []
   rules.yaml: ""

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-prometheus.yaml
@@ -9,7 +9,7 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
-    - job_name: 'pods-0'
+    - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -31,16 +31,14 @@ data:
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
         action: replace
-        target_label: role
-      - source_labels: [__meta_kubernetes_pod_label_release]
-        action: replace
-        target_label: release
+        target_label: job
+        separator: ''
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
     alerting:
       alertmanagers: []
   rules.yaml: ""

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-prometheus.yaml
@@ -9,7 +9,7 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
-    - job_name: 'pods-0'
+    - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -31,16 +31,14 @@ data:
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
         action: replace
-        target_label: role
-      - source_labels: [__meta_kubernetes_pod_label_release]
-        action: replace
-        target_label: release
+        target_label: job
+        separator: ''
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
     alerting:
       alertmanagers: []
   rules.yaml: ""


### PR DESCRIPTION
Using the app names as job labels makes for a more Prometheus canonical experience, as the targets are then separated again.

![screenshot from 2018-05-17 18-54-07](https://user-images.githubusercontent.com/872251/40192110-b8562020-5a03-11e8-86b2-c4157f2b7df0.png)

**Release note**:
```release-note
NONE
```