### PR TITLE
Use etcd client cert auth

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -58,9 +58,9 @@ func main() {
 	var imagesUnfiltered []string
 	if requestedVersion == "" {
 		glog.Infof("No version passed, downloading images for all available versions...")
-		for _, version := range versions {
-			glog.Infof("Collecting images for v%s", version.Version.String())
-			returnedImages, err := getImagesForVersion(versions, version.Version.String())
+		for _, v := range versions {
+			glog.Infof("Collecting images for v%s", v.Version.String())
+			returnedImages, err := getImagesForVersion(versions, v.Version.String())
 			if err != nil {
 				glog.Fatalf(err.Error())
 			}
@@ -121,7 +121,7 @@ func retagImages(registryName string, imageTagList []string) (retaggedImages []s
 		retaggedImageName := fmt.Sprintf("%s/%s", registryName, strings.Join(imageSplitted[1:], "/"))
 		glog.Infof("Tagging image %s as %s", image, retaggedImageName)
 		if out, err := execCommand("docker", "tag", image, retaggedImageName); err != nil {
-			return retaggedImages, fmt.Errorf("Failed to retag image: Error: %v, Output: %s", err, out)
+			return retaggedImages, fmt.Errorf("failed to retag image: Error: %v, Output: %s", err, out)
 		}
 	}
 
@@ -271,12 +271,16 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 			openvpnserverService,
 		},
 	}
-	secretList := createNamedSecrets([]string{"ca-cert",
-		"ca-key",
-		"tokens",
-		"apiserver-tls",
-		"kubelet-client-certificates",
-		"service-account-key"})
+	secretList := createNamedSecrets([]string{
+		resources.CACertSecretName,
+		resources.CAKeySecretName,
+		resources.TokensSecretName,
+		resources.ApiserverTLSSecretName,
+		resources.KubeletClientCertificatesSecretName,
+		resources.ServiceAccountKeySecretName,
+		resources.ApiserverEtcdClientCertificateSecretName,
+		resources.EtcdTLSCertificateSecretName,
+	})
 	objects := []runtime.Object{configMapList, secretList, serviceList}
 	client := kubefake.NewSimpleClientset(objects...)
 

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -120,7 +120,9 @@ func startBackupController(ctrlCtx controllerContext) error {
 		ctrlCtx.kubermaticClient,
 		ctrlCtx.kubeClient,
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
-		ctrlCtx.kubeInformerFactory.Batch().V1beta1().CronJobs())
+		ctrlCtx.kubeInformerFactory.Batch().V1beta1().CronJobs(),
+		ctrlCtx.kubeInformerFactory.Core().V1().Secrets(),
+	)
 	if err != nil {
 		return err
 	}

--- a/api/errcheck_excludes.txt
+++ b/api/errcheck_excludes.txt
@@ -1,2 +1,3 @@
 strconv.ParseBool
 os.RemoveAll
+fmt.Fprint

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -520,6 +520,7 @@ func (cc *Controller) ensureDeployments(c *kubermaticv1.Cluster) error {
 func GetSecretCreators() []resources.SecretCreator {
 	return []resources.SecretCreator{
 		etcd.TLSCertificate,
+		apiserver.EtcdClientCertificate,
 	}
 }
 

--- a/api/pkg/resources/apiserver/etcd-client-certificate.go
+++ b/api/pkg/resources/apiserver/etcd-client-certificate.go
@@ -1,0 +1,18 @@
+package apiserver
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EtcdClientCertificate returns a secret with the etcd client certificate
+func EtcdClientCertificate(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+	return certificates.GetClientCertificateCreator(
+		resources.ApiserverEtcdClientCertificateSecretName,
+		"apiserver",
+		nil,
+		resources.ApiserverEtcdClientCertificateCertSecretKey,
+		resources.ApiserverEtcdClientCertificateKeySecretKey)(data, existing)
+}

--- a/api/pkg/resources/certificates/client-certificate.go
+++ b/api/pkg/resources/certificates/client-certificate.go
@@ -1,0 +1,62 @@
+package certificates
+
+import (
+	"fmt"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/cert/triple"
+)
+
+type clientCertificateTemplateData interface {
+	GetClusterCA() (*triple.KeyPair, error)
+	GetClusterRef() metav1.OwnerReference
+}
+
+// GetClientCertificateCreator is a generic function to return a secret generator to create a client certificate signed by the cluster CA
+func GetClientCertificateCreator(name, commonName string, organizations []string, dataCertKey, dataKeyKey string) func(data clientCertificateTemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+	return func(data clientCertificateTemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+		var se *corev1.Secret
+		if existing != nil {
+			se = existing
+		} else {
+			se = &corev1.Secret{}
+		}
+
+		se.Name = name
+		se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
+
+		ca, err := data.GetClusterCA()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cluster ca: %v", err)
+		}
+
+		if b, exists := se.Data[dataCertKey]; exists {
+			certs, err := certutil.ParseCertsPEM(b)
+			if err != nil {
+				return nil, fmt.Errorf("failed to certificate (key=%s) from existing secret %s: %v", name, dataCertKey, err)
+			}
+
+			if resources.IsClientCertificateValidForAllOf(certs[0], commonName, organizations) {
+				return se, nil
+			}
+		}
+
+		newKP, err := triple.NewClientKeyPair(ca, commonName, organizations)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create %s key pair: %v", name, err)
+		}
+
+		se.Data = map[string][]byte{
+			dataKeyKey:  certutil.EncodePrivateKeyPEM(newKP.Key),
+			dataCertKey: certutil.EncodeCertPEM(newKP.Cert),
+			// Include the CA for simplicity
+			resources.CACertSecretKey: certutil.EncodeCertPEM(ca.Cert),
+		}
+
+		return se, nil
+	}
+}

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var (
@@ -51,12 +50,14 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 		},
 	}
 
