### PR TITLE
init container for controller manager shouldn't fail if there aren't …

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -21,7 +21,7 @@ spec:
         - /bin/sh
         - -ec
         - |-
-            CLUSTERS=$(kubectl get ns -o=custom-columns=:.metadata.name | egrep '^cluster-[a-z0-9]+$')
+            CLUSTERS=$(kubectl get ns -o=custom-columns=:.metadata.name | egrep '^cluster-[a-z0-9]+$' || true)
             for CLUSTER in $CLUSTERS; do
                 kubectl -n $CLUSTER delete prometheus prometheus || true;
                 kubectl -n $CLUSTER delete servicemonitor apiserver || true;


### PR DESCRIPTION
…any clusters to cleanup

**What this PR does / why we need it**:
Currently the controller-manager pod wouldn't get up if there aren't any cluster namespaces to be cleaned up. This fix will handle that case by ignoring it instead of failing.

**Release note**:
```release-note
NONE
```