### PR TITLE
Set backupcontrollers SuccessfulJobsHistoryLimit to zero

### DIFF
--- a/api/pkg/controller/backup/controller.go
+++ b/api/pkg/controller/backup/controller.go
@@ -317,6 +317,7 @@ func (c *Controller) cronJob(cluster *kubermaticv1.Cluster) (*batchv1beta1.CronJ
 	cronJob.Spec.Schedule = c.backupScheduleString
 	cronJob.Spec.ConcurrencyPolicy = batchv1beta1.ForbidConcurrent
 	cronJob.Spec.Suspend = boolPtr(false)
+	cronJob.Spec.SuccessfulJobsHistoryLimit = int32Ptr(int32(0))
 	etcdServiceAddr := fmt.Sprintf("etcd.%s.svc.cluster.local.:2379", cluster.Status.NamespaceName)
 	cronJob.Spec.JobTemplate.Spec.Template.Spec.InitContainers = []corev1.Container{
 		corev1.Container{Name: "backup-creator",
@@ -335,6 +336,10 @@ func (c *Controller) cronJob(cluster *kubermaticv1.Cluster) (*batchv1beta1.CronJ
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
 }
 
 func parseDuration(interval time.Duration) (string, error) {

--- a/api/pkg/controller/backup/controller_test.go
+++ b/api/pkg/controller/backup/controller_test.go
@@ -89,6 +89,11 @@ func TestEnsureBackupCronJob(t *testing.T) {
 		t.Fatalf("Expected exactly one cronjob, got %v", len(cronJobs.Items))
 	}
 
+	if *cronJobs.Items[0].Spec.SuccessfulJobsHistoryLimit != 0 {
+		t.Errorf("Expected spec.SuccessfulJobsHistoryLimit to be 0 but was %v",
+			*cronJobs.Items[0].Spec.SuccessfulJobsHistoryLimit)
+	}
+
 	cronJobs.Items[0].Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{}
 	cronJobs.Items[0].Spec.JobTemplate.Spec.Template.Spec.InitContainers = []corev1.Container{}
 	_, err = fakeKubeClient.BatchV1beta1().CronJobs(metav1.NamespaceSystem).Update(&cronJobs.Items[0])


### PR DESCRIPTION
This avoids false positive alerts due to pod staying in completed state
for a longer time.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
NONE
```