### PR TITLE
include release branches for chart export

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -175,7 +175,9 @@ pipeline:
       - git push origin master --tags
     when:
       event: [tag]
-      branch: master
+      branch:
+        include: [ master, release/* ]
+        exclude: [ release/v1.* ]
 
   deploy-dev:
     group: deploy


### PR DESCRIPTION
**What this PR does / why we need it**:
include release branches for chart export

**Release note**:
```release-note
NONE
```