### PR TITLE
cluster-dns (Part 2/2)

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -293,6 +293,7 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 	fakeCluster.Spec.Version = masterVersion.Version.String()
 	fakeCluster.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"172.25.0.0/16"}
 	fakeCluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.10.10.0/24"}
+	fakeCluster.Spec.ClusterNetwork.DNSDomain = "cluster.local"
 	fakeCluster.Status.NamespaceName = mockNamespaceName
 
 	stopChannel := make(chan struct{})

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -86,7 +86,10 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
+	if err != nil {
+		return nil, err
+	}
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -86,22 +86,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dnsConfigOptionNdots := "5"
-	dep.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
-	dep.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
-		Nameservers: []string{data.UserClusterDNSResolverIP()},
-		Searches: []string{
-			"kube-system.svc.cluster.local",
-			"svc.cluster.local",
-		},
-		Options: []corev1.PodDNSConfigOption{
-			{
-				Name:  "ndots",
-				Value: &dnsConfigOptionNdots,
-			},
-		},
-	}
-
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data)
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -86,7 +86,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data)
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -20,11 +20,6 @@ var (
 	defaultApiserverCPURequest    = resource.MustParse("100m")
 	defaultApiserverMemoryLimit   = resource.MustParse("1Gi")
 	defaultApiserverCPULimit      = resource.MustParse("500m")
-
-	defaultOpenVPNMemoryRequest = resource.MustParse("30Mi")
-	defaultOpenVPNCPURequest    = resource.MustParse("10m")
-	defaultOpenVPNMemoryLimit   = resource.MustParse("64Mi")
-	defaultOpenVPNCPULimit      = resource.MustParse("40m")
 )
 
 const (
@@ -90,6 +85,23 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		return nil, err
 	}
 
+	// Configure user cluster DNS resolver for this pod.
+	dnsConfigOptionNdots := "5"
+	dep.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
+	dep.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
+		Nameservers: []string{data.UserClusterDNSResolverIP()},
+		Searches: []string{
+			"kube-system.svc.cluster.local",
+			"svc.cluster.local",
+		},
+		Options: []corev1.PodDNSConfigOption{
+			{
+				Name:  "ndots",
+				Value: &dnsConfigOptionNdots,
+			},
+		},
+	}
+
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{
@@ -106,65 +118,12 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		},
 	}
 
-	openvpnServiceIP, err := data.ClusterIPByServiceName(resources.OpenVPNServerServiceName)
+	openvpnSidecar, err := resources.OpenVPNSidecarContainer(data, "openvpn-client")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
 	}
 	dep.Spec.Template.Spec.Containers = []corev1.Container{
-		{
-			Name:            "openvpn-client",
-			Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/openvpn:v0.4",
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Command:         []string{"/usr/sbin/openvpn"},
-			Args: []string{
-				"--client",
-				"--proto", "tcp",
-				"--dev", "tun",
-				"--auth-nocache",
-				"--remote", openvpnServiceIP, "1194",
-				"--nobind",
-				"--connect-timeout", "5",
-				"--connect-retry", "1",
-				"--ca", "/etc/kubernetes/ca-cert/ca.crt",
-				"--cert", "/etc/openvpn/certs/client.crt",
-				"--key", "/etc/openvpn/certs/client.key",
-				"--remote-cert-tls", "server",
-				"--link-mtu", "1432",
-				"--cipher", "AES-256-GCM",
-				"--auth", "SHA1",
-				"--keysize", "256",
-				"--script-security", "2",
-				"--status", "/run/openvpn-status",
-				"--log", "/dev/stdout",
-			},
-			SecurityContext: &corev1.SecurityContext{
-				Privileged: resources.Bool(true),
-			},
-			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: defaultOpenVPNMemoryRequest,
-					corev1.ResourceCPU:    defaultOpenVPNCPURequest,
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: defaultOpenVPNMemoryLimit,
-					corev1.ResourceCPU:    defaultOpenVPNCPULimit,
-				},
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					MountPath: "/etc/openvpn/certs",
-					Name:      resources.OpenVPNClientCertificatesSecretName,
-					ReadOnly:  true,
-				},
-				{
-					MountPath: "/etc/kubernetes/ca-cert",
-					Name:      resources.CACertSecretName,
-					ReadOnly:  true,
-				},
-			},
-		},
+		*openvpnSidecar,
 		{
 			Name:            name,
 			Image:           data.ImageRegistry(resources.RegistryKubernetesGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -75,7 +75,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data)
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
 
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -74,6 +74,23 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		return nil, err
 	}
 
