### PR TITLE
Cherry pick nodeport range flag

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1127,6 +1127,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c3b35c6541d2b0781a269cd25a0101b299aa0676f85e12494167052dfbb4ed8c"
+  inputs-digest = "25dce71ef436ab6ddeba62807c57590914ba0d9a9871d64ab433489238ba2cdb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -82,6 +82,8 @@ func startClusterController(ctrlCtx controllerContext) error {
 		cps,
 		clusterMetrics,
 		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
+		ctrlCtx.runOptions.overwriteRegistry,
+		ctrlCtx.runOptions.nodePortRange,
 
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		ctrlCtx.kubermaticInformerFactory.Etcd().V1beta2().EtcdClusters(),
@@ -97,8 +99,6 @@ func startClusterController(ctrlCtx controllerContext) error {
 		ctrlCtx.kubeInformerFactory.Rbac().V1().Roles(),
 		ctrlCtx.kubeInformerFactory.Rbac().V1().RoleBindings(),
 		ctrlCtx.kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
-
-		ctrlCtx.runOptions.overwriteRegistry,
 	)
 	if err != nil {
 		return err

--- a/api/pkg/controller/cluster/controller.go
+++ b/api/pkg/controller/cluster/controller.go
@@ -72,6 +72,8 @@ type Controller struct {
 	updates               []apiv1.MasterUpdate
 	defaultMasterVersion  *apiv1.MasterVersion
 	automaticUpdateSearch *version.UpdatePathSearch
+	overwriteRegistry     string
+	nodePortRange         string
 
 	metrics ControllerMetrics
 
@@ -103,8 +105,6 @@ type Controller struct {
 	roleBindingSynced        cache.InformerSynced
 	clusterRoleBindingLister rbacb1lister.ClusterRoleBindingLister
 	clusterRoleBindingSynced cache.InformerSynced
-
-	overwriteRegistry string
 }
 
 // ControllerMetrics contains metrics about the clusters & workers
@@ -129,6 +129,8 @@ func NewController(
 	cps map[string]provider.CloudProvider,
 	metrics ControllerMetrics,
 	userClusterConnProvider UserClusterConnectionProvider,
+	overwriteRegistry string,
+	nodePortRange string,
 
 	clusterInformer kubermaticv1informers.ClusterInformer,
 	etcdClusterInformer etcdoperatorv1beta2informers.EtcdClusterInformer,
@@ -143,9 +145,7 @@ func NewController(
 	ingressInformer extensionsv1beta1informers.IngressInformer,
 	roleInformer rbacv1informer.RoleInformer,
 	roleBindingInformer rbacv1informer.RoleBindingInformer,
-	clusterRoleBindingInformer rbacv1informer.ClusterRoleBindingInformer,
-
-	OverwriteRegistry string) (*Controller, error) {
+	clusterRoleBindingInformer rbacv1informer.ClusterRoleBindingInformer) (*Controller, error) {
 	cc := &Controller{
 		kubermaticClient:        kubermaticClient,
 		kubeClient:              kubeClient,
@@ -153,8 +153,10 @@ func NewController(
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cluster"),
 
-		updates:  updates,
-		versions: versions,
+		updates:           updates,
+		versions:          versions,
+		overwriteRegistry: overwriteRegistry,
+		nodePortRange:     nodePortRange,
 
 		masterResourcesPath: masterResourcesPath,
 		externalURL:         externalURL,
@@ -163,8 +165,6 @@ func NewController(
 		dcs:                 dcs,
 		cps:                 cps,
 		metrics:             metrics,
-
-		overwriteRegistry: OverwriteRegistry,
 	}
 
 	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/api/pkg/controller/cluster/controller_test.go
+++ b/api/pkg/controller/cluster/controller_test.go
@@ -48,6 +48,8 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		cps,
 		ControllerMetrics{},
 		client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
+		"",
+		"",
 
 		kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		kubermaticInformerFactory.Etcd().V1beta2().EtcdClusters(),
@@ -63,8 +65,6 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		kubeInformerFactory.Rbac().V1().Roles(),
 		kubeInformerFactory.Rbac().V1().RoleBindings(),
 		kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
-
-		"",
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -181,6 +181,7 @@ func (cc *Controller) getClusterTemplateData(c *kubermaticv1.Cluster) (*resource
 		cc.configMapLister,
 		cc.serviceLister,
 		cc.overwriteRegistry,
+		cc.nodePortRange,
 	), nil
 }
 

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -25,6 +25,8 @@ var (
 
 const (
 	name = "apiserver"
+
+	defaultNodePortRange = "30000-32767"
 )
 
 // Deployment returns the kubernetes Apiserver Deployment
@@ -239,6 +241,11 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 }
 
 func getApiserverFlags(data *resources.TemplateData, externalNodePort int32) []string {
+	nodePortRange := data.NodePortRange
+	if nodePortRange == "" {
+		nodePortRange = defaultNodePortRange
+	}
+
 	flags := []string{
 		"--advertise-address", data.Cluster.Address.IP,
 		"--secure-port", fmt.Sprintf("%d", externalNodePort),
@@ -254,7 +261,7 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32) []s
 		"--enable-bootstrap-token-auth", "true",
 		"--service-account-key-file", "/etc/kubernetes/service-account-key/sa.key",
 		"--service-cluster-ip-range", "10.10.10.0/24",
-		"--service-node-port-range", "30000-32767",
+		"--service-node-port-range", nodePortRange,
 		"--allow-privileged",
 		"--audit-log-maxage", "30",
 		"--audit-log-maxbackup", "3",

--- a/api/pkg/resources/load_files.go
+++ b/api/pkg/resources/load_files.go
@@ -131,6 +131,7 @@ type TemplateData struct {
 	ConfigMapLister   corev1lister.ConfigMapLister
 	ServiceLister     corev1lister.ServiceLister
 	OverwriteRegistry string
+	NodePortRange     string
 }
 
 // GetClusterRef returns a instance of a OwnerReference for the Cluster in the TemplateData
@@ -162,7 +163,8 @@ func NewTemplateData(
 	secretLister corev1lister.SecretLister,
 	configMapLister corev1lister.ConfigMapLister,
 	serviceLister corev1lister.ServiceLister,
-	overwriteRegistry string) *TemplateData {
+	overwriteRegistry string,
+	nodePortRange string) *TemplateData {
 	return &TemplateData{
 		Cluster:           cluster,
 		DC:                dc,
@@ -171,6 +173,7 @@ func NewTemplateData(
 		SecretLister:      secretLister,
 		ServiceLister:     serviceLister,
 		OverwriteRegistry: overwriteRegistry,
+		NodePortRange:     nodePortRange,
 	}
 }
 

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -269,7 +269,7 @@ func TestLoadFiles(t *testing.T) {
 				}()
 
 				kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, 10*time.Millisecond)
-				data := resources.NewTemplateData(cluster, version, &dc, kubeInformerFactory.Core().V1().Secrets().Lister(), kubeInformerFactory.Core().V1().ConfigMaps().Lister(), kubeInformerFactory.Core().V1().Services().Lister(), "")
+				data := resources.NewTemplateData(cluster, version, &dc, kubeInformerFactory.Core().V1().Secrets().Lister(), kubeInformerFactory.Core().V1().ConfigMaps().Lister(), kubeInformerFactory.Core().V1().Services().Lister(), "", "")
 				kubeInformerFactory.Start(wait.NeverStop)
 				kubeInformerFactory.WaitForCacheSync(wait.NeverStop)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick https://github.com/kubermatic/kubermatic/pull/1084 into v2.5
It enables to run kubermatic on seed-clusters with a non-default nodeport range