### PR TITLE
Update or add missing or outdated alerts

### DIFF
--- a/config/monitoring/prometheus/rules/etcd.yaml
+++ b/config/monitoring/prometheus/rules/etcd.yaml
@@ -20,7 +20,7 @@ groups:
   - alert: HighNumberOfLeaderChanges
     expr: increase(etcd_server_leader_changes_seen_total{job="etcd"}[1h]) > 5
     labels:
-      severity: 1
+      severity: warning
     annotations:
       description: etcd in namespace {{ $labels.namespace }} has seen {{ $value }} leader changes within the last hour
       summary: a high number of leader changes within the etcd cluster are happening
@@ -55,7 +55,7 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: etcd in namespace {{ $labels.namespace }} member communication is slow
+      description: etcd in namespace {{ $labels.namespace }} member communication with {{ $labels.To }} is slow
       summary: etcd member communication is slow
   - alert: HighNumberOfFailedProposals
     expr: increase(etcd_server_proposals_failed_total{job="etcd"}[1h]) > 5

--- a/config/monitoring/prometheus/rules/kubelet.yaml
+++ b/config/monitoring/prometheus/rules/kubelet.yaml
@@ -1,35 +1,47 @@
 groups:
-- name: kubelet
+- name: kubelet.rules
   rules:
-  - alert: KubernetesKubeletDown
-    expr: absent(up{job="kubelet"} == 1) or 100 * count(up{job="kubelet"} == 0) / count(up{job="kubelet"}) > 10
-    for: 15m
-    labels:
-      severity: critical
-    annotations:
-      summary: 'Kubelets not scrapeable'
-      description: 'Prometheus failed to scrape {{ $value }}% of kubelets, or all Kubelets have disappeared from service discovery.'
-  - alert: KubernetesKubeletTooManyPods
-    expr: kubelet_running_pod_count > 100
-    for: 1m
-    labels:
-      severity: warning
-    annotations:
-      summary: 'Kubelet is close to pod limit'
-      description: 'Kubelet {{$labels.instance}} is running {{$value}} pods, close to the limit of 110'
-  - alert: KubernetesManyNodesNotReady
-    expr: count(kube_node_status_condition{condition="Ready",status="true"} == 0) > 1 and (100 * (count(kube_node_status_condition{condition="Ready",status="true"} == 0) / count(kube_node_status_condition{condition="Ready",status="true"})) > 20)
-    for: 1m
-    labels:
-      severity: critical
-    annotations:
-      summary: 'Many Kubernetes nodes are Not Ready'
-      description: '{{ $value }} Kubernetes nodes (more than 10% are in the NotReady state).'
-  - alert: KubernetesNodeNotReady
+  - alert: K8SNodeNotReady
     expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-    for: 15m
+    for: 1h
     labels:
       severity: warning
     annotations:
-      summary: 'Kubernetes Node status is NotReady'
-      description: 'The Kubelet on {{ $labels.node }} is NotReady for more than 15min, please check this node'
+      description: The Kubelet on {{ $labels.node }} has not checked in with the API, or has set itself to NotReady, for more than an hour
+      summary: Node status is NotReady
+  - alert: K8SManyNodesNotReady
+    expr: count(kube_node_status_condition{condition="Ready",status="true"} == 0)
+      > 1 and (count(kube_node_status_condition{condition="Ready",status="true"} ==
+      0) / count(kube_node_status_condition{condition="Ready",status="true"})) > 0.2
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      description: '{{ $value }}% of Kubernetes nodes are not ready'
+  - alert: K8SKubeletDown
+    expr: count(up{job="kubelet"} == 0) / count(up{job="kubelet"}) * 100 > 3
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: Prometheus failed to scrape {{ $value }}% of kubelets.
+      summary: Prometheus failed to scrape
+  - alert: K8SKubeletDown
+    expr: (absent(up{job="kubelet"} == 1) or count(up{job="kubelet"} == 0) / count(up{job="kubelet"}))
+      * 100 > 10
+    for: 1h
+    labels:
+      severity: critical
+    annotations:
+      description: Prometheus failed to scrape {{ $value }}% of kubelets, or all Kubelets
+        have disappeared from service discovery.
+      summary: Many Kubelets cannot be scraped
+  - alert: K8SKubeletTooManyPods
+    expr: kubelet_running_pod_count > 100
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: Kubelet {{$labels.instance}} is running {{$value}} pods, close
+        to the limit of 110
+      summary: Kubelet is close to pod limit

