### PR TITLE
remove custom etcd timing flags

### DIFF
--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -351,8 +351,6 @@ echo "initial-cluster: ${INITIAL_CLUSTER}"
 exec /usr/local/bin/etcd \
     --name=${POD_NAME} \
     --data-dir="{{ .DataDir }}" \
-    --heartbeat-interval=500 \
-    --election-timeout=5000 \
     --initial-cluster=${INITIAL_CLUSTER} \
     --initial-cluster-token="{{ .Token }}" \
     --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -61,8 +61,6 @@ echo "initial-cluster: ${INITIAL_CLUSTER}"
 exec /usr/local/bin/etcd \
     --name=${POD_NAME} \
     --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-    --heartbeat-interval=500 \
-    --election-timeout=5000 \
     --initial-cluster=${INITIAL_CLUSTER} \
     --initial-cluster-token="lg69pmx8wf" \
     --initial-cluster-state=${INITIAL_STATE} \
@@ -133,8 +131,6 @@ echo "initial-cluster: ${INITIAL_CLUSTER}"
 exec /usr/local/bin/etcd \
     --name=${POD_NAME} \
     --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-    --heartbeat-interval=500 \
-    --election-timeout=5000 \
     --initial-cluster=${INITIAL_CLUSTER} \
     --initial-cluster-token="62m9k9tqlm" \
     --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
@@ -55,8 +55,6 @@ spec:
           exec /usr/local/bin/etcd \
               --name=${POD_NAME} \
               --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
-              --heartbeat-interval=500 \
-              --election-timeout=5000 \
               --initial-cluster=${INITIAL_CLUSTER} \
               --initial-cluster-token="de-test-01" \
               --initial-cluster-state=${INITIAL_STATE} \


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove custom etcd timing flags. I introduced them to reduce errors due to latency.
Though we're not running in environments where increasing the timings does any good.
For simplicity they should be removed.

**Release note**:
```release-note
etcd StatefulSet uses default timings again
```
