### PR TITLE
make nodeport range configurable

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1128,6 +1128,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f341a952637d84e047bac3001a0723d417c71de5e9972d44656c0e41a8f79acc"
+  inputs-digest = "71bb3df74a576b8cbe3b5d9974e7e66567dedad74c5517398f5837b43a93357e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -82,6 +82,8 @@ func startClusterController(ctrlCtx controllerContext) error {
 		cps,
 		clusterMetrics,
 		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
+		ctrlCtx.runOptions.overwriteRegistry,
+		ctrlCtx.runOptions.nodePortRange,
 
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		ctrlCtx.kubeInformerFactory.Core().V1().Namespaces(),
@@ -96,8 +98,6 @@ func startClusterController(ctrlCtx controllerContext) error {
 		ctrlCtx.kubeInformerFactory.Rbac().V1().Roles(),
 		ctrlCtx.kubeInformerFactory.Rbac().V1().RoleBindings(),
 		ctrlCtx.kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
-
-		ctrlCtx.runOptions.overwriteRegistry,
 	)
 	if err != nil {
 		return err

--- a/api/pkg/controller/cluster/controller.go
+++ b/api/pkg/controller/cluster/controller.go
@@ -70,6 +70,8 @@ type Controller struct {
 	updates               []apiv1.MasterUpdate
 	defaultMasterVersion  *apiv1.MasterVersion
 	automaticUpdateSearch *version.UpdatePathSearch
+	overwriteRegistry     string
+	nodePortRange         string
 
 	metrics ControllerMetrics
 
@@ -99,8 +101,6 @@ type Controller struct {
 	roleBindingSynced        cache.InformerSynced
 	clusterRoleBindingLister rbacb1lister.ClusterRoleBindingLister
 	clusterRoleBindingSynced cache.InformerSynced
-
-	overwriteRegistry string
 }
 
 // ControllerMetrics contains metrics about the clusters & workers
@@ -125,6 +125,8 @@ func NewController(
 	cps map[string]provider.CloudProvider,
 	metrics ControllerMetrics,
 	userClusterConnProvider UserClusterConnectionProvider,
+	overwriteRegistry string,
+	nodePortRange string,
 
 	clusterInformer kubermaticv1informers.ClusterInformer,
 	namespaceInformer corev1informers.NamespaceInformer,
@@ -138,9 +140,7 @@ func NewController(
 	ingressInformer extensionsv1beta1informers.IngressInformer,
 	roleInformer rbacv1informer.RoleInformer,
 	roleBindingInformer rbacv1informer.RoleBindingInformer,
-	clusterRoleBindingInformer rbacv1informer.ClusterRoleBindingInformer,
-
-	OverwriteRegistry string) (*Controller, error) {
+	clusterRoleBindingInformer rbacv1informer.ClusterRoleBindingInformer) (*Controller, error) {
 	cc := &Controller{
 		kubermaticClient:        kubermaticClient,
 		kubeClient:              kubeClient,
@@ -148,8 +148,10 @@ func NewController(
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cluster"),
 
-		updates:  updates,
-		versions: versions,
+		updates:           updates,
+		versions:          versions,
+		overwriteRegistry: overwriteRegistry,
+		nodePortRange:     nodePortRange,
 
 		masterResourcesPath: masterResourcesPath,
 		externalURL:         externalURL,
@@ -158,8 +160,6 @@ func NewController(
 		dcs:                 dcs,
 		cps:                 cps,
 		metrics:             metrics,
-
-		overwriteRegistry: OverwriteRegistry,
 	}
 
 	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/api/pkg/controller/cluster/controller_test.go
+++ b/api/pkg/controller/cluster/controller_test.go
@@ -48,6 +48,8 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		cps,
 		ControllerMetrics{},
 		client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
+		"",
+		"",
 
 		kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		kubeInformerFactory.Core().V1().Namespaces(),
@@ -62,8 +64,6 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		kubeInformerFactory.Rbac().V1().Roles(),
 		kubeInformerFactory.Rbac().V1().RoleBindings(),
 		kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
-
-		"",
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -181,6 +181,7 @@ func (cc *Controller) getClusterTemplateData(c *kubermaticv1.Cluster) (*resource
 		cc.configMapLister,
 		cc.serviceLister,
 		cc.overwriteRegistry,
+		cc.nodePortRange,
 	), nil
 }
 

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -25,6 +25,8 @@ var (
 
 const (
 	name = "apiserver"
+
+	defaultNodePortRange = "30000-32767"
 )
 
 // Deployment returns the kubernetes Apiserver Deployment
@@ -239,6 +241,11 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 }
 
 func getApiserverFlags(data *resources.TemplateData, externalNodePort int32) []string {
+	nodePortRange := data.NodePortRange
+	if nodePortRange == "" {
+		nodePortRange = defaultNodePortRange
+	}
+
 	flags := []string{
 		"--advertise-address", data.Cluster.Address.IP,
 		"--secure-port", fmt.Sprintf("%d", externalNodePort),
@@ -254,7 +261,7 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32) []s
 		"--enable-bootstrap-token-auth", "true",
 		"--service-account-key-file", "/etc/kubernetes/service-account-key/sa.key",
 		"--service-cluster-ip-range", "10.10.10.0/24",
-		"--service-node-port-range", "30000-32767",
+		"--service-node-port-range", nodePortRange,
 		"--allow-privileged",
 		"--audit-log-maxage", "30",
 		"--audit-log-maxbackup", "3",

--- a/api/pkg/resources/load_files.go
+++ b/api/pkg/resources/load_files.go
@@ -130,6 +130,7 @@ type TemplateData struct {
 	ConfigMapLister   corev1lister.ConfigMapLister
 	ServiceLister     corev1lister.ServiceLister
 	OverwriteRegistry string
+	NodePortRange     string
 }
 
 // GetClusterRef returns a instance of a OwnerReference for the Cluster in the TemplateData
@@ -166,7 +167,8 @@ func NewTemplateData(
 	secretLister corev1lister.SecretLister,
 	configMapLister corev1lister.ConfigMapLister,
 	serviceLister corev1lister.ServiceLister,
-	overwriteRegistry string) *TemplateData {
+	overwriteRegistry string,
+	nodePortRange string) *TemplateData {
 	return &TemplateData{
 		Cluster:           cluster,
 		DC:                dc,
@@ -175,6 +177,7 @@ func NewTemplateData(
 		SecretLister:      secretLister,
 		ServiceLister:     serviceLister,
 		OverwriteRegistry: overwriteRegistry,
+		NodePortRange:     nodePortRange,
 	}
 }
 

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -268,7 +268,7 @@ func TestLoadFiles(t *testing.T) {
 				}()
 
 				kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 10*time.Millisecond)
-				data := resources.NewTemplateData(cluster, version, &dc, kubeInformerFactory.Core().V1().Secrets().Lister(), kubeInformerFactory.Core().V1().ConfigMaps().Lister(), kubeInformerFactory.Core().V1().Services().Lister(), "")
+				data := resources.NewTemplateData(cluster, version, &dc, kubeInformerFactory.Core().V1().Secrets().Lister(), kubeInformerFactory.Core().V1().ConfigMaps().Lister(), kubeInformerFactory.Core().V1().Services().Lister(), "", "")
 				kubeInformerFactory.Start(wait.NeverStop)
 				kubeInformerFactory.WaitForCacheSync(wait.NeverStop)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make nodeport range for user clusters configurable via controller flag.
Needed on systems where the seed-cluster has a different range than default.

**Release note**:
```release-note
Nodeport range is now configurable
```