### PR TITLE
fixes typo in secret in rbac generator deployment

### DIFF
--- a/config/kubermatic/master/templates/dockerregistry-secret.yaml
+++ b/config/kubermatic/master/templates/dockerregistry-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dockeregistry
+  name: dockerregistry
 data:
   .dockerconfigjson: {{ .Values.kubermatic.docker.secret }}
 type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
**What this PR does / why we need it**: fixes typo in secret in rbac generator deployment

**Release note**:
```release-note
NONE
```