### PR TITLE
changes CluterRole/Binding name for s3 exporter

### DIFF
--- a/config/kubermatic/templates/s3-exporter-dep.yaml
+++ b/config/kubermatic/templates/s3-exporter-dep.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubermatic:clusters:reader
+  name: kubermatic:s3exporter:clusters:reader
 rules:
 - apiGroups:
   - kubermatic.k8s.io
@@ -21,11 +21,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kubermatic:clusters:reader
+  name: kubermatic:s3exporter:clusters:reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubermatic:clusters:reader
+  name: kubermatic:s3exporter:clusters:reader
 subjects:
 - kind: ServiceAccount
   name: s3-exporter


### PR DESCRIPTION
**What this PR does / why we need it**: this PR changes CluterRole/Binding names for s3 exporter
,the names were very alike to the ones generated by `rbac-generator`, for example for cluster resources there are `kubermatic:clusters:editors` and `kubermatic:clusters:owners`.
Thus a prefix `s3exporter` was added to the names to distinuguish them.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
