### PR TITLE
skipping project not assigned to the controller manager

### DIFF
--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -114,6 +114,7 @@ func startRBACGeneratorController(ctrlCtx controllerContext) error {
 	}
 	ctrl, err := rbacController.New(
 		rbacMetrics,
+		ctrlCtx.runOptions.workerName,
 		ctrlCtx.kubermaticClient,
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Projects(),
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Users(),

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -70,7 +70,7 @@ func main() {
 	flag.StringVar(&runOp.externalURL, "external-url", "", "The external url for the apiserver host and the the dc.(Required)")
 	flag.StringVar(&runOp.dc, "datacenter-name", "", "The name of the seed datacenter, the controller is running in. It will be used to build the absolute url for a customer cluster.")
 	flag.StringVar(&runOp.dcFile, "datacenters", "datacenters.yaml", "The datacenters.yaml file path")
-	flag.StringVar(&runOp.workerName, "worker-name", "", "Create clusters only processed by worker-name cluster controller")
+	flag.StringVar(&runOp.workerName, "worker-name", "", "Processes resources assigned to the given worker name")
 	flag.StringVar(&runOp.versionsFile, "versions", "versions.yaml", "The versions.yaml file path")
 	flag.StringVar(&runOp.updatesFile, "updates", "updates.yaml", "The updates.yaml file path")
 	flag.IntVar(&runOp.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")

--- a/api/pkg/controller/rbac/controller.go
+++ b/api/pkg/controller/rbac/controller.go
@@ -28,8 +28,9 @@ type Metrics struct {
 
 // Controller stores necessary components that are required to implement RBACGenerator
 type Controller struct {
-	queue   workqueue.RateLimitingInterface
-	metrics Metrics
+	queue      workqueue.RateLimitingInterface
+	metrics    Metrics
+	workerName string
 
 	kubermaticClient kubermaticclientset.Interface
 	projectLister    kubermaticv1lister.ProjectLister
@@ -48,6 +49,7 @@ type Controller struct {
 // managing RBAC roles for project's resources
 func New(
 	metrics Metrics,
+	workerName string,
 	kubermaticClient kubermaticclientset.Interface,
 	projectInformer kubermaticv1informers.ProjectInformer,
 	userInformer kubermaticv1informers.UserInformer,
@@ -57,6 +59,7 @@ func New(
 	c := &Controller{
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "RBACGenerator"),
 		metrics:          metrics,
+		workerName:       workerName,
 		kubermaticClient: kubermaticClient,
 		kubeClient:       kubeClient,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: projects with label(worker-name) different than the name of the controller manager will not be processed. By default the controller name is not set so all project will be processed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
NONE
```