### PR TITLE
fix wrong const in etcd statefulset causing always migration

### DIFF
--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -68,7 +68,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	// For migration purpose.
 	// We switched from the etcd-operator to a simple etcd-StatefulSet. Therefore we need to migrate the data.
 	var migrate bool
-	if _, err := data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get(resources.EtcdClientServiceName); err != nil {
+	if _, err := data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get("etcd-cluster-client"); err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix wrong const in etcd statefulset causing always migration.
The referenced service names comes from the old etcd-operator. If it exists, we know that we need to migrate. I falsly replaced the string with a const of the current service, always causing the migration code to be executed.

**Release note**:
```release-note
NONE
```