### PR TITLE
Always respond with a JSON object if a handler returns nil

### DIFF
--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -42,7 +42,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 		Name:             "scenario 1: tests deletion of a cluster and its dependant resources",
 		ExpectedActions:  12,
 		Body:             ``,
-		ExpectedResponse: `null`,
+		ExpectedResponse: `{}`,
 		HTTPStatus:       http.StatusOK,
 		ExistingProject: &kubermaticv1.Project{
 			ObjectMeta: metav1.ObjectMeta{
@@ -244,7 +244,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 			Name:                            "scenario 1: detaches one key from the cluster",
 			Body:                            ``,
 			KeyToDelete:                     "key-c08aa5c7abf34504f18552846485267d-yafn",
-			ExpectedDeleteResponse:          `null`,
+			ExpectedDeleteResponse:          `{}`,
 			ExpectedDeleteHTTPStatus:        http.StatusOK,
 			ExpectedGetHTTPStatus:           http.StatusOK,
 			ExpectedResponseOnGetAfterDelte: `[{"metadata":{"name":"key-abc-yafn","displayName":"key-display-name","creationTimestamp":"0001-01-01T00:00:00Z"},"spec":{"fingerprint":"","publicKey":""}}]`,
@@ -540,7 +540,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 1: an ssh key that belongs to the given project is assigned to the cluster",
 			Body:             `{"keyName":"key-c08aa5c7abf34504f18552846485267d-yafn"}`,
-			ExpectedResponse: `null`,
+			ExpectedResponse: `{}`,
 			HTTPStatus:       http.StatusCreated,
 			ExistingProject: &kubermaticv1.Project{
 				ObjectMeta: metav1.ObjectMeta{

--- a/api/pkg/handler/handler.go
+++ b/api/pkg/handler/handler.go
@@ -77,9 +77,9 @@ func setStatusCreatedHeader(f func(context.Context, http.ResponseWriter, interfa
 func encodeJSON(c context.Context, w http.ResponseWriter, response interface{}) (err error) {
 	w.Header().Set(headerContentType, contentTypeJSON)
 
-	//As long as we pipe the response from the listers we need this.
-	//The listers might return a uninitialized slice in case it has no results.
-	//This results to "null" when marshaling to json.
+	// As long as we pipe the response from the listers we need this.
+	// The listers might return a uninitialized slice in case it has no results.
+	// This results to "null" when marshaling to json.
 	t := reflect.TypeOf(response)
 	if t != nil && t.Kind() == reflect.Slice {
 		v := reflect.ValueOf(response)
@@ -87,6 +87,13 @@ func encodeJSON(c context.Context, w http.ResponseWriter, response interface{}) 
 			_, err := w.Write([]byte("[]"))
 			return err
 		}
+	}
+
+	// For completely empty responses, we still want to ensure that we
+	// send a JSON object instead of the string "null".
+	if response == nil {
+		_, err := w.Write([]byte("{}"))
+		return err
 	}
 
 	return json.NewEncoder(w).Encode(response)

--- a/api/pkg/handler/handler_test.go
+++ b/api/pkg/handler/handler_test.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestEncodeJSON(t *testing.T) {
+	var empty error
+
+	testcases := []struct {
+		input    interface{}
+		expected string
+	}{
+		{nil, `{}`},
+		{empty, `{}`},
+		{[]int{}, `[]`},
+		{[]int{1, 2, 3}, `[1,2,3]`},
+		{12, `12`},
+	}
+
+	ctx := context.TODO()
+
+	for _, testcase := range testcases {
+		writer := httptest.NewRecorder()
+
+		err := encodeJSON(ctx, writer, testcase.input)
+		if err != nil {
+			t.Errorf("failed to encode %#v as JSON: %v", testcase.input, err)
+		}
+
+		encoded, err := ioutil.ReadAll(writer.Body)
+		if err != nil {
+			t.Fatal("unable to read response body")
+		}
+
+		trimmed := strings.TrimSpace(string(encoded))
+
+		if trimmed != testcase.expected {
+			t.Errorf("expected to encode %#v as '%s', but got '%s'", testcase.input, testcase.expected, trimmed)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Just like the title says, this PR ensures a consistent JSON output, even if empty values as returned from handlers.

**Which issue(s) this PR fixes**:

Fixes #1559

**Release note**:

```release-note
NONE
```