+	podLabels, err := getTemplatePodLabels(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pod labels: %v", err)
+	}
+
 	set.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-		Name: name,
-		Labels: map[string]string{
-			resources.AppLabelKey: name,
-			"cluster":             data.Cluster.Name,
-		},
+		Name:   name,
+		Labels: podLabels,
 		Annotations: map[string]string{
 			"prometheus.io/scrape": "true",
 			"prometheus.io/path":   "/metrics",
@@ -67,8 +68,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	// For migration purpose.
 	// We switched from the etcd-operator to a simple etcd-StatefulSet. Therefore we need to migrate the data.
 	var migrate bool
-	_, err := data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get("etcd-cluster-client")
-	if err != nil {
+	if _, err := data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get(resources.EtcdClientServiceName); err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, err
 		}
@@ -107,6 +107,10 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 						},
 					},
 				},
+				{
+					Name:  "ETCDCTL_API",
+					Value: "3",
+				},
 			},
 			Ports: []corev1.ContainerPort{
 				{
@@ -136,10 +140,14 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 				SuccessThreshold: 1,
 				FailureThreshold: 3,
 				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path:   "/health",
-						Port:   intstr.FromInt(2379),
-						Scheme: corev1.URISchemeHTTPS,
+					Exec: &corev1.ExecAction{
+						Command: []string{
+							"/usr/local/bin/etcdctl",
+							"--cacert", "/etc/etcd/ca/ca.crt",
+							"--cert", "/etc/etcd/client/apiserver-etcd-client.crt",
+							"--key", "/etc/etcd/client/apiserver-etcd-client.key",
+							"--endpoints", "https://localhost:2379", "endpoint", "health",
+						},
 					},
 				},
 			},
@@ -155,6 +163,11 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 				{
 					Name:      resources.CACertSecretName,
 					MountPath: "/etc/etcd/ca",
+				},
+				{
+					Name:      resources.ApiserverEtcdClientCertificateSecretName,
+					MountPath: "/etc/etcd/client",
+					ReadOnly:  true,
 				},
 			},
 		},
@@ -175,6 +188,15 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  resources.CACertSecretName,
+					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+				},
+			},
+		},
+		{
+			Name: resources.ApiserverEtcdClientCertificateSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  resources.ApiserverEtcdClientCertificateSecretName,
 					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
 				},
 			},
@@ -206,6 +228,27 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	}
 
 	return set, nil
