### PR TITLE
Only deploy kubermatic and nodeport-proxt to US & Asia

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -112,15 +112,15 @@ local drone = import 'drone/drone.libsonnet';
     // Deployments
 
     local charts = [
-      {namespace: 'ingress-nginx', name: 'nginx', path: 'config/nginx-ingress-controller/'},
-      {namespace: 'oauth', name: 'oauth', path: 'config/oauth/'},
       {namespace: 'kubermatic', name: 'kubermatic', path: 'config/kubermatic/'},
-      {namespace: 'cert-manager', name: 'cert-manager', path: 'config/cert-manager/'},
-      {namespace: 'default', name: 'certs', path: 'config/certs/'},
       {namespace: 'nodeport-proxy', name: 'nodeport-proxy', path: 'config/nodeport-proxy/'},
     ],
 
-    local chartsMonitoring = [
+    local chartsEU = [
+      {namespace: 'ingress-nginx', name: 'nginx', path: 'config/nginx-ingress-controller/'},
+      {namespace: 'oauth', name: 'oauth', path: 'config/oauth/'},
+      {namespace: 'cert-manager', name: 'cert-manager', path: 'config/cert-manager/'},
+      {namespace: 'default', name: 'certs', path: 'config/certs/'},
       {namespace: 'monitoring', name: 'prometheus-operator', path: 'config/monitoring/prometheus-operator/'},
       {namespace: 'monitoring', name: 'node-exporter', path: 'config/monitoring/node-exporter/'},
       {namespace: 'monitoring', name: 'kube-state-metrics', path: 'config/monitoring/kube-state-metrics/'},
@@ -152,7 +152,7 @@ local drone = import 'drone/drone.libsonnet';
           {source: 'kubeconfig_cloud', target: 'kubeconfig'},
           {source: 'values_cloud_eu', target: 'values'},
         ],
-        charts: charts + chartsMonitoring,
+        charts: charts + chartsEU,
         values: [ 'values' ],
       } + {when: {branch: 'master'}},
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -173,21 +173,9 @@ pipeline:
       - tag
   9-deploy-dev:
     charts:
-    - name: nginx
-      namespace: ingress-nginx
-      path: config/nginx-ingress-controller/
-    - name: oauth
-      namespace: oauth
-      path: config/oauth/
     - name: kubermatic
       namespace: kubermatic
       path: config/kubermatic/
-    - name: cert-manager
-      namespace: cert-manager
-      path: config/cert-manager/
-    - name: certs
-      namespace: default
-      path: config/certs/
     - name: nodeport-proxy
       namespace: nodeport-proxy
       path: config/nodeport-proxy/
@@ -205,21 +193,9 @@ pipeline:
       branch: master
   10-deploy-cloud-asia:
     charts:
-    - name: nginx
-      namespace: ingress-nginx
-      path: config/nginx-ingress-controller/
-    - name: oauth
-      namespace: oauth
-      path: config/oauth/
     - name: kubermatic
       namespace: kubermatic
       path: config/kubermatic/
-    - name: cert-manager
-      namespace: cert-manager
-      path: config/cert-manager/
-    - name: certs
-      namespace: default
-      path: config/certs/
     - name: nodeport-proxy
       namespace: nodeport-proxy
       path: config/nodeport-proxy/
@@ -239,24 +215,24 @@ pipeline:
       branch: master
   10-deploy-cloud-europe:
     charts:
+    - name: kubermatic
+      namespace: kubermatic
+      path: config/kubermatic/
+    - name: nodeport-proxy
+      namespace: nodeport-proxy
+      path: config/nodeport-proxy/
     - name: nginx
       namespace: ingress-nginx
       path: config/nginx-ingress-controller/
     - name: oauth
       namespace: oauth
       path: config/oauth/
-    - name: kubermatic
-      namespace: kubermatic
-      path: config/kubermatic/
     - name: cert-manager
       namespace: cert-manager
       path: config/cert-manager/
     - name: certs
       namespace: default
       path: config/certs/
-    - name: nodeport-proxy
-      namespace: nodeport-proxy
-      path: config/nodeport-proxy/
     - name: prometheus-operator
       namespace: monitoring
       path: config/monitoring/prometheus-operator/
@@ -291,21 +267,9 @@ pipeline:
       branch: master
   10-deploy-cloud-us:
     charts:
-    - name: nginx
-      namespace: ingress-nginx
-      path: config/nginx-ingress-controller/
-    - name: oauth
-      namespace: oauth
-      path: config/oauth/
     - name: kubermatic
       namespace: kubermatic
       path: config/kubermatic/
-    - name: cert-manager
-      namespace: cert-manager
-      path: config/cert-manager/
-    - name: certs
-      namespace: default
-      path: config/certs/
     - name: nodeport-proxy
       namespace: nodeport-proxy
       path: config/nodeport-proxy/


### PR DESCRIPTION
**What this PR does / why we need it**:
Only deploy kubermatic and nodeport-proxt to US & Asia as nothing else is necessary on those regions.


**Release note**:
```release-note
NONE
```