### PR TITLE
enable multiline data for datacenters.yaml and kubeconfig

### DIFF
--- a/config/kubermatic/templates/datacenter-yaml-secret.yaml
+++ b/config/kubermatic/templates/datacenter-yaml-secret.yaml
@@ -4,4 +4,5 @@ metadata:
   name: datacenters
 type: Opaque
 data:
-  datacenters.yaml: {{ .Values.kubermatic.datacenters }}
+  datacenters.yaml: |
+{{ .Values.kubermatic.datacenters | indent 4 }}

--- a/config/kubermatic/templates/kubeconfig-secret.yaml
+++ b/config/kubermatic/templates/kubeconfig-secret.yaml
@@ -4,4 +4,5 @@ metadata:
   name: kubeconfig
 type: Opaque
 data:
-  kubeconfig: {{ .Values.kubermatic.kubeconfig }}
+  kubeconfig: |
+{{ .Values.kubermatic.kubeconfig  | indent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
enable multiline data for datacenters.yaml and kubeconfig

```release-note
NONE
```
