### PR TITLE
add static scrape config for etcd

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -2,17 +2,20 @@
 
 
 [[projects]]
+  digest = "1:9a6a08919845856ce9891445717f8e1d9f016647e2e5136a4607d80773ceb8c9"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "services/compute/mgmt/2018-04-01/compute",
     "services/network/mgmt/2018-04-01/network",
     "services/resources/mgmt/2018-02-01/resources",
-    "version"
+    "version",
   ]
+  pruneopts = "NUT"
   revision = "fbe7db0e3f9793ba3e5704efbab84f51436c136e"
   version = "v18.0.0"
 
 [[projects]]
+  digest = "1:b727ed6314141ef75a77f5dcfc8043cdcc74bc6a0a65eef6830710f85b333415"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -21,59 +24,77 @@
     "autorest/azure/auth",
     "autorest/date",
     "autorest/to",
-    "autorest/validation"
+    "autorest/validation",
   ]
+  pruneopts = "NUT"
   revision = "1f7cd6cfe0adea687ad44a512dfe76140f804318"
   version = "v10.12.0"
 
 [[projects]]
+  digest = "1:44ba3152ffe15e49d62050dffc6e68543a0d641e4dcf94ee715ad687c3a648ed"
   name = "github.com/Masterminds/semver"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "15d8430ab86497c5c0da827b748823945e1cf1e1"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:488fed6de34b17a9126520d2681885360bba914cc5a4667c027aec85f46f418c"
   name = "github.com/Masterminds/sprig"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b217b9c388de2cacde4354c536e520c52c055563"
   version = "v2.14.1"
 
 [[projects]]
+  digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  digest = "1:dfc48e1a293a468126069586733806f62cbf485d87780881ea9106cdb68d38bb"
   name = "github.com/ajeddeloh/yaml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6b94386aeefd8c4b8470aee72bfca084c2f91da9"
 
 [[projects]]
   branch = "master"
+  digest = "1:fdd419e104ec26bb5bd63cc62637c640453ed2929a7453f3afadbd9a0223da66"
   name = "github.com/alecthomas/units"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
+  digest = "1:975108e8d4f5dab096fc991326e96a5716ee8d02e5e7386bb4796171afc4ab9a"
   name = "github.com/aokoli/goutils"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3391d3790d23d03408670993e957e8f408993c34"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:2ca151c1203d07f3fca238e42bffbbf7525089585365070c4eff5bcbeaa951e1"
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "521b25f4b05fd26bec69d9dedeb8f9c9a83939a8"
   version = "v8"
 
 [[projects]]
+  digest = "1:7486450c6b7e0ff70ecb6ed087f2d78785114f21a4af541e4abe3fde51610273"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -101,18 +122,22 @@
     "private/protocol/xml/xmlutil",
     "service/ec2",
     "service/iam",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = "NUT"
   revision = "c9b25d6bfa986ab6d195479871a96e81b8882536"
   version = "v1.12.77"
 
 [[projects]]
   branch = "master"
+  digest = "1:cb0535f5823b47df7dcb9768ebb6c000b79ad115472910c70efe93c9ed9b2315"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "NUT"
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:15173ac9caac43ba3a8990716158f5fd08174293e259d0a9e67f6fc98cc39d35"
   name = "github.com/coreos/container-linux-config-transpiler"
   packages = [
     "config",
@@ -121,153 +146,197 @@
     "config/templating",
     "config/types",
     "config/types/util",
-    "internal/util"
+    "internal/util",
   ]
+  pruneopts = "NUT"
   revision = "b76ab0b2d66ff1ac6902f4fe118a02c1bed6e5ce"
   version = "v0.6.1"
 
 [[projects]]
+  digest = "1:8971ecb1f298af578992bccbc7e68f614fe8a2d00d2264b7261e52119c0074a4"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "a4973d9a4225417aecf5d450a9522f00c1f7130f"
 
 [[projects]]
+  digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
   name = "github.com/coreos/go-semver"
   packages = ["semver"]
+  pruneopts = "NUT"
   revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:fc8dac286d0071a9b7baccef9d02b96c8401c362446304ca686552d2c7979ffb"
   name = "github.com/coreos/go-systemd"
   packages = ["unit"]
+  pruneopts = "NUT"
   revision = "40e2722dffead74698ca12a750f64ef313ddce05"
   version = "v16"
 
 [[projects]]
+  digest = "1:6ce6e7cdfb6c329c9410b16c0ec8ceabeb9eb3aaf83749c54cf4565e3471c75f"
   name = "github.com/coreos/ignition"
   packages = [
     "config/v2_1/types",
     "config/validate",
     "config/validate/astnode",
-    "config/validate/report"
+    "config/validate/report",
   ]
+  pruneopts = "NUT"
   revision = "65f3f407178537b32d6075d042dea3a8fa9be501"
   version = "v0.22.0"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
+  digest = "1:219fef6e3f42a62ace57a4e912037da38b19b4e3f68db549703cd329cc1d3b62"
   name = "github.com/digitalocean/godo"
   packages = [
     ".",
-    "context"
+    "context",
   ]
+  pruneopts = "NUT"
   revision = "77ea48de76a7b31b234d854f15d003c68bb2fb90"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:ec6271918b59b872a2d25e374569a4f75f1839d91e4191470c297b7eaaaf7641"
   name = "github.com/dimchansky/utfbom"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6c6132ff69f0f6c088739067407b5d32c52e1d0f"
 
 [[projects]]
   branch = "master"
+  digest = "1:b7ffca49e9cfd3dfb04a8e0a59347708c6f78f68476a32c5e0a0edca5d1b258c"
   name = "github.com/dustin/go-humanize"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "02af3965c54e8cacf948b97fef38925c4120652c"
 
 [[projects]]
   branch = "master"
+  digest = "1:e8ffe2fb7368f65afaaf39769207bee2a7aeddf694e94f5bc05cffd750d4d98d"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "944e07253867aacae43c04b2e6a239005443f33a"
 
 [[projects]]
+  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:0c0eac431b07bd0da31ef684aa15b5b5eeeda8a820f666e6523d2bfb8ce868c4"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
   version = "v1.32.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:678872f6a7d7fd8a855bb7bffd8e25de7c0d0b1868fe98af998ea2dbd83f29c9"
   name = "github.com/go-kit/kit"
   packages = [
     "endpoint",
     "log",
-    "transport/http"
+    "transport/http",
   ]
+  pruneopts = "NUT"
   revision = "286fe7a0709da897bcafd638ca80289af53d40af"
 
 [[projects]]
+  digest = "1:341a7df38da99fe91ed40e4008c13cc5d02dcc98ed1a094360cb7d5df26d6d26"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d289fd98f0644f49f48910414ae9d4d50c169c4bdb09a91a1033427dc3f14e19"
   name = "github.com/go-openapi/analysis"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "f59a71f0ece6f9dfb438be7f45148f006cbad88e"
 
 [[projects]]
   branch = "master"
+  digest = "1:548f27fc69956ab8e5d513f990c31be0281ae0f6b9dc9493668e3274d7c371cd"
   name = "github.com/go-openapi/errors"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "7bcb96a367bac6b76e6e42fa84155bb5581dcff8"
 
 [[projects]]
   branch = "master"
+  digest = "1:feb16e4f0db0ca6111a5e1db7de9d50b49a5d1e49d1291508fa64ae8b18bd3b3"
   name = "github.com/go-openapi/inflect"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b1f6470ffb9c552dc105dd869f16e36ba86ba7d0"
 
 [[projects]]
   branch = "master"
+  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "779f45308c19820f1a69e9a4cd965f496e0da10f"
 
 [[projects]]
   branch = "master"
+  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "36d33bfe519efae5632669801b180bf1a245da3b"
 
 [[projects]]
   branch = "master"
+  digest = "1:3662a468030f6c819d695462664761f393908115314ef7af2742c44d0fe655ff"
   name = "github.com/go-openapi/loads"
   packages = [
     ".",
-    "fmts"
+    "fmts",
   ]
+  pruneopts = "NUT"
   revision = "2a2b323bab96e6b1fdee110e57d959322446e9c9"
 
 [[projects]]
   branch = "master"
+  digest = "1:785556d6f0960679d4953b126e839265375479b49d0b8b19e774f501d62071eb"
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
@@ -276,42 +345,54 @@
     "middleware/denco",
     "middleware/header",
     "middleware/untyped",
-    "security"
+    "security",
   ]
+  pruneopts = "NUT"
   revision = "09fac855d8504674b22594470227bd94e5005025"
 
 [[projects]]
   branch = "master"
+  digest = "1:5915a91a5943a55e0c1cf1df04f6c22c6a942cd2792efe38c844f97b89aa40d8"
   name = "github.com/go-openapi/spec"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1de3e0542de65ad8d75452a595886fdd0befb363"
 
 [[projects]]
   branch = "master"
