### PR TITLE
add helm resource policy to keep CRD's and LoadBalancer servies

### DIFF
--- a/config/kubermatic/templates/crd-addons.yaml
+++ b/config/kubermatic/templates/crd-addons.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: addons.kubermatic.k8s.io
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: kubermatic.k8s.io
   names:

--- a/config/kubermatic/templates/crd-clusters.yaml
+++ b/config/kubermatic/templates/crd-clusters.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusters.kubermatic.k8s.io
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: kubermatic.k8s.io
   names:

--- a/config/kubermatic/templates/crd-projects.yaml
+++ b/config/kubermatic/templates/crd-projects.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: projects.kubermatic.k8s.io
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: kubermatic.k8s.io
   names:

--- a/config/kubermatic/templates/crd-ssh-keys.yaml
+++ b/config/kubermatic/templates/crd-ssh-keys.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: usersshkeies.kubermatic.k8s.io
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: kubermatic.k8s.io
   names:

--- a/config/kubermatic/templates/crd-users.yaml
+++ b/config/kubermatic/templates/crd-users.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: users.kubermatic.k8s.io
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: kubermatic.k8s.io
   names:

--- a/config/nginx-ingress-controller/templates/nginx-svc.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-svc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx-ingress-controller
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   type: LoadBalancer
   ports:

--- a/config/nodeport-proxy/templates/lb.yaml
+++ b/config/nodeport-proxy/templates/lb.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nodeport-lb
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   selector:
     app: nodeport-proxy


### PR DESCRIPTION
**What this PR does / why we need it**:
add helm resource policy to keep CRD's and LoadBalancer servies
https://docs.helm.sh/developing_charts/#tell-tiller-not-to-delete-a-resource

**Release note**:
```release-note
NONE
```