### PR TITLE
change prometheus intervals

### DIFF
--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -43,8 +43,8 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
 }
 
 const prometheusConfig = `global:
-  evaluation_interval: 30s
-  scrape_interval: 30s
+  evaluation_interval: 1m
+  scrape_interval: 15s
   external_labels:
     cluster: "{{ .Cluster.Name }}"
 rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 15s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/config/monitoring/prometheus/config/prometheus.yml
+++ b/config/monitoring/prometheus/config/prometheus.yml
@@ -1,7 +1,7 @@
 global:
-  scrape_interval: 30s
+  scrape_interval: 15s
   scrape_timeout: 10s
-  evaluation_interval: 30s
+  evaluation_interval: 1m
   external_labels: {{ if eq (.Values.prometheus.externalLabels | len) 0 }}{}{{ end }}
     {{- range $k, $v := .Values.prometheus.externalLabels }}
     {{ $k }}: {{ $v | quote }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Change prometheus intervals to prevent alerts due to short peaks.
Scrape-interval: 15s
Evaluation-interval: 1m

**Release note**:
```release-note
NONE
```
