### PR TITLE
fix addons defaults for helm chart

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -23,9 +23,10 @@ kubermatic:
       tag: "latest"
       pullPolicy: "IfNotPresent"
     addons:
-      repository: "quay.io/kubermatic/addons"
-      tag: "v0.0.1"
-      pullPolicy: "IfNotPresent"
+      image:
+        repository: "quay.io/kubermatic/addons"
+        tag: "v0.0.1"
+        pullPolicy: "IfNotPresent"
   api:
     replicas: 2
     image:


### PR DESCRIPTION
**What this PR does / why we need it**:
fix addons defaults for helm chart. The defaults are currently broken in master

**Release note**:
```release-note
NONE
```