+}
+
+func getTemplatePodLabels(data *resources.TemplateData) (map[string]string, error) {
+	podLabels := map[string]string{
+		resources.AppLabelKey: name,
+		"cluster":             data.Cluster.Name,
+	}
+
+	secretDependencies := []string{
+		resources.ApiserverEtcdClientCertificateSecretName,
+		resources.EtcdTLSCertificateSecretName,
+	}
+	for _, name := range secretDependencies {
+		revision, err := data.SecretRevision(name)
+		if err != nil {
+			return nil, err
+		}
+		podLabels[fmt.Sprintf("%s-secret-revision", name)] = revision
+	}
+
+	return podLabels, nil
 }
 
 type commandTplData struct {
@@ -243,8 +286,7 @@ func getEtcdCommand(name, namespace string, migrate bool) ([]string, error) {
 }
 
 const (
-	etcdStartCommandTpl = `export ETCDCTL_API=3 
-export MASTER_ENDPOINT="https://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2379"
+	etcdStartCommandTpl = `export MASTER_ENDPOINT="https://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2379"
 
 {{ if .Migrate }}
 # If we're already initialized
@@ -314,7 +356,7 @@ exec /usr/local/bin/etcd \
     --listen-peer-urls "http://${POD_IP}:2380" \
     --initial-advertise-peer-urls "http://${POD_NAME}.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380" \
     --trusted-ca-file /etc/etcd/ca/ca.crt \
-    --client-cert-auth=false \
+    --client-cert-auth \
     --cert-file /etc/etcd/tls/etcd-tls.crt \
     --key-file /etc/etcd/tls/etcd-tls.key
 `

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -48,8 +48,7 @@ func TestGetEtcdCommand(t *testing.T) {
 }
 
 var (
-	noMigration = `export ETCDCTL_API=3 
-export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
+	noMigration = `export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
 
 
 export INITIAL_STATE="new"
@@ -72,13 +71,12 @@ exec /usr/local/bin/etcd \
     --listen-peer-urls "http://${POD_IP}:2380" \
     --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380" \
     --trusted-ca-file /etc/etcd/ca/ca.crt \
-    --client-cert-auth=false \
+    --client-cert-auth \
     --cert-file /etc/etcd/tls/etcd-tls.crt \
     --key-file /etc/etcd/tls/etcd-tls.key
 `
 
-	migration = `export ETCDCTL_API=3 
-export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379"
+	migration = `export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379"
 
 
 # If we're already initialized
@@ -145,7 +143,7 @@ exec /usr/local/bin/etcd \
     --listen-peer-urls "http://${POD_IP}:2380" \
     --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380" \
     --trusted-ca-file /etc/etcd/ca/ca.crt \
-    --client-cert-auth=false \
+    --client-cert-auth \
     --cert-file /etc/etcd/tls/etcd-tls.crt \
     --key-file /etc/etcd/tls/etcd-tls.key
 `

--- a/api/pkg/resources/etcd/tls-serving-certificate.go
+++ b/api/pkg/resources/etcd/tls-serving-certificate.go
@@ -29,7 +29,7 @@ func TLSCertificate(data *resources.TemplateData, existing *corev1.Secret) (*cor
 		return nil, fmt.Errorf("failed to get cluster ca: %v", err)
 	}
 
-	altNames := sets.NewString("127.0.0.1", "localhost")
+	altNames := sets.NewString("127.0.0.1", "localhost", fmt.Sprintf("%s-%s.svc.cluster.local.", resources.EtcdClientServiceName, data.Cluster.Name))
 	for i := 0; i < 3; i++ {
 		// Member name
 		podName := fmt.Sprintf("etcd-%d", i)
@@ -51,7 +51,7 @@ func TLSCertificate(data *resources.TemplateData, existing *corev1.Secret) (*cor
 			return nil, fmt.Errorf("failed to parse certificate (key=%s) from existing secret %s: %v", resources.EtcdTLSCertSecretKey, resources.EtcdTLSCertificateSecretName, err)
 		}
 
-		if resources.IsCertificateValidForAllOf(certs[0], "etcd", resources.EtcdClientServiceName, data.Cluster.Status.NamespaceName, "cluster.local", []string{clientIP}, altNames.List()) {
+		if resources.IsServerCertificateValidForAllOf(certs[0], "etcd", resources.EtcdClientServiceName, data.Cluster.Status.NamespaceName, "cluster.local", []string{clientIP}, altNames.List()) {
 			return se, nil
 		}
 	}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --enable-admission-plugins
@@ -226,6 +231,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -241,7 +249,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -251,8 +260,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -283,4 +292,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -226,6 +231,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -241,7 +249,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -251,8 +260,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -283,4 +292,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -226,6 +231,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -241,7 +249,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -251,8 +260,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -283,4 +292,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --enable-admission-plugins
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --enable-admission-plugins
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --enable-admission-plugins
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -213,6 +218,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -228,7 +236,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -238,8 +247,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -270,4 +279,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --enable-admission-plugins
@@ -217,6 +222,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -232,7 +240,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -242,8 +251,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -274,4 +283,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -217,6 +222,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -232,7 +240,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -242,8 +251,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -274,4 +283,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -217,6 +222,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -232,7 +240,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -242,8 +251,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -274,4 +283,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --enable-admission-plugins
@@ -217,6 +222,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -232,7 +240,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -242,8 +251,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -274,4 +283,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -217,6 +222,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -232,7 +240,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -242,8 +251,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -274,4 +283,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
         ca-cert-secret-revision: "123456"
@@ -111,7 +112,11 @@ spec:
         - --etcd-servers
         - https://192.0.2.12:2379
         - --etcd-cafile
-        - /etc/kubernetes/ca-cert/ca.crt
+        - /etc/etcd/apiserver/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/apiserver/apiserver-etcd-client.key
         - --storage-backend
         - etcd3
         - --admission-control
@@ -217,6 +222,9 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       dnsConfig:
         nameservers:
         - 10.10.10.10
@@ -232,7 +240,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/kubernetes/ca-cert/ca.crt
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/apiserver/ca.crt
+          --cert=/etc/etcd/apiserver/apiserver-etcd-client.crt --key=/etc/etcd/apiserver/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
           waiting for etcd; sleep 2; done;
         image: quay.io/coreos/etcd:v3.2.7
@@ -242,8 +251,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/kubernetes/ca-cert
-          name: ca-cert
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
           readOnly: true
       volumes:
       - name: apiserver-tls
@@ -274,4 +283,8 @@ spec:
           defaultMode: 420
           name: cloud-config
         name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
 status: {}

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -254,6 +254,20 @@ func TestLoadFiles(t *testing.T) {
 							Namespace:       cluster.Status.NamespaceName,
 						},
 					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.ApiserverEtcdClientCertificateSecretName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.EtcdTLSCertificateSecretName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
 					&v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "123456",


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables client cert authentication on etcd.

Whats missing:
- [x] Client cert for backup handling

Fixes #1436

**Release note**:
```release-note
Communication between apiserver and etcd is now encrypted
```