### PR TITLE
Fix controller-manager to allow running the vsphere cloud-provider on…

### DIFF
--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -34,14 +34,22 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
 	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	cm.Labels = resources.GetLabels("cloud-config")
 	cm.Data = map[string]string{
-		"config": configBuffer.String(),
+		"config":              configBuffer.String(),
+		FakeVMWareUUIDKeyName: fakeVMWareUUID,
 	}
 
 	return cm, nil
 }
 
 const (
-	config = `
+	// FakeVMWareUUIDKeyName is the name of the cloud-config configmap key
+	// that holds the fake vmware uuid
+	// It is required when activating the vsphere cloud-provider in the controller
+	// manager on a non-ESXi host
+	// Upstream issue: https://github.com/kubernetes/kubernetes/issues/65145
+	FakeVMWareUUIDKeyName = "fakeVmwareUUID"
+	fakeVMWareUUID        = "VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00"
+	config                = `
 {{- if .Cluster.Spec.Cloud.AWS }}
 [global]
 zone={{ .Cluster.Spec.Cloud.AWS.AvailabilityZone }}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/cloudconfig"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -150,6 +151,18 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 				},
 			},
 		},
+	}
+
+	if data.Cluster.Spec.Cloud.VSphere != nil {
+		fakeVMWareUUIDMount := corev1.VolumeMount{
+			Name:      resources.CloudConfigConfigMapName,
+			SubPath:   cloudconfig.FakeVMWareUUIDKeyName,
+			MountPath: "/sys/class/dmi/id/product_serial",
+			ReadOnly:  true,
+		}
+		// Required because of https://github.com/kubernetes/kubernetes/issues/65145
+		dep.Spec.Template.Spec.Containers[0].VolumeMounts = append(dep.Spec.Template.Spec.Containers[0].VolumeMounts,
+			fakeVMWareUUIDMount)
 	}
 
 	return dep, nil

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-cloud-config.yaml
@@ -9,6 +9,7 @@ data:
     SubnetID=aws-subnet-id
     RouteTableID=aws-route-table-id
     disablestrictzonecheck=true
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-cloud-config.yaml
@@ -9,6 +9,7 @@ data:
     SubnetID=aws-subnet-id
     RouteTableID=aws-route-table-id
     disablestrictzonecheck=true
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-cloud-config.yaml
@@ -1,6 +1,7 @@
 data:
   config: |2+
 
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-cloud-config.yaml
@@ -1,6 +1,7 @@
 data:
   config: |2+
 
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-cloud-config.yaml
@@ -1,6 +1,7 @@
 data:
   config: |2+
 
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-cloud-config.yaml
@@ -1,6 +1,7 @@
 data:
   config: |2+
 
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-cloud-config.yaml
@@ -12,6 +12,7 @@ data:
     [BlockStorage]
     trust-device-path = false
     bs-version = "v2"
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-cloud-config.yaml
@@ -13,6 +13,7 @@ data:
     trust-device-path = false
     bs-version = "v2"
     ignore-volume-az = true
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null
   labels:


### PR DESCRIPTION
… non-esxi hosts

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note cloud provider
Non-ESXi vsphere hosts are now supported
```