### PR TITLE
move masterVersion migration to cleanup container

### DIFF
--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -78,6 +78,7 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) {
 		cleanupMachineController,
 		cleanupScheduler,
 		removeDeprecatedFinalizers,
+		migrateVersion,
 	}
 
 	w := sync.WaitGroup{}
@@ -168,5 +169,16 @@ func removeDeprecatedFinalizers(cluster *kubermaticv1.Cluster, ctx *cleanupConte
 		}
 	}
 
+	return nil
+}
+
+// We moved MasterVersion to Version
+func migrateVersion(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	if cluster.Spec.Version == "" {
+		cluster.Spec.Version = cluster.Spec.MasterVersion
+		if _, err := ctx.kubermaticClient.KubermaticV1().Clusters().Update(cluster); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/api/pkg/controller/cluster/controller.go
+++ b/api/pkg/controller/cluster/controller.go
@@ -364,9 +364,6 @@ func (cc *Controller) syncCluster(key string) error {
 
 	glog.V(4).Infof("syncing cluster %s", key)
 
-	// In case we change fields
-	cc.migrateCluster(cluster)
-
 	for _, phase := range kubermaticv1.ClusterPhases {
 		value := 0.0
 		if phase == cluster.Status.Phase {
@@ -402,13 +399,6 @@ func (cc *Controller) syncCluster(key string) error {
 	}
 
 	return cc.updateCluster(originalData, cluster)
-}
-
-func (cc *Controller) migrateCluster(cluster *kubermaticv1.Cluster) {
-	if cluster.Spec.Version == "" {
-		cluster.Spec.Version = cluster.Spec.MasterVersion
-	}
-	cluster.Spec.MasterVersion = cluster.Spec.Version
 }
 
 func (cc *Controller) runWorker() {


### PR DESCRIPTION
**What this PR does / why we need it**:
move masterVersion migration to cleanup container.
No need to have it inside the controller. Its more readable and cleaner inside the cleanup container

**Release note**:
```release-note
NONE
```