### PR TITLE
Set kubeconfig context for helm and only deploy monitoring to EU

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -147,7 +147,7 @@ local drone = import 'drone/drone.libsonnet';
     // cloud
 
     '10-deploy-cloud-europe': drone.step.new('kubeciio/helm', group='deploy-cloud') + {
-        helm: 'upgrade --install' + tillerNamespace + versionsValues,
+        helm: 'upgrade --install --kube-context=europe-west3-c-1' + tillerNamespace + versionsValues,
         secrets: [
           {source: 'kubeconfig_cloud', target: 'kubeconfig'},
           {source: 'values_cloud_eu', target: 'values'},
@@ -157,7 +157,7 @@ local drone = import 'drone/drone.libsonnet';
       } + {when: {branch: 'master'}},
 
     '10-deploy-cloud-us': drone.step.new('kubeciio/helm', group='deploy-cloud') + {
-        helm: 'upgrade --install' + tillerNamespace + versionsValues,
+        helm: 'upgrade --install --kube-context=us-central1-c-1' + tillerNamespace + versionsValues,
         secrets: [
           {source: 'kubeconfig_cloud', target: 'kubeconfig'},
           {source: 'values_cloud_us', target: 'values'},
@@ -167,7 +167,7 @@ local drone = import 'drone/drone.libsonnet';
       } + {when: {branch: 'master'}},
 
     '10-deploy-cloud-asia': drone.step.new('kubeciio/helm', group='deploy-cloud') + {
-        helm: 'upgrade --install' + tillerNamespace + versionsValues,
+        helm: 'upgrade --install --kube-context=asia-east1-a-1' + tillerNamespace + versionsValues,
         secrets: [
           {source: 'kubeconfig_cloud', target: 'kubeconfig'},
           {source: 'values_cloud_as', target: 'values'},

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,6 +1,6 @@
 local drone = import 'drone/drone.libsonnet';
 
-// Please take a look into the README.md for instructions on how to build this.
+// Please take a look at the README.md for instructions on how to build this.
 
 {
   workspace: drone.workspace.new('/go', 'src/github.com/kubermatic/kubermatic'),
@@ -112,18 +112,21 @@ local drone = import 'drone/drone.libsonnet';
     // Deployments
 
     local charts = [
-      {namespace: 'monitoring', name: 'prometheus-operator', path: 'config/monitoring/prometheus-operator/'},
-      {namespace: 'monitoring', name: 'node-exporter', path: 'config/monitoring/node-exporter/'},
-      {namespace: 'monitoring', name: 'kube-state-metrics', path: 'config/monitoring/kube-state-metrics/'},
-      {namespace: 'monitoring', name: 'grafana', path: 'config/monitoring/grafana/'},
-      {namespace: 'monitoring', name: 'alertmanager', path: 'config/monitoring/alertmanager/'},
-      {namespace: 'monitoring', name: 'prometheus', path: 'config/monitoring/prometheus/'},
       {namespace: 'ingress-nginx', name: 'nginx', path: 'config/nginx-ingress-controller/'},
       {namespace: 'oauth', name: 'oauth', path: 'config/oauth/'},
       {namespace: 'kubermatic', name: 'kubermatic', path: 'config/kubermatic/'},
       {namespace: 'cert-manager', name: 'cert-manager', path: 'config/cert-manager/'},
       {namespace: 'default', name: 'certs', path: 'config/certs/'},
       {namespace: 'nodeport-proxy', name: 'nodeport-proxy', path: 'config/nodeport-proxy/'},
+    ],
+
+    local chartsMonitoring = [
+      {namespace: 'monitoring', name: 'prometheus-operator', path: 'config/monitoring/prometheus-operator/'},
+      {namespace: 'monitoring', name: 'node-exporter', path: 'config/monitoring/node-exporter/'},
+      {namespace: 'monitoring', name: 'kube-state-metrics', path: 'config/monitoring/kube-state-metrics/'},
+      {namespace: 'monitoring', name: 'grafana', path: 'config/monitoring/grafana/'},
+      {namespace: 'monitoring', name: 'alertmanager', path: 'config/monitoring/alertmanager/'},
+      {namespace: 'monitoring', name: 'prometheus', path: 'config/monitoring/prometheus/'},
     ],
 
     local versionsValues = ' --values config/versions-values.yaml',
@@ -149,7 +152,7 @@ local drone = import 'drone/drone.libsonnet';
           {source: 'kubeconfig_cloud', target: 'kubeconfig'},
           {source: 'values_cloud_eu', target: 'values'},
         ],
-        charts: charts,
+        charts: charts + chartsMonitoring,
         values: [ 'values' ],
       } + {when: {branch: 'master'}},
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -224,7 +224,8 @@ pipeline:
       namespace: nodeport-proxy
       path: config/nodeport-proxy/
     group: deploy-cloud
-    helm: upgrade --install --tiller-namespace=kubermatic-installer --values config/versions-values.yaml
+    helm: upgrade --install --kube-context=asia-east1-a-1 --tiller-namespace=kubermatic-installer
+      --values config/versions-values.yaml
     image: kubeciio/helm
     pull: true
     secrets:
@@ -275,7 +276,8 @@ pipeline:
       namespace: monitoring
       path: config/monitoring/prometheus/
     group: deploy-cloud
-    helm: upgrade --install --tiller-namespace=kubermatic-installer --values config/versions-values.yaml
+    helm: upgrade --install --kube-context=europe-west3-c-1 --tiller-namespace=kubermatic-installer
+      --values config/versions-values.yaml
     image: kubeciio/helm
     pull: true
     secrets:
@@ -308,7 +310,8 @@ pipeline:
       namespace: nodeport-proxy
       path: config/nodeport-proxy/
     group: deploy-cloud
-    helm: upgrade --install --tiller-namespace=kubermatic-installer --values config/versions-values.yaml
+    helm: upgrade --install --kube-context=us-central1-c-1 --tiller-namespace=kubermatic-installer
+      --values config/versions-values.yaml
     image: kubeciio/helm
     pull: true
     secrets:

--- a/.drone.yml
+++ b/.drone.yml
@@ -173,24 +173,6 @@ pipeline:
       - tag
   9-deploy-dev:
     charts:
-    - name: prometheus-operator
-      namespace: monitoring
-      path: config/monitoring/prometheus-operator/
-    - name: node-exporter
-      namespace: monitoring
-      path: config/monitoring/node-exporter/
-    - name: kube-state-metrics
-      namespace: monitoring
-      path: config/monitoring/kube-state-metrics/
-    - name: grafana
-      namespace: monitoring
-      path: config/monitoring/grafana/
-    - name: alertmanager
-      namespace: monitoring
-      path: config/monitoring/alertmanager/
-    - name: prometheus
-      namespace: monitoring
-      path: config/monitoring/prometheus/
     - name: nginx
       namespace: ingress-nginx
       path: config/nginx-ingress-controller/
@@ -223,24 +205,6 @@ pipeline:
       branch: master
   10-deploy-cloud-asia:
     charts:
-    - name: prometheus-operator
-      namespace: monitoring
-      path: config/monitoring/prometheus-operator/
-    - name: node-exporter
-      namespace: monitoring
-      path: config/monitoring/node-exporter/
-    - name: kube-state-metrics
-      namespace: monitoring
-      path: config/monitoring/kube-state-metrics/
-    - name: grafana
-      namespace: monitoring
-      path: config/monitoring/grafana/
-    - name: alertmanager
-      namespace: monitoring
-      path: config/monitoring/alertmanager/
-    - name: prometheus
-      namespace: monitoring
-      path: config/monitoring/prometheus/
     - name: nginx
       namespace: ingress-nginx
       path: config/nginx-ingress-controller/
@@ -274,24 +238,6 @@ pipeline:
       branch: master
   10-deploy-cloud-europe:
     charts:
-    - name: prometheus-operator
-      namespace: monitoring
-      path: config/monitoring/prometheus-operator/
-    - name: node-exporter
-      namespace: monitoring
-      path: config/monitoring/node-exporter/
-    - name: kube-state-metrics
-      namespace: monitoring
-      path: config/monitoring/kube-state-metrics/
-    - name: grafana
-      namespace: monitoring
-      path: config/monitoring/grafana/
-    - name: alertmanager
-      namespace: monitoring
-      path: config/monitoring/alertmanager/
-    - name: prometheus
-      namespace: monitoring
-      path: config/monitoring/prometheus/
     - name: nginx
       namespace: ingress-nginx
       path: config/nginx-ingress-controller/
@@ -310,21 +256,6 @@ pipeline:
     - name: nodeport-proxy
       namespace: nodeport-proxy
       path: config/nodeport-proxy/
-    group: deploy-cloud
-    helm: upgrade --install --tiller-namespace=kubermatic-installer --values config/versions-values.yaml
-    image: kubeciio/helm
-    pull: true
-    secrets:
-    - source: kubeconfig_cloud
-      target: kubeconfig
-    - source: values_cloud_eu
-      target: values
-    values:
-    - values
-    when:
-      branch: master
-  10-deploy-cloud-us:
-    charts:
     - name: prometheus-operator
       namespace: monitoring
       path: config/monitoring/prometheus-operator/
@@ -343,6 +274,21 @@ pipeline:
     - name: prometheus
       namespace: monitoring
       path: config/monitoring/prometheus/
+    group: deploy-cloud
+    helm: upgrade --install --tiller-namespace=kubermatic-installer --values config/versions-values.yaml
+    image: kubeciio/helm
+    pull: true
+    secrets:
+    - source: kubeconfig_cloud
+      target: kubeconfig
+    - source: values_cloud_eu
+      target: values
+    values:
+    - values
+    when:
+      branch: master
+  10-deploy-cloud-us:
+    charts:
     - name: nginx
       namespace: ingress-nginx
       path: config/nginx-ingress-controller/


### PR DESCRIPTION
**What this PR does / why we need it**:
Set kubeconfig context for helm and only deploy monitoring to EU

**Release note**:
```release-note
NONE
```