### PR TITLE
add kubeconfig to addons (#1673)

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -317,6 +317,7 @@ func (c *Controller) sync(key string) error {
 
 type templateData struct {
 	Addon             *kubermaticv1.Addon
+	Kubeconfig        string
 	Cluster           *kubermaticv1.Cluster
 	Variables         map[string]interface{}
 	OverwriteRegistry string
@@ -338,10 +339,16 @@ func (c *Controller) getAddonManifests(addon *kubermaticv1.Addon, cluster *kuber
 		return nil, err
 	}
 
+	kubeconfig, err := c.KubeconfigProvider.GetAdminKubeconfig(cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	data := &templateData{
 		Variables:         make(map[string]interface{}),
 		Cluster:           cluster,
 		Addon:             addon,
+		Kubeconfig:        string(kubeconfig),
 		OverwriteRegistry: c.registryURI,
 		DNSClusterIP:      clusterIP,
 		ClusterCIDR:       cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0],

--- a/api/pkg/controller/addon/addon_controller_test.go
+++ b/api/pkg/controller/addon/addon_controller_test.go
@@ -92,6 +92,12 @@ var (
 	combinedTestManifest = fmt.Sprintf("%s---\n%s\n---\n%s", testManifest1, testManifest2, testManifest3)
 )
 
+type fakeKubeconfigProvider struct{}
+
+func (f *fakeKubeconfigProvider) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
+	return []byte("foo"), nil
+}
+
 func TestController_combineManifests(t *testing.T) {
 	controller := &Controller{}
 
@@ -167,7 +173,8 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 	}
 
 	controller := &Controller{
-		addonDir: addonDir,
+		addonDir:           addonDir,
+		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(addon, cluster)
 	if err != nil {
@@ -218,8 +225,9 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 	}
 
 	controller := &Controller{
-		addonDir:    addonDir,
-		registryURI: parceRegistryURI("bar.io"),
+		addonDir:           addonDir,
+		registryURI:        parceRegistryURI("bar.io"),
+		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(addon, cluster)
 	if err != nil {
@@ -254,7 +262,8 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 	}
 
 	controller := &Controller{
-		addonDir: addonDir,
+		addonDir:           addonDir,
+		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(addon, cluster)
 	if err != nil {
@@ -294,7 +303,8 @@ func TestController_getAddonManifests(t *testing.T) {
 	}
 
 	controller := &Controller{
-		addonDir: addonDir,
+		addonDir:           addonDir,
+		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(addon, cluster)
 	if err != nil {
@@ -317,7 +327,9 @@ func TestController_getAddonManifests(t *testing.T) {
 }
 
 func TestController_ensureAddonLabelOnManifests(t *testing.T) {
-	controller := &Controller{}
+	controller := &Controller{
+		KubeconfigProvider: &fakeKubeconfigProvider{},
+	}
 
 	manifests := []*bytes.Buffer{
 		bytes.NewBufferString(testManifest1),


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick https://github.com/kubermatic/kubermatic/pull/1673 into v2.6 release branch

**Release note**:
```release-note
Make kubeconfig available in addon manifest templating
```
