### PR TITLE
use hostname as preferred addresses in byo environments

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -272,7 +272,6 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32) []s
 		"--client-ca-file", "/etc/kubernetes/ca-cert/ca.crt",
 		"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
 		"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",
-		"--kubelet-preferred-address-types", "ExternalIP,InternalIP",
 		"--v", "4",
 	}
 	if data.Cluster.Spec.Cloud.AWS != nil {
@@ -282,6 +281,12 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32) []s
 	if data.Cluster.Spec.Cloud.Openstack != nil {
 		flags = append(flags, "--cloud-provider", "openstack")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
+	}
+
+	if data.Cluster.Spec.Cloud.BringYourOwn != nil {
+		flags = append(flags, "--kubelet-preferred-address-types", "Hostname,InternalIP,ExternalIP")
+	} else {
+		flags = append(flags, "--kubelet-preferred-address-types", "ExternalIP,InternalIP")
 	}
 	return flags
 }

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -147,14 +147,14 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
         - --v
         - "4"
         - --cloud-provider
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -147,14 +147,14 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
         - --v
         - "4"
         - --cloud-provider
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -147,10 +147,10 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
         - --v
         - "4"
+        - --kubelet-preferred-address-types
+        - Hostname,InternalIP,ExternalIP
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -147,10 +147,10 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
         - --v
         - "4"
+        - --kubelet-preferred-address-types
+        - Hostname,InternalIP,ExternalIP
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -147,10 +147,10 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
         - --v
         - "4"
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -147,10 +147,10 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
         - --v
         - "4"
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -147,14 +147,14 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
         - --v
         - "4"
         - --cloud-provider
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -147,14 +147,14 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
         - --v
         - "4"
         - --cloud-provider
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
         command:
         - /hyperkube
         - apiserver


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes Arvato BYO issues (`kubectl logs | exec`) as they use nat.
Only a temporary solution until we managed to route apiserver-> kubelet traffic over the vpn

**Release note**:
```release-note
NONE
```