### PR TITLE
Create quay secret in nodeport-proxy namespace

### DIFF
--- a/config/nodeport-proxy/templates/quay-secret.yaml
+++ b/config/nodeport-proxy/templates/quay-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quay
+data:
+  .dockerconfigjson: {{ .Values.kubermatic.quay.secret }}
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to add the quay secret to the nodeport-proxy namespace where kubernetes will try to pull the image.

**Release note**:
```release-note
NONE
```
