### PR TITLE
Add flag to configure ginkgo timeout at runtime

### DIFF
--- a/api/cmd/kubermatic-e2e/e2e_test_runner.go
+++ b/api/cmd/kubermatic-e2e/e2e_test_runner.go
@@ -147,7 +147,7 @@ func (ctl *e2eTestRunner) run(ctx context.Context) error {
 }
 
 func (ctl *e2eTestRunner) execGinkgo(ctx context.Context, kubeconfig string) error {
-	execCtx, execCancel := context.WithTimeout(ctx, 3600*time.Second)
+	execCtx, execCancel := context.WithTimeout(ctx, ctl.runOpts.GinkgoTimeout)
 	defer execCancel()
 
 	cmd := exec.CommandContext(execCtx,

--- a/api/cmd/kubermatic-e2e/main.go
+++ b/api/cmd/kubermatic-e2e/main.go
@@ -28,6 +28,7 @@ type Opts struct {
 	TestBin        string
 	ClusterTimeout time.Duration
 	NodesTimeout   time.Duration
+	GinkgoTimeout  time.Duration
 }
 
 func main() {
@@ -43,6 +44,7 @@ func main() {
 	flag.DurationVar(&runOpts.ClusterTimeout, "cluster-timeout", 3*time.Minute, "cluster creation timeout")
 	flag.DurationVar(&runOpts.NodesTimeout, "nodes-timeout", 10*time.Minute, "nodes creation timeout")
 	flag.StringVar(&runOpts.GinkgoBin, "ginkgo-bin", "/usr/local/bin/ginkgo", "path to ginkgo binary")
+	flag.DurationVar(&runOpts.GinkgoTimeout, "ginkgo-timeout", 5400*time.Second, "ginkgo execution timeout")
 	flag.StringVar(&runOpts.Focus, "ginkgo-focus", `\[Conformance\]`, "tests focus")
 	flag.StringVar(&runOpts.Skip, "ginkgo-skip", `Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]`, "skip those groups of tests")
 	flag.StringVar(&runOpts.Parallel, "ginkgo-parallel", "1", "parallelism of tests")


### PR DESCRIPTION
**What this PR does / why we need it**:

ginkgo runs takes a lot of time (1h+), so we need to have control on timeouts

Release note:
```release-note
NONE
```