+  digest = "1:41638dcba4ce0e798b30b72d708e7408ec2003fabf35af114c515c0e2a3ccf60"
   name = "github.com/go-openapi/strfmt"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6d1a47fad79c81e8cd732889cb80e91123951860"
 
 [[projects]]
   branch = "master"
+  digest = "1:815448d1f6ec4496678dbfa951df7272e3baf68e3ce5958b59e1141e60d2e2bc"
   name = "github.com/go-openapi/swag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "84f4bee7c0a6db40e3166044c7983c1c32125429"
 
 [[projects]]
   branch = "master"
+  digest = "1:2ac8d2f1e4b1845defdd1a431ccca1034e8d68199b059f7121a6576849f1441f"
   name = "github.com/go-openapi/validate"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1ff04bd4a6c8a4af5813bd5bf3dc24c4756b9ee2"
 
 [[projects]]
+  digest = "1:a1efdbc2762667c8a41cbf02b19a0549c846bf2c1d08cad4f445e3344089f1f0"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c1d1044d9c50ac6db29b3d327b17ba12f77436f0a37405968e8a10f012f24828"
   name = "github.com/go-swagger/go-swagger"
   packages = [
     "cmd/swagger",
@@ -319,79 +400,99 @@
     "cmd/swagger/commands/generate",
     "cmd/swagger/commands/initcmd",
     "generator",
-    "scan"
+    "scan",
   ]
+  pruneopts = "NUT"
   revision = "95766d38e23b428e01b6d165b5947467d71f1c59"
 
 [[projects]]
+  digest = "1:3c04690dd1d3fad9a36c492c32863fad91bcf822fd95d5c4cae97be1e9abc361"
   name = "github.com/go-test/deep"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6592d9cc0a499ad2d5f574fde80a2b5c5cc3b4f5"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:1b3dd24f14a5280710fc7a3aa2480b6e4d20fdfc905841de9a3aa2aa2f1d4ee9"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = "NUT"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
+  digest = "1:3fb07f8e222402962fa190eb060608b34eddfb64562a18e2167df2de0ece85d8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
+  pruneopts = "NUT"
   revision = "66deaeb636dff1ac7d938ce666d090556056a4b0"
 
 [[projects]]
+  digest = "1:d470faddd8d4b027226f9a5ff9d88962c34bb1699dde2acd7e9bfb70a3703d45"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "NUT"
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
   packages = ["query"]
+  pruneopts = "NUT"
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
   branch = "master"
+  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:1bb197a3b5db4e06e00b7560f8e89836c486627f2a0338332ed37daa003d259e"
   name = "github.com/google/uuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "064e2069ce9c359c118179501254f67d7d37ba24"
   version = "0.2"
 
 [[projects]]
+  digest = "1:3d7c1446fc5c710351b246c0dc6700fae843ca27f5294d0bd9f68bab2a810c44"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = "NUT"
   revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c549bd4ec595922d02aeae0a7abfa1604c85fc5071a7f9aae9a1fbeac67988ab"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -419,39 +520,49 @@
     "openstack/networking/v2/ports",
     "openstack/networking/v2/subnets",
     "openstack/utils",
-    "pagination"
+    "pagination",
   ]
+  pruneopts = "NUT"
   revision = "19abc56a8cd8d3630ab9735173cb92c0bf635f33"
 
 [[projects]]
+  digest = "1:dbd86d229eacaa86a98b10f8fb3e3fc69a1913e0f4e010e7cc1f92bf12edca92"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:fe47be2bd5d0196679d314fcc6e02f40a51e641c09e1541528a05cccefee9b0e"
   name = "github.com/gorilla/handlers"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "90663712d74cb411cbef281bc1e08c19d1a76145"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:eced3d718020962f1cc6ac109b840ba17dc817a291062b5948ba7aecc8c6665d"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
   version = "v1.6.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "NUT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
+  digest = "1:9d28dd6ad84cf6c3e47e36b50761fb5092922a3ff15e775094d1694cb0deb64e"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -463,73 +574,95 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = "NUT"
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
+  digest = "1:7e4ef12bb4999fd90fd97b887964ac2278b168882217fccc0a183b1e8786daa8"
   name = "github.com/hetznercloud/hcloud-go"
   packages = [
     "hcloud",
-    "hcloud/schema"
+    "hcloud/schema",
   ]
+  pruneopts = "NUT"
   revision = "b37849e439d7a02b07d495f65e7b797bec30eeae"
   version = "v1.4.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:b7f860847a1d71f925ba9385ed95f1ebc0abfeb418a78e219ab61f48fdfeffad"
   name = "github.com/howeyc/gopass"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
   branch = "master"
+  digest = "1:f5db19d350bd0b542d17f7e7cf4e7068bac416c08adb6a129b3c6d1db8211051"
   name = "github.com/huandu/xstrings"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2bf18b218c51864a87384c06996e40ff9dcff8e1"
 
 [[projects]]
+  digest = "1:cf327083982a19eae01f70be6663a935a02bac3a2dc79efbc19668c8378bfbb3"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
   version = "0.3.2"
 
 [[projects]]
+  digest = "1:914f8eaa63b88fe6bcd656d81b3f3ccd2e8422df1787a6abe32554e4b75c0556"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "96dc06278ce32a0e9d957d590bb987c81ee66407"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:ac6d01547ec4f7f673311b4663909269bfb8249952de3279799289467837c3cc"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:513a04aad83573e78b933cdf7df1a289227702c574b500de8de386e83b811138"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "N"
   revision = "28452fcdec4e44348d2af0d91d1e9e38da3a9e0a"
   version = "1.0.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:f91bb67d051a94cf6ab2cf07eee0550432afc31655838d42cdec258db4b348f0"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
   branch = "master"
+  digest = "1:7b21c7fc5551b46d1308b4ffa9e9e49b66c7a8b0ba88c0130474b0e7a20d859f"
   name = "github.com/kr/pretty"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "cfb55aafdaf3ec08f0db22699ab822c50091b1c4"
 
 [[projects]]
   branch = "master"
+  digest = "1:c3a7836b5904db0f8b609595b619916a6831cb35b8b714aec39f96d00c6155d8"
   name = "github.com/kr/text"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "7cafcd837844e784b526369c9bce262804aebc60"
 
 [[projects]]
+  digest = "1:4cbbd64e7839abea9fec2e10f57f5a01697b4859e2dedc8d2233690b5c4f67af"
   name = "github.com/kubermatic/machine-controller"
   packages = [
     "pkg/client/clientset/versioned",
@@ -555,34 +688,42 @@
     "pkg/userdata/cloud",
     "pkg/userdata/coreos",
     "pkg/userdata/helper",
-    "pkg/userdata/ubuntu"
+    "pkg/userdata/ubuntu",
   ]
+  pruneopts = "NUT"
   revision = "2e0d2f0875316755ac1a8dbc3b61d2110abf5968"
   version = "v0.7.13"
 
 [[projects]]
+  digest = "1:35e5598ba3bc950039e13d91958ce37f675264735907cada569d11b243e5cacb"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
   version = "v1.7.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:cdf13ca0f5df719f31c0b466578feba0837bd6bb0aea95b3981a307844803704"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
+  pruneopts = "NUT"
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
+  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "NUT"
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:4812a87744ebaa12373e5b8fad9097de9f72c1947b06984708940e07dc8cbaf0"
   name = "github.com/minio/minio-go"
   packages = [
     ".",
@@ -590,182 +731,234 @@
     "pkg/encrypt",
     "pkg/s3signer",
     "pkg/s3utils",
-    "pkg/set"
+    "pkg/set",
   ]
+  pruneopts = "NUT"
   revision = "c6108c47ba5d86548404ebf9e51c5ca18769fe79"
   version = "6.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:9db29b604bd78452d167abed82386ddd2f93973df3841896fb6ab8aff936f1d6"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
 
 [[projects]]
   branch = "master"
+  digest = "1:4b9dacaf3496e8bd82173b88c38004028a103b03ddd2de15a0a108f04619e00b"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "a4e142e9c047c904fa2f1e144d9a84e6133024bc"
 
 [[projects]]
+  digest = "1:3b517122f3aad1ecce45a630ea912b3092b4729f25532a911d0cb2935a1f9352"
   name = "github.com/oklog/run"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:cce3a18fb0b96b5015cd8ca03a57d20a662679de03c4dc4b6ff5f17ea2050fa6"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:13b8f1a2ce177961dc9231606a52f709fab896c565f3988f60a7f6b4e543a902"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:0390d3bc2c954487663318db748434d5e8bbfde8ac890070c15f3eab619f2ea8"
   name = "github.com/pquerna/cachecontrol"
   packages = [
     ".",
-    "cacheobject"
+    "cacheobject",
   ]
+  pruneopts = "NUT"
   revision = "0dec1b30a0215bb68605dfc568e8855066c9202d"
 
 [[projects]]
   branch = "master"
