### PR TITLE
Access to nodes via VPN.

### DIFF
--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -15,9 +15,10 @@ spec:
       labels:
         role: openvpn-client
     spec:
+      serviceAccountName: vpn-client-kubermatic
       containers:
       - name: openvpn-client
-        image: kubermatic/openvpn:v0.2
+        image: kubermatic/openvpn:v0.4
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         readinessProbe:
@@ -36,6 +37,44 @@ spec:
         - mountPath: /etc/openvpn/certs
           name: openvpn-client-certificates
           readOnly: true
+      - name: dnat-controller
+        image: kubermatic/openvpn:v0.4
+        command:
+        - bash
+        - -ec
+        - |
+          # make sure we have two chains:
+          iptables -t nat -N host_dnat || true
+          iptables -t nat -N host_dnat_inactive || true
+          iptables -t nat -D PREROUTING -j host_dnat || true
+          iptables -t nat -D PREROUTING -j host_dnat_inactive || true
+
+          virtualnodenet='{{.Variables.NodeAccessNetwork}}'
+
+          # access node list via kubectl and generate iptables rules
+          # for DNAT from it.
+          while sleep 5; do
+            iptables -t nat -F host_dnat_inactive
+            # query nodes and create DNAT rules in inactive chain
+            kubectl get nodes -o json \
+                | jq -r '.items[]|  (.metadata|.name+" "+.uid) + " " + (.status.addresses[]|select(.type=="InternalIP")|.address)' \
+                | while read name uid ip; do
+                    left=$( echo $virtualnodenet | cut -d. -f1-2 )
+                    right=$( echo $ip | cut -d. -f3-4 )
+                    iptables -t nat -A host_dnat_inactive -d $left.$right -j DNAT --to $ip
+                done
+                # swap the chains (inactive / active):
+                iptables -t nat -I PREROUTING -j host_dnat_inactive
+                iptables -t nat -D PREROUTING -j host_dnat || true
+                iptables -t nat -E host_dnat host_dnat_old
+                iptables -t nat -E host_dnat_inactive host_dnat
+                iptables -t nat -E host_dnat_old host_dnat_inactive
+          done
+          echo "Terminating."
+
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN"]
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
       volumes:

--- a/addons/openvpn/vpn-client-cluster-role-binding.yaml
+++ b/addons/openvpn/vpn-client-cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: vpn-client-kubermatic
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vpn-client-kubermatic
+subjects:
+- kind: ServiceAccount
+  name: vpn-client-kubermatic
+  namespace: kube-system

--- a/addons/openvpn/vpn-client-cluster-role.yaml
+++ b/addons/openvpn/vpn-client-cluster-role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: vpn-client-kubermatic
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]

