### PR TITLE
Set useInstanceMetadata (azure) to false. (#1657)

### DIFF
--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -95,7 +95,8 @@ ignore-volume-az = {{ .DC.Spec.Openstack.IgnoreVolumeAZ }}
   "routeTableName": "{{ .Cluster.Spec.Cloud.Azure.RouteTableName }}",
   "securityGroupName": "{{ .Cluster.Spec.Cloud.Azure.SecurityGroup }}",
 
-  "useInstanceMetadata": true
+{{/* Consumed by apiserver and controller-manager */}}
+  "useInstanceMetadata": false
 }
 {{- end }}
 {{- if .Cluster.Spec.Cloud.VSphere }}

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-cloud-config.yaml
@@ -16,7 +16,8 @@ data:
       "routeTableName": "az-route-table-name",
       "securityGroupName": "az-sec-group",
 
-      "useInstanceMetadata": true
+
+      "useInstanceMetadata": false
     }
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-cloud-config.yaml
@@ -16,7 +16,8 @@ data:
       "routeTableName": "az-route-table-name",
       "securityGroupName": "az-sec-group",
 
-      "useInstanceMetadata": true
+
+      "useInstanceMetadata": false
     }
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-cloud-config.yaml
@@ -16,7 +16,8 @@ data:
       "routeTableName": "az-route-table-name",
       "securityGroupName": "az-sec-group",
 
-      "useInstanceMetadata": true
+
+      "useInstanceMetadata": false
     }
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:


### PR DESCRIPTION
cherry-pick from master b2c2b104fc62880d19d4ba8e66919ee99d68f1b1

Set useInstanceMetadata (azure) to false.

At least for the master components apiserver and controller-manager
it is better to always avoid using the metadata endpoint.
This change does not affect the cloud-config which goes to the
instances. That is handled by machine-controller.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
```
