### PR TITLE
skip backup handling if the cluster is not ready yet

### DIFF
--- a/api/pkg/controller/backup/controller.go
+++ b/api/pkg/controller/backup/controller.go
@@ -355,9 +355,8 @@ func (c *Controller) sync(key string) error {
 		return nil
 	}
 
-	// We need to know the namespace otherwise we do not know
-	// the address of the etcd
-	if clusterFromCache.Status.NamespaceName == "" {
+	// Wait until the cluster is ready enough
+	if clusterFromCache.Status.NamespaceName == "" || !clusterFromCache.Status.Health.Etcd {
 		return nil
 	}
 

--- a/api/pkg/controller/backup/controller_test.go
+++ b/api/pkg/controller/backup/controller_test.go
@@ -33,6 +33,11 @@ func TestEnsureBackupCronJob(t *testing.T) {
 		},
 		Status: kubermaticv1.ClusterStatus{
 			NamespaceName: "testnamespace",
+			Health: kubermaticv1.ClusterHealth{
+				ClusterHealthStatus: kubermaticv1.ClusterHealthStatus{
+					Etcd: true,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
skip backup handling if the cluster is not ready yet.
Causes errors like `could not generate secret: ca not found`

**Release note**:
```release-note
NONE
```