### PR TITLE
Cherry pick fixes into 2.6

### DIFF
--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -286,11 +286,24 @@ func (cc *Controller) updateCluster(name string, modify func(*kubermaticv1.Clust
 		if err != nil {
 			return err
 		}
+
 		currentCluster := cacheCluster.DeepCopy()
 		// Apply modifications
 		modify(currentCluster)
 		// Update the cluster
 		updatedCluster, err = cc.kubermaticClient.KubermaticV1().Clusters().Update(currentCluster)
+		if err != nil && kubeapierrors.IsConflict(err) {
+			//Get latest version from api
+			currentCluster, err := cc.kubermaticClient.KubermaticV1().Clusters().Get(name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			// Apply modifications
+			modify(currentCluster)
+			// Update the cluster
+			updatedCluster, err = cc.kubermaticClient.KubermaticV1().Clusters().Update(currentCluster)
+		}
+
 		return err
 	})
 

--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: nodeport-proxy
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: nodeport-proxy
@@ -24,11 +24,53 @@ spec:
       - name: nodeport-proxy
         image: {{ .Values.nodePortPoxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag }}
         command:
-        - "/nodeport-proxy"
+        - "/proxy"
         args: [
           "-listen-address", "0.0.0.0",
+          "-logtostderr",
+          "-v","4"
+        ]
+      tolerations:
+      - key: "only_critical"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: "kubermatic.io/type"
+                operator: In
+                values:
+                - "stable"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lb-updater
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lb-updater
+  template:
+    metadata:
+      labels:
+        app: lb-updater
+    spec:
+      serviceAccountName: nodeport-proxy
+      imagePullSecrets:
+        - name: quay
+      containers:
+      - name: lb-updater
+        image: {{ .Values.nodePortPoxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag }}
+        command:
+        - "/lb-updater"
+        args: [
           "-lb-namespace", "nodeport-proxy",
           "-lb-name", "nodeport-lb",
           "-logtostderr",
-          "-v","6"
+          "-v","4"
         ]

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -1,4 +1,4 @@
 nodePortPoxy:
   image:
     repository: "quay.io/kubermatic/nodeport-proxy"
-    tag: "v1.1"
+    tag: "v1.2"


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick fixes into 2.6:
- https://github.com/kubermatic/kubermatic/pull/1640
- https://github.com/kubermatic/kubermatic/pull/1639

**Release note**:
```release-note
Update nodeport-proxy and make it HA
```
