### PR TITLE
Add the imagePullSecret to nodeport-proxy deployment

### DIFF
--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         app: nodeport-proxy
     spec:
       serviceAccountName: nodeport-proxy
+      imagePullSecrets:
+        - name: quay
       containers:
       - name: nodeport-proxy
         image: {{ .Values.nodePortPoxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Actually using the quay secret when deploying this deployment would be good.... :sweat_smile: 

**Release note**:
```release-note
NONE
```