### PR TITLE
use volumes as base for pod labels to restart on configmap/secret revision change

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -227,8 +227,14 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 			Namespace: mockNamespaceName,
 		},
 	}
+	openvpnClientConfigsConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.OpenVPNClientConfigsConfigMapName,
+			Namespace: mockNamespaceName,
+		},
+	}
 	configMapList := &corev1.ConfigMapList{
-		Items: []corev1.ConfigMap{cloudConfigConfigMap, prometheusConfigMap, dnsResolverConfigMap},
+		Items: []corev1.ConfigMap{cloudConfigConfigMap, prometheusConfigMap, dnsResolverConfigMap, openvpnClientConfigsConfigMap},
 	}
 	apiServerExternalService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -298,6 +304,12 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 		resources.ServiceAccountKeySecretName,
 		resources.ApiserverEtcdClientCertificateSecretName,
 		resources.EtcdTLSCertificateSecretName,
+		resources.MachineControllerKubeconfigSecretName,
+		resources.ControllerManagerKubeconfigSecretName,
+		resources.SchedulerKubeconfigSecretName,
+		resources.KubeStateMetricsKubeconfigSecretName,
+		resources.OpenVPNServerCertificatesSecretName,
+		resources.OpenVPNClientCertificatesSecretName,
 	})
 	objects := []runtime.Object{configMapList, secretList, serviceList}
 	client := kubefake.NewSimpleClientset(objects...)

--- a/api/pkg/resources/apiserver/service.go
+++ b/api/pkg/resources/apiserver/service.go
@@ -19,7 +19,7 @@ func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Se
 
 	se.Name = resources.ApiserverInternalServiceName
 	se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	se.Labels = resources.GetLabels(name)
+	se.Labels = resources.BaseAppLabel(name, nil)
 
 	se.Spec.Type = corev1.ServiceTypeClusterIP
 	se.Spec.Selector = map[string]string{

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -12,6 +12,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	name = "cloud-config"
+)
+
 // ConfigMap returns a ConfigMap containing the cloud-config for the supplied data
 func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	var cm *corev1.ConfigMap
@@ -28,7 +32,7 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
 
 	cm.Name = resources.CloudConfigConfigMapName
 	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	cm.Labels = resources.GetLabels("cloud-config")
+	cm.Labels = resources.BaseAppLabel(name, nil)
 	cm.Data = map[string]string{
 		"config":              cloudConfig,
 		FakeVMWareUUIDKeyName: fakeVMWareUUID,

--- a/api/pkg/resources/controllermanager/clusterrolebinding.go
+++ b/api/pkg/resources/controllermanager/clusterrolebinding.go
@@ -16,7 +16,7 @@ func AdminClusterRoleBinding(data *resources.TemplateData, existing *rbacv1.Clus
 	}
 
 	crb.Name = resources.ControllerManagerClusterRoleBindingName
-	crb.Labels = resources.GetLabels(name)
+	crb.Labels = resources.BaseAppLabel(name, nil)
 	crb.RoleRef = rbacv1.RoleRef{
 		Name:     "cluster-admin",
 		Kind:     "ClusterRole",

--- a/api/pkg/resources/controllermanager/rolebinding.go
+++ b/api/pkg/resources/controllermanager/rolebinding.go
@@ -31,7 +31,7 @@ func createRoleBinding(existing *rbacv1.RoleBinding, namespace, roleRef string) 
 
 	rb.Name = resources.ControllerManagerRoleBindingName
 	rb.Namespace = namespace
-	rb.Labels = resources.GetLabels(name)
+	rb.Labels = resources.BaseAppLabel(name, nil)
 
 	rb.RoleRef = rbacv1.RoleRef{
 		Name:     roleRef,

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -12,21 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func getTemplatePodLabels(data *resources.TemplateData) (map[string]string, error) {
-	podLabels := map[string]string{
-		resources.AppLabelKey: resources.DNSResolverDeploymentName,
-	}
-	configRevision, err := data.ConfigMapRevision(resources.DNSResolverConfigMapName)
-	if err != nil {
-		return nil, err
-	}
-	podLabels[fmt.Sprintf("%s-configmap-revision", resources.DNSResolverConfigMapName)] = configRevision
-
-	return podLabels, err
-}
-
 // Service returns the service for the dns resolver
-func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
+func Service(_ *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
 	var svc *corev1.Service
 	if existing != nil {
 		svc = existing
@@ -60,13 +47,11 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 
 	dep.Name = resources.DNSResolverDeploymentName
 	dep.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	dep.Labels = resources.GetLabels(resources.DNSResolverDeploymentName)
+	dep.Labels = resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil)
 	dep.Spec.Replicas = resources.Int32(2)
 
 	dep.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			resources.AppLabelKey: resources.DNSResolverDeploymentName,
-		},
+		MatchLabels: resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil),
 	}
 	dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
 	dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
@@ -80,7 +65,8 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		},
 	}
 
