### PR TITLE
Authenticate apiserver when proxying

### DIFF
--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -13,9 +13,9 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -versions=../config/kubermatic/static/master/versions.yaml \
   -updates=../config/kubermatic/static/master/updates.yaml \
   -master-resources=../config/kubermatic/static/master \
-  -addons=../addons
+  -addons=../addons \
   -worker-name="$(hostname)" \
   -external-url=dev.kubermatic.io \
-  -backup-container=../config/kubermatic/static/backup-container.yaml
+  -backup-container=../config/kubermatic/static/backup-container.yaml \
   -logtostderr=1 \
   -v=6

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -277,6 +277,8 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32, etc
 		"--audit-log-path", "/var/log/audit.log",
 		"--tls-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
 		"--tls-private-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
+		"--proxy-client-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
+		"--proxy-client-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
 		"--client-ca-file", "/etc/kubernetes/ca-cert/ca.crt",
 		"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
 		"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -141,6 +141,10 @@ spec:
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
         - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
         - --client-ca-file
         - /etc/kubernetes/ca-cert/ca.crt
         - --kubelet-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -141,6 +141,10 @@ spec:
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
         - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
         - --client-ca-file
         - /etc/kubernetes/ca-cert/ca.crt
         - --kubelet-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -141,6 +141,10 @@ spec:
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
         - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
         - --client-ca-file
         - /etc/kubernetes/ca-cert/ca.crt
         - --kubelet-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -141,6 +141,10 @@ spec:
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
         - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
         - --client-ca-file
         - /etc/kubernetes/ca-cert/ca.crt
         - --kubelet-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -141,6 +141,10 @@ spec:
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
         - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
         - --client-ca-file
         - /etc/kubernetes/ca-cert/ca.crt
         - --kubelet-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -141,6 +141,10 @@ spec:
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
         - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
         - --client-ca-file
         - /etc/kubernetes/ca-cert/ca.crt
         - --kubelet-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -141,6 +141,10 @@ spec:
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
         - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
         - --client-ca-file
         - /etc/kubernetes/ca-cert/ca.crt
         - --kubelet-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -141,6 +141,10 @@ spec:
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
         - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
         - --client-ca-file
         - /etc/kubernetes/ca-cert/ca.crt
         - --kubelet-client-certificate

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -36,6 +37,8 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
+var update = flag.Bool("update", false, "Update test fixtures")
+
 func checkTestResult(t *testing.T, resFile string, testObj interface{}) {
 	path := filepath.Join("./fixtures", resFile+".yaml")
 	jsonRes, err := json.Marshal(testObj)
@@ -45,6 +48,12 @@ func checkTestResult(t *testing.T, resFile string, testObj interface{}) {
 	res, err := yaml.JSONToYAML(jsonRes)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if *update {
+		if err := ioutil.WriteFile(path, res, 0644); err != nil {
+			t.Fatalf("failed to update fixtures: %v", err)
+		}
 	}
 
 	exp, err := ioutil.ReadFile(path)


### PR DESCRIPTION
This fixes https://github.com/kubevirt/kubevirt/issues/1126 by adding
the --proxy-client-cert-file and --proxy-client-key-file flags

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```