### PR TITLE
[On Hold] Add new Kubernetes versions

### DIFF
--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -48,6 +48,9 @@ versions:
 - version: "1.8.13"
   default: false
   allowedNodeVersions: *node-versions
+- version: "1.8.14"
+  default: false
+  allowedNodeVersions: *node-versions
 # Kubernetes 1.9
 - version: "1.9.0"
   default: false
@@ -71,6 +74,12 @@ versions:
   default: false
   allowedNodeVersions: *node-versions
 - version: "1.9.7"
+  default: false
+  allowedNodeVersions: *node-versions
+- version: "1.9.8"
+  default: false
+  allowedNodeVersions: *node-versions
+- version: "1.9.9"
   default: true
   allowedNodeVersions: *node-versions
 # Kubernetes 1.10
@@ -84,5 +93,11 @@ versions:
   default: false
   allowedNodeVersions: *node-versions
 - version: "1.10.3"
+  default: false
+  allowedNodeVersions: *node-versions
+- version: "1.10.4"
+  default: false
+  allowedNodeVersions: *node-versions
+- version: "1.10.5"
   default: false
   allowedNodeVersions: *node-versions


### PR DESCRIPTION
**What this PR does / why we need it**:
add new versions

**Release note**:
```release-note
Added support for K8S `1.8.14`, `1.9.8`, `1.9.9`, `1.10.4` and `1.10.5`
```