### PR TITLE
Add Kubermatic alerts back

### DIFF
--- a/config/monitoring/prometheus/jsonnet/alerts/kubermatic.libsonnet
+++ b/config/monitoring/prometheus/jsonnet/alerts/kubermatic.libsonnet
@@ -1,0 +1,38 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'kubermatic',
+        rules: [
+          {
+            alert: 'KubermaticTooManyUnhandledErrors',
+            expr: |||
+              sum(rate(kubermatic_cluster_controller_unhandled_errors_total[5m])) > 0.01
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Kubermatic Controller Manager in {{ $labels.namespace }} has too many errors in its loop.',
+            },
+          },
+          {
+            alert: 'KubermaticStuckClusterPhase',
+            expr: |||
+              kubermatic_cluster_controller_cluster_status_phase{phase="running"} == 0 and
+              kubermatic_cluster_controller_cluster_status_phase{phase="deleting"} == 0
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Kubermatic cluster {{ $labels.cluster }} is stuck in unexpected phase {{ $labels.phase }}.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
+++ b/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
@@ -1,5 +1,6 @@
 local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
+(import './alerts/kubermatic.libsonnet') +
 (import 'kubernetes-mixin/mixin.libsonnet') +
 (import 'etcd-mixin/mixin.libsonnet') + {
   _config+:: {
@@ -19,6 +20,8 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     jobs+:: {
       Cadvisor: $._config.cadvisorSelector,
       Kubelet: $._config.kubeletSelector,
+      KubermaticAPI: 'job="pods",namespace="kubermatic",role="kubermatic-api"',
+      KubermaticControllerManager: 'job="pods",namespace="kubermatic",role="controller-manager"',
       KubernetesApiserver: $._config.kubeApiserverSelector,
       KubeStateMetrics: $._config.kubeStateMetricsSelector,
       // KubernetesControllerManager: $._config.kubeControllerManagerSelector,
@@ -36,3 +39,5 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       $._config.prometheus.rules,
   },
 }
+
+

--- a/config/monitoring/prometheus/rules/rules.yaml
+++ b/config/monitoring/prometheus/rules/rules.yaml
@@ -236,6 +236,29 @@ groups:
         node_namespace_pod:kube_pod_info:
       )
     record: node:node_net_saturation:sum_irate
+- name: kubermatic
+  rules:
+  - alert: KubermaticTooManyUnhandledErrors
+    annotations:
+      message: Kubermatic Controller Manager in {{ $labels.namespace }} has too many
+        errors in its loop.
+      runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubermatictoomanyunhandlederrors
+    expr: |
+      sum(rate(kubermatic_cluster_controller_unhandled_errors_total[5m])) > 0.01
+    for: 10m
+    labels:
+      severity: warning
+  - alert: KubermaticStuckClusterPhase
+    annotations:
+      message: Kubermatic cluster {{ $labels.cluster }} is stuck in unexpected phase
+        {{ $labels.phase }}.
+      runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubermaticstuckclusterphase
+    expr: |
+      kubermatic_cluster_controller_cluster_status_phase{phase="running"} == 0 and
+      kubermatic_cluster_controller_cluster_status_phase{phase="deleting"} == 0
+    for: 10m
+    labels:
+      severity: warning
 - name: kubernetes-absent
   rules:
   - alert: CadvisorDown
@@ -289,6 +312,25 @@ groups:
       runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown
     expr: |
       absent(up{job="kubelet"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+  - alert: KubermaticAPIDown
+    annotations:
+      message: KubermaticAPI has disappeared from Prometheus target discovery.
+      runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubermaticapidown
+    expr: |
+      absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+  - alert: KubermaticControllerManagerDown
+    annotations:
+      message: KubermaticControllerManager has disappeared from Prometheus target
+        discovery.
+      runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubermaticcontrollermanagerdown
+    expr: |
+      absent(up{job="pods",namespace="kubermatic",role="controller-manager"} == 1)
     for: 15m
     labels:
       severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:
We're currently missing the Kubermatic alerts.
These are the same as previously with the new alert format.

**Release note**:
```release-note
NONE
```