+  digest = "1:a535acb64f8dfaac6fa6b4a93119d937524741eda1fe7df257efadc4c3c23b12"
   name = "github.com/prometheus/client_golang"
   packages = [
     "api",
     "api/prometheus/v1",
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "NUT"
   revision = "82f5ff156b29e276022b1a958f7d385870fb9814"
 
 [[projects]]
   branch = "master"
+  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "NUT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:4a6bb73eb5d7b8e67f25d22d87c84116cc69dfa80299dfd06622b8eee47917a8"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "NUT"
   revision = "89604d197083d4781071d3c65855d24ecfb0a563"
 
 [[projects]]
   branch = "master"
+  digest = "1:b2f81139ed70ba4358171bc3024a5f2a3a9d2148ccc3fff03e3a011afe9b7543"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "NUT"
   revision = "282c8707aa210456a825798969cc27edda34992a"
 
 [[projects]]
+  digest = "1:53c3320ee307f01fd24a88e396a8d2239cd8346d1a085320209319f2d33f59cc"
   name = "github.com/robfig/cron"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b41be1df696709bb6395fe435af20370037c0b4c"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:6989062eb7ccf25cf38bf4fe3dba097ee209f896cda42cefdca3927047bef7b6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:39da3da7a735176ff518f7a6d8de9e4e03cb760dc7ef0b7b8dae6fc61406295c"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem"
+    "mem",
   ]
+  pruneopts = "NUT"
   revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:3fa7947ca83b98ae553590d993886e845a4bff19b7b007e869c6e0dd3b9da9cd"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:f29f83301ed096daed24a90f4af591b7560cb14b9cc3e1827abbf04db7269ab5"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
+  digest = "1:3ab855aa584d08db6541ce99dad60c12bd6a328ecb8a7358363887f85c976347"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3327c8113e7c4c420ea01123c73a5bf9fe79cf9de201d4bf4761a8b0fc5b31a4"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5"
 
 [[projects]]
   branch = "master"
+  digest = "1:a0aee89faaf795424d978b6b4bcee4af3dc71f5680e5e1b30bd1528639e61a9a"
   name = "github.com/tent/http-link-go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ac974c61c2f990f4115b119354b5e0b47550e888"
 
 [[projects]]
+  digest = "1:1f639e0ef8074e69314d01b90c2d6babe369a35fa421d454781ed1075585ddd7"
   name = "github.com/toqueteos/webbrowser"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3232c91b8ede8ca86e8962981d881af78875542f"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:df3d534f7b987f63a7076f86d9a2abd1c3f10d0236245405ba5cbb376511f80e"
   name = "github.com/tylerb/graceful"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb"
   version = "v1.2.15"
 
 [[projects]]
+  digest = "1:b7e175082fbe862fe0267c9c55043ac5f836dc70069b6fd44f4657e0eee80f4e"
   name = "github.com/ugorji/go"
   packages = ["codec/codecgen"]
+  pruneopts = "NUT"
   revision = "9831f2c3ac1068a78f50999a30db84270f647af6"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:5dba68a1600a235630e208cb7196b24e58fcbb77bb7a6bec08fcd23f081b0a58"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9b456727ce4101594aabddaa816c80464cd21a1e5fcd145297a902303be0085"
   name = "github.com/vincent-petithory/dataurl"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "9a301d65acbb728fcc3ace14f45f511a4cfeea9c"
 
 [[projects]]
+  digest = "1:5ebb30264b7ca0203560b0706405e09fab8677e847d3739d1a409f62d251a585"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -786,13 +979,15 @@
     "vim25/progress",
     "vim25/soap",
     "vim25/types",
-    "vim25/xml"
+    "vim25/xml",
   ]
+  pruneopts = "NUT"
   revision = "123ed177021588bac57b5c87c1a84270ddf2eca8"
   version = "v0.17.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:e444d860fba00b1b9adb8c1156460e5700ce90063f5d315719689298a88d361b"
   name = "golang.org/x/crypto"
   packages = [
     "argon2",
@@ -807,12 +1002,14 @@
     "poly1305",
     "scrypt",
     "ssh",
-    "ssh/terminal"
+    "ssh/terminal",
   ]
+  pruneopts = "NUT"
   revision = "650f4a345ab4e5b245a3034b110ebc7299e68186"
 
 [[projects]]
   branch = "master"
+  digest = "1:d0265dccbb98193d3e4fc66d31cadb1f35f6369db499b84ad87e5e3567b8a562"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -820,30 +1017,36 @@
     "http2",
     "http2/hpack",
     "idna",
-    "lex/httplex"
+    "lex/httplex",
   ]
+  pruneopts = "NUT"
   revision = "f5dfe339be1d06f81b22525fe34671ee7d2c8904"
 
 [[projects]]
   branch = "master"
+  digest = "1:f058f3811608b1c83a5939072f4e94b443a104e383137fd6b8e535e26e8abe31"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal"
+    "internal",
   ]
+  pruneopts = "NUT"
   revision = "543e37812f10c46c622c9575afd7ad22f22a12ba"
 
 [[projects]]
   branch = "master"
+  digest = "1:4301a4973691694236c322c1ed32273b7d42dbff3cd2d0bbb7b06f233edfbd8e"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "NUT"
   revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
   branch = "master"
+  digest = "1:e33513a825fcd765e97b5de639a2f7547542d1a8245df0cef18e1fd390b778a9"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -860,28 +1063,34 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width"
+    "width",
   ]
+  pruneopts = "NUT"
   revision = "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "NUT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
+  digest = "1:3cbc05413b8aac22b1f6d4350ed696b5a83a8515a4136db8f1ec3a0aee3d76e1"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "go/buildutil",
     "go/loader",
-    "imports"
+    "imports",
   ]
+  pruneopts = "NUT"
   revision = "ce871d178848e3eea1e8795e5cfb74053dde4bb9"
 
 [[projects]]
+  digest = "1:f229c599a645bffd97518107ac89955adfa6d5e5e4efa3e8cadb29789219639f"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -890,44 +1099,54 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = "NUT"
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:ef72505cf098abdd34efeea032103377bec06abb61d8a06f002d5d296a4b1185"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
   version = "v0.9.0"
 
 [[projects]]
   branch = "v2"
+  digest = "1:9e8ac8aa4f4c5557ba0b03a55d407b07b7030ed552b437a9dc7e5ec90f16ab39"
   name = "gopkg.in/mgo.v2"
   packages = [
     "bson",
-    "internal/json"
+    "internal/json",
   ]
+  pruneopts = "NUT"
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [[projects]]
+  digest = "1:986d8ff4c7da85fc3e1ac8cdbceda5fe91575443fb362d2cbe3d6f8bff5f9cbe"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
     "cipher",
-    "json"
+    "json",
   ]
+  pruneopts = "NUT"
   revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
   version = "v2.1.3"
 
 [[projects]]
   branch = "v2"
+  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
 
 [[projects]]
   branch = "release-1.10"
+  digest = "1:f541c95b242bf41dc42ba035d66e7d240c1e8c7ccd45480f81c6526237d0b940"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -957,12 +1176,14 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "NUT"
   revision = "edd5e319fc45211023fffb41c7aa5555229c4179"
 
 [[projects]]
   branch = "release-1.10"
+  digest = "1:77ead159dd31d230f6b72649f69371d2688b281827738d58f37705a6a5246889"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1010,12 +1231,14 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "NUT"
   revision = "01bc873149a1802eb74df583613872d126449ed5"
 
 [[projects]]
   branch = "release-7.0"
+  digest = "1:05a01401f8bce5f617c04bbca4ef32ab2427a3ce67db78d58802287c4ccaef3c"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1172,12 +1395,14 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = "NUT"
   revision = "33f2870a2b83179c823ddc90e5513f9e5fe43b38"
 
 [[projects]]
   branch = "release-1.10"
+  digest = "1:d2e7c34c2fb82f8274484d88f76a9af01f366a554d3f8d4b9a696448d43a7b4c"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -1190,11 +1415,13 @@
     "cmd/client-gen/types",
     "cmd/deepcopy-gen",
     "cmd/deepcopy-gen/args",
-    "pkg/util"
+    "pkg/util",
   ]
+  pruneopts = "T"
   revision = "cbd9dba38c3d8e0035d4bb554bd321e2c190e629"
 
 [[projects]]
+  digest = "1:721053d09232080be6cc67720e51b6137e235afcbd3229942e6486b6d7c37db6"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -1204,31 +1431,181 @@
     "generator",
     "namer",
     "parser",
-    "types"
+    "types",
   ]
+  pruneopts = "NUT"
   revision = "b6c426f7730e6d66e6e476a85d1c3eb7633880e0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e0d6dcb28c42a53c7243bb6380badd17f92fbd8488a075a07e984f91a07c0d23"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
+  pruneopts = "NUT"
   revision = "275e2ce91dec4c05a4094a7b1daee5560b555ac9"
 
 [[projects]]
+  digest = "1:623c67408d8d837f34ca8aca6382b1eb3c40caab10f4ad7ebeeeb8f1d1f94c44"
   name = "k8s.io/kubernetes"
   packages = ["pkg/printers"]
