### PR TITLE
add missing cloud provider flags on the apiserver and controller-manager for azure

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -268,6 +268,10 @@ func getApiserverFlags(data *resources.TemplateData, externalNodePort int32, etc
 		flags = append(flags, "--cloud-provider", "vsphere")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
 	}
+	if data.Cluster.Spec.Cloud.Azure != nil {
+		flags = append(flags, "--cloud-provider", "azure")
+		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
+	}
 
 	if data.Cluster.Spec.Cloud.BringYourOwn != nil {
 		flags = append(flags, "--kubelet-preferred-address-types", "Hostname,InternalIP,ExternalIP")

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -219,6 +219,10 @@ func getFlags(data *resources.TemplateData, kcDir string) []string {
 		flags = append(flags, "--cloud-provider", "vsphere")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
 	}
+	if data.Cluster.Spec.Cloud.Azure != nil {
+		flags = append(flags, "--cloud-provider", "azure")
+		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
+	}
 	return flags
 }
 

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -160,6 +160,10 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.key
         - --v
         - "4"
+        - --cloud-provider
+        - azure
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -114,6 +114,10 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - --cloud-provider
+        - azure
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -160,6 +160,10 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.key
         - --v
         - "4"
+        - --cloud-provider
+        - azure
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -114,6 +114,10 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - --cloud-provider
+        - azure
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -160,6 +160,10 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.key
         - --v
         - "4"
+        - --cloud-provider
+        - azure
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -114,6 +114,10 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - --cloud-provider
+        - azure
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
         command:
         - /hyperkube
         - controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing cloud provider flags on the apiserver and controller-manager for azure.

**Release note**:
```release-note cloud provider
Minor fixes for seed clusters running on Azure
```
