### PR TITLE
use type MasterVersion as response for update version endpoint

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -929,9 +929,9 @@
         ],
         "responses": {
           "200": {
-            "description": "AvailableMasterVersions",
+            "description": "MasterVersion",
             "schema": {
-              "$ref": "#/definitions/AvailableMasterVersions"
+              "$ref": "#/definitions/MasterVersion"
             }
           },
           "default": {

--- a/api/pkg/handler/routes_v3.go
+++ b/api/pkg/handler/routes_v3.go
@@ -293,7 +293,7 @@ func (r Routing) getNodeHandlerV3() http.Handler {
 //
 //     Responses:
 //       default: errorResponse
-//       200: AvailableMasterVersions
+//       200: MasterVersion
 func (r Routing) getPossibleClusterUpgradesV3() http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(

--- a/api/pkg/handler/upgrade.go
+++ b/api/pkg/handler/upgrade.go
@@ -32,11 +32,7 @@ func getClusterUpgrades(updateManager UpdateManager) endpoint.Endpoint {
 		if err != nil {
 			return nil, err
 		}
-		var sv []string
-		for _, v := range versions {
-			sv = append(sv, v.Version.String())
-		}
 
-		return sv, nil
+		return versions, nil
 	}
 }

--- a/api/pkg/handler/upgrade.go
+++ b/api/pkg/handler/upgrade.go
@@ -32,7 +32,14 @@ func getClusterUpgrades(updateManager UpdateManager) endpoint.Endpoint {
 		if err != nil {
 			return nil, err
 		}
+		var sv []*apiv1.MasterVersion
+		for v := range versions {
+			sv = append(sv, &apiv1.MasterVersion{
+				Version:             versions[v].Version,
+				AllowedNodeVersions: versions[v].AllowedNodeVersions,
+			})
+		}
 
-		return versions, nil
+		return sv, nil
 	}
 }

--- a/api/pkg/handler/upgrade_test.go
+++ b/api/pkg/handler/upgrade_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"sort"
 	"testing"
 
 	"github.com/Masterminds/semver"
@@ -23,7 +22,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 		cluster     *kubermaticv1.Cluster
 		versions    []*version.MasterVersion
 		updates     []*version.MasterUpdate
-		wantUpdates []string
+		wantUpdates []*version.MasterVersion
 	}{
 		{
 			name: "upgrade available",
@@ -34,7 +33,14 @@ func TestGetClusterUpgrades(t *testing.T) {
 				},
 				Spec: kubermaticv1.ClusterSpec{Version: "1.6.0"},
 			},
-			wantUpdates: []string{"1.6.1", "1.7.0"},
+			wantUpdates: []*version.MasterVersion{
+				{
+					Version: semver.MustParse("1.6.1"),
+				},
+				{
+					Version: semver.MustParse("1.7.0"),
+				},
+			},
 			versions: []*version.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.0"),
@@ -68,7 +74,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 				},
 				Spec: kubermaticv1.ClusterSpec{Version: "1.6.0"},
 			},
-			wantUpdates: []string{},
+			wantUpdates: []*version.MasterVersion{},
 			versions: []*version.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.0"),
@@ -92,14 +98,11 @@ func TestGetClusterUpgrades(t *testing.T) {
 				return
 			}
 
-			var gotUpdates []string
+			var gotUpdates []*version.MasterVersion
 			err = json.Unmarshal(res.Body.Bytes(), &gotUpdates)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			sort.Strings(gotUpdates)
-			sort.Strings(test.wantUpdates)
 
 			if diff := deep.Equal(gotUpdates, test.wantUpdates); diff != nil {
 				t.Errorf("got different upgrade response than expected. Diff: %v", diff)

--- a/api/pkg/handler/upgrade_test.go
+++ b/api/pkg/handler/upgrade_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/go-test/deep"
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 
@@ -22,7 +23,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 		cluster     *kubermaticv1.Cluster
 		versions    []*version.MasterVersion
 		updates     []*version.MasterUpdate
-		wantUpdates []*version.MasterVersion
+		wantUpdates []*apiv1.MasterVersion
 	}{
 		{
 			name: "upgrade available",
@@ -33,7 +34,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 				},
 				Spec: kubermaticv1.ClusterSpec{Version: "1.6.0"},
 			},
-			wantUpdates: []*version.MasterVersion{
+			wantUpdates: []*apiv1.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.1"),
 				},
@@ -74,7 +75,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 				},
 				Spec: kubermaticv1.ClusterSpec{Version: "1.6.0"},
 			},
-			wantUpdates: []*version.MasterVersion{},
+			wantUpdates: []*apiv1.MasterVersion{},
 			versions: []*version.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.0"),
@@ -98,7 +99,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 				return
 			}
 
-			var gotUpdates []*version.MasterVersion
+			var gotUpdates []*apiv1.MasterVersion
 			err = json.Unmarshal(res.Body.Bytes(), &gotUpdates)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
use type MasterVersion instead of AvailableMasterVersions as response for the update endpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1113

**Special notes for your reviewer**:
/

**Release note**:
```release-note
NONE
```