--- a/addons/openvpn/vpn-client-serviceaccount.yaml
+++ b/addons/openvpn/vpn-client-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpn-client-kubermatic
+  namespace: kube-system

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -265,11 +265,12 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 	kubeInformerFactory.WaitForCacheSync(stopChannel)
 
 	return &resources.TemplateData{
-		DC:              &provider.DatacenterMeta{},
-		SecretLister:    secretLister,
-		ServiceLister:   serviceLister,
-		ConfigMapLister: configMapLister,
-		Cluster:         fakeCluster}, nil
+		DC:                &provider.DatacenterMeta{},
+		SecretLister:      secretLister,
+		ServiceLister:     serviceLister,
+		ConfigMapLister:   configMapLister,
+		NodeAccessNetwork: "192.0.2.0/24",
+		Cluster:           fakeCluster}, nil
 }
 
 func createNamedSecrets(secretNames []string) *corev1.SecretList {

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -72,6 +72,7 @@ func startClusterController(ctrlCtx controllerContext) error {
 		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
 		ctrlCtx.runOptions.overwriteRegistry,
 		ctrlCtx.runOptions.nodePortRange,
+		ctrlCtx.runOptions.nodeAccessNetwork,
 		ctrlCtx.runOptions.etcdDiskSize,
 
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
@@ -173,6 +174,11 @@ func startUpdateController(ctrlCtx controllerContext) error {
 func startAddonController(ctrlCtx controllerContext) error {
 	ctrl, err := addon.New(
 		addon.NewMetrics(),
+		map[string]interface{}{ // addonVariables
+			"openvpn": map[string]interface{}{
+				"NodeAccessNetwork": ctrlCtx.runOptions.nodeAccessNetwork,
+			},
+		},
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.runOptions.addons,
 		ctrlCtx.runOptions.overwriteRegistry,

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -47,6 +47,7 @@ type controllerRunOptions struct {
 	workerCount          int
 	overwriteRegistry    string
 	nodePortRange        string
+	nodeAccessNetwork    string
 	addons               string
 	backupContainerFile  string
 	cleanupContainerFile string
@@ -83,6 +84,7 @@ func main() {
 	flag.IntVar(&runOp.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
 	flag.StringVar(&runOp.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
 	flag.StringVar(&runOp.nodePortRange, "nodeport-range", "30000-32767", "NodePort range to use for new clusters. It must be within the NodePort range of the seed-cluster")
+	flag.StringVar(&runOp.nodeAccessNetwork, "node-access-network", "10.254.0.0/16", "A network which allows direct access to nodes via VPN. Uses CIDR notation.")
 	flag.StringVar(&runOp.addons, "addons", "/opt/addons", "Path to addon manifests. Should contain sub-folders for each addon")
 	flag.StringVar(&runOp.backupContainerFile, "backup-container", "", fmt.Sprintf("[Required] Filepath of a backup container yaml. It must mount a volume named %s from which it reads the etcd backups", backupcontroller.SharedVolumeName))
 	flag.StringVar(&runOp.cleanupContainerFile, "cleanup-container", "", "[Required] Filepath of a cleanup container yaml. The container will be used to cleanup the backup directory for a cluster after it got deleted.")

--- a/api/pkg/controller/cluster/controller.go
+++ b/api/pkg/controller/cluster/controller.go
@@ -65,6 +65,7 @@ type Controller struct {
 
 	overwriteRegistry string
 	nodePortRange     string
+	nodeAccessNetwork string
 	etcdDiskSize      resource.Quantity
 
 	metrics *Metrics
@@ -110,6 +111,7 @@ func NewController(
 	userClusterConnProvider UserClusterConnectionProvider,
 	overwriteRegistry string,
 	nodePortRange string,
+	nodeAccessNetwork string,
 	etcdDiskSize string,
 
 	clusterInformer kubermaticv1informers.ClusterInformer,
@@ -134,6 +136,7 @@ func NewController(
 
 		overwriteRegistry: overwriteRegistry,
 		nodePortRange:     nodePortRange,
+		nodeAccessNetwork: nodeAccessNetwork,
 		etcdDiskSize:      resource.MustParse(etcdDiskSize),
 
 		externalURL: externalURL,

--- a/api/pkg/controller/cluster/controller_test.go
+++ b/api/pkg/controller/cluster/controller_test.go
@@ -43,6 +43,7 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
 		"",
 		"",
+		"192.0.2.0/24",
 		"5Gi",
 
 		kubermaticInformerFactory.Kubermatic().V1().Clusters(),

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -101,6 +101,7 @@ func (cc *Controller) getClusterTemplateData(c *kubermaticv1.Cluster) (*resource
 		cc.serviceLister,
 		cc.overwriteRegistry,
 		cc.nodePortRange,
+		cc.nodeAccessNetwork,
 		cc.etcdDiskSize,
 	), nil
 }

--- a/api/pkg/resources/openvpn/configmap.go
+++ b/api/pkg/resources/openvpn/configmap.go
@@ -3,17 +3,12 @@ package openvpn
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-const (
-	configTpl = `iroute %s %s
-iroute %s %s
-`
 )
 
 // ConfigMap returns a ConfigMap containing the openvpn config
@@ -29,24 +24,38 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
 	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	cm.Labels = resources.GetLabels(name)
 
-	podNetIP, podNet, err := net.ParseCIDR(data.Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+	var iroutes []string
+
+	// iroute for pod network
+	_, podNet, err := net.ParseCIDR(data.Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0])
 	if err != nil {
 		return nil, err
 	}
+	iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
+		podNet.IP.String(),
+		net.IP(podNet.Mask).String()))
 
-	serviceNetIP, serviceNet, err := net.ParseCIDR(data.Cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0])
+	// iroute for service network
+	_, serviceNet, err := net.ParseCIDR(data.Cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0])
 	if err != nil {
 		return nil, err
 	}
+	iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
+		serviceNet.IP.String(),
+		net.IP(serviceNet.Mask).String()))
 
+	_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork, err)
+	}
+	iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
+		nodeAccessNetwork.IP.String(),
+		net.IP(nodeAccessNetwork.Mask).String()))
+
+	// trailing newline
+	iroutes = append(iroutes, "")
 	cm.Data = map[string]string{
-		"user-cluster-client": fmt.Sprintf(
-			configTpl,
-			podNetIP.String(),
-			net.IP(podNet.Mask).String(),
-			serviceNetIP.String(),
-			net.IP(serviceNet.Mask).String(),
-		),
+		"user-cluster-client": strings.Join(iroutes, "\n"),
 	}
 
 	return cm, nil

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -151,6 +151,7 @@ type TemplateData struct {
 	ServiceLister     corev1lister.ServiceLister
 	OverwriteRegistry string
 	NodePortRange     string
+	NodeAccessNetwork string
 	EtcdDiskSize      resource.Quantity
 }
 
@@ -189,6 +190,7 @@ func NewTemplateData(
 	serviceLister corev1lister.ServiceLister,
 	overwriteRegistry string,
 	nodePortRange string,
+	nodeAccessNetwork string,
 	etcdDiskSize resource.Quantity) *TemplateData {
 	return &TemplateData{
 		Cluster:           cluster,
@@ -198,6 +200,7 @@ func NewTemplateData(
 		ServiceLister:     serviceLister,
 		OverwriteRegistry: overwriteRegistry,
 		NodePortRange:     nodePortRange,
+		NodeAccessNetwork: nodeAccessNetwork,
 		EtcdDiskSize:      etcdDiskSize,
 	}
 }

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-openvpn.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-openvpn.yaml
@@ -2,6 +2,7 @@ data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
     iroute 10.10.10.0 255.255.255.0
+    iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-openvpn.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-openvpn.yaml
@@ -2,6 +2,7 @@ data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
     iroute 10.10.10.0 255.255.255.0
+    iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-openvpn.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-openvpn.yaml
@@ -2,6 +2,7 @@ data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
     iroute 10.10.10.0 255.255.255.0
+    iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-openvpn.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-openvpn.yaml
@@ -2,6 +2,7 @@ data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
     iroute 10.10.10.0 255.255.255.0
+    iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-openvpn.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-openvpn.yaml
@@ -2,6 +2,7 @@ data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
     iroute 10.10.10.0 255.255.255.0
+    iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-openvpn.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-openvpn.yaml
@@ -2,6 +2,7 @@ data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
     iroute 10.10.10.0 255.255.255.0
+    iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-openvpn.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-openvpn.yaml
@@ -2,6 +2,7 @@ data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
     iroute 10.10.10.0 255.255.255.0
+    iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-openvpn.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-openvpn.yaml
@@ -2,6 +2,7 @@ data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
     iroute 10.10.10.0 255.255.255.0
+    iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -259,6 +259,7 @@ func TestLoadFiles(t *testing.T) {
 					kubeInformerFactory.Core().V1().Services().Lister(),
 					"",
 					"",
+					"192.0.2.0/24",
 					resource.MustParse("5Gi"),
 				)
 				kubeInformerFactory.Start(wait.NeverStop)

--- a/containers/openvpn/Dockerfile
+++ b/containers/openvpn/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.7
+LABEL maintainer "tobias.hintze@loodse.com"
+
+RUN apk add -U \
+	bash \
+	ca-certificates \
+	curl \
+	iptables \
+	jq \
+	openssl \
+	openvpn \
+	--no-cache
+
+# add kubectl
+RUN curl \
+	-o /usr/bin/kubectl \
+	-L "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN chmod 0755 /usr/bin/kubectl

--- a/containers/openvpn/release.sh
+++ b/containers/openvpn/release.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ver=v0.4
+
+set -euox pipefail
+
+docker build --no-cache --pull -t kubermatic/openvpn:$ver .
+docker push kubermatic/openvpn:$ver


### PR DESCRIPTION
**What this PR does / why we need it**:

While the openvpn addon currently provides access to services
and pods, it does not provide access to the user cluster 
workers' kubelet ports.

This PR adds another exposed network for the vpn:
This `NodeAccessNetwork` is a private network which is used
to make hosts/nodes from user-cluster accessible from the
apiserver via the openvpn connection. This is achieved by
associating an IP address from that network to each host/node
and doing destination network address translation (DNAT)
to map the virtual IP addresses to the real host IP addresses.

The `NodeAccessNetwork` is specified as a flag to controller-manager
and used as templating data for creation of openvpn client and server
deployments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Control plane can now reach the nodes via VPN
```