### PR TITLE
Build command before running it in hack scripts.

### DIFF
--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -10,6 +10,7 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 # Please make sure to set -enable-prometheus-endpoint=true if you want to use that endpoint.
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
+make kubermatic-api
 ./_build/kubermatic-api \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
   -datacenters=../../secrets/seed-clusters/dev.kubermatic.io/datacenters.yaml \

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -7,6 +7,7 @@ set -o pipefail
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
+make kubermatic-controller-manager
 ./_build/kubermatic-controller-manager \
   -datacenters=../../secrets/seed-clusters/dev.kubermatic.io/datacenters.yaml \
   -datacenter-name=europe-west3-c \

--- a/api/hack/run-rbac-generator.sh
+++ b/api/hack/run-rbac-generator.sh
@@ -7,6 +7,7 @@ set -o pipefail
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
+make rbac-generator
 ./_build/rbac-generator \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
   -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \


### PR DESCRIPTION
**What this PR does / why we need it**:

The `api/hack/run-*.sh` scripts run binaries built inside the working tree. To prevent running old versions this PR inserts the respective `make` command to build the command to be run first.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
