### PR TITLE
Add reconciling for the OpenVPN client config

### DIFF
--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -54,11 +54,11 @@ func (cc *Controller) reconcileCluster(cluster *kubermaticv1.Cluster) (*kubermat
 			return nil, err
 		}
 
-		if err := cc.launchingCreateOpenVPNConfigMap(cluster); err != nil {
+		if err := cc.userClusterEnsureRoles(cluster); err != nil {
 			return nil, err
 		}
 
-		if err := cc.userClusterEnsureRoles(cluster); err != nil {
+		if err := cc.userClusterEnsureConfigMaps(cluster); err != nil {
 			return nil, err
 		}
 

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -75,7 +75,7 @@ func (cc *Controller) ensureResourcesAreDeployed(cluster *kubermaticv1.Cluster) 
 		return err
 	}
 
-	// check that all ConfigMap's are available
+	// check that all ServerClientConfigsConfigMap's are available
 	if err := cc.ensureConfigMaps(cluster); err != nil {
 		return err
 	}
@@ -582,7 +582,7 @@ func (cc *Controller) ensureSecretsV2(c *kubermaticv1.Cluster) error {
 func GetConfigMapCreators() []resources.ConfigMapCreator {
 	return []resources.ConfigMapCreator{
 		cloudconfig.ConfigMap,
-		openvpn.ConfigMap,
+		openvpn.ServerClientConfigsConfigMap,
 		prometheus.ConfigMap,
 		dns.ConfigMap,
 	}
@@ -600,7 +600,7 @@ func (cc *Controller) ensureConfigMaps(c *kubermaticv1.Cluster) error {
 		var existing *corev1.ConfigMap
 		cm, err := create(data, nil)
 		if err != nil {
-			return fmt.Errorf("failed to build ConfigMap: %v", err)
+			return fmt.Errorf("failed to build ServerClientConfigsConfigMap: %v", err)
 		}
 
 		if existing, err = cc.configMapLister.ConfigMaps(c.Status.NamespaceName).Get(cm.Name); err != nil {
@@ -609,14 +609,14 @@ func (cc *Controller) ensureConfigMaps(c *kubermaticv1.Cluster) error {
 			}
 
 			if _, err = cc.kubeClient.CoreV1().ConfigMaps(c.Status.NamespaceName).Create(cm); err != nil {
-				return fmt.Errorf("failed to create ConfigMap %s: %v", cm.Name, err)
+				return fmt.Errorf("failed to create ServerClientConfigsConfigMap %s: %v", cm.Name, err)
 			}
 			continue
 		}
 
 		cm, err = create(data, existing.DeepCopy())
 		if err != nil {
-			return fmt.Errorf("failed to build ConfigMap: %v", err)
+			return fmt.Errorf("failed to build ServerClientConfigsConfigMap: %v", err)
 		}
 
 		if diff := deep.Equal(cm, existing); diff == nil {
@@ -624,7 +624,7 @@ func (cc *Controller) ensureConfigMaps(c *kubermaticv1.Cluster) error {
 		}
 
 		if _, err = cc.kubeClient.CoreV1().ConfigMaps(c.Status.NamespaceName).Update(cm); err != nil {
-			return fmt.Errorf("failed to update ConfigMap %s: %v", cm.Name, err)
+			return fmt.Errorf("failed to update ServerClientConfigsConfigMap %s: %v", cm.Name, err)
 		}
 	}
 

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -600,7 +600,7 @@ func (cc *Controller) ensureConfigMaps(c *kubermaticv1.Cluster) error {
 		var existing *corev1.ConfigMap
 		cm, err := create(data, nil)
 		if err != nil {
-			return fmt.Errorf("failed to build ServerClientConfigsConfigMap: %v", err)
+			return fmt.Errorf("failed to build ConfigMap: %v", err)
 		}
 
 		if existing, err = cc.configMapLister.ConfigMaps(c.Status.NamespaceName).Get(cm.Name); err != nil {
@@ -609,14 +609,14 @@ func (cc *Controller) ensureConfigMaps(c *kubermaticv1.Cluster) error {
 			}
 
 			if _, err = cc.kubeClient.CoreV1().ConfigMaps(c.Status.NamespaceName).Create(cm); err != nil {
-				return fmt.Errorf("failed to create ServerClientConfigsConfigMap %s: %v", cm.Name, err)
+				return fmt.Errorf("failed to create ConfigMap %s: %v", cm.Name, err)
 			}
 			continue
 		}
 
 		cm, err = create(data, existing.DeepCopy())
 		if err != nil {
-			return fmt.Errorf("failed to build ServerClientConfigsConfigMap: %v", err)
+			return fmt.Errorf("failed to build ConfigMap: %v", err)
 		}
 
 		if diff := deep.Equal(cm, existing); diff == nil {
@@ -624,7 +624,7 @@ func (cc *Controller) ensureConfigMaps(c *kubermaticv1.Cluster) error {
 		}
 
 		if _, err = cc.kubeClient.CoreV1().ConfigMaps(c.Status.NamespaceName).Update(cm); err != nil {
-			return fmt.Errorf("failed to update ServerClientConfigsConfigMap %s: %v", cm.Name, err)
+			return fmt.Errorf("failed to update ConfigMap %s: %v", cm.Name, err)
 		}
 	}
 

--- a/api/pkg/controller/cluster/userclusterresources.go
+++ b/api/pkg/controller/cluster/userclusterresources.go
@@ -10,7 +10,10 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources/controllermanager"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroler"
 
+	"github.com/kubermatic/kubermatic/api/pkg/resources/openvpn"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -185,9 +188,14 @@ func (cc *Controller) userClusterEnsureClusterRoleBindings(c *kubermaticv1.Clust
 		controllermanager.AdminClusterRoleBinding,
 	}
 
+	data, err := cc.getClusterTemplateData(c)
+	if err != nil {
+		return err
+	}
+
 	for _, create := range creators {
 		var existing *rbacv1.ClusterRoleBinding
-		crb, err := create(nil, nil)
+		crb, err := create(data, nil)
 		if err != nil {
 			return fmt.Errorf("failed to build ClusterRoleBinding: %v", err)
 		}
@@ -204,7 +212,7 @@ func (cc *Controller) userClusterEnsureClusterRoleBindings(c *kubermaticv1.Clust
 			continue
 		}
 
-		crb, err = create(nil, existing.DeepCopy())
+		crb, err = create(data, existing.DeepCopy())
 		if err != nil {
 			return fmt.Errorf("failed to build ClusterRoleBinding: %v", err)
 		}
@@ -217,6 +225,58 @@ func (cc *Controller) userClusterEnsureClusterRoleBindings(c *kubermaticv1.Clust
 			return fmt.Errorf("failed to update ClusterRoleBinding %s: %v", crb.Name, err)
 		}
 		glog.V(4).Infof("Updated ClusterRoleBinding %s inside user-cluster %s", crb.Name, c.Name)
+	}
+
+	return nil
+}
+
+func (cc *Controller) userClusterEnsureConfigMaps(c *kubermaticv1.Cluster) error {
+	client, err := cc.userClusterConnProvider.GetClient(c)
+	if err != nil {
+		return err
+	}
+
+	creators := []resources.ConfigMapCreator{
+		openvpn.ClientConfigConfigMap,
+	}
+
+	data, err := cc.getClusterTemplateData(c)
+	if err != nil {
+		return err
+	}
+
+	for _, create := range creators {
+		var existing *corev1.ConfigMap
+		cm, err := create(data, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build ConfigMap: %v", err)
+		}
+
+		if existing, err = client.CoreV1().ConfigMaps(cm.Namespace).Get(cm.Name, metav1.GetOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+
+			if _, err = client.CoreV1().ConfigMaps(cm.Namespace).Create(cm); err != nil {
+				return fmt.Errorf("failed to create ConfigMap %s: %v", cm.Name, err)
+			}
+			glog.V(4).Infof("Created ConfigMap %s inside user-cluster %s", cm.Name, c.Name)
+			continue
+		}
+
+		cm, err = create(data, existing.DeepCopy())
+		if err != nil {
+			return fmt.Errorf("failed to build ConfigMap: %v", err)
+		}
+
+		if equality.Semantic.DeepEqual(cm, existing) {
+			continue
+		}
+
+		if _, err = client.CoreV1().ConfigMaps(cm.Namespace).Update(cm); err != nil {
+			return fmt.Errorf("failed to update ConfigMap %s: %v", cm.Name, err)
+		}
+		glog.V(4).Infof("Updated ConfigMap %s inside user-cluster %s", cm.Name, c.Name)
 	}
 
 	return nil

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -255,7 +255,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 					ReadOnly:  true,
 				},
 				{
-					Name:      resources.OpenVPNClientConfigConfigMapName,
+					Name:      resources.OpenVPNClientConfigsConfigMapName,
 					MountPath: "/etc/openvpn/clients",
 					ReadOnly:  true,
 				},
@@ -313,11 +313,11 @@ func getVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: resources.OpenVPNClientConfigConfigMapName,
+			Name: resources.OpenVPNClientConfigsConfigMapName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: resources.OpenVPNClientConfigConfigMapName,
+						Name: resources.OpenVPNClientConfigsConfigMapName,
 					},
 					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
 				},

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	//AddonManagerDeploymentName is the name for the addon-manager deployment
-	AddonManagerDeploymentName = "addon-manager"
 	//ApiserverDeploymenName is the name for the apiserver deployment
 	ApiserverDeploymenName = "apiserver"
 	//ControllerManagerDeploymentName is the name for the controller manager deployment
@@ -92,8 +90,10 @@ const (
 
 	//CloudConfigConfigMapName is the name for the configmap containing the cloud-config
 	CloudConfigConfigMapName = "cloud-config"
-	//OpenVPNClientConfigConfigMapName is the name for the configmap containing the openvpn client config used within the user cluster
-	OpenVPNClientConfigConfigMapName = "openvpn-client-configs"
+	//OpenVPNClientConfigsConfigMapName is the name for the ConfigMap containing the OpenVPN client config used within the user cluster
+	OpenVPNClientConfigsConfigMapName = "openvpn-client-configs"
+	//OpenVPNClientConfigConfigMapName is the name for the ConfigMap containing the OpenVPN client config used by the client inside the user cluster
+	OpenVPNClientConfigConfigMapName = "openvpn-client-config"
 	//PrometheusConfigConfigMapName is the name for the configmap containing the prometheus config
 	PrometheusConfigConfigMapName = "prometheus"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we do only check if the openvpn config inside the user cluster exists or not.
If it does not exist, it will get created.
We don't checked if the existing configMap is deprecated though.
This PR will add a proper reconciling to it. (More will follow)

**Release note**:
```release-note
Add missing reconciling of the OpenVPN config inside the user cluster
```
