### PR TITLE
Handle errors from fmt.Fprintf

### DIFF
--- a/api/pkg/handler/openstack_test.go
+++ b/api/pkg/handler/openstack_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
@@ -114,7 +113,10 @@ func SetupOpenstackServer(t *testing.T) {
 				w.WriteHeader(200)
 			}
 
-			fmt.Fprintf(w, buf.String())
+			_, err := w.Write(buf.Bytes())
+			if err != nil {
+				t.Fatalf("failed to write rendered template to HTTP response: %v", err)
+			}
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an explicit error check for the return values of `fmt.Fprintf`, because more recent versions of `errcheck` do not ignore it by default anymore. See kisielk/errcheck#140 for more details.

```release-note
None
```