+	// Configure user cluster DNS resolver for this pod.
+	dnsConfigOptionNdots := "5"
+	dep.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
+	dep.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
+		Nameservers: []string{data.UserClusterDNSResolverIP()},
+		Searches: []string{
+			"kube-system.svc.cluster.local",
+			"svc.cluster.local",
+		},
+		Options: []corev1.PodDNSConfigOption{
+			{
+				Name:  "ndots",
+				Value: &dnsConfigOptionNdots,
+			},
+		},
+	}
+
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{
@@ -89,7 +106,13 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		},
 	}
+
+	openvpnSidecar, err := resources.OpenVPNSidecarContainer(data, "openvpn-client")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
+	}
 	dep.Spec.Template.Spec.Containers = []corev1.Container{
+		*openvpnSidecar,
 		{
 			Name:            name,
 			Image:           data.ImageRegistry(resources.RegistryKubernetesGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
@@ -266,6 +289,15 @@ func getVolumes() []corev1.Volume {
 						Name: resources.CloudConfigConfigMapName,
 					},
 					DefaultMode: resources.Int32(420),
+				},
+			},
+		},
+		{
+			Name: resources.OpenVPNClientCertificatesSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  resources.OpenVPNClientCertificatesSecretName,
+					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
 				},
 			},
 		},

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -75,21 +75,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dnsConfigOptionNdots := "5"
-	dep.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
-	dep.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
-		Nameservers: []string{data.UserClusterDNSResolverIP()},
-		Searches: []string{
-			"kube-system.svc.cluster.local",
-			"svc.cluster.local",
-		},
-		Options: []corev1.PodDNSConfigOption{
-			{
-				Name:  "ndots",
-				Value: &dnsConfigOptionNdots,
-			},
-		},
-	}
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data)
 
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -75,7 +75,10 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
+	if err != nil {
+		return nil, err
+	}
 
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{

--- a/api/pkg/resources/openvpnsidecar.go
+++ b/api/pkg/resources/openvpnsidecar.go
@@ -1,0 +1,79 @@
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+	defaultOpenVPNMemoryRequest = resource.MustParse("30Mi")
+	defaultOpenVPNCPURequest    = resource.MustParse("10m")
+	defaultOpenVPNMemoryLimit   = resource.MustParse("64Mi")
+	defaultOpenVPNCPULimit      = resource.MustParse("40m")
+)
+
+// OpenVPNSidecarContainer returns a `corev1.Container` for
+// running alongside a master component, providing vpn access
+// to user cluster networks.
+// Also required but not provided by this func:
+// * volumes: resources.OpenVPNClientCertificatesSecretName, resources.CACertSecretName
+func OpenVPNSidecarContainer(data *TemplateData, name string) (*corev1.Container, error) {
+	openvpnServiceIP, err := data.ClusterIPByServiceName(OpenVPNServerServiceName)
+	if err != nil {
+		return nil, err
+	}
+	return &corev1.Container{
+		Name:            "openvpn-client",
+		Image:           data.ImageRegistry("docker.io") + "/kubermatic/openvpn:v0.4",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command:         []string{"/usr/sbin/openvpn"},
+		Args: []string{
+			"--client",
+			"--proto", "tcp",
+			"--dev", "tun",
+			"--auth-nocache",
+			"--remote", openvpnServiceIP, "1194",
+			"--nobind",
+			"--connect-timeout", "5",
+			"--connect-retry", "1",
+			"--ca", "/etc/kubernetes/ca-cert/ca.crt",
+			"--cert", "/etc/openvpn/certs/client.crt",
+			"--key", "/etc/openvpn/certs/client.key",
+			"--remote-cert-tls", "server",
+			"--link-mtu", "1432",
+			"--cipher", "AES-256-GCM",
+			"--auth", "SHA1",
+			"--keysize", "256",
+			"--script-security", "2",
+			"--status", "/run/openvpn-status",
+			"--log", "/dev/stdout",
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: Bool(true),
+		},
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: defaultOpenVPNMemoryRequest,
+				corev1.ResourceCPU:    defaultOpenVPNCPURequest,
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: defaultOpenVPNMemoryLimit,
+				corev1.ResourceCPU:    defaultOpenVPNCPULimit,
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				MountPath: "/etc/openvpn/certs",
+				Name:      OpenVPNClientCertificatesSecretName,
+				ReadOnly:  true,
+			},
+			{
+				MountPath: "/etc/kubernetes/ca-cert",
+				Name:      CACertSecretName,
+				ReadOnly:  true,
+			},
+		},
+	}, nil
+}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -247,6 +247,17 @@ func UserClusterDNSResolverIP(cluster *kubermaticv1.Cluster) (string, error) {
 	return ip.String(), nil
 }
 
