### PR TITLE
add tolerations and nodeaffinity to make enable preemtible seed cluster setups

### DIFF
--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -61,6 +61,21 @@ spec:
               cpu: "250m"
       imagePullSecrets:
         - name: dockercfg
+      tolerations:
+      - key: "only_critical"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: "kubermatic.io/type"
+                operator: In
+                values:
+                - "stable"
       volumes:
         - name: kubeconfig
           secret:

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -83,6 +83,21 @@ spec:
               cpu: "200m"
       imagePullSecrets:
         - name: dockercfg
+      tolerations:
+      - key: "only_critical"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: "kubermatic.io/type"
+                operator: In
+                values:
+                - "stable"
       volumes:
         - name: master-files
           secret:

--- a/config/kubermatic/templates/kubermatic-ui-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-ui-dep.yaml
@@ -30,6 +30,21 @@ spec:
               readOnly: true
       imagePullSecrets:
         - name: dockercfg
+      tolerations:
+      - key: "only_critical"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: "kubermatic.io/type"
+                operator: In
+                values:
+                - "stable"
       volumes:
         - name: config
           configMap:

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -24,8 +24,8 @@ spec:
       hostNetwork: true
     {{ end }}
       serviceAccountName: nginx-ingress-serviceaccount
-      {{ if .Values.nginx.ignoreMasterTaint }}
       tolerations:
+      {{ if .Values.nginx.ignoreMasterTaint }}
       - key: dedicated
         operator: Equal
         value: master
@@ -33,6 +33,22 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       {{ end }}
+      - key: "only_critical"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+{{ if not .Values.nginx.asDaemonSet }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: "kubermatic.io/type"
+                operator: In
+                values:
+                - "stable"
+{{ end }}
       containers:
         - name: nginx-ingress-controller
           image: {{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}

--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -35,3 +35,18 @@ spec:
           "-logtostderr",
           "-v","6"
         ]
+      tolerations:
+      - key: "only_critical"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: "kubermatic.io/type"
+                operator: In
+                values:
+                - "stable"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds:
- Toleration for `NO_SCHEDULE	- only_critical=true` taint
- NodeAffinity for label `kubermatic.io/type: stable` (`preferredDuringSchedulingIgnoredDuringExecution`)

It would enable us to have stable nodes for kubermatic components but preemtible nodes for user-clusters. The changes are optional - it wont affect existing seed-clusters.

**Release note**:
```release-note
NONE
```
