### PR TITLE
passes kubeconfig to controller manager

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -49,6 +49,7 @@ spec:
           - -internal-address=0.0.0.0:8085
           - -addons=/opt/addons
           - -backup-container=/opt/backup-container.yaml
+          - -kubeconfig=/opt/.kube/kubeconfig
           image: '{{.Values.kubermatic.controller.image.repository}}:{{.Values.kubermatic.controller.image.tag}}'
           imagePullPolicy: {{.Values.kubermatic.controller.image.pullPolicy}}
           ports:
@@ -68,6 +69,9 @@ spec:
             - name: backup-container
               mountPath: "/opt/backup-container.yaml"
               subPath: "backup-container.yaml"
+              readOnly: true
+            - name: kubeconfig
+              mountPath: "/opt/.kube/"
               readOnly: true
           resources:
             requests:
@@ -90,3 +94,6 @@ spec:
         - name: backup-container
           configMap:
             name: backup-container
+        - name: kubeconfig
+          secret:
+            secretName: kubeconfig


### PR DESCRIPTION
**What this PR does / why we need it**: passes kubeconfig to controller manager as it is required to construct the list of REST clients for seed clusters.

**Release note**:
```release-note
NONE
```