### PR TITLE
Allow specific worker-name in hack/run-*.sh

### DIFF
--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -5,6 +5,8 @@ set -o nounset
 set -o pipefail
 set -x
 
+KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
+
 # Please make sure to set -enable-prometheus-endpoint=true if you want to use that endpoint.
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
@@ -14,7 +16,7 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -versions=../config/kubermatic/static/master/versions.yaml \
   -updates=../config/kubermatic/static/master/updates.yaml \
   -master-resources=../config/kubermatic/static/master \
-  -worker-name="$(uname -n | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]' )" \
+  -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
   -token-issuer=https://dev.kubermatic.io/dex \
   -internal-address=127.0.0.1:18085 \
   -prometheus-url=http://localhost:9090 \

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -4,6 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 ./_build/kubermatic-controller-manager \
@@ -14,7 +15,7 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -updates=../config/kubermatic/static/master/updates.yaml \
   -master-resources=../config/kubermatic/static/master \
   -addons=../addons \
-  -worker-name="$(uname -n | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')" \
+  -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
   -external-url=dev.kubermatic.io \
   -backup-container=../config/kubermatic/static/backup-container.yaml \
   -cleanup-container=../config/kubermatic/static/cleanup-container.yaml \

--- a/api/hack/run-rbac-generator.sh
+++ b/api/hack/run-rbac-generator.sh
@@ -4,10 +4,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 ./_build/rbac-generator \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
-  -worker-name="$(uname -n | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')" \
+  -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
   -logtostderr=1 \
   -v=6 $@


### PR DESCRIPTION
**What this PR does / why we need it**:

Context: the scripts api/hack/run-*.sh

My hostname (virtual machine) is just "vm" or "ubuntu". I want to use a worker-name which is a bit more unique and also refers to me. So I was always carrying some `git stash` with me, which hardcodes "thz-local" as workername in the script. This change allows to define the worker-name by setting `$KUBERMATIC_WORKERNAME` in your environment.

Without setting this variable in your environment, nothing will change for you. The worker-name default is still based on `uname -n`.

Quite a tiny change, but it removes some toil of always git stashing before merges/rebases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Release note:
```release-note
NONE
```