### PR TITLE
prevents sorting an empty collection

### DIFF
--- a/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
+++ b/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
@@ -218,6 +218,9 @@ func (p *RBACCompliantClusterProvider) createSeedImpersonationClientWrapper(user
 
 // sortBy sort the given clusters by the specified field name (sortBy param)
 func (p *RBACCompliantClusterProvider) sortBy(clusters []*kubermaticapiv1.Cluster, sortBy string) ([]*kubermaticapiv1.Cluster, error) {
+	if len(clusters) == 0 {
+		return clusters, nil
+	}
 	rawKeys := []runtime.Object{}
 	for index := range clusters {
 		rawKeys = append(rawKeys, clusters[index])

--- a/api/pkg/provider/kubernetes/rbac-compliant-ssh.go
+++ b/api/pkg/provider/kubernetes/rbac-compliant-ssh.go
@@ -185,6 +185,9 @@ func (p *RBACCompliantSSHKeyProvider) createMasterImpersonationClientWrapper(use
 
 // sortBy sort the given keys by the specified field name (sortBy param)
 func (p *RBACCompliantSSHKeyProvider) sortBy(keys []*kubermaticapiv1.UserSSHKey, sortBy string) ([]*kubermaticapiv1.UserSSHKey, error) {
+	if len(keys) == 0 {
+		return keys, nil
+	}
 	rawKeys := []runtime.Object{}
 	for index := range keys {
 		rawKeys = append(rawKeys, keys[index])


### PR DESCRIPTION
**What this PR does / why we need it**: prevents sorting an empty collection. Previously an error of the form `500: couldn't find any field with path "{.metadata.creationTimestamp}" in the list of objects`
was returned to the caller.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
