### PR TITLE
refresh cluster from api on update

### DIFF
--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -264,12 +264,11 @@ func (cc *Controller) enqueue(cluster *kubermaticv1.Cluster) {
 
 func (cc *Controller) updateCluster(name string, modify func(*kubermaticv1.Cluster)) (updatedCluster *kubermaticv1.Cluster, err error) {
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
-		//Get latest version from cache
-		cacheCluster, err := cc.clusterLister.Get(name)
+		//Get latest version from api
+		currentCluster, err := cc.kubermaticClient.KubermaticV1().Clusters().Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-		currentCluster := cacheCluster.DeepCopy()
 		// Apply modifications
 		modify(currentCluster)
 		// Update the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
Refresh cluster from api on update

**Release note**:
```release-note
NONE
```