+  pruneopts = "NUT"
   revision = "32ac1c9073b132b8ba18aa830f46b77dcceb0723"
   version = "v1.10.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:2385d1bef8989a5f919a71efee3f337df3f0ad7b29ee23204b5614aad3e3f577"
   name = "vbom.ml/util"
   packages = ["sortorder"]
+  pruneopts = "NUT"
   revision = "256737ac55c46798123f754ab7d2c784e2c71783"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "047cfbcc9787f363ac428c33ee888b74a33cb2ee2d41edd34840eacc860f7749"
+  input-imports = [
+    "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute",
+    "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network",
+    "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources",
+    "github.com/Azure/go-autorest/autorest",
+    "github.com/Azure/go-autorest/autorest/azure/auth",
+    "github.com/Azure/go-autorest/autorest/to",
+    "github.com/Masterminds/semver",
+    "github.com/Masterminds/sprig",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
+    "github.com/aws/aws-sdk-go/aws/credentials",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/ec2",
+    "github.com/aws/aws-sdk-go/service/iam",
+    "github.com/coreos/go-oidc",
+    "github.com/davecgh/go-spew/spew",
+    "github.com/digitalocean/godo",
+    "github.com/ghodss/yaml",
+    "github.com/go-kit/kit/endpoint",
+    "github.com/go-kit/kit/log",
+    "github.com/go-kit/kit/transport/http",
+    "github.com/go-swagger/go-swagger/cmd/swagger",
+    "github.com/go-test/deep",
+    "github.com/golang/glog",
+    "github.com/gophercloud/gophercloud",
+    "github.com/gophercloud/gophercloud/openstack",
+    "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
+    "github.com/gophercloud/gophercloud/openstack/identity/v3/projects",
+    "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
+    "github.com/gophercloud/gophercloud/openstack/identity/v3/users",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
+    "github.com/gophercloud/gophercloud/pagination",
+    "github.com/gorilla/handlers",
+    "github.com/gorilla/mux",
+    "github.com/hetznercloud/hcloud-go/hcloud",
+    "github.com/kubermatic/machine-controller/pkg/client/clientset/versioned",
+    "github.com/kubermatic/machine-controller/pkg/client/clientset/versioned/fake",
+    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws",
+    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure",
+    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean",
+    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/hetzner",
+    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack",
+    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere",
+    "github.com/kubermatic/machine-controller/pkg/containerruntime",
+    "github.com/kubermatic/machine-controller/pkg/machines/v1alpha1",
+    "github.com/kubermatic/machine-controller/pkg/providerconfig",
+    "github.com/kubermatic/machine-controller/pkg/userdata/centos",
+    "github.com/kubermatic/machine-controller/pkg/userdata/coreos",
+    "github.com/kubermatic/machine-controller/pkg/userdata/ubuntu",
+    "github.com/minio/minio-go",
+    "github.com/oklog/run",
+    "github.com/pmezard/go-difflib/difflib",
+    "github.com/prometheus/client_golang/api",
+    "github.com/prometheus/client_golang/api/prometheus/v1",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/prometheus/common/model",
+    "github.com/robfig/cron",
+    "github.com/ugorji/go/codec/codecgen",
+    "github.com/urfave/cli",
+    "github.com/vmware/govmomi",
+    "github.com/vmware/govmomi/find",
+    "github.com/vmware/govmomi/simulator",
+    "github.com/vmware/govmomi/vim25/types",
+    "golang.org/x/crypto/ssh",
+    "golang.org/x/oauth2",
+    "gopkg.in/yaml.v2",
+    "k8s.io/api/apps/v1",
+    "k8s.io/api/batch/v1",
+    "k8s.io/api/batch/v1beta1",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/policy/v1beta1",
+    "k8s.io/api/rbac/v1",
+    "k8s.io/api/rbac/v1beta1",
+    "k8s.io/apimachinery/pkg/api/equality",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/apimachinery/registered",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/diff",
+    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/json",
+    "k8s.io/apimachinery/pkg/util/jsonmergepatch",
+    "k8s.io/apimachinery/pkg/util/net",
+    "k8s.io/apimachinery/pkg/util/rand",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/sets",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/util/yaml",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/informers",
+    "k8s.io/client-go/informers/apps/v1",
+    "k8s.io/client-go/informers/batch/v1beta1",
+    "k8s.io/client-go/informers/core/v1",
+    "k8s.io/client-go/informers/extensions/v1beta1",
+    "k8s.io/client-go/informers/policy/v1beta1",
+    "k8s.io/client-go/informers/rbac/v1",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/fake",
+    "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/listers/apps/v1",
+    "k8s.io/client-go/listers/batch/v1beta1",
+    "k8s.io/client-go/listers/core/v1",
+    "k8s.io/client-go/listers/extensions/v1beta1",
+    "k8s.io/client-go/listers/policy/v1beta1",
+    "k8s.io/client-go/listers/rbac/v1",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/clientcmd/api",
+    "k8s.io/client-go/tools/clientcmd/api/v1",
+    "k8s.io/client-go/tools/leaderelection",
+    "k8s.io/client-go/tools/leaderelection/resourcelock",
+    "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/util/cert",
+    "k8s.io/client-go/util/cert/triple",
+    "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/integer",
+    "k8s.io/client-go/util/jsonpath",
+    "k8s.io/client-go/util/retry",
+    "k8s.io/client-go/util/workqueue",
+    "k8s.io/code-generator/cmd/client-gen",
+    "k8s.io/code-generator/cmd/deepcopy-gen",
+    "k8s.io/gengo/examples/defaulter-gen/generators",
+    "k8s.io/kubernetes/pkg/printers",
+    "vbom.ml/util/sortorder",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -2,20 +2,17 @@
 
 
 [[projects]]
-  digest = "1:9a6a08919845856ce9891445717f8e1d9f016647e2e5136a4607d80773ceb8c9"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "services/compute/mgmt/2018-04-01/compute",
     "services/network/mgmt/2018-04-01/network",
     "services/resources/mgmt/2018-02-01/resources",
-    "version",
+    "version"
   ]
-  pruneopts = "NUT"
   revision = "fbe7db0e3f9793ba3e5704efbab84f51436c136e"
   version = "v18.0.0"
 
 [[projects]]
-  digest = "1:b727ed6314141ef75a77f5dcfc8043cdcc74bc6a0a65eef6830710f85b333415"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -24,77 +21,59 @@
     "autorest/azure/auth",
     "autorest/date",
     "autorest/to",
-    "autorest/validation",
+    "autorest/validation"
   ]
-  pruneopts = "NUT"
   revision = "1f7cd6cfe0adea687ad44a512dfe76140f804318"
   version = "v10.12.0"
 
 [[projects]]
-  digest = "1:44ba3152ffe15e49d62050dffc6e68543a0d641e4dcf94ee715ad687c3a648ed"
   name = "github.com/Masterminds/semver"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "15d8430ab86497c5c0da827b748823945e1cf1e1"
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:488fed6de34b17a9126520d2681885360bba914cc5a4667c027aec85f46f418c"
   name = "github.com/Masterminds/sprig"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b217b9c388de2cacde4354c536e520c52c055563"
   version = "v2.14.1"
 
 [[projects]]
-  digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  digest = "1:dfc48e1a293a468126069586733806f62cbf485d87780881ea9106cdb68d38bb"
   name = "github.com/ajeddeloh/yaml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "6b94386aeefd8c4b8470aee72bfca084c2f91da9"
 
 [[projects]]
   branch = "master"
-  digest = "1:fdd419e104ec26bb5bd63cc62637c640453ed2929a7453f3afadbd9a0223da66"
   name = "github.com/alecthomas/units"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
-  digest = "1:975108e8d4f5dab096fc991326e96a5716ee8d02e5e7386bb4796171afc4ab9a"
   name = "github.com/aokoli/goutils"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3391d3790d23d03408670993e957e8f408993c34"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:2ca151c1203d07f3fca238e42bffbbf7525089585365070c4eff5bcbeaa951e1"
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "521b25f4b05fd26bec69d9dedeb8f9c9a83939a8"
   version = "v8"
 
 [[projects]]
-  digest = "1:7486450c6b7e0ff70ecb6ed087f2d78785114f21a4af541e4abe3fde51610273"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -122,22 +101,18 @@
     "private/protocol/xml/xmlutil",
     "service/ec2",
     "service/iam",
-    "service/sts",
+    "service/sts"
   ]
-  pruneopts = "NUT"
   revision = "c9b25d6bfa986ab6d195479871a96e81b8882536"
   version = "v1.12.77"
 
 [[projects]]
   branch = "master"
-  digest = "1:cb0535f5823b47df7dcb9768ebb6c000b79ad115472910c70efe93c9ed9b2315"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  pruneopts = "NUT"
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
-  digest = "1:15173ac9caac43ba3a8990716158f5fd08174293e259d0a9e67f6fc98cc39d35"
   name = "github.com/coreos/container-linux-config-transpiler"
   packages = [
     "config",
@@ -146,197 +121,153 @@
     "config/templating",
     "config/types",
     "config/types/util",
-    "internal/util",
+    "internal/util"
   ]
