### PR TITLE
Support for parallelise Conformance testing

### DIFF
--- a/api/Dockerfile.e2e
+++ b/api/Dockerfile.e2e
@@ -2,11 +2,11 @@ FROM alpine:3.7 AS builder
 
 LABEL maintainer "artiom@loodse.com"
 
-ENV KUBE_VERSION=v1.10.3
+ENV KUBE_VERSION=v1.10.5
 ENV KUBE_TEST_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes-test.tar.gz
-ENV KUBE_TEST_CHECKSUM=b075744e98972d9734d34b954a07428e2248ea2f
+ENV KUBE_TEST_CHECKSUM=7b2d0d8bf474c35ed30d89b00f601f2ccfa49ad3
 ENV KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_CHECKSUM=94f996d645e74634a4be67bbb5417f892774230b
+ENV KUBECTL_CHECKSUM=dbe431b2684f8ff4188335b3b3cea185d5a9ec44
 
 RUN apk add --no-cache curl
 RUN mkdir -p /_cache

--- a/api/cmd/kubermatic-e2e/README.md
+++ b/api/cmd/kubermatic-e2e/README.md
@@ -19,14 +19,8 @@ test suit.
 ## Flags
 All flags have reasonable defaults
 
-    -addons value
-        comma separated list of addons (default canal,dns,kube-proxy,openvpn,rbac)
     -alsologtostderr
         log to standard error as well as files
-    -cluster string
-        path to Cluster yaml (default "/manifests/cluster.yaml")
-    -cluster-timeout duration
-        cluster creation timeout (default 3m0s)
     -e2e-provider string
         cloud provider to use in tests (default "local")
     -e2e-results-dir string
@@ -37,24 +31,34 @@ All flags have reasonable defaults
         path to ginkgo binary (default "/usr/local/bin/ginkgo")
     -ginkgo-focus string
         tests focus (default "\\[Conformance\\]")
-    -ginkgo-parallel string
-        parallelism of tests (default "1")
+    -ginkgo-nocolor
+        don't show colors
+    -ginkgo-parallel int
+        parallelism of tests (default 3)
     -ginkgo-skip string
-        skip those groups of tests (default "Alpha|Kubectl|\\[(Disruptive|Feature:[^\\]]+|Flaky)\\]")
+        skip those groups of tests (default "Flaky")
+    -ginkgo-timeout duration
+        ginkgo execution timeout (default 1h30m0s)
     -kubeconfig string
         path to kubeconfig file (default "/config/kubeconfig")
+    -kubermatic-addons value
+        comma separated list of addons (default canal,dns,kube-proxy,openvpn,rbac)
+    -kubermatic-cluster string
+        path to Cluster yaml (default "/manifests/cluster.yaml")
+    -kubermatic-cluster-timeout duration
+        cluster creation timeout (default 3m0s)
+    -kubermatic-machine string
+        path to Machine yaml (default "/manifests/machine.yaml")
+    -kubermatic-nodes int
+        number of worker nodes (default 3)
+    -kubermatic-nodes-timeout duration
+        nodes creation timeout (default 10m0s)
     -log_backtrace_at value
         when logging hits line file:N, emit a stack trace
     -log_dir string
         If non-empty, write log files in this directory
     -logtostderr
         log to standard error instead of files
-    -machine string
-        path to Machine yaml (default "/manifests/machine.yaml")
-    -nodes int
-        number of worker nodes (default 1)
-    -nodes-timeout duration
-        nodes creation timeout (default 10m0s)
     -stderrthreshold value
         logs at or above this threshold go to stderr
     -v value

