### PR TITLE
Azzure sizes

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1177,6 +1177,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a29ab606e1b4b58f892151d7afe917267ad6a8bc1cdd2c5a81482f5d300b9159"
+  inputs-digest = "9741c5cb935b0a5ea50d59d3a5968f2041ebb62219b3fc751e929783ffaf52a8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -17,6 +17,29 @@
   },
   "host": "cloud.kubermatic.io",
   "paths": {
+    "/api/v1/azure/sizes": {
+      "get": {
+        "description": "Lists available VM sizes in an Azure region",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "azure"
+        ],
+        "operationId": "listAzureSizes",
+        "responses": {
+          "200": {
+            "description": "AzureSizeList",
+            "schema": {
+              "$ref": "#/definitions/AzureSizeList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/dc": {
       "get": {
         "produces": [
@@ -1280,6 +1303,50 @@
       },
       "x-go-name": "AzureNodeSpec",
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v2"
+    },
+    "AzureSize": {
+      "type": "object",
+      "title": "AzureSize is the object representing Azure VM sizes.",
+      "properties": {
+        "maxDataDiskCount": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "MaxDataDiskCount"
+        },
+        "memoryInMB": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "MemoryInMB"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "numberOfCores": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "NumberOfCores"
+        },
+        "osDiskSizeInMB": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "OsDiskSizeInMB"
+        },
+        "resourceDiskSizeInMB": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "ResourceDiskSizeInMB"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "AzureSizeList": {
+      "type": "array",
+      "title": "AzureSizeList represents an array of Azure VM sizes.",
+      "items": {
+        "$ref": "#/definitions/AzureSize"
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },
     "BringYourOwnCloudSpec": {
       "type": "object",

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -104,6 +104,21 @@ type DigitaloceanSize struct {
 	Regions      []string `json:"regions"`
 }
 
+// AzureSizeList represents an array of Azure VM sizes.
+// swagger:model AzureSizeList
+type AzureSizeList []AzureSize
+
+// AzureSize is the object representing Azure VM sizes.
+// swagger:model AzureSize
+type AzureSize struct {
+	Name                 *string `json:"name"`
+	NumberOfCores        *int32  `json:"numberOfCores"`
+	OsDiskSizeInMB       *int32  `json:"osDiskSizeInMB"`
+	ResourceDiskSizeInMB *int32  `json:"resourceDiskSizeInMB"`
+	MemoryInMB           *int32  `json:"memoryInMB"`
+	MaxDataDiskCount     *int32  `json:"maxDataDiskCount"`
+}
+
 // SSHKey represents a ssh key
 // swagger:model SSHKey
 type SSHKey struct {

--- a/api/pkg/handler/azure.go
+++ b/api/pkg/handler/azure.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/go-kit/kit/endpoint"
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+)
+
+func azureSizeEndpoint() endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(AzureSizeReq)
+
+		var err error
+		sizesClient := compute.NewVirtualMachineSizesClient(req.SubscriptionID)
+		sizesClient.Authorizer, err = auth.NewClientCredentialsConfig(req.ClientID, req.ClientSecret, req.TenantID).Authorizer()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create authorizer: %v", err)
+		}
+
+		sizesResult, err := sizesClient.List(ctx, req.Location)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list sizes: %v", err)
+		}
+
+		if sizesResult.Value == nil {
+			return nil, fmt.Errorf("failed to list sizes: Azure return a nil result")
+		}
+
+		var sizeList apiv1.AzureSizeList
+		for _, v := range *sizesResult.Value {
+			s := apiv1.AzureSize{
+				Name:                 v.Name,
+				NumberOfCores:        v.NumberOfCores,
+				OsDiskSizeInMB:       v.OsDiskSizeInMB,
+				ResourceDiskSizeInMB: v.ResourceDiskSizeInMB,
+				MemoryInMB:           v.MemoryInMB,
+				MaxDataDiskCount:     v.MaxDataDiskCount,
+			}
+
+			sizeList = append(sizeList, s)
+		}
+
+		return sizeList, nil
+	}
+}

--- a/api/pkg/handler/digitalocean.go
+++ b/api/pkg/handler/digitalocean.go
@@ -35,32 +35,22 @@ func digitaloceanSizeEndpoint() endpoint.Endpoint {
 		// type 3 isn't listed in the pricing anymore and only will be available for legacy issues until July 1st, 2018
 		// therefor we might not want to log all cases that aren't starting with s or c
 		for k := range sizes {
-			if reStandard.MatchString(sizes[k].Slug) {
-				sizeList.Standard = append(sizeList.Standard, apiv1.DigitaloceanSize{
-					Slug:         sizes[k].Slug,
-					Available:    sizes[k].Available,
-					Transfer:     sizes[k].Transfer,
-					PriceMonthly: sizes[k].PriceMonthly,
-					PriceHourly:  sizes[k].PriceHourly,
-					Memory:       sizes[k].Memory,
-					VCPUs:        sizes[k].Vcpus,
-					Disk:         sizes[k].Disk,
-					Regions:      sizes[k].Regions,
-				})
-				continue
-			} else if reOptimized.MatchString(sizes[k].Slug) {
-				sizeList.Optimized = append(sizeList.Optimized, apiv1.DigitaloceanSize{
-					Slug:         sizes[k].Slug,
-					Available:    sizes[k].Available,
-					Transfer:     sizes[k].Transfer,
-					PriceMonthly: sizes[k].PriceMonthly,
-					PriceHourly:  sizes[k].PriceHourly,
-					Memory:       sizes[k].Memory,
-					VCPUs:        sizes[k].Vcpus,
-					Disk:         sizes[k].Disk,
-					Regions:      sizes[k].Regions,
-				})
-				continue
+			s := apiv1.DigitaloceanSize{
+				Slug:         sizes[k].Slug,
+				Available:    sizes[k].Available,
+				Transfer:     sizes[k].Transfer,
+				PriceMonthly: sizes[k].PriceMonthly,
+				PriceHourly:  sizes[k].PriceHourly,
+				Memory:       sizes[k].Memory,
+				VCPUs:        sizes[k].Vcpus,
+				Disk:         sizes[k].Disk,
+				Regions:      sizes[k].Regions,
+			}
+			switch {
+			case reStandard.MatchString(sizes[k].Slug):
+				sizeList.Standard = append(sizeList.Standard, s)
+			case reOptimized.MatchString(sizes[k].Slug):
+				sizeList.Optimized = append(sizeList.Optimized, s)
 			}
 		}
 

--- a/api/pkg/handler/request.go
+++ b/api/pkg/handler/request.go
@@ -177,6 +177,26 @@ func decodeDoSizesReq(c context.Context, r *http.Request) (interface{}, error) {
 	return req, nil
 }
 
+// AzureSizeReq represent a request for Azure VM sizes
+type AzureSizeReq struct {
+	SubscriptionID string
+	TenantID       string
+	ClientID       string
+	ClientSecret   string
+	Location       string
+}
+
+func decodeAzureSizesReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req AzureSizeReq
+
+	req.SubscriptionID = r.Header.Get("SubscriptionID")
+	req.TenantID = r.Header.Get("TenantID")
+	req.ClientID = r.Header.Get("ClientID")
+	req.ClientSecret = r.Header.Get("ClientSecret")
+	req.Location = r.Header.Get("Location")
+	return req, nil
+}
+
 // OpenstackSizeReq represent a request for openstack sizes
 type OpenstackSizeReq struct {
 	Username       string

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -49,6 +49,10 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 		Handler(r.listDigitaloceanSizes())
 
 	mux.Methods(http.MethodGet).
+		Path("/azure/sizes").
+		Handler(r.listAzureSizes())
+
+	mux.Methods(http.MethodGet).
 		Path("/openstack/sizes").
 		Handler(r.listOpenstackSizes())
 
@@ -160,6 +164,28 @@ func (r Routing) listDigitaloceanSizes() http.Handler {
 			r.userSaverMiddleware(),
 		)(digitaloceanSizeEndpoint()),
 		decodeDoSizesReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/azure/sizes azure listAzureSizes
+//
+// Lists available VM sizes in an Azure region
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: AzureSizeList
+func (r Routing) listAzureSizes() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+		)(azureSizeEndpoint()),
+		decodeAzureSizesReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)


### PR DESCRIPTION
Fixes #1249 
Initially I was going to split the sizes into categories like for DO, but there are so many groups with so many product lines in the groups, and so irregular naming conventions, that it would be impractical.

ping @kgroschoff 

**Release note**:
```release-note
NONE
```