-	podLabels, err := getTemplatePodLabels(data)
+	volumes := getVolumes()
+	podLabels, err := data.GetPodTemplateLabels(resources.DNSResolverDeploymentName, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get podlabels: %v", err)
 	}
@@ -141,7 +127,14 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 			},
 		},
 	}
-	dep.Spec.Template.Spec.Volumes = []corev1.Volume{
+
+	dep.Spec.Template.Spec.Volumes = volumes
+
+	return dep, nil
+}
+
+func getVolumes() []corev1.Volume {
+	return []corev1.Volume{
 		{
 			Name: resources.DNSResolverConfigMapName,
 			VolumeSource: corev1.VolumeSource{
@@ -171,8 +164,6 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 			},
 		},
 	}
-
-	return dep, nil
 }
 
 // ConfigMap returns a ConfigMap containing the cloud-config for the supplied data

--- a/api/pkg/resources/kubestatemetrics/clusterrole.go
+++ b/api/pkg/resources/kubestatemetrics/clusterrole.go
@@ -16,7 +16,7 @@ func ClusterRole(_ *resources.TemplateData, existing *rbacv1.ClusterRole) (*rbac
 	}
 
 	r.Name = resources.KubeStateMetricsClusterRoleName
-	r.Labels = resources.GetLabels(name)
+	r.Labels = resources.BaseAppLabel(name, nil)
 
 	r.Rules = []rbacv1.PolicyRule{
 		{

--- a/api/pkg/resources/kubestatemetrics/clusterrolebinding.go
+++ b/api/pkg/resources/kubestatemetrics/clusterrolebinding.go
@@ -16,7 +16,7 @@ func ClusterRoleBinding(_ *resources.TemplateData, existing *rbacv1.ClusterRoleB
 	}
 
 	crb.Name = resources.KubeStateMetricsClusterRoleBindingName
-	crb.Labels = resources.GetLabels(name)
+	crb.Labels = resources.BaseAppLabel(name, nil)
 
 	crb.RoleRef = rbacv1.RoleRef{
 		Name:     resources.KubeStateMetricsClusterRoleName,

--- a/api/pkg/resources/machinecontroller/clusterrole.go
+++ b/api/pkg/resources/machinecontroller/clusterrole.go
@@ -16,7 +16,7 @@ func ClusterRole(data *resources.TemplateData, existing *rbacv1.ClusterRole) (*r
 	}
 
 	r.Name = resources.MachineControllerClusterRoleName
-	r.Labels = resources.GetLabels(name)
+	r.Labels = resources.BaseAppLabel(name, nil)
 
 	r.Rules = []rbacv1.PolicyRule{
 		{

--- a/api/pkg/resources/machinecontroller/clusterrolebinding.go
+++ b/api/pkg/resources/machinecontroller/clusterrolebinding.go
@@ -51,7 +51,7 @@ func createClusterRoleBinding(existing *rbacv1.ClusterRoleBinding, crbSuffix, cR
 	}
 
 	crb.Name = fmt.Sprintf("%s:%s", resources.MachineControllerClusterRoleBindingName, crbSuffix)
-	crb.Labels = resources.GetLabels(name)
+	crb.Labels = resources.BaseAppLabel(name, nil)
 
 	crb.RoleRef = rbacv1.RoleRef{
 		Name:     cRoleRef,

--- a/api/pkg/resources/machinecontroller/role.go
+++ b/api/pkg/resources/machinecontroller/role.go
@@ -19,7 +19,7 @@ func KubeSystemRole(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv
 
 	r.Name = resources.MachineControllerRoleName
 	r.Namespace = metav1.NamespaceSystem
-	r.Labels = resources.GetLabels(name)
+	r.Labels = resources.BaseAppLabel(name, nil)
 
 	r.Rules = []rbacv1.PolicyRule{
 		{
@@ -64,7 +64,7 @@ func KubePublicRole(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv
 
 	r.Name = resources.MachineControllerRoleName
 	r.Namespace = metav1.NamespacePublic
-	r.Labels = resources.GetLabels(name)
+	r.Labels = resources.BaseAppLabel(name, nil)
 
 	r.Rules = []rbacv1.PolicyRule{
 		{
@@ -92,7 +92,7 @@ func Role(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv1.Role, er
 
 	r.Name = resources.MachineControllerRoleName
 	r.Namespace = metav1.NamespaceDefault
-	r.Labels = resources.GetLabels(name)
+	r.Labels = resources.BaseAppLabel(name, nil)
 
 	r.Rules = []rbacv1.PolicyRule{
 		{

--- a/api/pkg/resources/machinecontroller/rolebinding.go
+++ b/api/pkg/resources/machinecontroller/rolebinding.go
@@ -36,7 +36,7 @@ func createRoleBinding(existing *rbacv1.RoleBinding, namespace string) (*rbacv1.
 
 	rb.Name = resources.MachineControllerRoleBindingName
 	rb.Namespace = namespace
-	rb.Labels = resources.GetLabels(name)
+	rb.Labels = resources.BaseAppLabel(name, nil)
 
 	rb.RoleRef = rbacv1.RoleRef{
 		Name:     resources.MachineControllerRoleName,

--- a/api/pkg/resources/openvpn/configmap.go
+++ b/api/pkg/resources/openvpn/configmap.go
@@ -22,7 +22,7 @@ func ServerClientConfigsConfigMap(data *resources.TemplateData, existing *corev1
 
 	cm.Name = resources.OpenVPNClientConfigsConfigMapName
 	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	cm.Labels = resources.GetLabels(name)
+	cm.Labels = resources.BaseAppLabel(name, nil)
 
 	var iroutes []string
 
@@ -73,7 +73,7 @@ func ClientConfigConfigMap(data *resources.TemplateData, existing *corev1.Config
 	cm.Name = resources.OpenVPNClientConfigConfigMapName
 	cm.Namespace = metav1.NamespaceSystem
 	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	cm.Labels = resources.GetLabels(name)
+	cm.Labels = resources.BaseAppLabel(name, nil)
 
 	openvpnSvc, err := data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get(resources.OpenVPNServerServiceName)
 	if err != nil {

--- a/api/pkg/resources/openvpn/service.go
+++ b/api/pkg/resources/openvpn/service.go
@@ -18,7 +18,7 @@ func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Se
 	}
 
 	se.Name = resources.OpenVPNServerServiceName
-	se.Labels = resources.GetLabels("openvpn")
+	se.Labels = resources.BaseAppLabel(name, nil)
 	se.Annotations = map[string]string{
 		"nodeport-proxy.k8s.io/expose": "true",
 	}

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -32,7 +32,7 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
 
 	cm.Name = resources.PrometheusConfigConfigMapName
 	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	cm.Labels = resources.GetLabels(name)
+	cm.Labels = resources.BaseAppLabel(name, nil)
 	cm.Data = map[string]string{
 		"prometheus.yaml": configBuffer.String(),
 		"rules.yaml":      prometheusRules,

--- a/api/pkg/resources/prometheus/role.go
+++ b/api/pkg/resources/prometheus/role.go
@@ -18,7 +18,7 @@ func Role(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv1.Role, er
 
 	r.Name = resources.PrometheusRoleName
 	r.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	r.Labels = resources.GetLabels(name)
+	r.Labels = resources.BaseAppLabel(name, nil)
 
 	r.Rules = []rbacv1.PolicyRule{
 		{

--- a/api/pkg/resources/prometheus/rolebinding.go
+++ b/api/pkg/resources/prometheus/rolebinding.go
@@ -18,7 +18,7 @@ func RoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*r
 
 	rb.Name = resources.PrometheusRoleBindingName
 	rb.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	rb.Labels = resources.GetLabels(name)
+	rb.Labels = resources.BaseAppLabel(name, nil)
 
 	rb.RoleRef = rbacv1.RoleRef{
 		Name:     resources.PrometheusRoleName,

--- a/api/pkg/resources/prometheus/service.go
+++ b/api/pkg/resources/prometheus/service.go
@@ -19,7 +19,7 @@ func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Se
 
 	se.Name = resources.PrometheusServiceName
 	se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	se.Labels = resources.GetLabels(name)
+	se.Labels = resources.BaseAppLabel(name, nil)
 	// We need to set cluster: user for the ServiceMonitor which federates metrics8
 	se.Labels["cluster"] = "user"
 

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -1,6 +1,8 @@
 package prometheus
 
 import (
+	"fmt"
+
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,31 +35,27 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 		set = &appsv1.StatefulSet{}
 	}
 
-	cm, err := data.ConfigMapLister.ConfigMaps(data.Cluster.Status.NamespaceName).Get(resources.PrometheusConfigConfigMapName)
-	if err != nil {
-		return nil, err
-	}
-
 	set.Name = resources.PrometheusStatefulSetName
 	set.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	set.Labels = resources.GetLabels(name)
+
+	requiredBaseLabels := map[string]string{"cluster": data.Cluster.Name}
+	set.Labels = resources.BaseAppLabel(name, requiredBaseLabels)
+	set.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: resources.BaseAppLabel(name, requiredBaseLabels),
+	}
 
 	set.Spec.Replicas = resources.Int32(1)
 	set.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
 	set.Spec.ServiceName = resources.PrometheusServiceName
-	set.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			resources.AppLabelKey: name,
-			"cluster":             data.Cluster.Name,
-		},
+
+	volumes := getVolumes()
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, requiredBaseLabels)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}
 
 	set.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-		Labels: map[string]string{
-			resources.AppLabelKey: name,
-			"cluster":             data.Cluster.Name,
-			"config-revision":     cm.ObjectMeta.ResourceVersion,
-		},
+		Labels: podLabels,
 	}
 	set.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
 	set.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
@@ -145,7 +143,13 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 		},
 	}
 
-	set.Spec.Template.Spec.Volumes = []corev1.Volume{
+	set.Spec.Template.Spec.Volumes = volumes
+
+	return set, nil
+}
+
+func getVolumes() []corev1.Volume {
+	return []corev1.Volume{
 		{
 			Name: volumeConfigName,
 			VolumeSource: corev1.VolumeSource{
@@ -172,6 +176,4 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 			},
 		},
 	}
-
-	return set, nil
 }

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -39,7 +39,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 
 	dep.Name = resources.SchedulerDeploymentName
 	dep.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	dep.Labels = resources.GetLabels(name)
+	dep.Labels = resources.BaseAppLabel(name, nil)
 
 	dep.Spec.Replicas = resources.Int32(1)
 	if data.Cluster.Spec.ComponentsOverride.Scheduler.Replicas != nil {
@@ -47,10 +47,15 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	dep.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			resources.AppLabelKey: name,
-		},
+		MatchLabels: resources.BaseAppLabel(name, nil),
 	}
+
+	volumes := getVolumes()
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pod labels: %v", err)
+	}
+
 	dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
 	dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
 		MaxSurge: &intstr.IntOrString{
@@ -64,9 +69,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-		Labels: map[string]string{
-			resources.AppLabelKey: name,
-		},
+		Labels: podLabels,
 		Annotations: map[string]string{
 			"prometheus.io-0/scrape": "true",
 			"prometheus.io-0/path":   "/metrics",
@@ -91,7 +94,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	kcDir := "/etc/kubernetes/scheduler"
-	dep.Spec.Template.Spec.Volumes = getVolumes()
+	dep.Spec.Template.Spec.Volumes = volumes
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{
 			Name:            "apiserver-running",

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         ca-cert-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
         tokens-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -32,6 +32,8 @@ spec:
         ca-cert-secret-revision: "123456"
         ca-key-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
@@ -25,7 +25,9 @@ spec:
       creationTimestamp: null
       labels:
         app: dns-resolver
+        ca-cert-secret-revision: "123456"
         dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
@@ -26,7 +26,8 @@ spec:
       labels:
         app: openvpn-server
         ca-cert-secret-revision: "123456"
-        cloud-config-configmap-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -29,6 +29,9 @@ spec:
       creationTimestamp: null
       labels:
         app: scheduler
+        ca-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-aws-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.8.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-aws-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.9.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-azure-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.8.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-azure-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.9.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.8.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.9.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.8.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.9.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-openstack-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.8.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-openstack-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.9.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.8.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.9.0-openvpn-server.yaml
@@ -3,7 +3,7 @@ metadata:
     nodeport-proxy.k8s.io/expose: "true"
   creationTimestamp: null
   labels:
-    app: openvpn
+    app: openvpn-server
   name: openvpn-server
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
         app: etcd
+        ca-cert-secret-revision: "123456"
         cluster: de-test-01
         etcd-tls-certificate-secret-revision: "123456"
       name: etcd

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-prometheus.yaml
@@ -2,6 +2,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+    cluster: de-test-01
   name: prometheus
   ownerReferences:
   - apiVersion: kubermatic.k8s.io/v1
@@ -21,9 +22,10 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
         app: prometheus
         cluster: de-test-01
-        config-revision: "123456"
+        prometheus-configmap-revision: "123456"
     spec:
       containers:
       - args:

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -267,6 +267,55 @@ func TestLoadFiles(t *testing.T) {
 							Namespace:       cluster.Status.NamespaceName,
 						},
 					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.MachineControllerKubeconfigSecretName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.OpenVPNServerCertificatesSecretName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.OpenVPNClientCertificatesSecretName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.ControllerManagerKubeconfigSecretName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.KubeStateMetricsKubeconfigSecretName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.SchedulerKubeconfigSecretName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
+					&v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.OpenVPNClientConfigsConfigMapName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
 					&v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "123456",


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses the Deployment/StatefulSet volumes to get all relevant revision labels.

**Release note**:
```release-note
NONE
```
