### PR TITLE
Put ui version into chart values

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -53,7 +53,7 @@ kubermatic:
     replicas: 2
     image:
       repository: "kubermatic/ui-v2"
-      tag: "latest"
+      tag: "v0.35"
       pullPolicy: "IfNotPresent"
     config: |
       {

--- a/config/versions-values.yaml
+++ b/config/versions-values.yaml
@@ -6,9 +6,6 @@ kubermatic:
   api:
     image:
       tag: "{API_IMAGE_TAG}"
-  ui:
-    image:
-      tag: "v0.35"
   rbac:
     image:
       tag: "{API_IMAGE_TAG}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Put ui version into chart values.
As we don't use the installer-container anymore - we need to set the stable ui version as default inside the chart.

**Release note**:
```release-note
NONE
```