### PR TITLE
Only alert on MachineControllerDown when clusters exist

### DIFF
--- a/config/monitoring/prometheus/rules/machine-controller.yaml
+++ b/config/monitoring/prometheus/rules/machine-controller.yaml
@@ -2,7 +2,7 @@ groups:
 - name: machine-controller
   rules:
   - alert: MachineControllerDown
-    expr: absent(up{job="machine-controller"} == 1)
+    expr: absent(up{job="machine-controller"} == 1) and (sum(kubermatic_cluster_controller_clusters) > 0)
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now on our dev cluster we get MachineControllerDown alerts when no clusters exist.
That's because when no clusters exist, there are no machine controllers.

We only want to alert on MachineControllerDown when clusters exist.

**Release note**:
```release-note
NONE
```