### PR TITLE
Feature/1168 controller manager cleanup go

### DIFF
--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -56,6 +56,12 @@ func main() {
 	ctx.config, err = clientcmd.BuildConfigFromFlags(
 		runOps.masterURL, runOps.kubeconfig)
 
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	// ctx.config.APIPath = "/apis"
+
 	ctx.config.NegotiatedSerializer = serializer.DirectCodecFactory{
 		CodecFactory: scheme.Codecs,
 	}
@@ -64,10 +70,6 @@ func main() {
 		Group:   "monitoring.coreos.com",
 		Version: "v1",
 	}*/
-
-	if err != nil {
-		glog.Fatal(err)
-	}
 
 	ctx.kubeClient = kubernetes.NewForConfigOrDie(ctx.config)
 	ctx.kubermaticClient = kubermaticclientset.NewForConfigOrDie(ctx.config)

--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -24,6 +24,8 @@ type cleanupContext struct {
 	config           *rest.Config
 }
 
+// Task represents a cleanup action, taking the current cluster for which the cleanup should be executed and the current context.
+// In case of an error, the correspondent error will be returned, else nil.
 type Task func(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error
 
 func main() {

--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -114,41 +114,37 @@ func deleteResourceIgnoreNonExistent(namespace string, group string, version str
 	return err
 }
 
-func getNamespaceForCluster(cluster *kubermaticv1.Cluster) string {
-	return "cluster-" + cluster.Name
-}
-
 func cleanupPrometheus(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
-	ns := getNamespaceForCluster(cluster)
+	ns := cluster.Status.NamespaceName
 	return deleteResourceIgnoreNonExistent(ns, "monitoring.coreos.com", "v1", "prometheus", "prometheus", ctx)
 }
 
 func cleanupAPIServer(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
-	ns := getNamespaceForCluster(cluster)
+	ns := cluster.Status.NamespaceName
 	return deleteResourceIgnoreNonExistent(ns, "monitoring.coreos.com", "v1", "servicemonitors", "apiserver", ctx)
 }
 
 func cleanupControllerManager(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
-	ns := getNamespaceForCluster(cluster)
+	ns := cluster.Status.NamespaceName
 	return deleteResourceIgnoreNonExistent(ns, "monitoring.coreos.com", "v1", "servicemonitors", "controller-manager", ctx)
 }
 
 func cleanupETCD(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
-	ns := getNamespaceForCluster(cluster)
+	ns := cluster.Status.NamespaceName
 	return deleteResourceIgnoreNonExistent(ns, "monitoring.coreos.com", "v1", "servicemonitors", "etcd", ctx)
 }
 
 func cleanupKubeStateMetrics(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
-	ns := getNamespaceForCluster(cluster)
+	ns := cluster.Status.NamespaceName
 	return deleteResourceIgnoreNonExistent(ns, "monitoring.coreos.com", "v1", "servicemonitors", "kube-state-metrics", ctx)
 }
 
 func cleanupMachineController(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
-	ns := getNamespaceForCluster(cluster)
+	ns := cluster.Status.NamespaceName
 	return deleteResourceIgnoreNonExistent(ns, "monitoring.coreos.com", "v1", "servicemonitors", "machine-controller", ctx)
 }
 
 func cleanupScheduler(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
-	ns := getNamespaceForCluster(cluster)
+	ns := cluster.Status.NamespaceName
 	return deleteResourceIgnoreNonExistent(ns, "monitoring.coreos.com", "v1", "servicemonitors", "scheduler", ctx)
 }

--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -35,42 +35,20 @@ type resource struct {
 func main() {
 	runOps := runOptions{}
 
-	flag.StringVar(
-		&runOps.kubeconfig,
-		"kubeconfig",
-		"",
-		"Path to a kubeconfig. Only required if out-of-cluster.")
-
-	flag.StringVar(
-		&runOps.masterURL,
-		"master",
-		"",
-		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-
+	flag.StringVar(&runOps.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&runOps.masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.Parse()
 
 	ctx := cleanupContext{}
 
 	var err error
-
-	ctx.config, err = clientcmd.BuildConfigFromFlags(
-		runOps.masterURL, runOps.kubeconfig)
+	ctx.config, err = clientcmd.BuildConfigFromFlags(runOps.masterURL, runOps.kubeconfig)
 
 	if err != nil {
 		glog.Fatal(err)
 	}
 
-	// ctx.config.APIPath = "/apis"
-
-	ctx.config.NegotiatedSerializer = serializer.DirectCodecFactory{
-		CodecFactory: scheme.Codecs,
-	}
-
-	/*ctx.config.ContentConfig.GroupVersion = &schema.GroupVersion{
-		Group:   "monitoring.coreos.com",
-		Version: "v1",
-	}*/
-
+	ctx.config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
 	ctx.kubeClient = kubernetes.NewForConfigOrDie(ctx.config)
 	ctx.kubermaticClient = kubermaticclientset.NewForConfigOrDie(ctx.config)
 
@@ -126,19 +104,11 @@ func cleanupNamespace(namespace string, ctx *cleanupContext) {
 				Error()
 
 			if err != nil && k8serrors.IsNotFound(err) {
-				glog.Infof(
-					"Skipping %s of kind %s in %s because it doesn't exist",
-					t.name,
-					t.kind,
-					namespace)
+				glog.Infof("Skipping %s of kind %s in %s because it doesn't exist", t.name, t.kind, namespace)
 			} else if err != nil {
 				glog.Error(err)
 			} else {
-				glog.Infof(
-					"Deleted %s of kind %s in %s",
-					t.name,
-					t.kind,
-					namespace)
+				glog.Infof("Deleted %s of kind %s in %s", t.name, t.kind, namespace)
 			}
 
 			w.Done()
@@ -149,8 +119,7 @@ func cleanupNamespace(namespace string, ctx *cleanupContext) {
 }
 
 func getClusterNamespaces(ctx *cleanupContext) ([]string, error) {
-	clusters, err := ctx.kubermaticClient.KubermaticV1().Clusters().List(
-		metav1.ListOptions{})
+	clusters, err := ctx.kubermaticClient.KubermaticV1().Clusters().List(metav1.ListOptions{})
 
 	if err != nil {
 		return nil, err

--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"flag"
+	"sync"
+
+	"github.com/golang/glog"
+	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type runOptions struct {
+	kubeconfig string
+	masterURL  string
+}
+
+type cleanupContext struct {
+	kubeClient       kubernetes.Interface
+	kubermaticClient kubermaticclientset.Interface
+	config           *rest.Config
+}
+
+type resource struct {
+	kind string
+	name string
+}
+
+func main() {
+	runOps := runOptions{}
+
+	flag.StringVar(
+		&runOps.kubeconfig,
+		"kubeconfig",
+		"",
+		"Path to a kubeconfig. Only required if out-of-cluster.")
+
+	flag.StringVar(
+		&runOps.masterURL,
+		"master",
+		"",
+		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+
+	flag.Parse()
+
+	ctx := cleanupContext{}
+
+	var err error
+
+	ctx.config, err = clientcmd.BuildConfigFromFlags(
+		runOps.masterURL, runOps.kubeconfig)
+
+	ctx.config.NegotiatedSerializer = serializer.DirectCodecFactory{
+		CodecFactory: scheme.Codecs,
+	}
+
+	/*ctx.config.ContentConfig.GroupVersion = &schema.GroupVersion{
+		Group:   "monitoring.coreos.com",
+		Version: "v1",
+	}*/
+
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	ctx.kubeClient = kubernetes.NewForConfigOrDie(ctx.config)
+	ctx.kubermaticClient = kubermaticclientset.NewForConfigOrDie(ctx.config)
+
+	namespaces, err := getClusterNamespaces(&ctx)
+
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	w := sync.WaitGroup{}
+	w.Add(len(namespaces))
+
+	for _, n := range namespaces {
+		go func(ns string) {
+			cleanupNamespace(ns, &ctx)
+			w.Done()
+		}(n)
+	}
+
+	w.Wait()
+}
+
+func cleanupNamespace(namespace string, ctx *cleanupContext) {
+	glog.Infof("Cleaning up namespace %s", namespace)
+
+	todos := [...]resource{
+		resource{kind: "prometheus", name: "prometheus"},
+		resource{kind: "servicemonitor", name: "apiserver"},
+		resource{kind: "servicemonitor", name: "controller-manager"},
+		resource{kind: "servicemonitor", name: "etcd"},
+		resource{kind: "servicemonitor", name: "kube-state-metrics"},
+		resource{kind: "servicemonitor", name: "machine-controller"},
+		resource{kind: "servicemonitor", name: "scheduler"},
+	}
+
+	w := sync.WaitGroup{}
+	w.Add(len(todos))
+
+	for _, todo := range todos {
+		go func(t resource) {
+			client, err := rest.UnversionedRESTClientFor(ctx.config)
+
+			if err != nil {
+				glog.Fatal(err)
+			}
+
+			err = client.
+				Delete().
+				Namespace(namespace).
+				Resource(t.kind).
+				Name(t.name).
+				Do().
+				Error()
+
+			if err != nil && k8serrors.IsNotFound(err) {
+				glog.Infof(
+					"Skipping %s of kind %s in %s because it doesn't exist",
+					t.name,
+					t.kind,
+					namespace)
+			} else if err != nil {
+				glog.Error(err)
+			} else {
+				glog.Infof(
+					"Deleted %s of kind %s in %s",
+					t.name,
+					t.kind,
+					namespace)
+			}
+
+			w.Done()
+		}(todo)
+	}
+
+	w.Wait()
+}
+
+func getClusterNamespaces(ctx *cleanupContext) ([]string, error) {
+	clusters, err := ctx.kubermaticClient.KubermaticV1().Clusters().List(
+		metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	namespaces := make([]string, len(clusters.Items), len(clusters.Items))
+
+	for i, cluster := range clusters.Items {
+		namespaces[i] = "cluster-" + cluster.Name
+	}
+
+	return namespaces, nil
+}

--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -33,9 +33,8 @@ func main() {
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.Parse()
 
-	ctx := cleanupContext{}
-
 	var err error
+	ctx := cleanupContext{}
 	ctx.config, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
 	if err != nil {
 		glog.Fatal(err)
@@ -83,7 +82,11 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) {
 	for _, task := range tasks {
 		go func(t Task) {
 			defer w.Done()
-			t(cluster, ctx)
+			err := t(cluster, ctx)
+
+			if err != nil {
+				glog.Error(err)
+			}
 		}(task)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Rewrite of the controller-manager-cleanup init container in go.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
WORK IN PROGRESS.

**Release note**:
```release-note
NONE
```