### PR TITLE
add missing return on deletion

### DIFF
--- a/api/pkg/controller/backup/controller.go
+++ b/api/pkg/controller/backup/controller.go
@@ -339,6 +339,7 @@ func (c *Controller) sync(key string) error {
 				return fmt.Errorf("failed to update cluster after removing cleanup finalizer: %v", err)
 			}
 		}
+		return nil
 	}
 
 	// Always add the finalizer first


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing return on deletion otherwise the controller will try to add a finalizer to a deleted cluster.

**Release note**:
```release-note
NONE
```