### PR TITLE
fixes path to kubeconfig

### DIFF
--- a/config/kubermatic/master/templates/kubermatic-rbac-generator-dep.yaml
+++ b/config/kubermatic/master/templates/kubermatic-rbac-generator-dep.yaml
@@ -21,7 +21,7 @@ spec:
         args:
         - -v=4
         - -logtostderr
-        - -kubeconfig=/opt/.kube/kubeconfigwithseeds
+        - -kubeconfig=/opt/.kube/kubeconfig
         image: '{{.Values.kubermatic.rbac.image.repository}}:{{.Values.kubermatic.rbac.image.tag}}'
         imagePullPolicy: {{.Values.kubermatic.rbac.image.pullPolicy}}
         volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**: fixes path to kubeconfig

**Release note**:
```release-note
NONE
```