### PR TITLE
Implement new API endpoint /v1/users/me

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -127,6 +127,32 @@
         }
       }
     },
+    "/api/v1/me": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "users"
+        ],
+        "summary": "Returns information about the current user.",
+        "operationId": "getCurrentUser",
+        "responses": {
+          "200": {
+            "description": "User",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/openstack/networks": {
       "get": {
         "description": "Lists networks from openstack",
@@ -1461,32 +1487,6 @@
             "schema": {
               "$ref": "#/definitions/SSHKey"
             }
-          },
-          "default": {
-            "$ref": "#/responses/errorResponse"
-          }
-        }
-      }
-    },
-    "/api/v1/users/me": {
-      "get": {
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "users"
-        ],
-        "summary": "Returns information about the current user.",
-        "operationId": "getCurrentUser",
-        "responses": {
-          "200": {
-            "description": "User",
-            "schema": {
-              "$ref": "#/definitions/User"
-            }
-          },
-          "401": {
-            "$ref": "#/responses/empty"
           },
           "default": {
             "$ref": "#/responses/errorResponse"

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1468,6 +1468,26 @@
         }
       }
     },
+    "/api/v1/users/me": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "users"
+        ],
+        "summary": "Returns information about the current user.",
+        "operationId": "getCurrentUser",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/NewUser"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/versions": {
       "get": {
         "description": "Lists all versions which don't result in automatic updates",

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1485,6 +1485,9 @@
               "$ref": "#/definitions/User"
             }
           },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
           "default": {
             "$ref": "#/responses/errorResponse"
           }

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1480,7 +1480,10 @@
         "operationId": "getCurrentUser",
         "responses": {
           "200": {
-            "$ref": "#/responses/NewUser"
+            "description": "User",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
           },
           "default": {
             "$ref": "#/responses/errorResponse"

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1106,6 +1106,7 @@ func (r Routing) addUserToProject() http.Handler {
 //     Responses:
 //       default: errorResponse
 //       200: User
+//       401: empty
 func (r Routing) getCurrentUser() http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1105,7 +1105,7 @@ func (r Routing) addUserToProject() http.Handler {
 //
 //     Responses:
 //       default: errorResponse
-//       200: NewUser
+//       200: User
 func (r Routing) getCurrentUser() http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -185,7 +185,7 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 	//
 	// Defines an endpoint to retrieve information about the current token owner
 	mux.Methods(http.MethodGet).
-		Path("/users/me").
+		Path("/me").
 		Handler(r.getCurrentUser())
 }
 
@@ -1096,7 +1096,7 @@ func (r Routing) addUserToProject() http.Handler {
 	)
 }
 
-// swagger:route GET /api/v1/users/me users getCurrentUser
+// swagger:route GET /api/v1/me users getCurrentUser
 //
 // Returns information about the current user.
 //

--- a/api/pkg/handler/user.go
+++ b/api/pkg/handler/user.go
@@ -93,6 +93,14 @@ func addUserToProject(projectProvider provider.ProjectProvider, userProvider pro
 	}
 }
 
+func getCurrentUserEndpoint(users provider.UserProvider) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		authenticatedUser := ctx.Value(userCRContextKey).(*kubermaticapiv1.User)
+
+		return convertInternalUserToExternal(authenticatedUser), nil
+	}
+}
+
 func convertInternalUserToExternal(internalUser *kubermaticapiv1.User) *apiv1.NewUser {
 	apiUser := &apiv1.NewUser{
 		NewObjectMeta: apiv1.NewObjectMeta{

--- a/api/pkg/handler/user_test.go
+++ b/api/pkg/handler/user_test.go
@@ -686,7 +686,7 @@ func TestGetCurrentUser(t *testing.T) {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
 
-			req := httptest.NewRequest("GET", "/api/v1/users/me", nil)
+			req := httptest.NewRequest("GET", "/api/v1/me", nil)
 			res := httptest.NewRecorder()
 			ep.ServeHTTP(res, req)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR provides a new HTTP API endpoint, `/api/v1/users/me`, which returns user/project information about the current user.

**Which issue(s) this PR fixes**:

Fixes #1596

**Release note**:
```release-note
NONE
```
