### PR TITLE
remove api group for RoleBinding with ServiceAccount

### DIFF
--- a/api/pkg/resources/prometheus/rolebinding.go
+++ b/api/pkg/resources/prometheus/rolebinding.go
@@ -30,7 +30,6 @@ func RoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*r
 			Kind:      "ServiceAccount",
 			Name:      resources.PrometheusServiceAccountName,
 			Namespace: data.Cluster.Status.NamespaceName,
-			APIGroup:  rbacv1.GroupName,
 		},
 	}
 	return rb, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove ApiGroup for RoleBinding with ServiceAccount. Its only allowed for Groups and Users

**Release note**:
```release-note
NONE
```