### PR TITLE
print group labels from alerts to Slack

### DIFF
--- a/config/monitoring/alertmanager/kubermatic.tmpl
+++ b/config/monitoring/alertmanager/kubermatic.tmpl
@@ -12,5 +12,10 @@
 {{ end }}
 
 {{ define "slack.kubermatic.title" }}{{ template "slack.kubermatic.title.range" . }}{{ end }}
-{{ define "slack.kubermatic.text" }}{{ template "slack.kubermatic.text.range" . }}{{ end }}
+{{ define "slack.kubermatic.text" }}
+{{ template "slack.kubermatic.text.range" . }}
+{{ range $k, $v := .GroupLabels }}
+{{- if ne $k "alertname" }}• *{{ $k }}*: {{ $v }}{{ end }}
+{{ end }}
+{{ end }}
 {{ define "slack.kubermatic.fallback" }}{{ template "slack.kubermatic.fallback.range" . }}{{ end }}

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -8,7 +8,7 @@ alertmanager:
       slack_api_url: https://
     route:
       receiver: 'default'
-      group_by: ['alertname', 'cluster']
+      group_by: ['alertname', 'cluster', 'region']
       group_wait: 10s
       group_interval: 5m
       repeat_interval: 1h


### PR DESCRIPTION
**What this PR does / why we need it**:

Alerts from the various alertmanagers are labelled with a region and often with a cluster name (in case the alert originates from within a user cluster). This PR makes it so that we can actually see these labels in Slack.

**Release note**:
```release-note
NONE
```
