### PR TITLE
Add Prometheus and Node Exporter alerts again

### DIFF
--- a/config/monitoring/jsonnetfile.json
+++ b/config/monitoring/jsonnetfile.json
@@ -34,7 +34,7 @@
             "name": "node_exporter",
             "source": {
                 "git": {
-                    "remote": "https://github.com/tomwilkie/node_exporter",
+                    "remote": "https://github.com/metalmatze/node_exporter",
                     "subdir": "node-mixin"
                 }
             },

--- a/config/monitoring/jsonnetfile.json
+++ b/config/monitoring/jsonnetfile.json
@@ -29,6 +29,26 @@
                 }
             },
             "version": "master"
+        },
+        {
+            "name": "node_exporter",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/tomwilkie/node_exporter",
+                    "subdir": "node-mixin"
+                }
+            },
+            "version": "mixin"
+        },
+        {
+            "name": "prometheus",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/tomwilkie/prometheus",
+                    "subdir": "prometheus-mixin"
+                }
+            },
+            "version": "mixin"
         }
     ]
 }

--- a/config/monitoring/jsonnetfile.lock.json
+++ b/config/monitoring/jsonnetfile.lock.json
@@ -9,6 +9,66 @@
                 }
             },
             "version": "83f20ee933bcd13fcf4ad1b49a40c92135c5569c"
+        },
+        {
+            "name": "kubernetes-mixin",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin",
+                    "subdir": ""
+                }
+            },
+            "version": "3c341913ddd3882c8f1edc1c20accdbcaaf10525"
+        },
+        {
+            "name": "grafonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/grafana/grafonnet-lib",
+                    "subdir": "grafonnet"
+                }
+            },
+            "version": "0fdef020a6360415d2c8fdc82b29122583e4df05"
+        },
+        {
+            "name": "grafana-builder",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/kausalco/public",
+                    "subdir": "grafana-builder"
+                }
+            },
+            "version": "42f72ac60fad1022d26f1a88062689e94219d582"
+        },
+        {
+            "name": "etcd-mixin",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/coreos/etcd",
+                    "subdir": "Documentation/etcd-mixin"
+                }
+            },
+            "version": "93be31d43a2728d1750120aeae7a483698ccead2"
+        },
+        {
+            "name": "node_exporter",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/metalmatze/node_exporter",
+                    "subdir": "node-mixin"
+                }
+            },
+            "version": "0fa5ec36b73fe67d417d07b22f3fe7871ff2f615"
+        },
+        {
+            "name": "prometheus",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/tomwilkie/prometheus",
+                    "subdir": "prometheus-mixin"
+                }
+            },
+            "version": "3dc646872c0412832a2879a2a59c6acaa77aa68d"
         }
     ]
 }

--- a/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
+++ b/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
@@ -3,7 +3,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 (import './alerts/kubermatic.libsonnet') +
 (import './alerts/machine-controller.libsonnet') +
 (import 'kubernetes-mixin/mixin.libsonnet') +
