### PR TITLE
add feature flags for kubelet client & server certificates

### DIFF
--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -204,6 +204,7 @@ func getFlags(data *resources.TemplateData, kcDir string) []string {
 		"--configure-cloud-routes=false",
 		"--allocate-node-cidrs=true",
 		"--controllers", "*,bootstrapsigner,tokencleaner",
+		"--feature-gates", "RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true",
 		"--v", "4",
 	}
 	if data.Cluster.Spec.Cloud.AWS != nil {

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -113,6 +113,8 @@ spec:
         - --allocate-node-cidrs=true
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
+        - --feature-gates
+        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --v
         - "4"
         - --cloud-provider


### PR DESCRIPTION
**What this PR does / why we need it**:
Add feature flags for kubelet client & server certificates

**Release note**:
```release-note
Activate kubelet certificate rotation feature flags
```

The client part has graduated to beta with 1.10 (Since then its activated by default), the server part will graduate with 1.12.