### PR TITLE
Add back machine-controller alerts

### DIFF
--- a/config/monitoring/prometheus/jsonnet/alerts/machine-controller.libsonnet
+++ b/config/monitoring/prometheus/jsonnet/alerts/machine-controller.libsonnet
@@ -1,0 +1,24 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'machine-controller',
+        rules: [
+          {
+            alert: 'MachineControllerTooManyErrors',
+            expr: |||
+              sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Machine Controller in {{ $labels.namespace }} has too many errors in its loop.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
+++ b/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
@@ -1,6 +1,7 @@
 local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
 (import './alerts/kubermatic.libsonnet') +
+(import './alerts/machine-controller.libsonnet') +
 (import 'kubernetes-mixin/mixin.libsonnet') +
 (import 'etcd-mixin/mixin.libsonnet') + {
   _config+:: {
@@ -15,6 +16,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     kubeSchedulerSelector: 'job="kube-scheduler"',
     kubeControllerManagerSelector: 'job="kube-controller-manager"',
     kubeApiserverSelector: 'job="apiserver"',
+    machineControllerSelector: 'job="machine-controller"',
 
     // We build alerts for the presence of all these jobs.
     jobs+:: {
@@ -24,6 +26,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       KubermaticControllerManager: 'job="pods",namespace="kubermatic",role="controller-manager"',
       KubernetesApiserver: $._config.kubeApiserverSelector,
       KubeStateMetrics: $._config.kubeStateMetricsSelector,
+      MachineController: $._config.machineControllerSelector,
       // KubernetesControllerManager: $._config.kubeControllerManagerSelector,
       // KubernetesScheduler: $._config.kubeSchedulerSelector,
     },

--- a/config/monitoring/prometheus/rules/rules.yaml
+++ b/config/monitoring/prometheus/rules/rules.yaml
@@ -259,6 +259,18 @@ groups:
     for: 10m
     labels:
       severity: warning
+- name: machine-controller
+  rules:
+  - alert: MachineControllerTooManyErrors
+    annotations:
+      message: Machine Controller in {{ $labels.namespace }} has too many errors in
+        its loop.
+      runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-machinecontrollertoomanyerrors
+    expr: |
+      sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+    for: 10m
+    labels:
+      severity: warning
 - name: kubernetes-absent
   rules:
   - alert: CadvisorDown
@@ -340,6 +352,15 @@ groups:
       runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubernetesapiserverdown
     expr: |
       absent(up{job="apiserver"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+  - alert: MachineControllerDown
+    annotations:
+      message: MachineController has disappeared from Prometheus target discovery.
+      runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-machinecontrollerdown
+    expr: |
+      absent(up{job="machine-controller"} == 1)
     for: 15m
     labels:
       severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:
We're currently missing the Machine Controller alerts.
These are the same as previously with the new alert format.

Release note:
```release-note
NONE
```