### PR TITLE
Use struct instead of pointer

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -259,7 +259,6 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 	fakeCluster.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"172.25.0.0/16"}
 	fakeCluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.10.10.0/24"}
 	fakeCluster.Status.NamespaceName = mockNamespaceName
-	fakeCluster.Address = &clusterv1.ClusterAddress{}
 
 	stopChannel := make(chan struct{})
 	kubeInformerFactory.Start(stopChannel)

--- a/api/pkg/controller/addon/controller.go
+++ b/api/pkg/controller/addon/controller.go
@@ -280,7 +280,7 @@ func (c *Controller) sync(key string) error {
 	}
 
 	//Reconciling
-	if cluster.Status.Health == nil || !cluster.Status.Health.Apiserver {
+	if !cluster.Status.Health.Apiserver {
 		return nil
 	}
 	if err := c.ensureIsInstalled(addon, cluster); err != nil {

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -117,7 +117,7 @@ func (cc *Controller) reconcileCluster(cluster *kubermaticv1.Cluster) error {
 	if err != nil {
 		return err
 	}
-	cluster.Status.Health = health
+	cluster.Status.Health = *health
 
 	if cluster.Status.Health.Apiserver {
 		if err := cc.ensureClusterReachable(cluster); err != nil {
@@ -208,9 +208,6 @@ func (cc *Controller) ensureNamespaceExists(c *kubermaticv1.Cluster) error {
 
 // ensureAddress will set the cluster hostname and the url under which the apiserver will be reachable
 func (cc *Controller) ensureAddress(c *kubermaticv1.Cluster) error {
-	if c.Address == nil {
-		c.Address = &kubermaticv1.ClusterAddress{}
-	}
 	c.Address.ExternalName = fmt.Sprintf("%s.%s.%s", c.Name, cc.dc, cc.externalURL)
 
 	//Always update the ip

--- a/api/pkg/controller/cluster/pending_test.go
+++ b/api/pkg/controller/cluster/pending_test.go
@@ -18,7 +18,7 @@ func TestPendingCreateAddressesSuccessfully(t *testing.T) {
 			Name: TestClusterName,
 		},
 		Spec:    kubermaticv1.ClusterSpec{},
-		Address: &kubermaticv1.ClusterAddress{},
+		Address: kubermaticv1.ClusterAddress{},
 		Status: kubermaticv1.ClusterStatus{
 			NamespaceName: "cluster-" + TestClusterName,
 		},
@@ -68,7 +68,7 @@ func TestLaunchingCreateNamespace(t *testing.T) {
 					Name: "henrik1",
 				},
 				Spec:    kubermaticv1.ClusterSpec{},
-				Address: &kubermaticv1.ClusterAddress{},
+				Address: kubermaticv1.ClusterAddress{},
 				Status: kubermaticv1.ClusterStatus{
 					NamespaceName: "cluster-henrik1",
 				},
@@ -82,7 +82,7 @@ func TestLaunchingCreateNamespace(t *testing.T) {
 					Name: "henrik1",
 				},
 				Spec:    kubermaticv1.ClusterSpec{},
-				Address: &kubermaticv1.ClusterAddress{},
+				Address: kubermaticv1.ClusterAddress{},
 				Status: kubermaticv1.ClusterStatus{
 					NamespaceName: "cluster-henrik1",
 				},

--- a/api/pkg/controller/rbac/sync_dependant_test.go
+++ b/api/pkg/controller/rbac/sync_dependant_test.go
@@ -59,7 +59,7 @@ func TestEnsureDependantsRBACRole(t *testing.T) {
 						},
 					},
 					Spec:    kubermaticv1.ClusterSpec{},
-					Address: &kubermaticv1.ClusterAddress{},
+					Address: kubermaticv1.ClusterAddress{},
 					Status: kubermaticv1.ClusterStatus{
 						NamespaceName: "cluster-abcd",
 					},

--- a/api/pkg/controller/update/controller.go
+++ b/api/pkg/controller/update/controller.go
@@ -178,7 +178,7 @@ func (c *Controller) sync(key string) error {
 		return nil
 	}
 
-	if cluster.Status.Health == nil || !cluster.Status.Health.AllHealthy() {
+	if !cluster.Status.Health.AllHealthy() {
 		// Cluster not healthy yet. Nothing to do.
 		// If it gets healthy we'll get notified by the event. No need to requeue
 		return nil

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -57,9 +57,9 @@ type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec    ClusterSpec     `json:"spec"`
-	Address *ClusterAddress `json:"address,omitempty"`
-	Status  ClusterStatus   `json:"status,omitempty"`
+	Spec    ClusterSpec    `json:"spec"`
+	Address ClusterAddress `json:"address,omitempty"`
+	Status  ClusterStatus  `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -118,10 +118,10 @@ type ClusterAddress struct {
 
 // ClusterStatus stores status information about a cluster.
 type ClusterStatus struct {
-	LastUpdated               metav1.Time    `json:"lastUpdated,omitempty"`
-	Phase                     ClusterPhase   `json:"phase,omitempty"`
-	Health                    *ClusterHealth `json:"health,omitempty"`
-	LastDeployedMasterVersion string         `json:"lastDeployedMasterVersion"`
+	LastUpdated               metav1.Time   `json:"lastUpdated,omitempty"`
+	Phase                     ClusterPhase  `json:"phase,omitempty"`
+	Health                    ClusterHealth `json:"health,omitempty"`
+	LastDeployedMasterVersion string        `json:"lastDeployedMasterVersion"`
 
 	RootCA            KeyCert `json:"rootCA"`
 	ApiserverCert     KeyCert `json:"apiserverCert"`

--- a/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -230,15 +230,7 @@ func (in *Cluster) DeepCopyInto(out *Cluster) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
-	if in.Address != nil {
-		in, out := &in.Address, &out.Address
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ClusterAddress)
-			**out = **in
-		}
-	}
+	out.Address = in.Address
 	in.Status.DeepCopyInto(&out.Status)
 	return
 }
@@ -394,15 +386,7 @@ func (in *ClusterSpec) DeepCopy() *ClusterSpec {
 func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 	*out = *in
 	in.LastUpdated.DeepCopyInto(&out.LastUpdated)
-	if in.Health != nil {
-		in, out := &in.Health, &out.Health
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ClusterHealth)
-			(*in).DeepCopyInto(*out)
-		}
-	}
+	in.Health.DeepCopyInto(&out.Health)
 	in.RootCA.DeepCopyInto(&out.RootCA)
 	in.ApiserverCert.DeepCopyInto(&out.ApiserverCert)
 	in.KubeletCert.DeepCopyInto(&out.KubeletCert)

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -33,7 +33,7 @@ func TestClusterEndpoint(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 				},
-				Address: &kubermaticv1.ClusterAddress{
+				Address: kubermaticv1.ClusterAddress{
 					AdminToken: "admintoken",
 					URL:        "https://foo.bar:8443",
 				},
@@ -52,7 +52,7 @@ func TestClusterEndpoint(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 				},
-				Address: &kubermaticv1.ClusterAddress{
+				Address: kubermaticv1.ClusterAddress{
 					AdminToken: "admintoken",
 					URL:        "https://foo.bar:8443",
 				},
@@ -71,7 +71,7 @@ func TestClusterEndpoint(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 				},
-				Address: &kubermaticv1.ClusterAddress{
+				Address: kubermaticv1.ClusterAddress{
 					AdminToken: "admintoken",
 					URL:        "https://foo.bar:8443",
 				},
@@ -120,7 +120,7 @@ func TestClustersEndpoint(t *testing.T) {
 			Status: kubermaticv1.ClusterStatus{
 				RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 			},
-			Address: &kubermaticv1.ClusterAddress{
+			Address: kubermaticv1.ClusterAddress{
 				AdminToken: "admintoken",
 				URL:        "https://foo.bar:8443",
 			},
@@ -134,7 +134,7 @@ func TestClustersEndpoint(t *testing.T) {
 			Status: kubermaticv1.ClusterStatus{
 				RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 			},
-			Address: &kubermaticv1.ClusterAddress{
+			Address: kubermaticv1.ClusterAddress{
 				AdminToken: "admintoken",
 				URL:        "https://foo.bar:8443",
 			},
@@ -148,7 +148,7 @@ func TestClustersEndpoint(t *testing.T) {
 			Status: kubermaticv1.ClusterStatus{
 				RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 			},
-			Address: &kubermaticv1.ClusterAddress{
+			Address: kubermaticv1.ClusterAddress{
 				AdminToken: "admintoken",
 				URL:        "https://foo.bar:8443",
 			},
@@ -246,7 +246,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 				},
-				Address: &kubermaticv1.ClusterAddress{
+				Address: kubermaticv1.ClusterAddress{
 					AdminToken:   "cccccc.cccccccccccccccc",
 					KubeletToken: "cccccc.cccccccccccccccc",
 					URL:          "https://foo.bar:8443",
@@ -276,7 +276,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 				},
-				Address: &kubermaticv1.ClusterAddress{
+				Address: kubermaticv1.ClusterAddress{
 					AdminToken:   "cccccc.cccccccccccccccc",
 					KubeletToken: "cccccc.cccccccccccccccc",
 					URL:          "https://foo.bar:8443",
@@ -306,7 +306,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 				},
-				Address: &kubermaticv1.ClusterAddress{
+				Address: kubermaticv1.ClusterAddress{
 					AdminToken:   "cccccc.cccccccccccccccc",
 					KubeletToken: "cccccc.cccccccccccccccc",
 					URL:          "https://foo.bar:8443",
@@ -336,7 +336,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
 				},
-				Address: &kubermaticv1.ClusterAddress{
+				Address: kubermaticv1.ClusterAddress{
 					AdminToken:   "cccccc.cccccccccccccccc",
 					KubeletToken: "cccccc.cccccccccccccccc",
 					URL:          "https://foo.bar:8443",

--- a/api/pkg/handler/kubeconfig_test.go
+++ b/api/pkg/handler/kubeconfig_test.go
@@ -49,7 +49,7 @@ func TestKubeConfigEndpoint(t *testing.T) {
 		Status: kubermaticv1.ClusterStatus{
 			NamespaceName: "cluster-foo",
 		},
-		Address: &kubermaticv1.ClusterAddress{
+		Address: kubermaticv1.ClusterAddress{
 			AdminToken: "admintoken",
 			URL:        "https://foo.bar:8443",
 		},

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -99,7 +99,7 @@ func (p *ClusterProvider) NewCluster(user apiv1.User, spec *kubermaticv1.Cluster
 			UserName:      user.Name,
 			NamespaceName: NamespaceName(name),
 		},
-		Address: &kubermaticv1.ClusterAddress{},
+		Address: kubermaticv1.ClusterAddress{},
 	}
 
 	cluster, err = p.client.KubermaticV1().Clusters().Create(cluster)

--- a/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
+++ b/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
@@ -97,7 +97,7 @@ func (p *RBACCompliantClusterProvider) New(project *kubermaticapiv1.Project, use
 			UserName:      user.Name,
 			NamespaceName: NamespaceName(name),
 		},
-		Address: &kubermaticapiv1.ClusterAddress{},
+		Address: kubermaticapiv1.ClusterAddress{},
 	}
 
 	seedImpersonatedClient, err := p.createSeedImpersonationClientWrapper(user, project)

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -169,7 +169,7 @@ func TestLoadFiles(t *testing.T) {
 							DNSDomain: "cluster.local",
 						},
 					},
-					Address: &kubermaticv1.ClusterAddress{
+					Address: kubermaticv1.ClusterAddress{
 						ExternalName: "jh8j81chn.europe-west3-c.dev.kubermatic.io",
 						IP:           "35.198.93.90",
 						AdminToken:   "6hzr76.u8txpkk4vhgmtgdp",
@@ -334,7 +334,7 @@ func TestExecute(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "docluster-1a2b3c4d5e",
 					},
-					Address: &kubermaticv1.ClusterAddress{},
+					Address: kubermaticv1.ClusterAddress{},
 					Status:  kubermaticv1.ClusterStatus{},
 					Spec: kubermaticv1.ClusterSpec{
 						Cloud: &kubermaticv1.CloudSpec{
@@ -407,7 +407,7 @@ func TestExecute(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "awscluster-1a2b3c4d5e",
 					},
-					Address: &kubermaticv1.ClusterAddress{},
+					Address: kubermaticv1.ClusterAddress{},
 					Status:  kubermaticv1.ClusterStatus{},
 					Spec: kubermaticv1.ClusterSpec{
 						Cloud: &kubermaticv1.CloudSpec{
@@ -501,7 +501,7 @@ func TestExecute(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "openstackcluster-1a2b3c4d5e",
 					},
-					Address: &kubermaticv1.ClusterAddress{},
+					Address: kubermaticv1.ClusterAddress{},
 					Status:  kubermaticv1.ClusterStatus{},
 					Spec: kubermaticv1.ClusterSpec{
 						Cloud: &kubermaticv1.CloudSpec{
@@ -583,7 +583,7 @@ func TestExecute(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "azurecluster-1a2b3c4d5e",
 					},
-					Address: &kubermaticv1.ClusterAddress{},
+					Address: kubermaticv1.ClusterAddress{},
 					Status:  kubermaticv1.ClusterStatus{},
 					Spec: kubermaticv1.ClusterSpec{
 						Cloud: &kubermaticv1.CloudSpec{
@@ -660,7 +660,7 @@ func TestExecute(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "hetznercluster-1a2b3c4d5e",
 					},
-					Address: &kubermaticv1.ClusterAddress{},
+					Address: kubermaticv1.ClusterAddress{},
 					Status:  kubermaticv1.ClusterStatus{},
 					Spec: kubermaticv1.ClusterSpec{
 						Cloud: &kubermaticv1.CloudSpec{
@@ -727,7 +727,7 @@ func TestExecute(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "vsphere-1a2b3c4d5e",
 					},
-					Address: &kubermaticv1.ClusterAddress{},
+					Address: kubermaticv1.ClusterAddress{},
 					Status:  kubermaticv1.ClusterStatus{},
 					Spec: kubermaticv1.ClusterSpec{
 						Cloud: &kubermaticv1.CloudSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Use struct instead of pointer. Using a pointer caused now several issues with NPE's in the Dashboard or even in the controller.
Using a pointer here does not make sense as both structs are sane with empty values

**Release note**:
```release-note
NONE
```