### PR TITLE
Enable {Mutating,Validating}AdmissionWebhook for k8s 1.9+

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -255,7 +255,7 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32, etc
 		nodePortRange = defaultNodePortRange
 	}
 
-	admissionControlFlags := getAdmissionControlFlags(data)
+	admissionControlFlagName, admissionControlFlagValue := getAdmissionControlFlags(data)
 
 	flags := []string{
 		"--advertise-address", data.Cluster.Address.IP,
@@ -265,7 +265,7 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32, etc
 		"--insecure-port", "8080",
 		"--etcd-servers", strings.Join(etcds, ","),
 		"--storage-backend", "etcd3",
-		admissionControlFlags[0], admissionControlFlags[1],
+		admissionControlFlagName, admissionControlFlagValue,
 		"--authorization-mode", "Node,RBAC",
 		"--external-hostname", data.Cluster.Address.ExternalName,
 		"--token-auth-file", "/etc/kubernetes/tokens/tokens.csv",
@@ -309,14 +309,14 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32, etc
 	return flags
 }
 
-func getAdmissionControlFlags(data *resources.TemplateData) [2]string {
+func getAdmissionControlFlags(data *resources.TemplateData) (string, string) {
 	// We use these as default in case semver parsing fails
 	admissionControlFlagValue := "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction"
 	admissionControlFlagName := "--admission-control"
 
 	clusterVersionSemVer, err := semver.NewVersion(data.Cluster.Spec.Version)
 	if err != nil {
-		return [2]string{admissionControlFlagName, admissionControlFlagValue}
+		return admissionControlFlagName, admissionControlFlagValue
 	}
 
 	// Enable {Mutating,Validating}AdmissionWebhook for 1.9+
@@ -333,7 +333,7 @@ func getAdmissionControlFlags(data *resources.TemplateData) [2]string {
 	// must come last
 	admissionControlFlagValue += ",ResourceQuota"
 
-	return [2]string{admissionControlFlagName, admissionControlFlagValue}
+	return admissionControlFlagName, admissionControlFlagValue
 }
 
 func getTemplatePodLabels(data *resources.TemplateData) (map[string]string, error) {

--- a/api/pkg/resources/apiserver/deployment_test.go
+++ b/api/pkg/resources/apiserver/deployment_test.go
@@ -9,27 +9,28 @@ import (
 
 func TestGetAdmissionControlFlags(t *testing.T) {
 	tests := []struct {
-		name              string
-		kubernetesVersion string
-		expectedFlags     [2]string
+		name                              string
+		kubernetesVersion                 string
+		expectedAdmissionControlFlagName  string
+		expectedAdmissionControlFlagValue string
 	}{
 		{
-			name:              "Ensure no admission webhooks pre 1.9",
-			kubernetesVersion: "1.8.0",
-			expectedFlags: [2]string{"--admission-control",
-				"NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota"},
+			name:                              "Ensure no admission webhooks pre 1.9",
+			kubernetesVersion:                 "1.8.0",
+			expectedAdmissionControlFlagName:  "--admission-control",
+			expectedAdmissionControlFlagValue: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota",
 		},
 		{
-			name:              "Ensure admission webhooks 1.9+",
-			kubernetesVersion: "1.9.0",
-			expectedFlags: [2]string{"--admission-control",
-				"NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"},
+			name:                              "Ensure admission webhooks 1.9+",
+			kubernetesVersion:                 "1.9.0",
+			expectedAdmissionControlFlagName:  "--admission-control",
+			expectedAdmissionControlFlagValue: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
 		},
 		{
-			name:              "Ensure new admission flagname 1.10+",
-			kubernetesVersion: "1.10.0",
-			expectedFlags: [2]string{"--enable-admission-plugins",
-				"NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"},
+			name:                              "Ensure new admission flagname 1.10+",
+			kubernetesVersion:                 "1.10.0",
+			expectedAdmissionControlFlagName:  "--enable-admission-plugins",
+			expectedAdmissionControlFlagValue: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
 		},
 	}
 
@@ -38,13 +39,15 @@ func TestGetAdmissionControlFlags(t *testing.T) {
 		templateData.Cluster = &kubermaticv1.Cluster{}
 		templateData.Cluster.Spec.Version = test.kubernetesVersion
 
-		admissionControlFlags := getAdmissionControlFlags(&templateData)
-
-		for idx := range admissionControlFlags {
-			if admissionControlFlags[idx] != test.expectedFlags[idx] {
-				t.Errorf("Expected admission control flag to be %s but was %s", test.expectedFlags[idx], admissionControlFlags[idx])
-			}
+		admissionControlFlagName, admissionControlFlagValue := getAdmissionControlFlags(&templateData)
+		if admissionControlFlagName != test.expectedAdmissionControlFlagName {
+			t.Errorf("Expected admission control flag name to be %s but was %s", test.expectedAdmissionControlFlagName, admissionControlFlagName)
 		}
+
+		if admissionControlFlagValue != test.expectedAdmissionControlFlagValue {
+			t.Errorf("Expected admission control flag value to be %s but was %s", test.expectedAdmissionControlFlagValue, admissionControlFlagValue)
+		}
+
 	}
 
 }

--- a/api/pkg/resources/apiserver/deployment_test.go
+++ b/api/pkg/resources/apiserver/deployment_test.go
@@ -1,0 +1,99 @@
+package apiserver
+
+import (
+	"reflect"
+	"testing"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+)
+
+func TestGetApiserverFlags(t *testing.T) {
+	tests := []struct {
+		name              string
+		kubernetesVersion string
+		expected          []string
+	}{
+		{
+			name:              "Ensure no admission webhooks pre 1.9",
+			kubernetesVersion: "1.8.0",
+			expected: []string{
+				"--advertise-address", "",
+				"--secure-port", "0",
+				"--kubernetes-service-node-port", "0",
+				"--insecure-bind-address", "0.0.0.0",
+				"--insecure-port", "8080",
+				"--etcd-servers", "etcd-0",
+				"--storage-backend", "etcd3",
+				"--admission-control", "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction",
+				"--authorization-mode", "Node,RBAC",
+				"--external-hostname", "",
+				"--token-auth-file", "/etc/kubernetes/tokens/tokens.csv",
+				"--enable-bootstrap-token-auth", "true",
+				"--service-account-key-file", "/etc/kubernetes/service-account-key/sa.key",
+				"--service-cluster-ip-range", "10.0.0.0",
+				"--service-node-port-range", "30000-32767",
+				"--allow-privileged",
+				"--audit-log-maxage", "30",
+				"--audit-log-maxbackup", "3",
+				"--audit-log-maxsize", "100",
+				"--audit-log-path", "/var/log/audit.log",
+				"--tls-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
+				"--tls-private-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
+				"--proxy-client-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
+				"--proxy-client-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
+				"--client-ca-file", "/etc/kubernetes/ca-cert/ca.crt",
+				"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
+				"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",
+				"--v", "4",
+				"--kubelet-preferred-address-types", "ExternalIP,InternalIP"},
+		},
+		{
+			name:              "Ensure admission webhooks 1.9+",
+			kubernetesVersion: "1.9.0",
+			expected: []string{
+				"--advertise-address", "",
+				"--secure-port", "0",
+				"--kubernetes-service-node-port", "0",
+				"--insecure-bind-address", "0.0.0.0",
+				"--insecure-port", "8080",
+				"--etcd-servers", "etcd-0",
+				"--storage-backend", "etcd3",
+				"--admission-control", "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
+				"--authorization-mode", "Node,RBAC",
+				"--external-hostname", "",
+				"--token-auth-file", "/etc/kubernetes/tokens/tokens.csv",
+				"--enable-bootstrap-token-auth", "true",
+				"--service-account-key-file", "/etc/kubernetes/service-account-key/sa.key",
+				"--service-cluster-ip-range", "10.0.0.0",
+				"--service-node-port-range", "30000-32767",
+				"--allow-privileged",
+				"--audit-log-maxage", "30",
+				"--audit-log-maxbackup", "3",
+				"--audit-log-maxsize", "100",
+				"--audit-log-path", "/var/log/audit.log",
+				"--tls-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
+				"--tls-private-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
+				"--proxy-client-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
+				"--proxy-client-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
+				"--client-ca-file", "/etc/kubernetes/ca-cert/ca.crt",
+				"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
+				"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",
+				"--v", "4",
+				"--kubelet-preferred-address-types", "ExternalIP,InternalIP"},
+		},
+	}
+
+	for _, test := range tests {
+		templateData := resources.TemplateData{}
+		templateData.Cluster = &kubermaticv1.Cluster{}
+		templateData.Cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.0.0.0"}
+		templateData.Cluster.Spec.Cloud = &kubermaticv1.CloudSpec{}
+		templateData.Cluster.Spec.Version = test.kubernetesVersion
+
+		if flags := getApiserverFlags(&templateData, 0, []string{"etcd-0"}); !reflect.DeepEqual(flags, test.expected) {
+			t.Errorf("Result flags \n%v\n do not match expected \n%v\n!", flags, test.expected)
+		}
+	}
+
+}

--- a/api/pkg/resources/apiserver/deployment_test.go
+++ b/api/pkg/resources/apiserver/deployment_test.go
@@ -1,86 +1,37 @@
 package apiserver
 
 import (
-	"reflect"
 	"testing"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestGetApiserverFlags(t *testing.T) {
 	tests := []struct {
 		name              string
 		kubernetesVersion string
-		expected          []string
+		expectedFlags     []string
 	}{
 		{
-			name:              "Ensure no admission webhooks pre 1.9",
+			name:              "Ensure_no_admission_webhooks_pre_1.9",
 			kubernetesVersion: "1.8.0",
-			expected: []string{
-				"--advertise-address", "",
-				"--secure-port", "0",
-				"--kubernetes-service-node-port", "0",
-				"--insecure-bind-address", "0.0.0.0",
-				"--insecure-port", "8080",
-				"--etcd-servers", "etcd-0",
-				"--storage-backend", "etcd3",
-				"--admission-control", "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction",
-				"--authorization-mode", "Node,RBAC",
-				"--external-hostname", "",
-				"--token-auth-file", "/etc/kubernetes/tokens/tokens.csv",
-				"--enable-bootstrap-token-auth", "true",
-				"--service-account-key-file", "/etc/kubernetes/service-account-key/sa.key",
-				"--service-cluster-ip-range", "10.0.0.0",
-				"--service-node-port-range", "30000-32767",
-				"--allow-privileged",
-				"--audit-log-maxage", "30",
-				"--audit-log-maxbackup", "3",
-				"--audit-log-maxsize", "100",
-				"--audit-log-path", "/var/log/audit.log",
-				"--tls-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
-				"--tls-private-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
-				"--proxy-client-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
-				"--proxy-client-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
-				"--client-ca-file", "/etc/kubernetes/ca-cert/ca.crt",
-				"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
-				"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",
-				"--v", "4",
-				"--kubelet-preferred-address-types", "ExternalIP,InternalIP"},
+			expectedFlags: []string{"--admission-control",
+				"NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota"},
 		},
 		{
-			name:              "Ensure admission webhooks 1.9+",
+			name:              "Ensure_admission_webhooks_1.9+",
 			kubernetesVersion: "1.9.0",
-			expected: []string{
-				"--advertise-address", "",
-				"--secure-port", "0",
-				"--kubernetes-service-node-port", "0",
-				"--insecure-bind-address", "0.0.0.0",
-				"--insecure-port", "8080",
-				"--etcd-servers", "etcd-0",
-				"--storage-backend", "etcd3",
-				"--admission-control", "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
-				"--authorization-mode", "Node,RBAC",
-				"--external-hostname", "",
-				"--token-auth-file", "/etc/kubernetes/tokens/tokens.csv",
-				"--enable-bootstrap-token-auth", "true",
-				"--service-account-key-file", "/etc/kubernetes/service-account-key/sa.key",
-				"--service-cluster-ip-range", "10.0.0.0",
-				"--service-node-port-range", "30000-32767",
-				"--allow-privileged",
-				"--audit-log-maxage", "30",
-				"--audit-log-maxbackup", "3",
-				"--audit-log-maxsize", "100",
-				"--audit-log-path", "/var/log/audit.log",
-				"--tls-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
-				"--tls-private-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
-				"--proxy-client-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
-				"--proxy-client-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
-				"--client-ca-file", "/etc/kubernetes/ca-cert/ca.crt",
-				"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
-				"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",
-				"--v", "4",
-				"--kubelet-preferred-address-types", "ExternalIP,InternalIP"},
+			expectedFlags: []string{"--admission-control",
+				"NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"},
+		},
+		{
+			name:              "Ensure_new_admission_flagname_1.10.0",
+			kubernetesVersion: "1.10.0",
+			expectedFlags: []string{"--enable-admission-plugins",
+				"NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"},
 		},
 	}
 
@@ -91,8 +42,13 @@ func TestGetApiserverFlags(t *testing.T) {
 		templateData.Cluster.Spec.Cloud = &kubermaticv1.CloudSpec{}
 		templateData.Cluster.Spec.Version = test.kubernetesVersion
 
-		if flags := getApiserverFlags(&templateData, 0, []string{"etcd-0"}); !reflect.DeepEqual(flags, test.expected) {
-			t.Errorf("Result flags \n%v\n do not match expected \n%v\n!", flags, test.expected)
+		flags := getApiserverFlags(&templateData, 0, []string{"etcd-0"})
+		flagSet := sets.NewString(flags...)
+
+		for _, expectedFlag := range test.expectedFlags {
+			if !flagSet.Has(expectedFlag) {
+				t.Errorf("Expected flag '%s' in test '%s' but was not present!", expectedFlag, test.name)
+			}
 		}
 	}
 

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --authorization-mode
         - Node,RBAC
         - --external-hostname

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -113,7 +113,7 @@ spec:
         - --storage-backend
         - etcd3
         - --admission-control
-        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+        - NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
         - --authorization-mode
         - Node,RBAC
         - --external-hostname


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable admission webhooks so applicants have a chance to get their exercises working :)

I would btw. be very, very much in favor of moving all non-optional fields in the kubermaticv1.Cluster struct that currently are a pointer to a literal, because:

* This makes writing tests much easier
* This reduces the chance of getting NPEs inside the controlller

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Enabled Mutating/Validating Admission Webhooks for K8S 1.9+
```