### PR TITLE
Fix aws tagging

### DIFF
--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -26,7 +26,7 @@ const (
 	instanceProfileCleanupFinalizer = "kubermatic.io/cleanup-aws-instance-profile"
 	tagCleanupFinalizer             = "kubermatic.io/cleanup-aws-tags"
 
-	tagNameKubernetesClusterLegacy = "KubernetesCluster"
+	TagNameKubernetesClusterPrefix = "kubernetes.io/cluster/"
 )
 
 var roleARNS = []string{policyRoute53FullAccess, policyEC2FullAccess}
@@ -176,8 +176,8 @@ func tagResources(cluster *kubermaticv1.Cluster, client *ec2.EC2) error {
 		Resources: resourceIDs,
 		Tags: []*ec2.Tag{
 			{
-				Key:   aws.String(tagNameKubernetesClusterLegacy),
-				Value: aws.String(cluster.Name),
+				Key:   aws.String(TagNameKubernetesClusterPrefix + cluster.Name),
+				Value: aws.String(""),
 			},
 		},
 	})
@@ -205,8 +205,8 @@ func removeTags(cluster *kubermaticv1.Cluster, client *ec2.EC2) error {
 		Resources: resourceIDs,
 		Tags: []*ec2.Tag{
 			{
-				Key:   aws.String(tagNameKubernetesClusterLegacy),
-				Value: aws.String(cluster.Name),
+				Key:   aws.String(TagNameKubernetesClusterPrefix + cluster.Name),
+				Value: aws.String(""),
 			},
 		},
 	})

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -26,7 +26,7 @@ const (
 	instanceProfileCleanupFinalizer = "kubermatic.io/cleanup-aws-instance-profile"
 	tagCleanupFinalizer             = "kubermatic.io/cleanup-aws-tags"
 
-	TagNameKubernetesClusterPrefix = "kubernetes.io/cluster/"
+	tagNameKubernetesClusterPrefix = "kubernetes.io/cluster/"
 )
 
 var roleARNS = []string{policyRoute53FullAccess, policyEC2FullAccess}
@@ -176,7 +176,7 @@ func tagResources(cluster *kubermaticv1.Cluster, client *ec2.EC2) error {
 		Resources: resourceIDs,
 		Tags: []*ec2.Tag{
 			{
-				Key:   aws.String(TagNameKubernetesClusterPrefix + cluster.Name),
+				Key:   aws.String(tagNameKubernetesClusterPrefix + cluster.Name),
 				Value: aws.String(""),
 			},
 		},
@@ -205,7 +205,7 @@ func removeTags(cluster *kubermaticv1.Cluster, client *ec2.EC2) error {
 		Resources: resourceIDs,
 		Tags: []*ec2.Tag{
 			{
-				Key:   aws.String(TagNameKubernetesClusterPrefix + cluster.Name),
+				Key:   aws.String(tagNameKubernetesClusterPrefix + cluster.Name),
 				Value: aws.String(""),
 			},
 		},

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -55,7 +55,6 @@ const (
 zone={{ .Cluster.Spec.Cloud.AWS.AvailabilityZone }}
 VPC={{ .Cluster.Spec.Cloud.AWS.VPCID }}
 KubernetesClusterID={{ .Cluster.Name }}
-KubernetesClusterTag={{ .Cluster.Name }}
 disablesecuritygroupingress=false
 SubnetID={{ .Cluster.Spec.Cloud.AWS.SubnetID }}
 RouteTableID={{ .Cluster.Spec.Cloud.AWS.RouteTableID }}

--- a/api/pkg/resources/machine/machine.go
+++ b/api/pkg/resources/machine/machine.go
@@ -153,7 +153,7 @@ func getAWSProviderSpec(c *kubermaticv1.Cluster, node *apiv2.Node, dc provider.D
 	for key, value := range node.Spec.Cloud.AWS.Tags {
 		config.Tags[key] = value
 	}
-	config.Tags["KubernetesCluster"] = c.Name
+	config.Tags["kubernetes.io/cluster/"+c.Name] = ""
 
 	ext := &runtime.RawExtension{}
 	b, err := json.Marshal(config)

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-cloud-config.yaml
@@ -5,7 +5,6 @@ data:
     zone=aws-availability-zone
     VPC=aws-vpn-id
     KubernetesClusterID=de-test-01
-    KubernetesClusterTag=de-test-01
     disablesecuritygroupingress=false
     SubnetID=aws-subnet-id
     RouteTableID=aws-route-table-id

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-cloud-config.yaml
@@ -5,7 +5,6 @@ data:
     zone=aws-availability-zone
     VPC=aws-vpn-id
     KubernetesClusterID=de-test-01
-    KubernetesClusterTag=de-test-01
     disablesecuritygroupingress=false
     SubnetID=aws-subnet-id
     RouteTableID=aws-route-table-id

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-cloud-config.yaml
@@ -5,7 +5,6 @@ data:
     zone=aws-availability-zone
     VPC=aws-vpn-id
     KubernetesClusterID=de-test-01
-    KubernetesClusterTag=de-test-01
     disablesecuritygroupingress=false
     SubnetID=aws-subnet-id
     RouteTableID=aws-route-table-id

--- a/api/pkg/resources/test/fixtures/machine-aws.yaml
+++ b/api/pkg/resources/test/fixtures/machine-aws.yaml
@@ -23,7 +23,7 @@ spec:
       tags:
         AWSExampleTagKey1: AWSExampleTagValue1
         AWSExampleTagKey2: AWSExampleTagValue2
-        KubernetesCluster: awscluster-1a2b3c4d5e
+        kubernetes.io/cluster/awscluster-1a2b3c4d5e: ""
       vpcId: aws-vpc-ic
     operatingSystem: ubuntu
     operatingSystemSpec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the new way of tagging in AWS instead of the old way.
The old way only allowed a single cluster per subnet/vpc. The new way allows multiple clusters.

Fixes #1479 
**Release note**:
```release-note cloud provider
AWS: multiple clusters per subnet/VPC are now allowed
```