### PR TITLE
Add -kubermatic-delete-cluster flag, true by default

### DIFF
--- a/api/cmd/kubermatic-e2e/README.md
+++ b/api/cmd/kubermatic-e2e/README.md
@@ -47,6 +47,8 @@ All flags have reasonable defaults
         path to Cluster yaml (default "/manifests/cluster.yaml")
     -kubermatic-cluster-timeout duration
         cluster creation timeout (default 3m0s)
+    -kubermatic-delete-cluster
+        delete test cluster at the exit (default true)
     -kubermatic-namespace string
         namespace where kubermatic and it's configs deployed (default "kubermatic")
     -kubermatic-node string

--- a/api/cmd/kubermatic-e2e/e2e_test_runner.go
+++ b/api/cmd/kubermatic-e2e/e2e_test_runner.go
@@ -77,7 +77,9 @@ func (ctl *e2eTestRunner) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer ctl.deleteCluster(cluster.Name)
+	if ctl.runOpts.DeleteCluster {
+		defer ctl.deleteCluster(cluster.Name)
+	}
 	log.Infof("created cluster named: %s", cluster.Name)
 
 	log.Info("waiting for cluster to become healthy")

--- a/api/cmd/kubermatic-e2e/main.go
+++ b/api/cmd/kubermatic-e2e/main.go
@@ -17,6 +17,7 @@ type Opts struct {
 	Addons              flagopts.StringArray
 	ClusterPath         string
 	ClusterTimeout      time.Duration
+	DeleteCluster       bool
 	Focus               string
 	GinkgoBin           string
 	GinkgoNoColor       bool
@@ -47,6 +48,7 @@ func main() {
 	flag.DurationVar(&runOpts.ClusterTimeout, "kubermatic-cluster-timeout", 3*time.Minute, "cluster creation timeout")
 	flag.DurationVar(&runOpts.NodesTimeout, "kubermatic-nodes-timeout", 10*time.Minute, "nodes creation timeout")
 	flag.StringVar(&runOpts.GinkgoBin, "ginkgo-bin", "/usr/local/bin/ginkgo", "path to ginkgo binary")
+	flag.BoolVar(&runOpts.DeleteCluster, "kubermatic-delete-cluster", true, "delete test cluster at the exit")
 	flag.BoolVar(&runOpts.GinkgoNoColor, "ginkgo-nocolor", false, "don't show colors")
 	flag.DurationVar(&runOpts.GinkgoTimeout, "ginkgo-timeout", 5400*time.Second, "ginkgo execution timeout")
 	flag.StringVar(&runOpts.Focus, "ginkgo-focus", `\[Conformance\]`, "tests focus")


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow test clusters to continue to live after kubermatic-e2e exit, for debug purpose.

**Release note**:
```release-note
NONE
```