-  pruneopts = "NUT"
   revision = "b76ab0b2d66ff1ac6902f4fe118a02c1bed6e5ce"
   version = "v0.6.1"
 
 [[projects]]
-  digest = "1:8971ecb1f298af578992bccbc7e68f614fe8a2d00d2264b7261e52119c0074a4"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "a4973d9a4225417aecf5d450a9522f00c1f7130f"
 
 [[projects]]
-  digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
   name = "github.com/coreos/go-semver"
   packages = ["semver"]
-  pruneopts = "NUT"
   revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:fc8dac286d0071a9b7baccef9d02b96c8401c362446304ca686552d2c7979ffb"
   name = "github.com/coreos/go-systemd"
   packages = ["unit"]
-  pruneopts = "NUT"
   revision = "40e2722dffead74698ca12a750f64ef313ddce05"
   version = "v16"
 
 [[projects]]
-  digest = "1:6ce6e7cdfb6c329c9410b16c0ec8ceabeb9eb3aaf83749c54cf4565e3471c75f"
   name = "github.com/coreos/ignition"
   packages = [
     "config/v2_1/types",
     "config/validate",
     "config/validate/astnode",
-    "config/validate/report",
+    "config/validate/report"
   ]
-  pruneopts = "NUT"
   revision = "65f3f407178537b32d6075d042dea3a8fa9be501"
   version = "v0.22.0"
 
 [[projects]]
-  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
-  digest = "1:219fef6e3f42a62ace57a4e912037da38b19b4e3f68db549703cd329cc1d3b62"
   name = "github.com/digitalocean/godo"
   packages = [
     ".",
-    "context",
+    "context"
   ]
-  pruneopts = "NUT"
   revision = "77ea48de76a7b31b234d854f15d003c68bb2fb90"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:ec6271918b59b872a2d25e374569a4f75f1839d91e4191470c297b7eaaaf7641"
   name = "github.com/dimchansky/utfbom"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "6c6132ff69f0f6c088739067407b5d32c52e1d0f"
 
 [[projects]]
   branch = "master"
-  digest = "1:b7ffca49e9cfd3dfb04a8e0a59347708c6f78f68476a32c5e0a0edca5d1b258c"
   name = "github.com/dustin/go-humanize"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "02af3965c54e8cacf948b97fef38925c4120652c"
 
 [[projects]]
   branch = "master"
-  digest = "1:e8ffe2fb7368f65afaaf39769207bee2a7aeddf694e94f5bc05cffd750d4d98d"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "944e07253867aacae43c04b2e6a239005443f33a"
 
 [[projects]]
-  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
-  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:0c0eac431b07bd0da31ef684aa15b5b5eeeda8a820f666e6523d2bfb8ce868c4"
   name = "github.com/go-ini/ini"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
   version = "v1.32.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:678872f6a7d7fd8a855bb7bffd8e25de7c0d0b1868fe98af998ea2dbd83f29c9"
   name = "github.com/go-kit/kit"
   packages = [
     "endpoint",
     "log",
-    "transport/http",
+    "transport/http"
   ]
-  pruneopts = "NUT"
   revision = "286fe7a0709da897bcafd638ca80289af53d40af"
 
 [[projects]]
-  digest = "1:341a7df38da99fe91ed40e4008c13cc5d02dcc98ed1a094360cb7d5df26d6d26"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:d289fd98f0644f49f48910414ae9d4d50c169c4bdb09a91a1033427dc3f14e19"
   name = "github.com/go-openapi/analysis"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "f59a71f0ece6f9dfb438be7f45148f006cbad88e"
 
 [[projects]]
   branch = "master"
-  digest = "1:548f27fc69956ab8e5d513f990c31be0281ae0f6b9dc9493668e3274d7c371cd"
   name = "github.com/go-openapi/errors"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "7bcb96a367bac6b76e6e42fa84155bb5581dcff8"
 
 [[projects]]
   branch = "master"
-  digest = "1:feb16e4f0db0ca6111a5e1db7de9d50b49a5d1e49d1291508fa64ae8b18bd3b3"
   name = "github.com/go-openapi/inflect"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b1f6470ffb9c552dc105dd869f16e36ba86ba7d0"
 
 [[projects]]
   branch = "master"
-  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "779f45308c19820f1a69e9a4cd965f496e0da10f"
 
 [[projects]]
   branch = "master"
-  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "36d33bfe519efae5632669801b180bf1a245da3b"
 
 [[projects]]
   branch = "master"
-  digest = "1:3662a468030f6c819d695462664761f393908115314ef7af2742c44d0fe655ff"
   name = "github.com/go-openapi/loads"
   packages = [
     ".",
-    "fmts",
+    "fmts"
   ]
-  pruneopts = "NUT"
   revision = "2a2b323bab96e6b1fdee110e57d959322446e9c9"
 
 [[projects]]
   branch = "master"
-  digest = "1:785556d6f0960679d4953b126e839265375479b49d0b8b19e774f501d62071eb"
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
@@ -345,54 +276,42 @@
     "middleware/denco",
     "middleware/header",
     "middleware/untyped",
-    "security",
+    "security"
   ]
-  pruneopts = "NUT"
   revision = "09fac855d8504674b22594470227bd94e5005025"
 
 [[projects]]
   branch = "master"
-  digest = "1:5915a91a5943a55e0c1cf1df04f6c22c6a942cd2792efe38c844f97b89aa40d8"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "1de3e0542de65ad8d75452a595886fdd0befb363"
 
 [[projects]]
   branch = "master"
-  digest = "1:41638dcba4ce0e798b30b72d708e7408ec2003fabf35af114c515c0e2a3ccf60"
   name = "github.com/go-openapi/strfmt"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "6d1a47fad79c81e8cd732889cb80e91123951860"
 
 [[projects]]
   branch = "master"
-  digest = "1:815448d1f6ec4496678dbfa951df7272e3baf68e3ce5958b59e1141e60d2e2bc"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "84f4bee7c0a6db40e3166044c7983c1c32125429"
 
 [[projects]]
   branch = "master"
-  digest = "1:2ac8d2f1e4b1845defdd1a431ccca1034e8d68199b059f7121a6576849f1441f"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "1ff04bd4a6c8a4af5813bd5bf3dc24c4756b9ee2"
 
 [[projects]]
-  digest = "1:a1efdbc2762667c8a41cbf02b19a0549c846bf2c1d08cad4f445e3344089f1f0"
   name = "github.com/go-stack/stack"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c1d1044d9c50ac6db29b3d327b17ba12f77436f0a37405968e8a10f012f24828"
   name = "github.com/go-swagger/go-swagger"
   packages = [
     "cmd/swagger",
@@ -400,99 +319,79 @@
     "cmd/swagger/commands/generate",
     "cmd/swagger/commands/initcmd",
     "generator",
-    "scan",
+    "scan"
   ]
-  pruneopts = "NUT"
   revision = "95766d38e23b428e01b6d165b5947467d71f1c59"
 
 [[projects]]
-  digest = "1:3c04690dd1d3fad9a36c492c32863fad91bcf822fd95d5c4cae97be1e9abc361"
   name = "github.com/go-test/deep"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "6592d9cc0a499ad2d5f574fde80a2b5c5cc3b4f5"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:1b3dd24f14a5280710fc7a3aa2480b6e4d20fdfc905841de9a3aa2aa2f1d4ee9"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys",
+    "sortkeys"
   ]
-  pruneopts = "NUT"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
-  digest = "1:3fb07f8e222402962fa190eb060608b34eddfb64562a18e2167df2de0ece85d8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
-  pruneopts = "NUT"
   revision = "66deaeb636dff1ac7d938ce666d090556056a4b0"
 
 [[projects]]
-  digest = "1:d470faddd8d4b027226f9a5ff9d88962c34bb1699dde2acd7e9bfb70a3703d45"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "NUT"
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
   packages = ["query"]
-  pruneopts = "NUT"
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
   branch = "master"
-  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:1bb197a3b5db4e06e00b7560f8e89836c486627f2a0338332ed37daa003d259e"
   name = "github.com/google/uuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "064e2069ce9c359c118179501254f67d7d37ba24"
   version = "0.2"
 
 [[projects]]
-  digest = "1:3d7c1446fc5c710351b246c0dc6700fae843ca27f5294d0bd9f68bab2a810c44"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
-  pruneopts = "NUT"
   revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c549bd4ec595922d02aeae0a7abfa1604c85fc5071a7f9aae9a1fbeac67988ab"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -520,49 +419,39 @@
     "openstack/networking/v2/ports",
     "openstack/networking/v2/subnets",
     "openstack/utils",
-    "pagination",
+    "pagination"
   ]
-  pruneopts = "NUT"
   revision = "19abc56a8cd8d3630ab9735173cb92c0bf635f33"
 
 [[projects]]
