### PR TITLE
Fix etcd migration

### DIFF
--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -249,7 +249,7 @@ INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cl
 echo ${INITIAL_STATE}
 echo ${INITIAL_CLUSTER}
 
-/usr/local/bin/etcd \
+exec /usr/local/bin/etcd \
     --name=${POD_NAME} \
     --data-dir="{{ .DataDir }}" \
     --heartbeat-interval=500 \

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -64,7 +64,19 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 		},
 	}
 
-	etcdStartCmd, err := getEtcdStartCommand(data)
+	// For migration purpose.
+	// We switched from the etcd-operator to a simple etcd-StatefulSet. Therefore we need to migrate the data.
+	var migrate bool
+	_, err := data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get("etcd-cluster-client")
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
+	} else {
+		migrate = true
+	}
+
+	etcdStartCmd, err := getEtcdCommand(data.Cluster.Name, data.Cluster.Status.NamespaceName, migrate)
 	if err != nil {
 		return nil, err
 	}
@@ -154,49 +166,6 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 		},
 	}
 
-	// For migration purpose.
-	// We switched from the etcd-operator to a simple etcd-StatefulSet. Therefore we need to migrate the data.
-	_, err = data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get("etcd-cluster-client")
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// No operator service, found -> nothing more to do
-			return set, nil
-		}
-		return nil, err
-	}
-	etcdRestoreCmd, err := getEtcdRestoreCommand(data)
-	if err != nil {
-		return nil, err
-	}
-
-	set.Spec.Template.Spec.InitContainers = []corev1.Container{
-		{
-			Name:                     "restore",
-			Image:                    data.ImageRegistry("quay.io") + "/coreos/etcd:v3.2.20",
-			ImagePullPolicy:          corev1.PullIfNotPresent,
-			Command:                  etcdRestoreCmd,
-			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-			Env: []corev1.EnvVar{
-				{
-					Name: "POD_NAME",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							APIVersion: "v1",
-							FieldPath:  "metadata.name",
-						},
-					},
-				},
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "data",
-					MountPath: "/var/run/etcd",
-				},
-			},
-		},
-	}
-
 	return set, nil
 }
 
@@ -205,27 +174,21 @@ type commandTplData struct {
 	Namespace   string
 	Token       string
 	DataDir     string
+	Migrate     bool
 }
 
