### PR TITLE
synchronizes project's resources for seed clusters

### DIFF
--- a/api/pkg/controller/rbac/cluster_provider.go
+++ b/api/pkg/controller/rbac/cluster_provider.go
@@ -1,0 +1,72 @@
+package rbac
+
+import (
+	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
+
+	"fmt"
+
+	kuberinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	rbaclister "k8s.io/client-go/listers/rbac/v1"
+)
+
+const (
+	masterProviderName = "master"
+)
+
+// ClusterProvider holds set of clients that allow for communication with the cluster and
+// that are required to properly generate RBAC for resources in that particular cluster
+type ClusterProvider struct {
+	providerName              string
+	kubeClient                kubernetes.Interface
+	kubeInformerFactory       kuberinformers.SharedInformerFactory
+	kubermaticClient          kubermaticclientset.Interface
+	kubermaticInformerFactory externalversions.SharedInformerFactory
+
+	rbacClusterRoleLister        rbaclister.ClusterRoleLister
+	rbacClusterRoleBindingLister rbaclister.ClusterRoleBindingLister
+}
+
+// NewClusterProvider creates a brand new ClusterProvider
+//
+// Note:
+// This method will create and register Listers for RBAC Roles and Bindings
+func NewClusterProvider(providerName string, kubeClient kubernetes.Interface, kubeInformerFactory kuberinformers.SharedInformerFactory, kubermaticClient kubermaticclientset.Interface, kubermaticInformerFactory externalversions.SharedInformerFactory) *ClusterProvider {
+	cp := &ClusterProvider{
+		providerName:              providerName,
+		kubeClient:                kubeClient,
+		kubeInformerFactory:       kubeInformerFactory,
+		kubermaticClient:          kubermaticClient,
+		kubermaticInformerFactory: kubermaticInformerFactory,
+	}
+
+	cp.rbacClusterRoleLister = cp.kubeInformerFactory.Rbac().V1().ClusterRoles().Lister()
+	cp.rbacClusterRoleBindingLister = cp.kubeInformerFactory.Rbac().V1().ClusterRoleBindings().Lister()
+
+	return cp
+}
+
+// StartInformers starts shared informers factories
+func (p *ClusterProvider) StartInformers(stopCh <-chan struct{}) {
+	p.kubeInformerFactory.Start(stopCh)
+	p.kubermaticInformerFactory.Start(stopCh)
+}
+
+// WaitForCachesToSync waits for all started informers' cache until they are synced.
+func (p *ClusterProvider) WaitForCachesToSync(stopCh <-chan struct{}) error {
+	infSyncStatus := p.kubermaticInformerFactory.WaitForCacheSync(stopCh)
+	for informerType, informerSynced := range infSyncStatus {
+		if !informerSynced {
+			return fmt.Errorf("Unable to sync caches for seed cluster provider %s for informer %v", p.providerName, informerType)
+		}
+	}
+
+	infKubeSyncStatus := p.kubeInformerFactory.WaitForCacheSync(stopCh)
+	for informerType, informerSynced := range infKubeSyncStatus {
+		if !informerSynced {
+			return fmt.Errorf("Unable to sync caches for seed cluster provider %s for informer %v", p.providerName, informerType)
+		}
+	}
+	return nil
+}

--- a/api/pkg/controller/rbac/controller.go
+++ b/api/pkg/controller/rbac/controller.go
@@ -27,9 +27,8 @@ import (
 )
 
 const (
-	metricNamespace                   = "kubermatic"
-	destinationSeed                   = "seed"
-	dependantResyncTime time.Duration = 5 * time.Minute
+	metricNamespace = "kubermatic"
+	destinationSeed = "seed"
 )
 
 // Metrics contains metrics that this controller will collect and expose
@@ -338,6 +337,7 @@ func (c *Controller) enqueueProjectResource(obj interface{}, gvr schema.GroupVer
 }
 
 const projectResourcesResyncTime time.Duration = 5 * time.Minute
+
 type projectResourceQueueItem struct {
 	gvr             schema.GroupVersionResource
 	kind            string

--- a/api/pkg/controller/rbac/controller.go
+++ b/api/pkg/controller/rbac/controller.go
@@ -176,7 +176,7 @@ func New(
 	for _, clusterProvider := range allClusterProviders {
 		for _, resource := range c.projectResources {
 			if len(resource.destination) == 0 && clusterProvider.providerName != masterProviderName {
-				glog.V(4).Infof("skipping adding a shared informer for a project's resource %q for provider %q, as it is meant only for the master cluster provider", resource.gvr.String(), clusterProvider.providerName)
+				glog.V(6).Infof("skipping adding a shared informer for a project's resource %q for provider %q, as it is meant only for the master cluster provider", resource.gvr.String(), clusterProvider.providerName)
 				continue
 			}
 			informer, err := c.informerFor(clusterProvider.kubermaticInformerFactory, resource.gvr, resource.kind, clusterProvider)

--- a/api/pkg/controller/rbac/sync_project_test.go
+++ b/api/pkg/controller/rbac/sync_project_test.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	kubermaticfakeclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-
-	"time"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"


### PR DESCRIPTION
**What this PR does / why we need it**: synchronises project's resources for seed clusters. since the RBAC Generator application is only run on the master cluster the changes in this pull adjusts the existing code to this requirement. in practice it means that the app will monitor the project's resources e.g clusters and generate the proper set of RBAC Roles/Bindings for them in the given seed cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1237 

**Release note**:
```release-note
NONE
```