### PR TITLE
fix VMWare bug introduced by #1379

### DIFF
--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -95,10 +95,6 @@ spec:
         - mountPath: /etc/kubernetes/ca-cert
           name: ca-cert
           readOnly: true
-        - mountPath: /sys/class/dmi/id/product_serial
-          name: cloud-config
-          readOnly: true
-          subPath: fakeVmwareUUID
       - args:
         - --master
         - http://192.0.2.11:8080
@@ -167,6 +163,10 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /sys/class/dmi/id/product_serial
+          name: cloud-config
+          readOnly: true
+          subPath: fakeVmwareUUID
       dnsConfig:
         nameservers:
         - 10.10.10.10

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -95,10 +95,6 @@ spec:
         - mountPath: /etc/kubernetes/ca-cert
           name: ca-cert
           readOnly: true
-        - mountPath: /sys/class/dmi/id/product_serial
-          name: cloud-config
-          readOnly: true
-          subPath: fakeVmwareUUID
       - args:
         - --master
         - http://192.0.2.11:8080
@@ -167,6 +163,10 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /sys/class/dmi/id/product_serial
+          name: cloud-config
+          readOnly: true
+          subPath: fakeVmwareUUID
       dnsConfig:
         nameservers:
         - 10.10.10.10

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -95,10 +95,6 @@ spec:
         - mountPath: /etc/kubernetes/ca-cert
           name: ca-cert
           readOnly: true
-        - mountPath: /sys/class/dmi/id/product_serial
-          name: cloud-config
-          readOnly: true
-          subPath: fakeVmwareUUID
       - args:
         - --master
         - http://192.0.2.11:8080
@@ -167,6 +163,10 @@ spec:
         - mountPath: /etc/kubernetes/cloud
           name: cloud-config
           readOnly: true
+        - mountPath: /sys/class/dmi/id/product_serial
+          name: cloud-config
+          readOnly: true
+          subPath: fakeVmwareUUID
       dnsConfig:
         nameservers:
         - 10.10.10.10


### PR DESCRIPTION
Commit `fa4e3d60ad5a3a804b822ba02850d015f08a0e50` introduced a new container
to the controller-manager pod, however later code added a critical volume mount
to the original container, indexing it by costant int 0. However, adding
the new container in front shifted the old container to index 1.
Thus the volume mount was added to the wrong container.

**Release note**:
```release-note
NONE
```