### PR TITLE
Update addons image

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -7,9 +7,9 @@ The docker image should be freely accessible to let customers extend & modify th
 ### Releasing
 
 ```bash
-export TAG=v1.0
-docker build -t kubermatic/addons:${TAG} .
-docker push kubermatic/addons:${TAG}
+export TAG=v0.1.0
+docker build -t quay.io/kubermatic/addons:${TAG} .
+docker push quay.io/kubermatic/addons:${TAG}
 ```
 
 ### Using in the kubermatic-addon-controller

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -41,7 +41,7 @@ kubermatic:
     addons:
       image:
         repository: "quay.io/kubermatic/addons"
-        tag: "v0.0.1"
+        tag: "v0.1.0"
         pullPolicy: "IfNotPresent"
   api:
     replicas: 2


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the `addons/README.md` to reflect the correct addons image registry and bumps the referenced version for deployments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1362 

**Special notes for your reviewer**:

v0.1.0 is already pushed towards quay.

**Release note**:
```release-note
Updated addon manager to `v0.1.0`
```