### PR TITLE
update machine controller to 0.7.14

### DIFF
--- a/api/pkg/resources/machinecontroler/deployment.go
+++ b/api/pkg/resources/machinecontroler/deployment.go
@@ -14,7 +14,7 @@ import (
 const (
 	name = "machine-controller"
 
-	tag = "v0.7.11"
+	tag = "v0.7.14"
 )
 
 // Deployment returns the machine-controller Deployment

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -46,7 +46,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -46,7 +46,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -46,7 +46,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -54,7 +54,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -54,7 +54,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -54,7 +54,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.11
+        image: docker.io/kubermatic/machine-controller:v0.7.14
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8


### PR DESCRIPTION
**What this PR does / why we need it**:
Update machine-controller to v0.7.14. Backport of https://github.com/kubermatic/kubermatic/pull/1634

**Release note**:
```release-note
Updated machine-controller to v0.7.14
```
