### PR TITLE
temporarily comments error handling code

### DIFF
--- a/api/pkg/controller/rbac/sync_dependant.go
+++ b/api/pkg/controller/rbac/sync_dependant.go
@@ -1,8 +1,6 @@
 package rbac
 
 import (
-	"fmt"
-
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -27,7 +25,14 @@ func (c *Controller) syncDependant(item *dependantQueueItem) error {
 		}
 	}
 	if len(projectName) == 0 {
-		return fmt.Errorf("unable to find owing project for the object name = %s, gvr = %s", item.metaObject.GetName(), item.gvr.String())
+		return nil
+		//
+		// TODO: uncomment this when existing object are migrated to projects
+		//
+		//return fmt.Errorf("unable to find owing project for the object name = %s, gvr = %s", item.metaObject.GetName(), item.gvr.String())
+		//
+		//  END of TODO
+		//
 	}
 
 	if err := c.ensureClusterRBACRoleForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject); err != nil {

--- a/api/pkg/controller/rbac/sync_dependant_test.go
+++ b/api/pkg/controller/rbac/sync_dependant_test.go
@@ -168,7 +168,11 @@ func TestEnsureDependantsRBACRole(t *testing.T) {
 		},
 
 		// scenario 2
-		{
+		//
+		// TODO: uncomment this when existing object are migrated to projects
+		//
+		//
+		/*{
 			name:            "scenario 2 no-op for a cluster that doesn't belong to a project",
 			expectError:     true,
 			existingProject: createProject("thunderball", createUser("James Bond")),
@@ -191,7 +195,10 @@ func TestEnsureDependantsRBACRole(t *testing.T) {
 					},
 				},
 			},
-		},
+		},*/
+		//
+		//  END of TODO
+		//
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
since existing object don't belong to any project sync loop
generates a lots of errors which in turn trigger alert manager

**Release note**:
```release-note
NONE
```