### PR TITLE
fix flag for offline usage

### DIFF
--- a/config/deploy_master_helm_charts.sh
+++ b/config/deploy_master_helm_charts.sh
@@ -48,7 +48,7 @@ kubectl apply -f ${CHARTS_PATH}/installer/tiller-serviceaccount.yaml
 kubectl delete -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml || true
 kubectl create -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml
 
-helm ${HELM_OPTS} init --history-max 5 --service-account tiller --upgrade --stable-repo-url=""
+helm ${HELM_OPTS} init --history-max 5 --service-account tiller --upgrade --skip-refresh
 
 ############# MONITORING #############
 # All monitoring charts require the monitoring ns.

--- a/config/deploy_seed_helm_charts.sh
+++ b/config/deploy_seed_helm_charts.sh
@@ -48,7 +48,7 @@ kubectl apply -f ${CHARTS_PATH}/installer/tiller-serviceaccount.yaml
 kubectl delete -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml || true
 kubectl create -f ${CHARTS_PATH}/installer/tiller-clusterrolebinding.yaml
 
-helm ${HELM_OPTS} init --history-max 5 --service-account tiller --upgrade --stable-repo-url=""
+helm ${HELM_OPTS} init --history-max 5 --service-account tiller --upgrade --skip-refresh
 
 #TODO: Add federation
 ############# MONITORING #############


### PR DESCRIPTION
**What this PR does / why we need it**:
`--stable-repo-url=""` leads to errors. `--skip-refresh` is the correct flag which prevents calls to the upstream repo

**Release note**:
```release-note
NONE
```