### PR TITLE
Make vsphere folder creation idempotent and clean up

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1204,6 +1204,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8622a789f0709a49ed9f1d6958161d4c44ee82765e527eabf74c148ac907c3a1"
+  inputs-digest = "f5a0ffbd389c0423a8f93c3c1a25514502567cab364d4bdfe37e01cee588a000"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -71,15 +71,6 @@ func (v *vsphere) getVsphereRootPath(cluster *kubermaticv1.Cluster) (string, err
 
 // createVMFolderForCluster adds a vm folder beneath the rootpath set in the datacenter.yamls with the name of the cluster.
 func (v *vsphere) createVMFolderForCluster(cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
-	cloud := cluster.Spec.Cloud
-	dc, found := v.dcs[cloud.DatacenterName]
-	if !found || dc.Spec.VSphere == nil {
-		return nil, fmt.Errorf("invalid datacenter %q", cloud.DatacenterName)
-	}
-
-	if dc.Spec.VSphere.RootPath == "" {
-		return nil, fmt.Errorf("missing rootpath for datacenter %s", cloud.DatacenterName)
-	}
 	dcRootPath, err := v.getVsphereRootPath(cluster)
 	if err != nil {
 		return nil, err
@@ -88,7 +79,7 @@ func (v *vsphere) createVMFolderForCluster(cluster *kubermaticv1.Cluster) (*kube
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, err := v.getClient(cloud)
+	client, err := v.getClient(cluster.Spec.Cloud)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -111,9 +111,6 @@ func (v *vsphere) createVMFolderForCluster(cluster *kubermaticv1.Cluster) (*kube
 		if _, err = rootFolder.CreateFolder(ctx, cluster.Name); err != nil {
 			return nil, fmt.Errorf("failed to create cluster folder %s/%s: %v", rootFolder, cluster.Name, err)
 		}
-		// We successfully created the folder, so ensure finalizer is there
-		cluster = ensureFolderDeleteFinalizer(cluster)
-		return cluster, nil
 	}
 
 	// Folder exists so ensure finalizer is there

--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -94,7 +94,7 @@ func (v *vsphere) createVMFolderForCluster(cluster *kubermaticv1.Cluster) (*kube
 	}
 	defer func() {
 		if err := client.Logout(context.Background()); err != nil {
-			glog.V(4).Infof("Failed to logout after creating vsphere cluster folder: %v", err)
+			glog.V(0).Infof("Failed to logout after creating vsphere cluster folder: %v", err)
 		}
 	}()
 
@@ -105,15 +105,14 @@ func (v *vsphere) createVMFolderForCluster(cluster *kubermaticv1.Cluster) (*kube
 	}
 	_, err = finder.Folder(ctx, cluster.ObjectMeta.Name)
 	if err != nil {
-		if _, ok := err.(*find.NotFoundError); ok {
-			if _, err = rootFolder.CreateFolder(ctx, cluster.ObjectMeta.Name); err != nil {
-				return nil, fmt.Errorf("failed to create cluster folder: %v", err)
-			}
-			cluster.Finalizers = append(cluster.Finalizers, folderCleanupFinalizer)
-			return cluster, nil
-
+		if _, ok := err.(*find.NotFoundError); !ok {
+			return nil, fmt.Errorf("Failed to get cluster folder: %v", err)
 		}
-		return cluster, fmt.Errorf("Failed to get cluster folder: %v", err)
+		if _, err = rootFolder.CreateFolder(ctx, cluster.ObjectMeta.Name); err != nil {
+			return nil, fmt.Errorf("failed to create cluster folder: %v", err)
+		}
+		cluster.Finalizers = append(cluster.Finalizers, folderCleanupFinalizer)
+		return cluster, nil
 	}
 
 	return cluster, nil
@@ -151,7 +150,7 @@ func (v *vsphere) CleanUpCloudProvider(cluster *kubermaticv1.Cluster) (*kubermat
 		}
 		defer func() {
 			if err := client.Logout(context.Background()); err != nil {
-				glog.V(4).Infof("Failed to logout after creating vsphere cluster folder: %v", err)
+				glog.V(0).Infof("Failed to logout after creating vsphere cluster folder: %v", err)
 			}
 		}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* Ensures the vsphere folder gets only created when its not there
* Adds a finalizer upon creation
* Cleans up the folder when the cluster gets deleted

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note cloud provider
VSphere target folder will be properly cleaned up on cluster deletion.
```