### PR TITLE
handle not existing claims

### DIFF
--- a/api/pkg/handler/authentication.go
+++ b/api/pkg/handler/authentication.go
@@ -84,10 +84,21 @@ func (o openIDAuthenticator) Verifier() endpoint.Middleware {
 				return nil, errors.NewNotAuthorized()
 			}
 
+			var (
+				name  string
+				email string
+			)
+			if cn, found := claims["name"]; found {
+				name = cn.(string)
+			}
+			if ce, found := claims["email"]; found {
+				email = ce.(string)
+			}
+
 			user := apiv1.User{
 				ID:    claims["sub"].(string),
-				Name:  claims["name"].(string),
-				Email: claims["email"].(string),
+				Name:  name,
+				Email: email,
 				Roles: map[string]struct{}{},
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We cannot expect the name or email to always be included in the claims of a openid-connect token.
If one is missing we otherwise hit a nil-pointer exception.

**Release note**:
```release-note
NONE
```