### PR TITLE
Fix default-http-backend port for metrics

### DIFF
--- a/config/nginx-ingress-controller/templates/default-backend-dep.yaml
+++ b/config/nginx-ingress-controller/templates/default-backend-dep.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '10254'
+        kubermatic/scrape_port: '8080'
       labels:
         app: default-http-backend
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

The [defaultbackend](http://gcr.io/google_containers/defaultbackend:1.4) container does not expose metrics on a custom port, but rather on its default port:

```
xrstf ~ % docker run --rm -d --net=host gcr.io/google-containers/defaultbackend:1.4
xrstf ~ % curl http://127.0.0.1:8080/metrics <--- works
xrstf ~ % curl http://127.0.0.1:10254/metrics <--- nothing listens on that port
```

We most likely specified 10254 because the nginx-ingress container does indeed use that port. This PR adjusts the port to make sure that Prometheus can properly scrape the defaultbackend.

**Release note**:
```release-note
NONE
```