-  digest = "1:dbd86d229eacaa86a98b10f8fb3e3fc69a1913e0f4e010e7cc1f92bf12edca92"
   name = "github.com/gorilla/context"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
-  digest = "1:fe47be2bd5d0196679d314fcc6e02f40a51e641c09e1541528a05cccefee9b0e"
   name = "github.com/gorilla/handlers"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "90663712d74cb411cbef281bc1e08c19d1a76145"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:eced3d718020962f1cc6ac109b840ba17dc817a291062b5948ba7aecc8c6665d"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
   version = "v1.6.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = "NUT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
-  digest = "1:9d28dd6ad84cf6c3e47e36b50761fb5092922a3ff15e775094d1694cb0deb64e"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -574,95 +463,73 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token",
+    "json/token"
   ]
-  pruneopts = "NUT"
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
-  digest = "1:7e4ef12bb4999fd90fd97b887964ac2278b168882217fccc0a183b1e8786daa8"
   name = "github.com/hetznercloud/hcloud-go"
   packages = [
     "hcloud",
-    "hcloud/schema",
+    "hcloud/schema"
   ]
-  pruneopts = "NUT"
   revision = "b37849e439d7a02b07d495f65e7b797bec30eeae"
   version = "v1.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:b7f860847a1d71f925ba9385ed95f1ebc0abfeb418a78e219ab61f48fdfeffad"
   name = "github.com/howeyc/gopass"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
   branch = "master"
-  digest = "1:f5db19d350bd0b542d17f7e7cf4e7068bac416c08adb6a129b3c6d1db8211051"
   name = "github.com/huandu/xstrings"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2bf18b218c51864a87384c06996e40ff9dcff8e1"
 
 [[projects]]
-  digest = "1:cf327083982a19eae01f70be6663a935a02bac3a2dc79efbc19668c8378bfbb3"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
   version = "0.3.2"
 
 [[projects]]
-  digest = "1:914f8eaa63b88fe6bcd656d81b3f3ccd2e8422df1787a6abe32554e4b75c0556"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "96dc06278ce32a0e9d957d590bb987c81ee66407"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:ac6d01547ec4f7f673311b4663909269bfb8249952de3279799289467837c3cc"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0b12d6b5"
 
 [[projects]]
-  digest = "1:513a04aad83573e78b933cdf7df1a289227702c574b500de8de386e83b811138"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = "N"
   revision = "28452fcdec4e44348d2af0d91d1e9e38da3a9e0a"
   version = "1.0.5"
 
 [[projects]]
   branch = "master"
-  digest = "1:f91bb67d051a94cf6ab2cf07eee0550432afc31655838d42cdec258db4b348f0"
   name = "github.com/kr/logfmt"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
   branch = "master"
-  digest = "1:7b21c7fc5551b46d1308b4ffa9e9e49b66c7a8b0ba88c0130474b0e7a20d859f"
   name = "github.com/kr/pretty"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "cfb55aafdaf3ec08f0db22699ab822c50091b1c4"
 
 [[projects]]
   branch = "master"
-  digest = "1:c3a7836b5904db0f8b609595b619916a6831cb35b8b714aec39f96d00c6155d8"
   name = "github.com/kr/text"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "7cafcd837844e784b526369c9bce262804aebc60"
 
 [[projects]]
-  digest = "1:4cbbd64e7839abea9fec2e10f57f5a01697b4859e2dedc8d2233690b5c4f67af"
   name = "github.com/kubermatic/machine-controller"
   packages = [
     "pkg/client/clientset/versioned",
@@ -688,42 +555,34 @@
     "pkg/userdata/cloud",
     "pkg/userdata/coreos",
     "pkg/userdata/helper",
-    "pkg/userdata/ubuntu",
+    "pkg/userdata/ubuntu"
   ]
-  pruneopts = "NUT"
   revision = "2e0d2f0875316755ac1a8dbc3b61d2110abf5968"
   version = "v0.7.13"
 
 [[projects]]
-  digest = "1:35e5598ba3bc950039e13d91958ce37f675264735907cada569d11b243e5cacb"
   name = "github.com/magiconair/properties"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
   version = "v1.7.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:cdf13ca0f5df719f31c0b466578feba0837bd6bb0aea95b3981a307844803704"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
-  pruneopts = "NUT"
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
-  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  pruneopts = "NUT"
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:4812a87744ebaa12373e5b8fad9097de9f72c1947b06984708940e07dc8cbaf0"
   name = "github.com/minio/minio-go"
   packages = [
     ".",
@@ -731,234 +590,182 @@
     "pkg/encrypt",
     "pkg/s3signer",
     "pkg/s3utils",
-    "pkg/set",
+    "pkg/set"
   ]
-  pruneopts = "NUT"
   revision = "c6108c47ba5d86548404ebf9e51c5ca18769fe79"
   version = "6.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:9db29b604bd78452d167abed82386ddd2f93973df3841896fb6ab8aff936f1d6"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
 
 [[projects]]
   branch = "master"
-  digest = "1:4b9dacaf3496e8bd82173b88c38004028a103b03ddd2de15a0a108f04619e00b"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "a4e142e9c047c904fa2f1e144d9a84e6133024bc"
 
 [[projects]]
-  digest = "1:3b517122f3aad1ecce45a630ea912b3092b4729f25532a911d0cb2935a1f9352"
   name = "github.com/oklog/run"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:cce3a18fb0b96b5015cd8ca03a57d20a662679de03c4dc4b6ff5f17ea2050fa6"
   name = "github.com/pborman/uuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
-  digest = "1:13b8f1a2ce177961dc9231606a52f709fab896c565f3988f60a7f6b4e543a902"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:0390d3bc2c954487663318db748434d5e8bbfde8ac890070c15f3eab619f2ea8"
   name = "github.com/pquerna/cachecontrol"
   packages = [
     ".",
-    "cacheobject",
+    "cacheobject"
   ]
-  pruneopts = "NUT"
   revision = "0dec1b30a0215bb68605dfc568e8855066c9202d"
 
 [[projects]]
   branch = "master"
-  digest = "1:a535acb64f8dfaac6fa6b4a93119d937524741eda1fe7df257efadc4c3c23b12"
   name = "github.com/prometheus/client_golang"
   packages = [
     "api",
     "api/prometheus/v1",
     "prometheus",
-    "prometheus/promhttp",
+    "prometheus/promhttp"
   ]
-  pruneopts = "NUT"
   revision = "82f5ff156b29e276022b1a958f7d385870fb9814"
 
 [[projects]]
   branch = "master"
-  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  pruneopts = "NUT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
-  digest = "1:4a6bb73eb5d7b8e67f25d22d87c84116cc69dfa80299dfd06622b8eee47917a8"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model",
+    "model"
   ]
-  pruneopts = "NUT"
   revision = "89604d197083d4781071d3c65855d24ecfb0a563"
 
 [[projects]]
   branch = "master"
-  digest = "1:b2f81139ed70ba4358171bc3024a5f2a3a9d2148ccc3fff03e3a011afe9b7543"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs",
+    "xfs"
   ]
-  pruneopts = "NUT"
   revision = "282c8707aa210456a825798969cc27edda34992a"
 
 [[projects]]
-  digest = "1:53c3320ee307f01fd24a88e396a8d2239cd8346d1a085320209319f2d33f59cc"
   name = "github.com/robfig/cron"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b41be1df696709bb6395fe435af20370037c0b4c"
   version = "v1.1"
 
 [[projects]]
-  digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:6989062eb7ccf25cf38bf4fe3dba097ee209f896cda42cefdca3927047bef7b6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
-  digest = "1:39da3da7a735176ff518f7a6d8de9e4e03cb760dc7ef0b7b8dae6fc61406295c"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem",
+    "mem"
   ]
-  pruneopts = "NUT"
   revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:3fa7947ca83b98ae553590d993886e845a4bff19b7b007e869c6e0dd3b9da9cd"
   name = "github.com/spf13/cast"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:f29f83301ed096daed24a90f4af591b7560cb14b9cc3e1827abbf04db7269ab5"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
-  digest = "1:3ab855aa584d08db6541ce99dad60c12bd6a328ecb8a7358363887f85c976347"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3327c8113e7c4c420ea01123c73a5bf9fe79cf9de201d4bf4761a8b0fc5b31a4"
   name = "github.com/spf13/viper"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5"
 
 [[projects]]
   branch = "master"
-  digest = "1:a0aee89faaf795424d978b6b4bcee4af3dc71f5680e5e1b30bd1528639e61a9a"
   name = "github.com/tent/http-link-go"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ac974c61c2f990f4115b119354b5e0b47550e888"
 
 [[projects]]
-  digest = "1:1f639e0ef8074e69314d01b90c2d6babe369a35fa421d454781ed1075585ddd7"
   name = "github.com/toqueteos/webbrowser"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3232c91b8ede8ca86e8962981d881af78875542f"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:df3d534f7b987f63a7076f86d9a2abd1c3f10d0236245405ba5cbb376511f80e"
   name = "github.com/tylerb/graceful"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb"
   version = "v1.2.15"
 
 [[projects]]
