### PR TITLE
Improve machine-controller down alert only if clusters running

### DIFF
--- a/config/monitoring/prometheus/rules/machine-controller.yaml
+++ b/config/monitoring/prometheus/rules/machine-controller.yaml
@@ -2,7 +2,7 @@ groups:
 - name: machine-controller
   rules:
   - alert: MachineControllerDown
-    expr: absent(up{job="machine-controller"} == 1) and (sum(kubermatic_cluster_controller_clusters) > 0)
+    expr: absent(up{job="machine-controller"} == 1) and (kubermatic_cluster_controller_cluster_status_phase{phase="running"} > 0)
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
We only want to alert on machine controllers being down if their clusters are actually up and running

**Release note**:
```release-note
NONE
```