-func getEtcdStartCommand(data *resources.TemplateData) ([]string, error) {
-	return getEtcdCommand(data, etcdStartCommandTpl)
-}
-
-func getEtcdRestoreCommand(data *resources.TemplateData) ([]string, error) {
-	return getEtcdCommand(data, etcdRestoreCommandTpl)
-}
-
-func getEtcdCommand(data *resources.TemplateData, cmdTpl string) ([]string, error) {
-	tpl, err := template.New("base").Funcs(sprig.TxtFuncMap()).Parse(cmdTpl)
+func getEtcdCommand(name, namespace string, migrate bool) ([]string, error) {
+	tpl, err := template.New("base").Funcs(sprig.TxtFuncMap()).Parse(etcdStartCommandTpl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse etcd command template: %v", err)
 	}
 
 	tplData := commandTplData{
 		ServiceName: resources.EtcdServiceName,
-		Token:       data.Cluster.Name,
-		Namespace:   data.Cluster.Status.NamespaceName,
+		Token:       name,
+		Namespace:   namespace,
 		DataDir:     dataDir,
+		Migrate:     migrate,
 	}
 
 	buf := bytes.Buffer{}
@@ -241,28 +204,61 @@ func getEtcdCommand(data *resources.TemplateData, cmdTpl string) ([]string, erro
 }
 
 const (
-	etcdStartCommandTpl = `/usr/local/bin/etcd \
---name=${POD_NAME} \
---data-dir="{{ .DataDir }}" \
---heartbeat-interval=500 \
---election-timeout=5000 \
---initial-cluster="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-2=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380" \
---initial-cluster-token="{{ .Token }}" \
---initial-cluster-state=new \
---advertise-client-urls http://${POD_NAME}.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2379 \
---listen-client-urls http://0.0.0.0:2379 \
---enable-v2=false \
---listen-peer-urls http://0.0.0.0:2380
-`
+	etcdStartCommandTpl = `ETCDCTL_API=3
+MASTER_ENDPOINT="http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2379"
 
-	etcdRestoreCommandTpl = `if [ ! -d "{{ .DataDir }}" ]; then
-	ETCDCTL_API=3 etcdctl --endpoints http://etcd-cluster-client:2379 snapshot save snapshot.db
-	ETCDCTL_API=3 etcdctl snapshot restore snapshot.db \
-		--name ${POD_NAME} \
-		--data-dir="{{ .DataDir }}" \
-		--initial-cluster="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-2=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380" \
-		--initial-cluster-token="{{ .Token }}" \
-		--initial-advertise-peer-urls http://${POD_NAME}.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380
+{{ if .Migrate }}
+# If we're already initialized
+if [ -d "{{ .DataDir }}" ]; then
+    INITIAL_STATE="existing"
+    INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-2=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"
+else
+    if [ "${POD_NAME}" = "etcd-0" ]; then
+        echo "i'm etcd-0. I do the restore"
+        etcdctl --endpoints http://etcd-cluster-client:2379 snapshot save snapshot.db
+        etcdctl snapshot restore snapshot.db \
+            --name etcd-0 \
+            --data-dir="{{ .DataDir }}" \
+            --initial-cluster="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380" \
+            --initial-cluster-token="{{ .Token }}" \
+            --initial-advertise-peer-urls http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380
+        INITIAL_STATE="new"
+        INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"
+    fi
+
+    if [ "${POD_NAME}" = "etcd-1" ]; then
+        echo "i'm etcd-1. I join as new member as soon as etcd-0 comes up"
+        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2379
+        INITIAL_STATE="existing"
+        INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"
+    fi
+
+    if [ "${POD_NAME}" = "etcd-2" ]; then
+        echo "i'm etcd-2. I join as new member as soon as we have 2 existing & healthy members"
+        until etcdctl --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
+        INITIAL_STATE="existing"
+        INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-2=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"
+    fi
 fi
+
+{{ else }}
+INITIAL_STATE="new"
+INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-2=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"
+{{ end }}
+
+echo ${INITIAL_STATE}
+echo ${INITIAL_CLUSTER}
+
+/usr/local/bin/etcd \
+    --name=${POD_NAME} \
+    --data-dir="{{ .DataDir }}" \
+    --heartbeat-interval=500 \
+    --election-timeout=5000 \
+    --initial-cluster=${INITIAL_CLUSTER} \
+    --initial-cluster-token="{{ .Token }}" \
+    --initial-cluster-state=${INITIAL_STATE} \
+    --advertise-client-urls http://${POD_NAME}.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2379 \
+    --listen-client-urls http://0.0.0.0:2379 \
+    --listen-peer-urls http://0.0.0.0:2380
 `
 )

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -48,16 +48,15 @@ func TestGetEtcdCommand(t *testing.T) {
 }
 
 var (
-	noMigration = `ETCDCTL_API=3
-MASTER_ENDPOINT="http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
+	noMigration = `export MASTER_ENDPOINT="http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
 
 
-INITIAL_STATE="new"
-INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380"
+export INITIAL_STATE="new"
+export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380"
 
 
-echo ${INITIAL_STATE}
-echo ${INITIAL_CLUSTER}
+echo "initial-state: ${INITIAL_STATE}"
+echo "initial-cluster: ${INITIAL_CLUSTER}"
 
 exec /usr/local/bin/etcd \
     --name=${POD_NAME} \
@@ -72,47 +71,61 @@ exec /usr/local/bin/etcd \
     --listen-peer-urls http://0.0.0.0:2380
 `
 
-	migration = `ETCDCTL_API=3
-MASTER_ENDPOINT="http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379"
+	migration = `export MASTER_ENDPOINT="http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379"
 
 
 # If we're already initialized
 if [ -d "/var/run/etcd/pod_${POD_NAME}/" ]; then
-    INITIAL_STATE="existing"
-    INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+    echo "we're already initialized"
+    if [ "${POD_NAME}" = "etcd-0" ]; then
+        export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+        export INITIAL_STATE="existing"
+    fi
+    if [ "${POD_NAME}" = "etcd-1" ]; then
+        export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+        export INITIAL_STATE="existing"
+    fi
+    if [ "${POD_NAME}" = "etcd-2" ]; then
+        export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+        export INITIAL_STATE="existing"
+    fi
 else
     if [ "${POD_NAME}" = "etcd-0" ]; then
         echo "i'm etcd-0. I do the restore"
-        etcdctl --endpoints http://etcd-cluster-client:2379 snapshot save snapshot.db
-        etcdctl snapshot restore snapshot.db \
+        ETCDCTL_API=3 etcdctl --endpoints http://etcd-cluster-client:2379 snapshot save snapshot.db
+        ETCDCTL_API=3 etcdctl snapshot restore snapshot.db \
             --name etcd-0 \
             --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
             --initial-cluster="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380" \
             --initial-cluster-token="62m9k9tqlm" \
             --initial-advertise-peer-urls http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
-        INITIAL_STATE="new"
-        INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+        echo "restored from snapshot"
+        export INITIAL_STATE="new"
+        export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
     fi
 
     if [ "${POD_NAME}" = "etcd-1" ]; then
         echo "i'm etcd-1. I join as new member as soon as etcd-0 comes up"
-        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379
-        INITIAL_STATE="existing"
-        INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+        ETCDCTL_API=3 etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
+        echo "added etcd-1 to members"
+        export INITIAL_STATE="existing"
+        export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
     fi
 
     if [ "${POD_NAME}" = "etcd-2" ]; then
         echo "i'm etcd-2. I join as new member as soon as we have 2 existing & healthy members"
-        until etcdctl --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
-        INITIAL_STATE="existing"
-        INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+        until ETCDCTL_API=3 etcdctl --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
+        ETCDCTL_API=3 etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-2 --peer-urls=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
+        echo "added etcd-2 to members"
+        export INITIAL_STATE="existing"
+        export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
     fi
 fi
 
 
 
-echo ${INITIAL_STATE}
-echo ${INITIAL_CLUSTER}
+echo "initial-state: ${INITIAL_STATE}"
+echo "initial-cluster: ${INITIAL_CLUSTER}"
 
 exec /usr/local/bin/etcd \
     --name=${POD_NAME} \

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -59,7 +59,7 @@ INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:
 echo ${INITIAL_STATE}
 echo ${INITIAL_CLUSTER}
 
-/usr/local/bin/etcd \
+exec /usr/local/bin/etcd \
     --name=${POD_NAME} \
     --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
     --heartbeat-interval=500 \
@@ -114,7 +114,7 @@ fi
 echo ${INITIAL_STATE}
 echo ${INITIAL_CLUSTER}
 
-/usr/local/bin/etcd \
+exec /usr/local/bin/etcd \
     --name=${POD_NAME} \
     --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
     --heartbeat-interval=500 \

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -1,7 +1,6 @@
 package etcd
 
 import (
-	"io/ioutil"
 	"testing"
 )
 
@@ -42,7 +41,6 @@ func TestGetEtcdCommand(t *testing.T) {
 			}
 			cmd := args[2]
 			if cmd != test.expected {
-				ioutil.WriteFile("cmd.sh", []byte(cmd), 0644)
 				t.Errorf("expected \n%s \n\nGot:\n\n%s", test.expected, cmd)
 			}
 		})

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -1,0 +1,129 @@
+package etcd
+
+import (
+	"testing"
+)
+
+func TestGetEtcdCommand(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		clusterName      string
+		clusterNamespace string
+		migrate          bool
+		expected         string
+	}{
+		{
+			name:             "test new cluster without migration",
+			clusterName:      "lg69pmx8wf",
+			clusterNamespace: "cluster-lg69pmx8wf",
+			migrate:          false,
+			expected:         noMigration,
+		},
+		{
+			name:             "test existing cluster with migration",
+			clusterName:      "62m9k9tqlm",
+			clusterNamespace: "cluster-62m9k9tqlm",
+			migrate:          true,
+			expected:         migration,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args, err := getEtcdCommand(test.clusterName, test.clusterNamespace, test.migrate)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(args) != 3 {
+				t.Fatalf("got less arguments than expected. got %d expected %d", len(args), 3)
+			}
+			cmd := args[2]
+			if cmd != test.expected {
+				t.Errorf("expected \n%s \n\nGot:\n\n%s", test.expected, cmd)
+			}
+		})
+	}
+}
+
+var (
+	noMigration = `ETCDCTL_API=3
+MASTER_ENDPOINT="http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
+
+
+INITIAL_STATE="new"
+INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380"
+
+
+echo ${INITIAL_STATE}
+echo ${INITIAL_CLUSTER}
+
+/usr/local/bin/etcd \
+    --name=${POD_NAME} \
+    --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+    --heartbeat-interval=500 \
+    --election-timeout=5000 \
+    --initial-cluster=${INITIAL_CLUSTER} \
+    --initial-cluster-token="lg69pmx8wf" \
+    --initial-cluster-state=${INITIAL_STATE} \
+    --advertise-client-urls http://${POD_NAME}.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379 \
+    --listen-client-urls http://0.0.0.0:2379 \
+    --listen-peer-urls http://0.0.0.0:2380
+`
+
+	migration = `ETCDCTL_API=3
+MASTER_ENDPOINT="http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379"
+
+
+# If we're already initialized
+if [ -d "/var/run/etcd/pod_${POD_NAME}/" ]; then
+    INITIAL_STATE="existing"
+    INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+else
+    if [ "${POD_NAME}" = "etcd-0" ]; then
+        echo "i'm etcd-0. I do the restore"
+        etcdctl --endpoints http://etcd-cluster-client:2379 snapshot save snapshot.db
+        etcdctl snapshot restore snapshot.db \
+            --name etcd-0 \
+            --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+            --initial-cluster="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380" \
+            --initial-cluster-token="62m9k9tqlm" \
+            --initial-advertise-peer-urls http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
+        INITIAL_STATE="new"
+        INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+    fi
+
+    if [ "${POD_NAME}" = "etcd-1" ]; then
+        echo "i'm etcd-1. I join as new member as soon as etcd-0 comes up"
+        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379
+        INITIAL_STATE="existing"
+        INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+    fi
+
+    if [ "${POD_NAME}" = "etcd-2" ]; then
+        echo "i'm etcd-2. I join as new member as soon as we have 2 existing & healthy members"
+        until etcdctl --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
+        INITIAL_STATE="existing"
+        INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
+    fi
+fi
+
+
+
+echo ${INITIAL_STATE}
+echo ${INITIAL_CLUSTER}
+
+/usr/local/bin/etcd \
+    --name=${POD_NAME} \
+    --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+    --heartbeat-interval=500 \
+    --election-timeout=5000 \
+    --initial-cluster=${INITIAL_CLUSTER} \
+    --initial-cluster-token="62m9k9tqlm" \
+    --initial-cluster-state=${INITIAL_STATE} \
+    --advertise-client-urls http://${POD_NAME}.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379 \
+    --listen-client-urls http://0.0.0.0:2379 \
+    --listen-peer-urls http://0.0.0.0:2380
+`
+)

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -1,6 +1,7 @@
 package etcd
 
 import (
+	"io/ioutil"
 	"testing"
 )
 