-  digest = "1:b7e175082fbe862fe0267c9c55043ac5f836dc70069b6fd44f4657e0eee80f4e"
   name = "github.com/ugorji/go"
   packages = ["codec/codecgen"]
-  pruneopts = "NUT"
   revision = "9831f2c3ac1068a78f50999a30db84270f647af6"
   version = "v1.1"
 
 [[projects]]
-  digest = "1:5dba68a1600a235630e208cb7196b24e58fcbb77bb7a6bec08fcd23f081b0a58"
   name = "github.com/urfave/cli"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c9b456727ce4101594aabddaa816c80464cd21a1e5fcd145297a902303be0085"
   name = "github.com/vincent-petithory/dataurl"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9a301d65acbb728fcc3ace14f45f511a4cfeea9c"
 
 [[projects]]
-  digest = "1:5ebb30264b7ca0203560b0706405e09fab8677e847d3739d1a409f62d251a585"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -979,15 +786,13 @@
     "vim25/progress",
     "vim25/soap",
     "vim25/types",
-    "vim25/xml",
+    "vim25/xml"
   ]
-  pruneopts = "NUT"
   revision = "123ed177021588bac57b5c87c1a84270ddf2eca8"
   version = "v0.17.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:e444d860fba00b1b9adb8c1156460e5700ce90063f5d315719689298a88d361b"
   name = "golang.org/x/crypto"
   packages = [
     "argon2",
@@ -1002,14 +807,12 @@
     "poly1305",
     "scrypt",
     "ssh",
-    "ssh/terminal",
+    "ssh/terminal"
   ]
-  pruneopts = "NUT"
   revision = "650f4a345ab4e5b245a3034b110ebc7299e68186"
 
 [[projects]]
   branch = "master"
-  digest = "1:d0265dccbb98193d3e4fc66d31cadb1f35f6369db499b84ad87e5e3567b8a562"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -1017,36 +820,30 @@
     "http2",
     "http2/hpack",
     "idna",
-    "lex/httplex",
+    "lex/httplex"
   ]
-  pruneopts = "NUT"
   revision = "f5dfe339be1d06f81b22525fe34671ee7d2c8904"
 
 [[projects]]
   branch = "master"
-  digest = "1:f058f3811608b1c83a5939072f4e94b443a104e383137fd6b8e535e26e8abe31"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal",
+    "internal"
   ]
-  pruneopts = "NUT"
   revision = "543e37812f10c46c622c9575afd7ad22f22a12ba"
 
 [[projects]]
   branch = "master"
-  digest = "1:4301a4973691694236c322c1ed32273b7d42dbff3cd2d0bbb7b06f233edfbd8e"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "NUT"
   revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
   branch = "master"
-  digest = "1:e33513a825fcd765e97b5de639a2f7547542d1a8245df0cef18e1fd390b778a9"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -1063,34 +860,28 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width",
+    "width"
   ]
-  pruneopts = "NUT"
   revision = "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1"
 
 [[projects]]
   branch = "master"
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = "NUT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
-  digest = "1:3cbc05413b8aac22b1f6d4350ed696b5a83a8515a4136db8f1ec3a0aee3d76e1"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "go/buildutil",
     "go/loader",
-    "imports",
+    "imports"
   ]
-  pruneopts = "NUT"
   revision = "ce871d178848e3eea1e8795e5cfb74053dde4bb9"
 
 [[projects]]
-  digest = "1:f229c599a645bffd97518107ac89955adfa6d5e5e4efa3e8cadb29789219639f"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -1099,54 +890,44 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
-  pruneopts = "NUT"
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:ef72505cf098abdd34efeea032103377bec06abb61d8a06f002d5d296a4b1185"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
   version = "v0.9.0"
 
 [[projects]]
   branch = "v2"
-  digest = "1:9e8ac8aa4f4c5557ba0b03a55d407b07b7030ed552b437a9dc7e5ec90f16ab39"
   name = "gopkg.in/mgo.v2"
   packages = [
     "bson",
-    "internal/json",
+    "internal/json"
   ]
-  pruneopts = "NUT"
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [[projects]]
-  digest = "1:986d8ff4c7da85fc3e1ac8cdbceda5fe91575443fb362d2cbe3d6f8bff5f9cbe"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
     "cipher",
-    "json",
+    "json"
   ]
-  pruneopts = "NUT"
   revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
   version = "v2.1.3"
 
 [[projects]]
   branch = "v2"
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
 
 [[projects]]
   branch = "release-1.10"
-  digest = "1:f541c95b242bf41dc42ba035d66e7d240c1e8c7ccd45480f81c6526237d0b940"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -1176,14 +957,12 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
-  pruneopts = "NUT"
   revision = "edd5e319fc45211023fffb41c7aa5555229c4179"
 
 [[projects]]
   branch = "release-1.10"
-  digest = "1:77ead159dd31d230f6b72649f69371d2688b281827738d58f37705a6a5246889"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1231,14 +1010,12 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
-  pruneopts = "NUT"
   revision = "01bc873149a1802eb74df583613872d126449ed5"
 
 [[projects]]
   branch = "release-7.0"
-  digest = "1:05a01401f8bce5f617c04bbca4ef32ab2427a3ce67db78d58802287c4ccaef3c"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1395,14 +1172,12 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
-    "util/workqueue",
+    "util/workqueue"
   ]
-  pruneopts = "NUT"
   revision = "33f2870a2b83179c823ddc90e5513f9e5fe43b38"
 
 [[projects]]
   branch = "release-1.10"
-  digest = "1:d2e7c34c2fb82f8274484d88f76a9af01f366a554d3f8d4b9a696448d43a7b4c"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -1415,13 +1190,11 @@
     "cmd/client-gen/types",
     "cmd/deepcopy-gen",
     "cmd/deepcopy-gen/args",
-    "pkg/util",
+    "pkg/util"
   ]
-  pruneopts = "T"
   revision = "cbd9dba38c3d8e0035d4bb554bd321e2c190e629"
 
 [[projects]]
-  digest = "1:721053d09232080be6cc67720e51b6137e235afcbd3229942e6486b6d7c37db6"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -1431,181 +1204,31 @@
     "generator",
     "namer",
     "parser",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "b6c426f7730e6d66e6e476a85d1c3eb7633880e0"
 
 [[projects]]
   branch = "master"
-  digest = "1:e0d6dcb28c42a53c7243bb6380badd17f92fbd8488a075a07e984f91a07c0d23"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
-  pruneopts = "NUT"
   revision = "275e2ce91dec4c05a4094a7b1daee5560b555ac9"
 
 [[projects]]
-  digest = "1:623c67408d8d837f34ca8aca6382b1eb3c40caab10f4ad7ebeeeb8f1d1f94c44"
   name = "k8s.io/kubernetes"
   packages = ["pkg/printers"]
-  pruneopts = "NUT"
   revision = "32ac1c9073b132b8ba18aa830f46b77dcceb0723"
   version = "v1.10.5"
 
 [[projects]]
   branch = "master"
-  digest = "1:2385d1bef8989a5f919a71efee3f337df3f0ad7b29ee23204b5614aad3e3f577"
   name = "vbom.ml/util"
   packages = ["sortorder"]
-  pruneopts = "NUT"
   revision = "256737ac55c46798123f754ab7d2c784e2c71783"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute",
