### PR TITLE
add timeout to token verifier

### DIFF
--- a/api/pkg/handler/authentication.go
+++ b/api/pkg/handler/authentication.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -46,9 +47,20 @@ type openIDAuthenticator struct {
 func NewOpenIDAuthenticator(issuer, clientID string, extractor TokenExtractor, insecureSkipVerify bool) (Authenticator, error) {
 	ctx := context.Background()
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: insecureSkipVerify},
 	}
 	client := &http.Client{Transport: tr}
+
 	p, err := oidc.NewProvider(context.WithValue(ctx, oauth2.HTTPClient, client), issuer)
 	if err != nil {
 		return nil, err

--- a/api/pkg/handler/authentication.go
+++ b/api/pkg/handler/authentication.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-oidc"
 	"github.com/go-kit/kit/endpoint"
@@ -70,7 +71,9 @@ func (o openIDAuthenticator) Verifier() endpoint.Middleware {
 				return nil, errors.NewNotAuthorized()
 			}
 
-			idToken, err := o.verifier.Verify(ctx, token)
+			verifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			idToken, err := o.verifier.Verify(verifyCtx, token)
 			if err != nil {
 				glog.Error(err)
 				return nil, errors.NewNotAuthorized()


### PR DESCRIPTION
**What this PR does / why we need it**:
add timeout to token verifier. As the verification does a mutex-lock it will never get unlocked when we have a hanging request.

**Release note**:
```release-note
NONE
```