-(import 'etcd-mixin/mixin.libsonnet') + {
+(import 'etcd-mixin/mixin.libsonnet') +
+(import 'prometheus/mixin.libsonnet') +
+{
   _config+:: {
     namespace: 'monitoring',
 

--- a/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
+++ b/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
@@ -5,6 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 (import 'kubernetes-mixin/mixin.libsonnet') +
 (import 'etcd-mixin/mixin.libsonnet') +
 (import 'prometheus/mixin.libsonnet') +
+(import 'node_exporter/mixin.libsonnet') +
 {
   _config+:: {
     namespace: 'monitoring',

--- a/config/monitoring/prometheus/rules/rules.yaml
+++ b/config/monitoring/prometheus/rules/rules.yaml
@@ -236,6 +236,65 @@ groups:
         node_namespace_pod:kube_pod_info:
       )
     record: node:node_net_saturation:sum_irate
+- name: node.rules
+  rules:
+  - expr: |
+      count by (instance) (
+        sum by (instance, cpu) (
+          node_cpu{app="node-exporter"}
+        )
+      )
+    record: instance:node_num_cpu:sum
+  - expr: |
+      1 - avg by (instance) (
+        rate(node_cpu{app="node-exporter",mode="idle"}[1m])
+      )
+    record: instance:node_cpu_utilisation:avg1m
+  - expr: |
+      sum by (instance) (node_load1{app="node-exporter"})
+      /
+      instance:node_num_cpu:sum
+    record: 'instance:node_cpu_saturation_load1:'
+  - expr: |
+      sum by (instance) (
+        node_memory_MemTotal{app="node-exporter"}
+      )
+    record: instance:node_memory_bytes_total:sum
+  - expr: |
+      1 - (
+          node_memory_MemAvailable{%(nodeExporterSelector)s}
+        /
+          node_memory_MemTotal{%(nodeExporterSelector)s}
+      )
+    record: instance:node_memory_utilisation:ratio
+  - expr: |
+      1e3 * sum by (instance) (
+        (rate(node_vmstat_pgpgin{app="node-exporter"}[1m])
+         + rate(node_vmstat_pgpgout{app="node-exporter"}[1m]))
+      )
+    record: instance:node_memory_swap_io_bytes:sum_rate
+  - expr: |
+      sum by (instance) (
+        irate(node_disk_io_time_ms{app="node-exporter",device=~"(sd|xvd).+"}[1m]) / 1e3
+      )
+    record: instance:node_disk_utilisation:sum_irate
+  - expr: |
+      sum by (instance) (
+        irate(node_disk_io_time_weighted{app="node-exporter",device=~"(sd|xvd).+"}[1m]) / 1e3
+      )
+    record: instance:node_disk_saturation:sum_irate
+  - expr: |
+      sum by (instance) (
+        (irate(node_network_receive_bytes{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
+         irate(node_network_transmit_bytes{app="node-exporter",device=~"eth[0-9]+"}[1m]))
+      )
+    record: instance:node_net_utilisation:sum_irate
+  - expr: |
+      sum by (instance) (
+        (irate(node_network_receive_drop{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
+         irate(node_network_transmit_drop{app="node-exporter",device=~"eth[0-9]+"}[1m]))
+      )
+    record: instance:node_net_saturation:sum_irate
 - name: kubermatic
   rules:
   - alert: KubermaticTooManyUnhandledErrors
@@ -873,5 +932,121 @@ groups:
     expr: |
       rate(prometheus_rule_evaluation_failures_total{job="prometheus"}[1m]) > 0
     for: 15m
+    labels:
+      severity: critical
+- name: node
+  rules:
+  - alert: NodeFilesystemSpaceFillingUp
+    annotations:
+      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
+        to run out of space within the next 24 hours.
+    expr: |
+      predict_linear(node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"}[6h], 24*60*60) < 0
+      and
+      node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_size{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} < 0.4
+      and
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+    for: 1h
+    labels:
+      severity: warning
+  - alert: NodeFilesystemSpaceFillingUp
+    annotations:
+      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
+        to run out of space within the next 4 hours.
+    expr: |
+      predict_linear(node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"}[6h], 4*60*60) < 0
+      and
+      node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_size{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} < 0.2
+      and
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+    for: 1h
+    labels:
+      severity: critical
+  - alert: NodeFilesystemOutOfSpace
+    annotations:
+      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
+        {{ $value }}% available space left.
+    expr: |
+      node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_size{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} * 100 < 5
+      and
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+    for: 1h
+    labels:
+      severity: warning
+  - alert: NodeFilesystemOutOfSpace
+    annotations:
+      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
+        {{ $value }}% available space left.
+    expr: |
+      node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_size{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} * 100 < 3
+      and
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+    for: 1h
+    labels:
+      severity: critical
+  - alert: NodeFilesystemFilesFillingUp
+    annotations:
+      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
+        to run out of files within the next 24 hours.
+    expr: |
+      predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"}[6h], 24*60*60) < 0
+      and
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} < 0.4
+      and
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+    for: 1h
+    labels:
+      severity: warning
+  - alert: NodeFilesystemFilesFillingUp
+    annotations:
+      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
+        to run out of files within the next 4 hours.
+    expr: |
+      predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"}[6h], 4*60*60) < 0
+      and
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} < 0.2
+      and
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+    for: 1h
+    labels:
+      severity: warning
+  - alert: NodeFilesystemOutOfFiles
+    annotations:
+      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
+        {{ $value }}% available inodes left.
+    expr: |
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} * 100 < 5
+      and
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+    for: 1h
+    labels:
+      severity: warning
+  - alert: NodeFilesystemOutOfSpace
+    annotations:
+      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
+        {{ $value }}% available space left.
+    expr: |
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} * 100 < 3
+      and
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+    for: 1h
+    labels:
+      severity: critical
+  - alert: NodeNetworkReceiveErrs
+    annotations:
+      message: '{{ $labels.instance }} interface {{ $labels.device }} shows errors
+        while receiving packets ({{ $value }} errors in two minutes).'
+    expr: |
+      increase(node_network_receive_errs[2m]) > 10
+    for: 1h
+    labels:
+      severity: critical
+  - alert: NodeNetworkTransmitErrs
+    annotations:
+      message: '{{ $labels.instance }} interface {{ $labels.device }} shows errors
+        while transmitting packets ({{ $value }} errors in two minutes).'
+    expr: |
+      increase(node_network_transmit_errs[2m]) > 10
+    for: 1h
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/rules.yaml
+++ b/config/monitoring/prometheus/rules/rules.yaml
@@ -262,9 +262,9 @@ groups:
     record: instance:node_memory_bytes_total:sum
   - expr: |
       1 - (
-          node_memory_MemAvailable{%(nodeExporterSelector)s}
+          node_memory_MemAvailable{app="node-exporter"}
         /
-          node_memory_MemTotal{%(nodeExporterSelector)s}
+          node_memory_MemTotal{app="node-exporter"}
       )
     record: instance:node_memory_utilisation:ratio
   - expr: |

--- a/config/monitoring/prometheus/rules/rules.yaml
+++ b/config/monitoring/prometheus/rules/rules.yaml
@@ -821,3 +821,57 @@ groups:
     for: 10m
     labels:
       severity: critical
+- name: prometheus
+  rules:
+  - alert: PromScrapeFailed
+    annotations:
+      message: Prometheus failed to scrape a target {{ $labels.job }} / {{ $labels.instance
+        }}
+    expr: |
+      up != 1
+    for: 15m
+    labels:
+      severity: warning
+  - alert: PromBadConfig
+    annotations:
+      mesage: Prometheus failed to reload config, see container logs
+    expr: |
+      prometheus_config_last_reload_successful{job="prometheus"} == 0
+    for: 15m
+    labels:
+      severity: critical
+  - alert: PromAlertmanagerBadConfig
+    annotations:
+      message: Alertmanager failed to reload config, see container logs
+    expr: |
+      alertmanager_config_last_reload_successful{job="alertmanager"} == 0
+    for: 10m
+    labels:
+      severity: critical
+  - alert: PromAlertsFailed
+    annotations:
+      message: Alertmanager failed to send an alert.
+    expr: |
+      sum(increase(alertmanager_notifications_failed_total{job="alertmanager"}[5m])) by (namespace) > 0
+    for: 5m
+    labels:
+      severity: critical
+  - alert: PromRemoteStorageFailures
+    annotations:
+      message: Prometheus failed to send {{ printf "%.1f" $value }}% samples
+    expr: |
+      (rate(prometheus_remote_storage_failed_samples_total{job="prometheus"}[1m]) * 100)
+        /
+      (rate(prometheus_remote_storage_failed_samples_total{job="prometheus"}[1m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus"}[1m]))
+        > 1
+    for: 15m
+    labels:
+      severity: critical
+  - alert: PromRuleFailures
+    annotations:
+      message: Prometheus failed to evaluate {{ printf "%.1f" $value }} rules / s
+    expr: |
+      rate(prometheus_rule_evaluation_failures_total{job="prometheus"}[1m]) > 0
+    for: 15m
+    labels:
+      severity: critical

--- a/config/monitoring/prometheus/rules/rules.yaml
+++ b/config/monitoring/prometheus/rules/rules.yaml
@@ -236,7 +236,7 @@ groups:
         node_namespace_pod:kube_pod_info:
       )
     record: node:node_net_saturation:sum_irate
-- name: node.rules
+- name: node-exporter.rules
   rules:
   - expr: |
       count by (instance) (
@@ -934,7 +934,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-- name: node
+- name: node-exporter
   rules:
   - alert: NodeFilesystemSpaceFillingUp
     annotations:


### PR DESCRIPTION
What this PR does / why we need it:
We currently don't alert on Prometheus and Node metrics. We did previously and want to do that again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1489 and fixes #1551 

**Special notes for your reviewer**:
I've fixed the naming of groups upstream and tested the rules and alerts locally with the promtool.

Release-note
```release-note
NONE
```