### PR TITLE
add missing default values to prevent update calls

### DIFF
--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -39,9 +39,10 @@ func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Se
 	}
 	svc.Spec.Ports = []corev1.ServicePort{
 		{
-			Name:     "dns",
-			Protocol: corev1.ProtocolUDP,
-			Port:     int32(53),
+			Name:       "dns",
+			Protocol:   corev1.ProtocolUDP,
+			Port:       int32(53),
+			TargetPort: intstr.FromInt(53),
 		},
 	}
 
@@ -102,9 +103,10 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	dep.Spec.Template.Spec.Containers = []corev1.Container{
 		*openvpnSidecar,
 		{
-			Name:  resources.DNSResolverDeploymentName,
-			Image: data.ImageRegistry(resources.RegistryKubernetesGCR) + "/google_containers/coredns:1.1.3",
-			Args:  []string{"-conf", "/etc/coredns/Corefile"},
+			Name:            resources.DNSResolverDeploymentName,
+			Image:           data.ImageRegistry(resources.RegistryKubernetesGCR) + "/google_containers/coredns:1.1.3",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Args:            []string{"-conf", "/etc/coredns/Corefile"},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: requestedMemory,
@@ -115,6 +117,8 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 					corev1.ResourceCPU:    requestedCPU,
 				},
 			},
+			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      resources.DNSResolverConfigMapName,

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -220,27 +220,24 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	}
 
 	// Make sure, we don't change size of existing pvc's
+	// Phase needs to be taken from an existing
 	diskSize := data.EtcdDiskSize
-	if len(set.Spec.VolumeClaimTemplates) > 0 {
-		if size, exists := set.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]; exists {
-			diskSize = size
-		}
-	}
-
-	set.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "data",
-				OwnerReferences: []metav1.OwnerReference{data.GetClusterRef()},
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				StorageClassName: resources.String("kubermatic-fast"),
-				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceStorage: diskSize},
+	if len(set.Spec.VolumeClaimTemplates) == 0 {
+		set.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "data",
+					OwnerReferences: []metav1.OwnerReference{data.GetClusterRef()},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: resources.String("kubermatic-fast"),
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: diskSize},
+					},
 				},
 			},
-		},
+		}
 	}
 
 	return set, nil

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.8.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.9.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.8.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.9.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.8.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.9.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.8.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.9.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.8.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.9.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.8.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.9.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
-    targetPort: 0
+    targetPort: 53
   selector:
     app: dns-resolver
 status:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing default values to resources. The missing values caused the equality-check to fail and trigger an update on each sync

**Release note**:
```release-note
NONE
```
