### PR TITLE
Ensure that the controller-manager deployment is updated when the backup-container configmap is updated

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -14,6 +14,7 @@ spec:
         kubermatic/scrape_port: '8085'
         checksum/master-files: {{ include (print $.Template.BasePath "/master-files-secret.yaml") . | sha256sum }}
         checksum/datecenters: {{ include (print $.Template.BasePath "/datacenter-yaml-secret.yaml") . | sha256sum }}
+        checksum/backup-container-configmap: {{ include (print $.Template.BasePath "/backup-container-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: kubermatic
       initContainers:


### PR DESCRIPTION
**What this PR does / why we need it**:  Ensure that the controller-manager deployment is updated when the backup-container configmap is updated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
controller-manager will now automatically restart on backup config change
```