### PR TITLE
fix matching of machine & nodes

### DIFF
--- a/api/pkg/handler/node_v2.go
+++ b/api/pkg/handler/node_v2.go
@@ -294,11 +294,8 @@ func createNodeEndpointV2(dcs map[string]provider.DatacenterMeta, dp provider.SS
 }
 
 func getNodeForMachine(machine *v1alpha1.Machine, nodes []corev1.Node) *corev1.Node {
-	if machine.Status.NodeRef == nil {
-		return nil
-	}
 	for _, node := range nodes {
-		if node.UID == machine.Status.NodeRef.UID || node.Name == machine.Name {
+		if (machine.Status.NodeRef != nil && node.UID == machine.Status.NodeRef.UID) || node.Name == machine.Name {
 			return &node
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now we sometimes see duplicated nodes in the `list-nodes` endpoint.
This change will fix this by matching machine&nodes by name. 

**Release note**:
```release-note bugfix
Fixed a rare issue with duplicate entries on the list of nodes
```