+// UserClusterDNSPolicyAndConfig returns a DNSPolicy and DNSConfig to configure Pods to use user cluster DNS
+func UserClusterDNSPolicyAndConfig(data *TemplateData) (corev1.DNSPolicy, *corev1.PodDNSConfig) {
+	// DNSNone indicates that the pod should use empty DNS settings. DNS
+	// parameters such as nameservers and search paths should be defined via
+	// DNSConfig.
+	return corev1.DNSNone, &corev1.PodDNSConfig{
+		Nameservers: []string{data.UserClusterDNSResolverIP()},
+		Searches:    []string{},
+	}
+}
+
 // SecretRevision returns the resource version of the secret specified by name. A empty string will be returned in case of an error
 func (d *TemplateData) SecretRevision(name string) (string, error) {
 	secret, err := d.SecretLister.Secrets(d.Cluster.Status.NamespaceName).Get(name)

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -263,7 +263,7 @@ func UserClusterDNSPolicyAndConfig(cluster *kubermaticv1.Cluster) (corev1.DNSPol
 	return corev1.DNSNone, &corev1.PodDNSConfig{
 		Nameservers: []string{dnsConfigResolverIP},
 		Searches: []string{
-			"cluster.local",
+			cluster.Spec.ClusterNetwork.DNSDomain,
 		},
 		Options: []corev1.PodDNSConfigOption{
 			{

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -248,12 +248,12 @@ func UserClusterDNSResolverIP(cluster *kubermaticv1.Cluster) (string, error) {
 }
 
 // UserClusterDNSPolicyAndConfig returns a DNSPolicy and DNSConfig to configure Pods to use user cluster DNS
-func UserClusterDNSPolicyAndConfig(data *TemplateData) (corev1.DNSPolicy, *corev1.PodDNSConfig) {
+func UserClusterDNSPolicyAndConfig(cluster *kubermaticv1.Cluster) (corev1.DNSPolicy, *corev1.PodDNSConfig) {
 	// DNSNone indicates that the pod should use empty DNS settings. DNS
 	// parameters such as nameservers and search paths should be defined via
 	// DNSConfig.
 	return corev1.DNSNone, &corev1.PodDNSConfig{
-		Nameservers: []string{data.UserClusterDNSResolverIP()},
+		Nameservers: []string{UserClusterDNSResolverIP(cluster)},
 		Searches:    []string{},
 	}
 }

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -263,6 +263,8 @@ func UserClusterDNSPolicyAndConfig(cluster *kubermaticv1.Cluster) (corev1.DNSPol
 	return corev1.DNSNone, &corev1.PodDNSConfig{
 		Nameservers: []string{dnsConfigResolverIP},
 		Searches: []string{
+			fmt.Sprintf("kube-system.svc.%s", cluster.Spec.ClusterNetwork.DNSDomain),
+			fmt.Sprintf("svc.%s", cluster.Spec.ClusterNetwork.DNSDomain),
 			cluster.Spec.ClusterNetwork.DNSDomain,
 		},
 		Options: []corev1.PodDNSConfigOption{

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -252,9 +252,18 @@ func UserClusterDNSPolicyAndConfig(cluster *kubermaticv1.Cluster) (corev1.DNSPol
 	// DNSNone indicates that the pod should use empty DNS settings. DNS
 	// parameters such as nameservers and search paths should be defined via
 	// DNSConfig.
+	dnsConfigOptionNdots := "5"
 	return corev1.DNSNone, &corev1.PodDNSConfig{
 		Nameservers: []string{UserClusterDNSResolverIP(cluster)},
-		Searches:    []string{},
+		Searches: []string{
+			"cluster.local",
+		},
+		Options: []corev1.PodDNSConfigOption{
+			{
+				Name:  "ndots",
+				Value: &dnsConfigOptionNdots,
+			},
+		},
 	}
 }
 

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -75,7 +75,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data)
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
 
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -75,21 +75,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dnsConfigOptionNdots := "5"
-	dep.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
-	dep.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
-		Nameservers: []string{data.UserClusterDNSResolverIP()},
-		Searches: []string{
-			"kube-system.svc.cluster.local",
-			"svc.cluster.local",
-		},
-		Options: []corev1.PodDNSConfigOption{
-			{
-				Name:  "ndots",
-				Value: &dnsConfigOptionNdots,
-			},
-		},
-	}
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data)
 
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -75,7 +75,10 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// Configure user cluster DNS resolver for this pod.
-	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
+	dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data.Cluster)
+	if err != nil {
+		return nil, err
+	}
 
 	dep.Spec.Template.Spec.Volumes = getVolumes()
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -224,6 +224,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -227,12 +227,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -227,6 +227,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -231,6 +231,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -175,6 +175,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -112,6 +172,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -141,4 +211,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -175,12 +175,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -179,6 +179,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -224,6 +224,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -227,12 +227,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -227,6 +227,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -231,6 +231,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -175,6 +175,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -112,6 +172,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -141,4 +211,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -175,12 +175,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -179,6 +179,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -224,6 +224,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -227,12 +227,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -227,6 +227,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -231,6 +231,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -175,6 +175,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -112,6 +172,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -141,4 +211,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -175,12 +175,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -179,6 +179,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -214,6 +214,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -214,12 +214,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -218,6 +218,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -211,6 +211,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -99,6 +159,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -128,4 +198,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -162,12 +162,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -166,6 +166,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -162,6 +162,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -218,6 +218,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -222,6 +222,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -215,6 +215,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -218,12 +218,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -166,12 +166,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -103,6 +163,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -132,4 +202,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -166,6 +166,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -170,6 +170,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -218,6 +218,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -222,6 +222,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -215,6 +215,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -218,12 +218,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -166,12 +166,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -103,6 +163,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -132,4 +202,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -166,6 +166,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -170,6 +170,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -218,6 +218,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -222,6 +222,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -215,6 +215,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -218,12 +218,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -166,12 +166,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -36,6 +36,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -103,6 +163,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -132,4 +202,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -166,6 +166,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -170,6 +170,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -218,6 +218,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -222,6 +222,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -215,6 +215,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -218,12 +218,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -170,12 +170,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -174,6 +174,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -36,6 +36,70 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+        - mountPath: /sys/class/dmi/id/product_serial
+          name: cloud-config
+          readOnly: true
+          subPath: fakeVmwareUUID
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -103,10 +167,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
-        - mountPath: /sys/class/dmi/id/product_serial
-          name: cloud-config
-          readOnly: true
-          subPath: fakeVmwareUUID
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -136,4 +206,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -170,6 +170,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -218,6 +218,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -222,6 +222,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -215,6 +215,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -218,12 +218,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -170,12 +170,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -174,6 +174,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -36,6 +36,70 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+        - mountPath: /sys/class/dmi/id/product_serial
+          name: cloud-config
+          readOnly: true
+          subPath: fakeVmwareUUID
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -103,10 +167,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
-        - mountPath: /sys/class/dmi/id/product_serial
-          name: cloud-config
-          readOnly: true
-          subPath: fakeVmwareUUID
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -136,4 +206,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -170,6 +170,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -218,6 +218,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -222,6 +222,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -215,6 +215,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -218,12 +218,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -170,12 +170,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -174,6 +174,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -36,6 +36,70 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+        - mountPath: /sys/class/dmi/id/product_serial
+          name: cloud-config
+          readOnly: true
+          subPath: fakeVmwareUUID
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --service-account-private-key-file
@@ -103,10 +167,16 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
-        - mountPath: /sys/class/dmi/id/product_serial
-          name: cloud-config
-          readOnly: true
-          subPath: fakeVmwareUUID
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -136,4 +206,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -170,6 +170,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -135,6 +135,8 @@ spec:
         - name: ndots
           value: "5"
         searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
         - cluster.local
       dnsPolicy: None
       initContainers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -131,6 +131,11 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -32,6 +32,66 @@ spec:
     spec:
       containers:
       - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - 192.0.2.13
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/kubernetes/ca-cert/ca.crt
+        - --cert
+        - /etc/openvpn/certs/client.crt
+        - --key
+        - /etc/openvpn/certs/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 40m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/openvpn/certs
+          name: openvpn-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/ca-cert
+          name: ca-cert
+          readOnly: true
+      - args:
         - --master
         - http://192.0.2.11:8080
         - --v
@@ -68,6 +128,16 @@ spec:
             memory: 64Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      dnsConfig:
+        nameservers:
+        - 10.10.10.10
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+      dnsPolicy: None
       initContainers:
       - command:
         - /bin/sh
@@ -80,4 +150,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          defaultMode: 256
+          secretName: openvpn-client-certificates
+      - name: ca-cert
+        secret:
+          defaultMode: 256
+          secretName: ca-cert
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -131,12 +131,6 @@ spec:
       dnsConfig:
         nameservers:
         - 10.10.10.10
-        options:
-        - name: ndots
-          value: "5"
-        searches:
-        - kube-system.svc.cluster.local
-        - svc.cluster.local
       dnsPolicy: None
       initContainers:
       - command:

--- a/config/test/admission-webhooks/admissionvalidator-svc.yaml
+++ b/config/test/admission-webhooks/admissionvalidator-svc.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-validator
+spec:
+  selector:
+    matchLabels:
+      run: demo-validator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: demo-validator
+    spec:
+      volumes:
+      - name: snakeoil-tls
+        secret:
+          secretName: snakeoil-tls
+      containers:
+      - name: demo-validator
+        image: thzpub/vnf-swak-diag
+        volumeMounts:
+        - mountPath: /mnt/snakeoil-tls
+          name: snakeoil-tls
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          printf "Running demo-validator...\n"
+          cat <<"EOF">handler.sh
+          #!/bin/bash
+          ltmp=$(mktemp -d) ; trap "rm -r $ltmp" EXIT
+
+          # read request
+          read method path version
+
+          # read header
+          contentlength=0
+          while read -r header value; do
+            header=`echo "$header" | tr -d '\r\n'`
+            value=`echo "$value" | tr -d '\r\n'`
+            [ "${header^^}" = "CONTENT-LENGTH:" ] && contentlength="$value"
+            [ -z "$header" ] && break
+          done
+
+          # read body (if any)
+          if [ $contentlength -gt 0 ]; then
+            dd status=none bs=1 count=$contentlength | jq . |tee $ltmp/req.json > /dev/stderr
+          fi
+
+          fail() {
+            printf "HTTP/1.1 400 OK\nContent-Type: text/plain\n\n"
+            echo "$*"
+            exit 0
+          }
+          deny() {
+            printf "HTTP/1.1 200 OK\nContent-Type: application/json\n\n"
+            cat <<-RESPONSE
+            {
+              "response": {
+                "allowed": false,
+                "status": {
+                  "status": "Failure",
+                  "reason": "operation denied",
+                  "message": "$*",
+                  "code": 402
+                }
+              }
+            }
+          RESPONSE
+            echo "denied: $*" > /dev/stderr
+            exit 0
+          }
+          admit() {
+            printf "HTTP/1.1 200 OK\nContent-Type: application/json\n\n"
+            echo '{"response": { "allowed": true}}'
+            echo "admitted: $*" > /dev/stderr
+            exit 0
+          }
+
+          req=$ltmp/req.json
+          [ `jq -r '.kind' $req` = AdmissionReview ] || fail "Only kind=AdmissionReview is handled here."
+          [ `jq -r '.request.kind.kind' $req` = Namespace ] || admit "non-namespace"
+          [ `jq -r '.request.operation' $req` = CREATE ] || admit "non-CREATE op"
+          [ `jq -r '.request.object.metadata.name' $req` = foobar ] || admit "not foobar named."
+          deny "Please pick a better name. Foobar is too generic"
+          EOF
+
+          # serve the validator
+          chmod 755 handler.sh
+          cert=/mnt/snakeoil-tls/snakeoil.crt
+          key=/mnt/snakeoil-tls/snakeoil.key
+          socat \
+            openssl-listen:443,reuseaddr,fork,cert=$cert,key=$key,verify=0 \
+            system:./handler.sh
+          printf "Terminating.\n"
+          exit 0
+        ports:
+        - containerPort: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-validator
+  labels:
+    run: demo-validator
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+  selector:
+    run: demo-validator
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: snakeoil-tls
+type: Opaque
+data:
+  snakeoil.crt: Run create-secrets.sh
+  snakeoil.key: Run create-secrets.sh

--- a/config/test/admission-webhooks/create-secrets.sh
+++ b/config/test/admission-webhooks/create-secrets.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+name=demo-validator.default.svc
+
+if [ ! -s ./snakeoil.key -o ! -s ./snakeoil.crt ]; then
+	echo "Creating new snakeoil-secrets..."
+	openssl req -newkey rsa:1024 -nodes \
+		-days 30 -x509 \
+		-subj "/O=Snakeoil Inc/CN=$name" \
+		-keyout snakeoil.key -out snakeoil.crt
+fi
+
+echo "Injecting snakeoil-secrets into manifests..."
+sed -i "s/snakeoil.crt:.*$/snakeoil.crt: `openssl base64 -A < snakeoil.crt`/" \
+	admissionvalidator-svc.yaml
+sed -i "s/snakeoil.key:.*$/snakeoil.key: `openssl base64 -A < snakeoil.key`/" \
+	admissionvalidator-svc.yaml
+sed -i "s/caBundle:.*$/caBundle: `openssl base64 -A < snakeoil.crt`/" \
+	master-admission-config.yaml
+
+echo "Done."

--- a/config/test/admission-webhooks/master-admission-config.yaml
+++ b/config/test/admission-webhooks/master-admission-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: demo-validator
+webhooks:
+- name: demo-validator.cluster.local
+  rules:
+  - apiGroups:
+    - "*"
+    apiVersions:
+    - "*"
+    operations:
+    - CREATE
+    resources:
+    - "*"
+  clientConfig:
+    service:
+      namespace: default
+      name: demo-validator
+    caBundle: Run ./create-secrets.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds openvpn sidecars for `scheduler` and `controllermanager` and configures master components' pods to use the user-cluster's DNS resolver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #871 

**Special notes for your reviewer**:


Release note:
```release-note
Master components can now talk to cluster DNS
```