@@ -41,6 +42,7 @@ func TestGetEtcdCommand(t *testing.T) {
 			}
 			cmd := args[2]
 			if cmd != test.expected {
+				ioutil.WriteFile("cmd.sh", []byte(cmd), 0644)
 				t.Errorf("expected \n%s \n\nGot:\n\n%s", test.expected, cmd)
 			}
 		})
@@ -48,7 +50,8 @@ func TestGetEtcdCommand(t *testing.T) {
 }
 
 var (
-	noMigration = `export MASTER_ENDPOINT="http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
+	noMigration = `export ETCDCTL_API=3 
+export MASTER_ENDPOINT="http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
 
 
 export INITIAL_STATE="new"
@@ -71,29 +74,28 @@ exec /usr/local/bin/etcd \
     --listen-peer-urls http://0.0.0.0:2380
 `
 
-	migration = `export MASTER_ENDPOINT="http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379"
+	migration = `export ETCDCTL_API=3 
+export MASTER_ENDPOINT="http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379"
 
 
 # If we're already initialized
 if [ -d "/var/run/etcd/pod_${POD_NAME}/" ]; then
     echo "we're already initialized"
+    export INITIAL_STATE="existing"
     if [ "${POD_NAME}" = "etcd-0" ]; then
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
-        export INITIAL_STATE="existing"
     fi
     if [ "${POD_NAME}" = "etcd-1" ]; then
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
-        export INITIAL_STATE="existing"
     fi
     if [ "${POD_NAME}" = "etcd-2" ]; then
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
-        export INITIAL_STATE="existing"
     fi
 else
     if [ "${POD_NAME}" = "etcd-0" ]; then
         echo "i'm etcd-0. I do the restore"
-        ETCDCTL_API=3 etcdctl --endpoints http://etcd-cluster-client:2379 snapshot save snapshot.db
-        ETCDCTL_API=3 etcdctl snapshot restore snapshot.db \
+        etcdctl --endpoints http://etcd-cluster-client:2379 snapshot save snapshot.db
+        etcdctl snapshot restore snapshot.db \
             --name etcd-0 \
             --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
             --initial-cluster="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380" \
@@ -106,7 +108,7 @@ else
 
     if [ "${POD_NAME}" = "etcd-1" ]; then
         echo "i'm etcd-1. I join as new member as soon as etcd-0 comes up"
-        ETCDCTL_API=3 etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
+        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
         echo "added etcd-1 to members"
         export INITIAL_STATE="existing"
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
@@ -114,8 +116,8 @@ else
 
     if [ "${POD_NAME}" = "etcd-2" ]; then
         echo "i'm etcd-2. I join as new member as soon as we have 2 existing & healthy members"
-        until ETCDCTL_API=3 etcdctl --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
-        ETCDCTL_API=3 etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-2 --peer-urls=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
+        until etcdctl --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
+        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-2 --peer-urls=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
         echo "added etcd-2 to members"
         export INITIAL_STATE="existing"
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the way we migration from the operator to the StatefulSet.
Instead of letting every etcd pod get a snapshot & restore from it, restore only on the master & then add each member.

Fixes #1326 

**Release note**:
```release-note
NONE
```