### PR TITLE
cluster-controller: don't panic on missing provider spec

### DIFF
--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -174,6 +174,9 @@ func (cc *Controller) ensureCloudProviderIsInitialize(cluster *kubermaticv1.Clus
 	if err != nil {
 		return err
 	}
+	if prov == nil {
+		return fmt.Errorf("no valid provider specified")
+	}
 
 	cloud, err := prov.InitializeCloudProvider(cluster.Spec.Cloud, cluster.Name)
 	if err != nil {


### PR DESCRIPTION
Currently, when a cluster object is missing a valid provider spec, the code will try to run the `InitializeCloudProvider` method on a nil object, resulting in a panic.

**Release note**:
```release-note
NONE
```