--- a/api/cmd/kubermatic-e2e/e2e_test_runner.go
+++ b/api/cmd/kubermatic-e2e/e2e_test_runner.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	log "github.com/golang/glog"
@@ -29,7 +30,9 @@ import (
 )
 
 const (
-	e2eGenerateName = "e2e-test-runner-"
+	e2eGenerateName   = "e2e-test-runner-"
+	ginkgoSerial      = `\[Serial\]`
+	ginkgoConformance = `\[Conformance\]`
 )
 
 func newE2ETestRunner(runOpts Opts) (*e2eTestRunner, error) {
@@ -143,25 +146,54 @@ func (ctl *e2eTestRunner) run(ctx context.Context) error {
 		return err
 	}
 
-	return ctl.execGinkgo(ctx, e2eKubeConfig.Name())
-}
-
-func (ctl *e2eTestRunner) execGinkgo(ctx context.Context, kubeconfig string) error {
 	execCtx, execCancel := context.WithTimeout(ctx, ctl.runOpts.GinkgoTimeout)
 	defer execCancel()
 
-	cmd := exec.CommandContext(execCtx,
-		ctl.runOpts.GinkgoBin,
-		"--focus="+ctl.runOpts.Focus,
-		"--skip="+ctl.runOpts.Skip,
-		"--noColor=true",
-		"--nodes="+ctl.runOpts.Parallel,
-		ctl.runOpts.TestBin,
+	if ctl.runOpts.Parallel == 1 {
+		return execGinkgo(execCtx, ctl.runOpts, e2eKubeConfig.Name())
+	}
+
+	// copy options for local edits
+	parallelOpts := ctl.runOpts
+
+	if parallelOpts.Skip != "" {
+		parallelOpts.Skip = fmt.Sprintf("%s|%s", parallelOpts.Skip, ginkgoSerial)
+	} else {
+		parallelOpts.Skip = ginkgoSerial
+	}
+
+	// first run only parallel safe (skip [Serial]) tests
+	if err := execGinkgo(execCtx, parallelOpts, e2eKubeConfig.Name()); err != nil {
+		return err
+	}
+
+	parallelOpts.Parallel = 1
+	// restore original skip
+	parallelOpts.Skip = ctl.runOpts.Skip
+
+	if parallelOpts.Focus == ginkgoConformance {
+		parallelOpts.Focus = fmt.Sprintf("%s.*%s", ginkgoSerial, ginkgoConformance)
+	} else {
+		parallelOpts.Focus = fmt.Sprintf("%s.*%s.*%s", parallelOpts.Focus, ginkgoSerial, ginkgoConformance)
+	}
+
+	// second run only [Serial] conformance tests
+	return execGinkgo(execCtx, parallelOpts, e2eKubeConfig.Name())
+}
+
+func execGinkgo(ctx context.Context, opts Opts, kubeconfig string) error {
+	cmd := exec.CommandContext(ctx,
+		opts.GinkgoBin,
+		`--focus=`+opts.Focus,
+		"--skip="+opts.Skip,
+		"--noColor="+strconv.FormatBool(opts.GinkgoNoColor),
+		"--nodes="+strconv.Itoa(opts.Parallel),
+		opts.TestBin,
 		"--",
 		"--disable-log-dump",
 		"--repo-root=/kubernetes",
-		"--provider="+ctl.runOpts.Provider,
-		"--report-dir="+ctl.runOpts.ReportsDir,
+		"--provider="+opts.Provider,
+		"--report-dir="+opts.ReportsDir,
 		"--kubeconfig="+kubeconfig)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/api/cmd/kubermatic-e2e/main.go
+++ b/api/cmd/kubermatic-e2e/main.go
@@ -16,19 +16,20 @@ import (
 type Opts struct {
 	Addons         flagopts.StringArray
 	ClusterPath    string
+	ClusterTimeout time.Duration
 	Focus          string
 	GinkgoBin      string
+	GinkgoNoColor  bool
+	GinkgoTimeout  time.Duration
 	KubeconfPath   string
 	MachinePath    string
 	Nodes          int
-	Parallel       string
+	NodesTimeout   time.Duration
+	Parallel       int
 	Provider       string
 	ReportsDir     string
 	Skip           string
 	TestBin        string
-	ClusterTimeout time.Duration
-	NodesTimeout   time.Duration
-	GinkgoTimeout  time.Duration
 }
 
 func main() {
@@ -37,17 +38,18 @@ func main() {
 	}
 
 	flag.StringVar(&runOpts.KubeconfPath, "kubeconfig", "/config/kubeconfig", "path to kubeconfig file")
-	flag.StringVar(&runOpts.ClusterPath, "cluster", "/manifests/cluster.yaml", "path to Cluster yaml")
-	flag.StringVar(&runOpts.MachinePath, "machine", "/manifests/machine.yaml", "path to Machine yaml")
-	flag.Var(&runOpts.Addons, "addons", "comma separated list of addons")
-	flag.IntVar(&runOpts.Nodes, "nodes", 1, "number of worker nodes")
-	flag.DurationVar(&runOpts.ClusterTimeout, "cluster-timeout", 3*time.Minute, "cluster creation timeout")
-	flag.DurationVar(&runOpts.NodesTimeout, "nodes-timeout", 10*time.Minute, "nodes creation timeout")
+	flag.StringVar(&runOpts.ClusterPath, "kubermatic-cluster", "/manifests/cluster.yaml", "path to Cluster yaml")
+	flag.StringVar(&runOpts.MachinePath, "kubermatic-machine", "/manifests/machine.yaml", "path to Machine yaml")
+	flag.Var(&runOpts.Addons, "kubermatic-addons", "comma separated list of addons")
+	flag.IntVar(&runOpts.Nodes, "kubermatic-nodes", 3, "number of worker nodes")
+	flag.DurationVar(&runOpts.ClusterTimeout, "kubermatic-cluster-timeout", 3*time.Minute, "cluster creation timeout")
+	flag.DurationVar(&runOpts.NodesTimeout, "kubermatic-nodes-timeout", 10*time.Minute, "nodes creation timeout")
 	flag.StringVar(&runOpts.GinkgoBin, "ginkgo-bin", "/usr/local/bin/ginkgo", "path to ginkgo binary")
+	flag.BoolVar(&runOpts.GinkgoNoColor, "ginkgo-nocolor", false, "don't show colors")
 	flag.DurationVar(&runOpts.GinkgoTimeout, "ginkgo-timeout", 5400*time.Second, "ginkgo execution timeout")
 	flag.StringVar(&runOpts.Focus, "ginkgo-focus", `\[Conformance\]`, "tests focus")
-	flag.StringVar(&runOpts.Skip, "ginkgo-skip", `Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]`, "skip those groups of tests")
-	flag.StringVar(&runOpts.Parallel, "ginkgo-parallel", "1", "parallelism of tests")
+	flag.StringVar(&runOpts.Skip, "ginkgo-skip", `Flaky`, "skip those groups of tests")
+	flag.IntVar(&runOpts.Parallel, "ginkgo-parallel", 3, "parallelism of tests")
 	flag.StringVar(&runOpts.TestBin, "e2e-test-bin", "/usr/local/bin/e2e.test", "path to e2e.test binary")
 	flag.StringVar(&runOpts.Provider, "e2e-provider", "local", "cloud provider to use in tests")
 	flag.StringVar(&runOpts.ReportsDir, "e2e-results-dir", "/tmp/results", "directory to save test results")


### PR DESCRIPTION
**What this PR does / why we need it**:

* Upgrade tests to 1.10.5
* Parallelise Conformance tests runs 

Release note:
```release-note
NONE
```