### PR TITLE
add field 'Default' to MasterVersion struct

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2473,6 +2473,10 @@
           },
           "x-go-name": "AllowedNodeVersions"
         },
+        "default": {
+          "type": "boolean",
+          "x-go-name": "Default"
+        },
         "version": {
           "$ref": "#/definitions/Version"
         }

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -205,4 +205,5 @@ type AvailableMasterVersions []MasterVersion
 type MasterVersion struct {
 	Version             *semver.Version `json:"version"`
 	AllowedNodeVersions []string        `json:"allowedNodeVersions"`
+	Default             bool            `json:"default,omitempty"`
 }

--- a/api/pkg/handler/upgrade.go
+++ b/api/pkg/handler/upgrade.go
@@ -57,6 +57,7 @@ func getMasterVersions(updateManager UpdateManager) endpoint.Endpoint {
 			sv[v] = &apiv1.MasterVersion{
 				Version:             versions[v].Version,
 				AllowedNodeVersions: versions[v].AllowedNodeVersions,
+				Default:             versions[v].Default,
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
add field `Default` to struct `MasterVersion`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1178

**Special notes for your reviewer**:

**Question:** Does it make sense to extend the `MasterVersion` struct (like I did), as we also use it in `getClusterUpgrades()`, where we don't 'set' a default version:
```
var sv []*apiv1.MasterVersion
for v := range versions {
  sv = append(sv, &apiv1.MasterVersion{
    Version:             versions[v].Version,
    AllowedNodeVersions: versions[v].AllowedNodeVersions,
  })
}
```
Or should we introduce a new struct for it?


**Release note**:
```release-note
NONE
```