### PR TITLE
Verify addon version

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -15,6 +15,7 @@ local drone = import 'drone/drone.libsonnet';
     '3-license-validation': drone.step.new('metalmatze/wwhrd:1.9', group='lint', commands=['cd api', 'wwhrd check -f ../allowed_licensed.yaml']),
     '3-lint': drone.step.new('metalmatze/gometalinter:1.9', group='lint', commands=['cd api', 'make lint']),
     '3-verify-swagger-spec': drone.step.new(goImage, group='lint', commands=['cd api', './hack/verify-swagger.sh']),
+    '3-verify-addons-up-to-date': drone.step.new('docker:dind', group='lint', commands=['./api/hack/verify-addon-version.sh']),
 
     // Building
     '4-test': drone.step.new(goImage, group='build', commands=['cd api', 'make test']),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -15,7 +15,8 @@ local drone = import 'drone/drone.libsonnet';
     '3-license-validation': drone.step.new('metalmatze/wwhrd:1.9', group='lint', commands=['cd api', 'wwhrd check -f ../allowed_licensed.yaml']),
     '3-lint': drone.step.new('metalmatze/gometalinter:1.9', group='lint', commands=['cd api', 'make lint']),
     '3-verify-swagger-spec': drone.step.new(goImage, group='lint', commands=['cd api', './hack/verify-swagger.sh']),
-    '3-verify-addons-up-to-date': drone.step.new('docker:dind', group='lint', commands=['./api/hack/verify-addon-version.sh']),
+    '3-verify-addons-up-to-date': drone.step.new('docker:dind', group='lint',
+      commands=['./api/hack/verify-addon-version.sh']),
 
     // Building
     '4-test': drone.step.new(goImage, group='build', commands=['cd api', 'make test']),

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,12 @@ pipeline:
     group: lint
     image: metalmatze/gometalinter:1.9
     pull: true
+  3-verify-addons-up-to-date:
+    commands:
+    - ./api/hack/verify-addon-version.sh
+    group: lint
+    image: docker:dind
+    pull: true
   3-verify-swagger-spec:
     commands:
     - cd api

--- a/.drone.yml
+++ b/.drone.yml
@@ -37,6 +37,8 @@ pipeline:
     group: lint
     image: docker:dind
     pull: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
   3-verify-swagger-spec:
     commands:
     - cd api

--- a/api/hack/verify-addon-version.sh
+++ b/api/hack/verify-addon-version.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/env sh
 
-set -ex
+set -e
+
+function finish {
+  OLD_EXIT_CODE=$?
+  docker rm -f $CONTAINER_NAME >/dev/null
+  rm -rf ./addons-from-container
+  exit $OLD_EXIT_CODE
+}
+trap finish EXIT
 
 cd $(dirname $0)/../..
 
 IMAGE=$(cat config/kubermatic/values.yaml |grep 'addons:' -A3|grep repository|awk '{ print $2 }'|tr -d '"')
 TAG=$(cat config/kubermatic/values.yaml |grep 'addons:' -A3|grep tag|awk '{ print $2 }'|tr -d '"')
 
-docker run --rm \
-  -v $PWD/addons:/tmp/addons-from-repo \
-    $IMAGE:$TAG \
-      /bin/sh -c "cd /tmp/addons-from-repo && cp .dockerignore Dockerfile README.md /addons/ && diff --brief -r /addons /tmp/addons-from-repo"
+CONTAINER_NAME=$(docker create $IMAGE:$TAG)
+
+docker cp $CONTAINER_NAME:/addons ./addons-from-container
+
+cp addons/.dockerignore ./addons-from-container
+cp addons/Dockerfile ./addons-from-container
+cp addons/README.md ./addons-from-container
+
+diff --brief -r ./addons ./addons-from-container

--- a/api/hack/verify-addon-version.sh
+++ b/api/hack/verify-addon-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -ex
+
+cd $(dirname $0)/../..
+
+IMAGE=$(cat config/kubermatic/values.yaml |grep 'addons:' -A3|grep repository|awk '{ print $2 }'|tr -d '"')
+TAG=$(cat config/kubermatic/values.yaml |grep 'addons:' -A3|grep tag|awk '{ print $2 }'|tr -d '"')
+
+docker run --rm \
+  -v $PWD/addons:/tmp/addons-from-repo \
+    $IMAGE:$TAG \
+      /bin/sh -c "cd /tmp/addons-from-repo && cp .dockerignore Dockerfile README.md /addons/ && diff --brief -r /addons /tmp/addons-from-repo"

--- a/api/hack/verify-addon-version.sh
+++ b/api/hack/verify-addon-version.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-function finish {
+function cleanup {
   OLD_EXIT_CODE=$?
   docker rm -f $CONTAINER_NAME >/dev/null
   rm -rf ./addons-from-container
   exit $OLD_EXIT_CODE
 }
-trap finish EXIT
+trap cleanup EXIT
 
 cd $(dirname $0)/../..
 
@@ -19,8 +19,8 @@ CONTAINER_NAME=$(docker create $IMAGE:$TAG)
 
 docker cp $CONTAINER_NAME:/addons ./addons-from-container
 
-cp addons/.dockerignore ./addons-from-container
-cp addons/Dockerfile ./addons-from-container
-cp addons/README.md ./addons-from-container
+for ignored_file in $(cat addons/.dockerignore); do
+  cp addons/$ignored_file ./addons-from-container/
+done
 
 diff --brief -r ./addons ./addons-from-container


### PR DESCRIPTION
**What this PR does / why we need it**:

Verifiedsthe addon image specified in the `values.yaml` has the same contents as the addons folder, minus the contents of the `.dockerignore`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Unfortunately the `drone.jsonnet` library does not allow specifying volumes, so I have manually added the directive to the `.drone.yaml`, this means regenerating it is currently not possible.

I have opened https://github.com/metalmatze/drone-jsonnet/issues/1 to get that fixed.

**Release note**:
```release-note
NONE
```