### PR TITLE
always allocate public ip on new machines

### DIFF
--- a/api/pkg/resources/machine/machine.go
+++ b/api/pkg/resources/machine/machine.go
@@ -191,7 +191,8 @@ func getAzureProviderSpec(c *kubermaticv1.Cluster, node *apiv2.Node, dc provider
 		SubnetName:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SubnetName},
 		RouteTableName: providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.RouteTableName},
 
-		AssignPublicIP: providerconfig.ConfigVarBool{Value: node.Spec.Cloud.Azure.AssignPublicIP},
+		// Revisit when we have the DNAT topic complete and we can use private machines. Then we can use: node.Spec.Cloud.Azure.AssignPublicIP
+		AssignPublicIP: providerconfig.ConfigVarBool{Value: true},
 	}
 	config.Tags = map[string]string{}
 	for key, value := range node.Spec.Cloud.Azure.Tags {

--- a/api/pkg/resources/test/fixtures/machine-azure.yaml
+++ b/api/pkg/resources/test/fixtures/machine-azure.yaml
@@ -8,7 +8,7 @@ spec:
   providerConfig:
     cloudProvider: azure
     cloudProviderSpec:
-      assignPublicIP: false
+      assignPublicIP: true
       clientID: 32hrf23oh89f32
       clientSecret: rbyughv438oh32f23v2
       location: westeurope


### PR DESCRIPTION
**What this PR does / why we need it**:
Always allocate public IP on new machines when using Azure

**Release note**:
```release-note cloud provider
Azure: public IPs will always be allocated on new machines
```
