### PR TITLE
add missing addon-manager cleanup

### DIFF
--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -79,6 +79,7 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) {
 		cleanupScheduler,
 		removeDeprecatedFinalizers,
 		migrateVersion,
+		cleanupAddonManager,
 	}
 
 	w := sync.WaitGroup{}
@@ -155,6 +156,11 @@ func cleanupMachineController(cluster *kubermaticv1.Cluster, ctx *cleanupContext
 func cleanupScheduler(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
 	ns := cluster.Status.NamespaceName
 	return deleteResourceIgnoreNonExistent(ns, "monitoring.coreos.com", "v1", "servicemonitors", "scheduler", ctx)
+}
+
+func cleanupAddonManager(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	ns := cluster.Status.NamespaceName
+	return deleteResourceIgnoreNonExistent(ns, "extensions", "v1beta1", "deployments", "addon-manager", ctx)
 }
 
 // We changed the finalizers in https://github.com/kubermatic/kubermatic/pull/1196


### PR DESCRIPTION
**What this PR does / why we need it**:
As we migrated away from the kubernetes addon manager to our own, we now need to delete the old addon-manager deployments.
The old deployment causes concurrency issues as our addon-controller and the old one have different manifests for the openvpn-client Deployment. This causes each controller to overwrite the other one, ending in a changed deployment every ~30seconds.

**Release note**:
```release-note
With the introduction of Kubermatic's addon manager, the K8S addon manager's deployments will be automatically cleaned up on old setups
```