--- a/config/monitoring/prometheus/rules/kubernetes.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes.yaml
@@ -1,79 +1,88 @@
 groups:
 - name: kubernetes
   rules:
-  - record: cluster_namespace_controller_pod_container:spec_memory_limit_bytes
-    expr: sum(label_replace(container_spec_memory_limit_bytes{container_name!=""}, "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name)
-  - record: cluster_namespace_controller_pod_container:spec_cpu_shares
-    expr: sum(label_replace(container_spec_cpu_shares{container_name!=""}, "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name)
-  - record: cluster_namespace_controller_pod_container:cpu_usage:rate
-    expr: sum(label_replace(irate(container_cpu_usage_seconds_total{container_name!=""}[5m]), "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name)
-  - record: cluster_namespace_controller_pod_container:memory_usage:bytes
-    expr: sum(label_replace(container_memory_usage_bytes{container_name!=""}, "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name)
-  - record: cluster_namespace_controller_pod_container:memory_working_set:bytes
-    expr: sum(label_replace(container_memory_working_set_bytes{container_name!=""}, "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name)
-  - record: cluster_namespace_controller_pod_container:memory_rss:bytes
-    expr: sum(label_replace(container_memory_rss{container_name!=""}, "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name)
-  - record: cluster_namespace_controller_pod_container:memory_cache:bytes
-    expr: sum(label_replace(container_memory_cache{container_name!=""}, "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name)
-  - record: cluster_namespace_controller_pod_container:disk_usage:bytes
-    expr: sum(label_replace(container_disk_usage_bytes{container_name!=""}, "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name)
-  - record: cluster_namespace_controller_pod_container:memory_pagefaults:rate
-    expr: sum(label_replace(irate(container_memory_failures_total{container_name!=""}[5m]), "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name, scope, type)
-  - record: cluster_namespace_controller_pod_container:memory_oom:rate
-    expr: sum(label_replace(irate(container_memory_failcnt{container_name!=""}[5m]), "controller", "$1", "pod_name", "^(.*)-[a-z0-9]+")) BY (cluster, namespace, controller, pod_name, container_name, scope, type)
-  - record: cluster:memory_allocation:percent
-    expr: 100 * sum(container_spec_memory_limit_bytes{pod_name!=""}) BY (cluster) / sum(machine_memory_bytes) BY (cluster)
-  - record: cluster:memory_used:percent
-    expr: 100 * sum(container_memory_usage_bytes{pod_name!=""}) BY (cluster) / sum(machine_memory_bytes) BY (cluster)
-  - record: cluster:cpu_allocation:percent
-    expr: 100 * sum(container_spec_cpu_shares{pod_name!=""}) BY (cluster) / sum(container_spec_cpu_shares{id="/"} * ON(cluster, instance) machine_cpu_cores) BY (cluster)
-  - record: cluster:node_cpu_use:percent
-    expr: 100 * sum(rate(node_cpu{mode!="idle"}[5m])) BY (cluster) / sum(machine_cpu_cores) BY (cluster)
-  - record: cluster_resource_verb:apiserver_latency:quantile_seconds
-    expr: histogram_quantile(0.99, sum(apiserver_request_latencies_bucket) BY (le, cluster, job, resource, verb)) / 1e+06
+  - record: pod_name:container_memory_usage_bytes:sum
+    expr: sum(container_memory_usage_bytes{container_name!="POD",pod_name!=""}) BY (pod_name)
+  - record: pod_name:container_spec_cpu_shares:sum
+    expr: sum(container_spec_cpu_shares{container_name!="POD",pod_name!=""}) BY (pod_name)
+  - record: pod_name:container_cpu_usage:sum
+    expr: sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[5m])) BY (pod_name)
+  - record: pod_name:container_fs_usage_bytes:sum
+    expr: sum(container_fs_usage_bytes{container_name!="POD",pod_name!=""}) BY (pod_name)
+  - record: namespace:container_memory_usage_bytes:sum
+    expr: sum(container_memory_usage_bytes{container_name!=""}) BY (namespace)
+  - record: namespace:container_spec_cpu_shares:sum
+    expr: sum(container_spec_cpu_shares{container_name!=""}) BY (namespace)
+  - record: namespace:container_cpu_usage:sum
+    expr: sum(rate(container_cpu_usage_seconds_total{container_name!="POD"}[5m])) BY (namespace)
+  - record: cluster:memory_usage:ratio
+    expr: sum(container_memory_usage_bytes{container_name!="POD",pod_name!=""}) BY (cluster) / sum(machine_memory_bytes) BY (cluster)
+  - record: cluster:container_spec_cpu_shares:ratio
+    expr: sum(container_spec_cpu_shares{container_name!="POD",pod_name!=""}) / 1000 / sum(machine_cpu_cores)
+  - record: cluster:container_cpu_usage:ratio
+    expr: sum(rate(container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[5m])) / sum(machine_cpu_cores)
+  - record: apiserver_latency_seconds:quantile
+    expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
     labels:
       quantile: "0.99"
-  - record: cluster_resource_verb:apiserver_latency:quantile_seconds
-    expr: histogram_quantile(0.9, sum(apiserver_request_latencies_bucket) BY (le, cluster, job, resource, verb)) / 1e+06
+  - record: apiserver_latency:quantile_seconds
+    expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
     labels:
       quantile: "0.9"
-  - record: cluster_resource_verb:apiserver_latency:quantile_seconds
-    expr: histogram_quantile(0.5, sum(apiserver_request_latencies_bucket) BY (le, cluster, job, resource, verb)) / 1e+06
+  - record: apiserver_latency_seconds:quantile
+    expr: histogram_quantile(0.5, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
     labels:
       quantile: "0.5"
-  - record: cluster:scheduler_e2e_scheduling_latency:quantile_seconds
-    expr: histogram_quantile(0.99, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - alert: APIServerLatencyHigh
+    expr: apiserver_latency_seconds:quantile{quantile="0.99",subresource!="log",verb!~"^(?:WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
+    for: 10m
     labels:
-      quantile: "0.99"
-  - record: cluster:scheduler_e2e_scheduling_latency:quantile_seconds
-    expr: histogram_quantile(0.9, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+      severity: warning
+    annotations:
+      description: the API server has a 99th percentile latency of {{ $value }} seconds for {{$labels.verb}} {{$labels.resource}}
+      summary: API server high latency
+  - alert: APIServerLatencyHigh
+    expr: apiserver_latency_seconds:quantile{quantile="0.99",subresource!="log",verb!~"^(?:WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
+    for: 10m
     labels:
-      quantile: "0.9"
-  - record: cluster:scheduler_e2e_scheduling_latency:quantile_seconds
-    expr: histogram_quantile(0.5, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+      severity: critical
+    annotations:
+      description: the API server has a 99th percentile latency of {{ $value }} seconds for {{$labels.verb}} {{$labels.resource}}
+      summary: API server high latency
+  - alert: APIServerErrorsHigh
+    expr: rate(apiserver_request_count{code=~"^(?:5..)$"}[5m]) / rate(apiserver_request_count[5m]) * 100 > 2
+    for: 10m
     labels:
-      quantile: "0.5"
-  - record: cluster:scheduler_scheduling_algorithm_latency:quantile_seconds
-    expr: histogram_quantile(0.99, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+      severity: warning
+    annotations:
+      description: API server returns errors for {{ $value }}% of requests
+      summary: API server request errors
+  - alert: APIServerErrorsHigh
+    expr: rate(apiserver_request_count{code=~"^(?:5..)$"}[5m]) / rate(apiserver_request_count[5m]) * 100 > 5
+    for: 10m
     labels:
-      quantile: "0.99"
-  - record: cluster:scheduler_scheduling_algorithm_latency:quantile_seconds
-    expr: histogram_quantile(0.9, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+      severity: critical
+    annotations:
+      description: API server returns errors for {{ $value }}% of requests
+  - alert: ApiserverDown
+    expr: absent(up{job="apiserver"} == 1)
+    for: 20m
     labels:
-      quantile: "0.9"
-  - record: cluster:scheduler_scheduling_algorithm_latency:quantile_seconds
-    expr: histogram_quantile(0.5, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+      severity: critical
+    annotations:
+      description: No API servers are reachable or all have disappeared from service discovery
+      summary: No API servers are reachable
+  - alert: CertificateExpirationNotice
     labels:
-      quantile: "0.5"
-  - record: cluster:scheduler_binding_latency:quantile_seconds
-    expr: histogram_quantile(0.99, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+      severity: warning
+    annotations:
+      description: Kubernetes API Certificate is expiring soon (less than 7 days)
+      summary: Kubernetes API Certificate is expiering soon
+    expr: sum(apiserver_client_certificate_expiration_seconds_bucket{le="604800"}) > 0
+  - alert: CertificateExpirationNotice
     labels:
-      quantile: "0.99"
-  - record: cluster:scheduler_binding_latency:quantile_seconds
-    expr: histogram_quantile(0.9, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
-    labels:
-      quantile: "0.9"
-  - record: cluster:scheduler_binding_latency:quantile_seconds
-    expr: histogram_quantile(0.5, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
-    labels:
-      quantile: "0.5"
+      severity: critical
+    annotations:
+      description: Kubernetes API Certificate is expiring in less than 1 day
+      summary: Kubernetes API Certificate is expiering
+    expr: sum(apiserver_client_certificate_expiration_seconds_bucket{le="86400"}) > 0

--- a/config/monitoring/prometheus/rules/node.yml
+++ b/config/monitoring/prometheus/rules/node.yml
@@ -1,6 +1,50 @@
 groups:
 - name: node
   rules:
+  - record: instance:node_cpu:rate:sum
+    expr: sum(rate(node_cpu{mode!="idle",mode!="iowait",mode!~"^(?:guest.*)$"}[3m])) BY (instance)
+  - record: instance:node_filesystem_usage:sum
+    expr: sum((node_filesystem_size{mountpoint="/"} - node_filesystem_free{mountpoint="/"})) BY (instance)
+  - record: instance:node_network_receive_bytes:rate:sum
+    expr: sum(rate(node_network_receive_bytes[3m])) BY (instance)
+  - record: instance:node_network_transmit_bytes:rate:sum
+    expr: sum(rate(node_network_transmit_bytes[3m])) BY (instance)
+  - record: instance:node_cpu:ratio
+    expr: sum(rate(node_cpu{mode!="idle"}[5m])) WITHOUT (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu) BY (instance, cpu)) BY (instance)
+  - record: cluster:node_cpu:sum_rate5m
+    expr: sum(rate(node_cpu{mode!="idle"}[5m]))
+  - record: cluster:node_cpu:ratio
+    expr: cluster:node_cpu:rate5m / count(sum(node_cpu) BY (instance, cpu))
+
+  - alert: NodeExporterDown
+    expr: absent(up{job="node-exporter"} == 1)
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Prometheus could not scrape a node-exporter"
+      description: "Prometheus could not scrape a node-exporter for more than 10m, or node-exporters have disappeared from discovery."
+  - alert: KubernetesNodeOutOfDisk
+    expr: kube_node_status_condition{condition="OutOfDisk",status="true"} == 1
+    labels:
+      severity: critical
+    annotations:
+      summary: "Node ran out of disk space"
+      description: '{{ $labels.node }} has run out of disk space.'
+  - alert: KubernetesNodeMemoryPressure
+    expr: kube_node_status_condition{condition="MemoryPressure",status="true"} == 1
+    labels:
+      severity: warning
+    annotations:
+      summary: "Node is under memory pressure"
+      description: '{{ $labels.node }} is under memory pressure.'
+  - alert: KubernetesNodeDiskPressure
+    expr: kube_node_status_condition{condition="DiskPressure",status="true"} == 1
+    labels:
+      severity: warning
+    annotations:
+      summary: "Node is under disk pressure"
+      description: '{{ $labels.node }} is under disk pressure.'
   - alert: NodeDiskWillFillIn4Hours
     expr: predict_linear(node_filesystem_free{job="node-exporter"}[1h], 4 * 3600) < 0
     for: 15m
@@ -17,35 +61,3 @@ groups:
     annotations:
       description: "Device {{ $labels.device }} of instance {{ $labels.instance }} is filling quickly."
       summary: "Disk will fill in 4 hours"
-  - alert: NodeExporterDown
-    expr: absent(up{job="node-exporter"} == 1)
-    for: 10m
-    labels:
-      severity: warning
-    annotations:
-      summary: "node-exporter cannot be scraped"
-      description: "Prometheus could not scrape a node-exporter for more than 10m, or node-exporters have disappeared from discovery."
-  - alert: KubernetesNodeOutOfDisk
-    expr: kube_node_status_condition{condition="OutOfDisk",status="true"} == 1
-    labels:
-      service: k8s
-      severity: critical
-    annotations:
-      summary: "Node ran out of disk space"
-      description: '{{ $labels.node }} has run out of disk space.'
-  - alert: KubernetesNodeMemoryPressure
-    expr: kube_node_status_condition{condition="MemoryPressure",status="true"} == 1
-    labels:
-      service: k8s
-      severity: warning
-    annotations:
-      summary: "Node is under memory pressure"
-      description: '{{ $labels.node }} is under memory pressure.'
-  - alert: KubernetesNodeDiskPressure
-    expr: kube_node_status_condition{condition="DiskPressure",status="true"} == 1
-    labels:
-      service: k8s
-      severity: warning
-    annotations:
-      summary: "Node is under disk pressure"
-      description: '{{ $labels.node }} is under disk pressure.'

--- a/config/monitoring/prometheus/rules/prometheus.yaml
+++ b/config/monitoring/prometheus/rules/prometheus.yaml
@@ -1,11 +1,93 @@
 groups:
-- name: prometheus
+- name: prometheus.rules
   rules:
-  - alert: PrometheusFailedReload
+  - alert: PrometheusConfigReloadFailed
     expr: prometheus_config_last_reload_successful == 0
     for: 10m
     labels:
       severity: warning
     annotations:
-      description: Reloading Prometheus' configuration has failed for {{ $labels.namespace }}/{{ $labels.pod}}.
-      summary: Prometheus configuration reload has failed
+      description: Reloading Prometheus' configuration has failed for {{$labels.namespace}}/{{$labels.pod}}
+      summary: Reloading Promehteus' configuration failed
+
+  - alert: PrometheusNotificationQueueRunningFull
+    expr: predict_linear(prometheus_notifications_queue_length[5m], 60 * 30) > prometheus_notifications_queue_capacity
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: Prometheus' alert notification queue is running full for {{$labels.namespace}}/{{
+        $labels.pod}}
+      summary: Prometheus' alert notification queue is running full
+
+  - alert: PrometheusErrorSendingAlerts
+    expr: rate(prometheus_notifications_errors_total[5m]) / rate(prometheus_notifications_sent_total[5m]) > 0.01
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: Errors while sending alerts from Prometheus {{$labels.namespace}}/{{$labels.pod}} to Alertmanager {{$labels.Alertmanager}}
+      summary: Errors while sending alert from Prometheus
+
+  - alert: PrometheusErrorSendingAlerts
+    expr: rate(prometheus_notifications_errors_total[5m]) / rate(prometheus_notifications_sent_total[5m]) > 0.03
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      description: Errors while sending alerts from Prometheus {{$labels.namespace}}/{{$labels.pod}} to Alertmanager {{$labels.Alertmanager}}
+      summary: Errors while sending alerts from Prometheus
+
+  - alert: PrometheusNotConnectedToAlertmanagers
+    expr: prometheus_notifications_alertmanagers_discovered < 1
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: Prometheus {{ $labels.namespace }}/{{ $labels.pod}} is not connected to any Alertmanagers
+      summary: Prometheus is not connected to any Alertmanagers
+
+  - alert: PrometheusTSDBReloadsFailing
+    expr: increase(prometheus_tsdb_reloads_failures_total[2h]) > 0
+    for: 12h
+    labels:
+      severity: warning
+    annotations:
+      description: '{{$labels.job}} at {{$labels.instance}} had {{$value | humanize}} reload failures over the last four hours.'
+      summary: Prometheus has issues reloading data blocks from disk
+
+  - alert: PrometheusTSDBCompactionsFailing
+    expr: increase(prometheus_tsdb_compactions_failed_total[2h]) > 0
+    for: 12h
+    labels:
+      severity: warning
+    annotations:
+      description: '{{$labels.job}} at {{$labels.instance}} had {{$value | humanize}} compaction failures over the last four hours.'
+      summary: Prometheus has issues compacting sample blocks
+
+  - alert: PrometheusTSDBWALCorruptions
+    expr: prometheus_tsdb_wal_corruptions_total > 0
+    for: 4h
+    labels:
+      severity: warning
+    annotations:
+      description: '{{$labels.job}} at {{$labels.instance}} has a corrupted write-ahead log (WAL).'
+      summary: Prometheus write-ahead log is corrupted
+
+  - alert: PrometheusNotIngestingSamples
+    expr: rate(prometheus_tsdb_head_samples_appended_total[5m]) <= 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "Prometheus {{ $labels.namespace }}/{{ $labels.pod}} isn't ingesting samples."
+      summary: "Prometheus isn't ingesting samples"
+
+  - alert: PrometheusTargetScapesDuplicate
+    expr: increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[5m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "{{$labels.namespace}}/{{$labels.pod}} has many samples rejected due to duplicate timestamps but different values"
+      summary: Prometheus has many samples rejected


### PR DESCRIPTION
**What this PR does / why we need it**:
In the call with SysEleven about monitoring yesterday I noticed some alerts where missing, so I went through all alerts in the Prometheus Operator and added / merged them with our current alerts.

Especially, we're now alerting on API Server latencies again, which should be more stable now, due to etcd being stable.

Fixes #1161 

**Release note**:
```release-note
NONE
```