### PR TITLE
add command and output to error message when it fails

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -573,6 +573,9 @@ func (c *Controller) ensureIsInstalled(addon *kubermaticv1.Addon, cluster *kuber
 	glog.V(6).Infof("applying addon %s to cluster %s: %s ...", addon.Name, cluster.Name, strings.Join(cmd.Args, " "))
 	out, err := cmd.CombinedOutput()
 	glog.V(6).Infof("executed '%s' for addon %s of cluster %s: \n%s", strings.Join(cmd.Args, " "), addon.Name, cluster.Name, string(out))
+	if err != nil {
+		return fmt.Errorf("failed to execute '%s' for addon %s of cluster %s: \n%s", strings.Join(cmd.Args, " "), addon.Name, cluster.Name, string(out))
+	}
 	return err
 }
 
@@ -588,7 +591,10 @@ func (c *Controller) cleanupManifests(addon *kubermaticv1.Addon, cluster *kuberm
 		glog.V(6).Infof("deleting addon (%s) manifests from cluster %s: %s ...", addon.Name, cluster.Name, strings.Join(cmd.Args, " "))
 		out, err := cmd.CombinedOutput()
 		glog.V(6).Infof("executed '%s' for addon %s of cluster %s: \n%s", strings.Join(cmd.Args, " "), addon.Name, cluster.Name, string(out))
-		return err
+		if err != nil {
+			return fmt.Errorf("failed to execute '%s' for addon %s of cluster %s: \n%s", strings.Join(cmd.Args, " "), addon.Name, cluster.Name, string(out))
+		}
+		return nil
 	}
 
 	finalizers := sets.NewString(addon.Finalizers...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we would need to increase the loglevel when we want to know why a apply command failed inside the addon-controller.
This fix, addes the command and output to the error message handled by the error-handler

**Release note**:
```release-note
NONE
```