### PR TITLE
Fix cadvisor/kubelet monitoring

### DIFF
--- a/config/monitoring/prometheus/config/prometheus.yml
+++ b/config/monitoring/prometheus/config/prometheus.yml
@@ -92,30 +92,31 @@ scrape_configs:
 - job_name: kubelet
   scheme: http
   kubernetes_sd_configs:
-  - role: endpoints
-    namespaces:
-      names:
-      - kube-system
+  - role: node
   relabel_configs:
-  - source_labels: [__meta_kubernetes_endpoint_port_name]
-    regex: http-metrics
-    replacement: $1
-    action: keep
+  - action: labelmap
+    regex: __meta_kubernetes_node_label_(.+)
+  - source_labels: [__address__]
+    action: replace
+    target_label: __address__
+    regex: ([^:;]+):(\d+)
+    replacement: ${1}:10255
 
 - job_name: cadvisor
-  honor_labels: true
   scheme: http
   kubernetes_sd_configs:
-  - role: endpoints
-    namespaces:
-      names:
-      - kube-system
+  - role: node
   relabel_configs:
-  - source_labels: [__meta_kubernetes_endpoint_port_name]
-    separator: ;
-    regex: cadvisor
-    replacement: $1
-    action: keep
+  - action: labelmap
+    regex: __meta_kubernetes_node_label_(.+)
+  - source_labels: [__address__]
+    action: replace
+    target_label: __address__
+    regex: ([^:;]+):(\d+)
+    replacement: ${1}:10255
+  - target_label: __metrics_path__
+    action: replace
+    replacement: /metrics/cadvisor
 
 - job_name: kube-state-metrics
   honor_labels: true

--- a/config/monitoring/prometheus/config/prometheus.yml
+++ b/config/monitoring/prometheus/config/prometheus.yml
@@ -90,33 +90,38 @@ scrape_configs:
     regex: default;kubernetes;https
 
 - job_name: kubelet
-  scheme: http
+  scheme: https
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   kubernetes_sd_configs:
   - role: node
   relabel_configs:
   - action: labelmap
     regex: __meta_kubernetes_node_label_(.+)
-  - source_labels: [__address__]
-    action: replace
-    target_label: __address__
-    regex: ([^:;]+):(\d+)
-    replacement: ${1}:10255
+  - target_label: __address__
+    replacement: kubernetes.default.svc:443
+  - source_labels: [__meta_kubernetes_node_name]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}/proxy/metrics
 
 - job_name: cadvisor
-  scheme: http
+  scheme: https
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   kubernetes_sd_configs:
   - role: node
   relabel_configs:
   - action: labelmap
     regex: __meta_kubernetes_node_label_(.+)
-  - source_labels: [__address__]
-    action: replace
-    target_label: __address__
-    regex: ([^:;]+):(\d+)
-    replacement: ${1}:10255
-  - target_label: __metrics_path__
-    action: replace
-    replacement: /metrics/cadvisor
+  - target_label: __address__
+    replacement: kubernetes.default.svc:443
+  - source_labels: [__meta_kubernetes_node_name]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 
 - job_name: kube-state-metrics
   honor_labels: true

--- a/config/monitoring/prometheus/templates/clusterrole.yaml
+++ b/config/monitoring/prometheus/templates/clusterrole.yaml
@@ -7,6 +7,7 @@ rules:
   - ""
   resources:
   - nodes
+  - nodes/proxy
   - services
   - endpoints
   - pods


### PR DESCRIPTION
**What this PR does / why we need it**:

Fetching k8s endpoints is broken and does not give us an up-to-date list of actual nodes in the cluster. This PR changes the Prometheus configuration to the [upstream example config](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml). This not only fixes the scraping, but also secures it by using HTTPS. In order to allow proxying the metrics via the API server, the role had to be extended to allow access to `nodes/proxy`.

Changes are already deployed to dev and cloud.

**Release note**:
```release-note
NONE
```
