### PR TITLE
fixes typo in rbac generator deployment

### DIFF
--- a/config/kubermatic/master/templates/kubermatic-rbac-generator-dep.yaml
+++ b/config/kubermatic/master/templates/kubermatic-rbac-generator-dep.yaml
@@ -25,7 +25,7 @@ spec:
         image: '{{.Values.kubermatic.rbac.image.repository}}:{{.Values.kubermatic.rbac.image.tag}}'
         imagePullPolicy: {{.Values.kubermatic.rbac.image.pullPolicy}}
         volumeMounts:
-          - name: kubeconfig
+          - name: kubeconfigwithseeds
             mountPath: "/opt/.kube/"
             readOnly: true
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**: fixes typo in RBAC generator deployment.

**Release note**:
```release-note
NONE
```

