### PR TITLE
add possible images/templates to datacenter.yaml for Openstack and vSphere

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2485,6 +2485,14 @@
       "x-go-name": "HetznerNodeSpec",
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v2"
     },
+    "ImageList": {
+      "description": "ImageList defines a map of operating system and the image to use",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
     "Initializer": {
       "type": "object",
       "title": "Initializer is information about an initializer that has not yet completed.",
@@ -3474,6 +3482,9 @@
           "type": "string",
           "x-go-name": "AvailabilityZone"
         },
+        "images": {
+          "$ref": "#/definitions/ImageList"
+        },
         "region": {
           "type": "string",
           "x-go-name": "Region"
@@ -3973,6 +3984,9 @@
         "endpoint": {
           "type": "string",
           "x-go-name": "Endpoint"
+        },
+        "templates": {
+          "$ref": "#/definitions/ImageList"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -28,12 +28,16 @@ type HetznerDatacenterSpec struct {
 	Location   string `json:"location"`
 }
 
+// ImageList defines a map of operating system and the image to use
+type ImageList map[string]string
+
 // VSphereDatacenterSpec specifies a datacenter of VSphere.
 type VSphereDatacenterSpec struct {
-	Endpoint   string `json:"endpoint"`
-	Datacenter string `json:"datacenter"`
-	Datastore  string `json:"datastore"`
-	Cluster    string `json:"cluster"`
+	Endpoint   string    `json:"endpoint"`
+	Datacenter string    `json:"datacenter"`
+	Datastore  string    `json:"datastore"`
+	Cluster    string    `json:"cluster"`
+	Templates  ImageList `json:"templates"`
 }
 
 // BringYourOwnDatacenterSpec specifies a data center with bring-your-own nodes.
@@ -51,9 +55,10 @@ type AzureDatacenterSpec struct {
 
 // OpenstackDatacenterSpec specifies a generic bare metal datacenter.
 type OpenstackDatacenterSpec struct {
-	AvailabilityZone string `json:"availability_zone"`
-	Region           string `json:"region"`
-	AuthURL          string `json:"auth_url"`
+	AvailabilityZone string    `json:"availability_zone"`
+	Region           string    `json:"region"`
+	AuthURL          string    `json:"auth_url"`
+	Images           ImageList `json:"images"`
 }
 
 // DatacenterSpec specifies the data for a datacenter.

--- a/api/pkg/handler/datacenter.go
+++ b/api/pkg/handler/datacenter.go
@@ -82,6 +82,14 @@ func datacenterEndpoint(dcs map[string]provider.DatacenterMeta) endpoint.Endpoin
 	}
 }
 
+func imagesMap(images provider.ImageList) map[string]string {
+	m := map[string]string{}
+	for os, image := range images {
+		m[string(os)] = image
+	}
+	return m
+}
+
 func apiSpec(dc *provider.DatacenterMeta) (*apiv1.DatacenterSpec, error) {
 	p, err := provider.DatacenterCloudProviderName(&dc.Spec)
 	if err != nil {
@@ -110,6 +118,7 @@ func apiSpec(dc *provider.DatacenterMeta) (*apiv1.DatacenterSpec, error) {
 			AuthURL:          dc.Spec.Openstack.AuthURL,
 			AvailabilityZone: dc.Spec.Openstack.AvailabilityZone,
 			Region:           dc.Spec.Openstack.Region,
+			Images:           imagesMap(dc.Spec.Openstack.Images),
 		}
 	case dc.Spec.Hetzner != nil:
 		spec.Hetzner = &apiv1.HetznerDatacenterSpec{
@@ -122,6 +131,7 @@ func apiSpec(dc *provider.DatacenterMeta) (*apiv1.DatacenterSpec, error) {
 			Datacenter: dc.Spec.VSphere.Datacenter,
 			Datastore:  dc.Spec.VSphere.Datastore,
 			Cluster:    dc.Spec.VSphere.Cluster,
+			Templates:  imagesMap(dc.Spec.VSphere.Templates),
 		}
 	case dc.Spec.Azure != nil:
 		spec.Azure = &apiv1.AzureDatacenterSpec{

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	"gopkg.in/yaml.v2"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -23,25 +24,13 @@ type HetznerSpec struct {
 	Location   string `yaml:"location"`
 }
 
-// OperatingSystem type definition for the operating system
-type OperatingSystem string
-
-const (
-	// OperatingSystemCoreos name of the operating system coreos
-	OperatingSystemCoreos OperatingSystem = "coreos"
-	// OperatingSystemUbuntu name of the operating system ubuntu
-	OperatingSystemUbuntu OperatingSystem = "ubuntu"
-	// OperatingSystemCentOS name of the operating system centos
-	OperatingSystemCentOS OperatingSystem = "centos"
-)
-
 var (
 	// AllOperatingSystems defines all available operating systems
-	AllOperatingSystems = sets.NewString(string(OperatingSystemCoreos), string(OperatingSystemCentOS), string(OperatingSystemUbuntu))
+	AllOperatingSystems = sets.NewString(string(providerconfig.OperatingSystemCoreos), string(providerconfig.OperatingSystemCentOS), string(providerconfig.OperatingSystemUbuntu))
 )
 
 // ImageList defines a map of operating system and the image to use
-type ImageList map[OperatingSystem]string
+type ImageList map[providerconfig.OperatingSystem]string
 
 // OpenstackSpec describes a open stack datacenter
 type OpenstackSpec struct {

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -2,10 +2,14 @@ package provider
 
 import (
 	"bufio"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v2"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // DigitaloceanSpec describes a DigitalOcean datacenter
@@ -19,6 +23,26 @@ type HetznerSpec struct {
 	Location   string `yaml:"location"`
 }
 
+// OperatingSystem type definition for the operating system
+type OperatingSystem string
+
+const (
+	// OperatingSystemCoreos name of the operating system coreos
+	OperatingSystemCoreos OperatingSystem = "coreos"
+	// OperatingSystemUbuntu name of the operating system ubuntu
+	OperatingSystemUbuntu OperatingSystem = "ubuntu"
+	// OperatingSystemCentOS name of the operating system centos
+	OperatingSystemCentOS OperatingSystem = "centos"
+)
+
+var (
+	// AllOperatingSystems defines all available operating systems
+	AllOperatingSystems = sets.NewString(string(OperatingSystemCoreos), string(OperatingSystemCentOS), string(OperatingSystemUbuntu))
+)
+
+// ImageList defines a map of operating system and the image to use
+type ImageList map[OperatingSystem]string
+
 // OpenstackSpec describes a open stack datacenter
 type OpenstackSpec struct {
 	AuthURL          string `yaml:"auth_url"`
@@ -26,7 +50,8 @@ type OpenstackSpec struct {
 	Region           string `yaml:"region"`
 	IgnoreVolumeAZ   bool   `yaml:"ignore_volume_az"`
 	// Used for automatic network creation
-	DNSServers []string `yaml:"dns_servers"`
+	DNSServers []string  `yaml:"dns_servers"`
+	Images     ImageList `yaml:"images"`
 }
 
 // AzureSpec describes an Azure cloud datacenter
@@ -39,10 +64,11 @@ type VSphereSpec struct {
 	Endpoint      string `yaml:"endpoint"`
 	AllowInsecure bool   `yaml:"allow_insecure"`
 
-	Datastore  string `yaml:"datastore"`
-	Datacenter string `yaml:"datacenter"`
-	Cluster    string `yaml:"cluster"`
-	RootPath   string `yaml:"root_path"`
+	Datastore  string    `yaml:"datastore"`
+	Datacenter string    `yaml:"datacenter"`
+	Cluster    string    `yaml:"cluster"`
+	RootPath   string    `yaml:"root_path"`
+	Templates  ImageList `yaml:"templates"`
 }
 
 // AWSSpec describes a aws datacenter
@@ -100,5 +126,32 @@ func LoadDatacentersMeta(path string) (map[string]DatacenterMeta, error) {
 		return nil, err
 	}
 
-	return dcs.Datacenters, nil
+	return dcs.Datacenters, validateDatacenters(dcs.Datacenters)
+}
+
+func validateImageList(images ImageList) error {
+	for s := range images {
+		if !AllOperatingSystems.Has(string(s)) {
+			return fmt.Errorf("invalid operating system defined '%s'. Possible values: %s", s, strings.Join(AllOperatingSystems.List(), ","))
+		}
+	}
+
+	return nil
+}
+
+func validateDatacenters(datacenters map[string]DatacenterMeta) error {
+	for name, dc := range datacenters {
+		if dc.Spec.VSphere != nil {
+			if err := validateImageList(dc.Spec.VSphere.Templates); err != nil {
+				return fmt.Errorf("invalid datacenter defined '%s': %v", name, err)
+			}
+		}
+		if dc.Spec.Openstack != nil {
+			if err := validateImageList(dc.Spec.Openstack.Images); err != nil {
+				return fmt.Errorf("invalid datacenter defined '%s': %v", name, err)
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will add a static definition of operating system & image/template to the datacenters.yaml definition for vSphere and OpenStack.
The Dashboard should use this information to prefill the required inputs or offer a dropdown.

Fixes #1297 

**Release note**:
```release-note cloud provider
Image templates can now be configured in datacenter.yaml for Openstack and vSphere
```