### PR TITLE
remove description from addon crd's

### DIFF
--- a/addons/canal/crd-globalbgpconfigs.yaml.yaml
+++ b/addons/canal/crd-globalbgpconfigs.yaml.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global BGP Configuration
 kind: CustomResourceDefinition
 metadata:
   name: globalbgpconfigs.crd.projectcalico.org

--- a/addons/canal/crd-globalfelixconfigs.yaml.yaml
+++ b/addons/canal/crd-globalfelixconfigs.yaml.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Felix Configuration
 kind: CustomResourceDefinition
 metadata:
   name: globalfelixconfigs.crd.projectcalico.org

--- a/addons/canal/crd-globalnetworkpolicies.yaml.yaml
+++ b/addons/canal/crd-globalnetworkpolicies.yaml.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org

--- a/addons/canal/crd-ippools.yaml.yaml
+++ b/addons/canal/crd-ippools.yaml.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico IP Pools
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.1.3
+export TAG=v0.1.4
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -31,7 +31,7 @@ kubermatic:
     addons:
       image:
         repository: "quay.io/kubermatic/addons"
-        tag: "v0.1.3"
+        tag: "v0.1.4"
         pullPolicy: "IfNotPresent"
       # list of Addons to install into every user-cluster. All need to exist in the addons image
       defaultAddons:


### PR DESCRIPTION
**What this PR does / why we need it**:
remove description from addon crd's as it breaks the kubectl validation for 1.11

**Release note**:
```release-note
NONE
```