### PR TITLE
Fix labels in MachineControllerDown alert

### DIFF
--- a/config/monitoring/prometheus/rules/machine-controller.yaml
+++ b/config/monitoring/prometheus/rules/machine-controller.yaml
@@ -7,7 +7,7 @@ groups:
     labels:
       severity: critical
     annotations:
-      description: "Machine Controller in namespace {{ $labels.namespace }} is down for more than 5 minutes."
+      description: "Machine Controller for cluster {{ $labels.cluster }} is down for more than 5 minutes."
       summary: "Machine Controller is down"
   - alert: MachineControllerTooManyErrors
     expr: sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01


### PR DESCRIPTION
**What this PR does / why we need it**:
There's no `namespace` label on these metrics, but a `cluster` label.

**Release note**:
```release-note
NONE
```