### PR TITLE
adds ability to generate RBAC roles/binding automatically

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1130,6 +1130,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "778efe53ee56d1a136dd766aee7ecf4339bc3e4aa3abcc0914cea7fddfc366ff"
+  inputs-digest = "af5f8ecda8e3f6ad76e327822af4406149bf11015233d05d5db750f83d0d6e28"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -106,8 +106,7 @@ func startRBACGeneratorController(ctrlCtx controllerContext) error {
 		rbacMetrics,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.kubermaticClient,
-		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Projects(),
-		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Users(),
+		ctrlCtx.kubermaticInformerFactory,
 		ctrlCtx.kubeClient,
 		ctrlCtx.kubeInformerFactory.Rbac().V1().ClusterRoles(),
 		ctrlCtx.kubeInformerFactory.Rbac().V1().ClusterRoleBindings())

--- a/api/pkg/controller/rbac/sync.go
+++ b/api/pkg/controller/rbac/sync.go
@@ -23,7 +23,7 @@ func (c *Controller) sync(key string) error {
 	sharedProject, err := c.projectLister.Get(key)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			glog.V(2).Infof("project '%s' in work queue no longer exists", key)
+			glog.V(2).Infof("project '%s' in work projectQueue no longer exists", key)
 			return nil
 		}
 		return err

--- a/api/pkg/controller/rbac/sync_dependant.go
+++ b/api/pkg/controller/rbac/sync_dependant.go
@@ -1,0 +1,5 @@
+package rbac
+
+func (c *Controller) syncDependant(item *dependantQueueItem) error {
+	return nil
+}

--- a/api/vendor/gopkg.in/yaml.v2/NOTICE
+++ b/api/vendor/gopkg.in/yaml.v2/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
resources that belong to a project have to have a proper set of RBAC roles/binding in place.
The changes in this pull avoid writing and maintaining a custom code,
instead allow to register resources to monitor in an array.

**Special notes for your reviewer**: See #1140 

**Release note**:
```release-note
NONE
```