-    "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network",
-    "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources",
-    "github.com/Azure/go-autorest/autorest",
-    "github.com/Azure/go-autorest/autorest/azure/auth",
-    "github.com/Azure/go-autorest/autorest/to",
-    "github.com/Masterminds/semver",
-    "github.com/Masterminds/sprig",
-    "github.com/aws/aws-sdk-go/aws",
-    "github.com/aws/aws-sdk-go/aws/awserr",
-    "github.com/aws/aws-sdk-go/aws/credentials",
-    "github.com/aws/aws-sdk-go/aws/session",
-    "github.com/aws/aws-sdk-go/service/ec2",
-    "github.com/aws/aws-sdk-go/service/iam",
-    "github.com/coreos/go-oidc",
-    "github.com/davecgh/go-spew/spew",
-    "github.com/digitalocean/godo",
-    "github.com/ghodss/yaml",
-    "github.com/go-kit/kit/endpoint",
-    "github.com/go-kit/kit/log",
-    "github.com/go-kit/kit/transport/http",
-    "github.com/go-swagger/go-swagger/cmd/swagger",
-    "github.com/go-test/deep",
-    "github.com/golang/glog",
-    "github.com/gophercloud/gophercloud",
-    "github.com/gophercloud/gophercloud/openstack",
-    "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
-    "github.com/gophercloud/gophercloud/openstack/identity/v3/projects",
-    "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-    "github.com/gophercloud/gophercloud/openstack/identity/v3/users",
-    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external",
-    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
-    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules",
-    "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
-    "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
-    "github.com/gophercloud/gophercloud/pagination",
-    "github.com/gorilla/handlers",
-    "github.com/gorilla/mux",
-    "github.com/hetznercloud/hcloud-go/hcloud",
-    "github.com/kubermatic/machine-controller/pkg/client/clientset/versioned",
-    "github.com/kubermatic/machine-controller/pkg/client/clientset/versioned/fake",
-    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws",
-    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure",
-    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean",
-    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/hetzner",
-    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack",
-    "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere",
-    "github.com/kubermatic/machine-controller/pkg/containerruntime",
-    "github.com/kubermatic/machine-controller/pkg/machines/v1alpha1",
-    "github.com/kubermatic/machine-controller/pkg/providerconfig",
-    "github.com/kubermatic/machine-controller/pkg/userdata/centos",
-    "github.com/kubermatic/machine-controller/pkg/userdata/coreos",
-    "github.com/kubermatic/machine-controller/pkg/userdata/ubuntu",
-    "github.com/minio/minio-go",
-    "github.com/oklog/run",
-    "github.com/pmezard/go-difflib/difflib",
-    "github.com/prometheus/client_golang/api",
-    "github.com/prometheus/client_golang/api/prometheus/v1",
-    "github.com/prometheus/client_golang/prometheus",
-    "github.com/prometheus/client_golang/prometheus/promhttp",
-    "github.com/prometheus/common/model",
-    "github.com/robfig/cron",
-    "github.com/ugorji/go/codec/codecgen",
-    "github.com/urfave/cli",
-    "github.com/vmware/govmomi",
-    "github.com/vmware/govmomi/find",
-    "github.com/vmware/govmomi/simulator",
-    "github.com/vmware/govmomi/vim25/types",
-    "golang.org/x/crypto/ssh",
-    "golang.org/x/oauth2",
-    "gopkg.in/yaml.v2",
-    "k8s.io/api/apps/v1",
-    "k8s.io/api/batch/v1",
-    "k8s.io/api/batch/v1beta1",
-    "k8s.io/api/core/v1",
-    "k8s.io/api/policy/v1beta1",
-    "k8s.io/api/rbac/v1",
-    "k8s.io/api/rbac/v1beta1",
-    "k8s.io/apimachinery/pkg/api/equality",
-    "k8s.io/apimachinery/pkg/api/errors",
-    "k8s.io/apimachinery/pkg/api/meta",
-    "k8s.io/apimachinery/pkg/api/resource",
-    "k8s.io/apimachinery/pkg/apimachinery/registered",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-    "k8s.io/apimachinery/pkg/labels",
-    "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/schema",
-    "k8s.io/apimachinery/pkg/runtime/serializer",
-    "k8s.io/apimachinery/pkg/types",
-    "k8s.io/apimachinery/pkg/util/diff",
-    "k8s.io/apimachinery/pkg/util/intstr",
-    "k8s.io/apimachinery/pkg/util/json",
-    "k8s.io/apimachinery/pkg/util/jsonmergepatch",
-    "k8s.io/apimachinery/pkg/util/net",
-    "k8s.io/apimachinery/pkg/util/rand",
-    "k8s.io/apimachinery/pkg/util/runtime",
-    "k8s.io/apimachinery/pkg/util/sets",
-    "k8s.io/apimachinery/pkg/util/wait",
-    "k8s.io/apimachinery/pkg/util/yaml",
-    "k8s.io/apimachinery/pkg/watch",
-    "k8s.io/client-go/discovery",
-    "k8s.io/client-go/discovery/fake",
-    "k8s.io/client-go/informers",
-    "k8s.io/client-go/informers/apps/v1",
-    "k8s.io/client-go/informers/batch/v1beta1",
-    "k8s.io/client-go/informers/core/v1",
-    "k8s.io/client-go/informers/extensions/v1beta1",
-    "k8s.io/client-go/informers/policy/v1beta1",
-    "k8s.io/client-go/informers/rbac/v1",
-    "k8s.io/client-go/kubernetes",
-    "k8s.io/client-go/kubernetes/fake",
-    "k8s.io/client-go/kubernetes/scheme",
-    "k8s.io/client-go/kubernetes/typed/core/v1",
-    "k8s.io/client-go/listers/apps/v1",
-    "k8s.io/client-go/listers/batch/v1beta1",
-    "k8s.io/client-go/listers/core/v1",
-    "k8s.io/client-go/listers/extensions/v1beta1",
-    "k8s.io/client-go/listers/policy/v1beta1",
-    "k8s.io/client-go/listers/rbac/v1",
-    "k8s.io/client-go/rest",
-    "k8s.io/client-go/testing",
-    "k8s.io/client-go/tools/cache",
-    "k8s.io/client-go/tools/clientcmd",
-    "k8s.io/client-go/tools/clientcmd/api",
-    "k8s.io/client-go/tools/clientcmd/api/v1",
-    "k8s.io/client-go/tools/leaderelection",
-    "k8s.io/client-go/tools/leaderelection/resourcelock",
-    "k8s.io/client-go/tools/record",
-    "k8s.io/client-go/util/cert",
-    "k8s.io/client-go/util/cert/triple",
-    "k8s.io/client-go/util/flowcontrol",
-    "k8s.io/client-go/util/integer",
-    "k8s.io/client-go/util/jsonpath",
-    "k8s.io/client-go/util/retry",
-    "k8s.io/client-go/util/workqueue",
-    "k8s.io/code-generator/cmd/client-gen",
-    "k8s.io/code-generator/cmd/deepcopy-gen",
-    "k8s.io/gengo/examples/defaulter-gen/generators",
-    "k8s.io/kubernetes/pkg/printers",
-    "vbom.ml/util/sortorder",
-  ]
+  inputs-digest = "047cfbcc9787f363ac428c33ee888b74a33cb2ee2d41edd34840eacc860f7749"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -56,13 +56,9 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	}
 
 	set.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-		Name:   name,
-		Labels: podLabels,
-		Annotations: map[string]string{
-			"prometheus.io/scrape": "true",
-			"prometheus.io/path":   "/metrics",
-			"prometheus.io/port":   "2379",
-		},
+		Name:        name,
+		Labels:      podLabels,
+		Annotations: map[string]string{},
 	}
 
 	// For migration purpose.

--- a/api/pkg/resources/etcd/tls-serving-certificate.go
+++ b/api/pkg/resources/etcd/tls-serving-certificate.go
@@ -29,7 +29,7 @@ func TLSCertificate(data *resources.TemplateData, existing *corev1.Secret) (*cor
 		return nil, fmt.Errorf("failed to get cluster ca: %v", err)
 	}
 
-	altNames := sets.NewString("127.0.0.1", "localhost", fmt.Sprintf("%s-%s.svc.cluster.local.", resources.EtcdClientServiceName, data.Cluster.Name))
+	altNames := sets.NewString("127.0.0.1", "localhost", fmt.Sprintf("%s-%s.svc.cluster.local", resources.EtcdClientServiceName, data.Cluster.Name))
 	for i := 0; i < 3; i++ {
 		// Member name
 		podName := fmt.Sprintf("etcd-%d", i)

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -51,6 +51,16 @@ global:
 rule_files:
 - "/etc/prometheus/config/rules.yaml"
 scrape_configs:
+- job_name: etcd
+  scheme: https
+  metrics_path: '/metrics'
+  static_configs:
+  - targets: ['etcd-0.etcd.{{ .Cluster.Status.NamespaceName }}.svc.cluster.local:2379','etcd-1.etcd.{{ .Cluster.Status.NamespaceName }}.svc.cluster.local:2379','etcd-2.etcd.{{ .Cluster.Status.NamespaceName }}.svc.cluster.local:2379']
+  tls_config:
+    ca_file: /etc/etcd/apiserver/ca.crt
+    cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+    key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
 - job_name: 'pods'
   kubernetes_sd_configs:
   - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.8.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.0-prometheus.yaml
@@ -9,6 +9,16 @@ data:
     rule_files:
     - "/etc/prometheus/config/rules.yaml"
     scrape_configs:
+    - job_name: etcd
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets: ['etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379','etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379']
+      tls_config:
+        ca_file: /etc/etcd/apiserver/ca.crt
+        cert_file: /etc/etcd/apiserver/apiserver-etcd-client.crt
+        key_file: /etc/etcd/apiserver/apiserver-etcd-client.key
+
     - job_name: 'pods'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
@@ -18,10 +18,6 @@ spec:
   serviceName: etcd
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "2379"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-prometheus.yaml
@@ -67,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/prometheus/data
           name: data
+        - mountPath: /etc/etcd/apiserver
+          name: apiserver-etcd-client-certificate
+          readOnly: true
       restartPolicy: Always
       securityContext:
         fsGroup: 2000
@@ -80,6 +83,10 @@ spec:
         name: config
       - emptyDir: {}
         name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          defaultMode: 256
+          secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate
 status:


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we move to client-cert authentication on the etcd, prometheus stopped scraping it.
This change will add client certificates to etcd, so it can scrape it again.

**Release note**:
```release-note
NONE
```
