### PR TITLE
remove hardcoded port from the test

### DIFF
--- a/api/pkg/handler/datacenter_test.go
+++ b/api/pkg/handler/datacenter_test.go
@@ -24,7 +24,7 @@ func TestDatacentersEndpoint(t *testing.T) {
 		t.Fatalf("Expected route to return code 200, got %d: %s", res.Code, res.Body.String())
 	}
 
-	compareWithResult(t, res, `[{"metadata":{"name":"moon-1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"Moon States","location":"Dark Side","provider":"vsphere","vsphere":{"endpoint":"http://127.0.0.1:8989","datacenter":"ha-datacenter","datastore":"LocalDS_0","cluster":"localhost.localdomain","templates":{}}}},{"metadata":{"name":"regular-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"}}},{"metadata":{"name":"us-central1","resourceVersion":"1"},"spec":{"seed":"","country":"US","location":"us-central","provider":"digitalocean","digitalocean":{"region":"ams2"}},"seed":true}]`)
+	compareWithResult(t, res, `[{"metadata":{"name":"regular-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"}}},{"metadata":{"name":"us-central1","resourceVersion":"1"},"spec":{"seed":"","country":"US","location":"us-central","provider":"digitalocean","digitalocean":{"region":"ams2"}},"seed":true}]`)
 }
 
 func TestDatacenterEndpointNotFound(t *testing.T) {

--- a/api/pkg/handler/routing_test.go
+++ b/api/pkg/handler/routing_test.go
@@ -156,21 +156,6 @@ func buildDatacenterMeta() map[string]provider.DatacenterMeta {
 				},
 			},
 		},
-		"moon-1": {
-			Location: "Dark Side",
-			Seed:     "us-central1",
-			Country:  "Moon States",
-			Spec: provider.DatacenterSpec{
-				VSphere: &provider.VSphereSpec{
-					Endpoint:      "http://127.0.0.1:8989",
-					AllowInsecure: true,
-					Datastore:     "LocalDS_0",
-					Datacenter:    "ha-datacenter",
-					Cluster:       "localhost.localdomain",
-					RootPath:      "/ha-datacenter/vm/",
-				},
-			},
-		},
 	}
 }
 

--- a/api/pkg/handler/vsphere_test.go
+++ b/api/pkg/handler/vsphere_test.go
@@ -1,15 +1,17 @@
 package handler
 
 import (
-	"flag"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/vmware/govmomi/simulator"
 )
+
+const vSphereDatacenterName = "moon-1"
 
 type vSphereMock struct {
 	model  *simulator.Model
@@ -17,17 +19,10 @@ type vSphereMock struct {
 }
 
 func (v *vSphereMock) tearUp() error {
-	// Yeah this is sucky, but api doesnt offer any other method without getting too low level.
-	f := flag.Lookup("httptest.serve")
-	err := f.Value.Set("127.0.0.1:8989")
-	if err != nil {
-		return err
-	}
-
 	// ESXi model + initial set of objects (VMs, network, datastore)
 	v.model = simulator.ESX()
 
-	err = v.model.Create()
+	err := v.model.Create()
 	if err != nil {
 		return err
 	}
@@ -54,14 +49,14 @@ func TestVsphereNetworksEndpoint(t *testing.T) {
 	defer mock.tearDown()
 
 	req := httptest.NewRequest("GET", "/api/v1/vsphere/networks", nil)
-	req.Header.Add("DatacenterName", "moon-1")
+	req.Header.Add("DatacenterName", vSphereDatacenterName)
 	req.Header.Add("Username", "user")
 	req.Header.Add("Password", "pass")
 
 	apiUser := getUser(testUserEmail, testUserID, testUserName, false)
 
 	res := httptest.NewRecorder()
-	ep, err := createTestEndpoint(apiUser, []runtime.Object{}, []runtime.Object{apiUserToKubermaticUser(apiUser)}, nil, nil)
+	ep, _, err := createTestEndpointAndGetClients(apiUser, mock.buildVSphereDatacenterMeta(), []runtime.Object{}, []runtime.Object{apiUserToKubermaticUser(apiUser)}, []runtime.Object{}, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create test endpoint due to %v", err)
 	}
@@ -72,4 +67,24 @@ func TestVsphereNetworksEndpoint(t *testing.T) {
 	}
 
 	compareWithResult(t, res, `[{"name":"VM Network"}]`)
+}
+
+func (v *vSphereMock) buildVSphereDatacenterMeta() map[string]provider.DatacenterMeta {
+	return map[string]provider.DatacenterMeta{
+		vSphereDatacenterName: {
+			Location: "Dark Side",
+			Seed:     "us-central1",
+			Country:  "Moon States",
+			Spec: provider.DatacenterSpec{
+				VSphere: &provider.VSphereSpec{
+					Endpoint:      v.server.Server.URL,
+					AllowInsecure: true,
+					Datastore:     "LocalDS_0",
+					Datacenter:    "ha-datacenter",
+					Cluster:       "localhost.localdomain",
+					RootPath:      "/ha-datacenter/vm/",
+				},
+			},
+		},
+	}
 }

--- a/api/pkg/handler/vsphere_test.go
+++ b/api/pkg/handler/vsphere_test.go
@@ -56,7 +56,7 @@ func TestVsphereNetworksEndpoint(t *testing.T) {
 	apiUser := getUser(testUserEmail, testUserID, testUserName, false)
 
 	res := httptest.NewRecorder()
-	ep, _, err := createTestEndpointAndGetClients(apiUser, mock.buildVSphereDatacenterMeta(), []runtime.Object{}, []runtime.Object{apiUserToKubermaticUser(apiUser)}, []runtime.Object{}, nil, nil)
+	ep, _, err := createTestEndpointAndGetClients(apiUser, mock.buildVSphereDatacenterMeta(), []runtime.Object{}, []runtime.Object{}, []runtime.Object{apiUserToKubermaticUser(apiUser)}, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create test endpoint due to %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

from time to time we have a failing test:
```
=== CONT  TestOpenstackEndpoints
httptest: serving on http://127.0.0.1:8989
--- FAIL: TestVsphereNetworksEndpoint (0.00s)
panic: httptest: failed to listen on 127.0.0.1:8989: listen tcp 127.0.0.1:8989: bind: address already in use [recovered]
	panic: httptest: failed to listen on 127.0.0.1:8989: listen tcp 127.0.0.1:8989: bind: address already in use
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
