### PR TITLE
Revert "change prometheus intervals (#1781)"

### DIFF
--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -43,8 +43,8 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
 }
 
 const prometheusConfig = `global:
-  evaluation_interval: 1m
-  scrape_interval: 15s
+  evaluation_interval: 30s
+  scrape_interval: 30s
   external_labels:
     cluster: "{{ .Cluster.Name }}"
 rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.8.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.0-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.10-prometheus.yaml
@@ -1,8 +1,8 @@
 data:
   prometheus.yaml: |
     global:
-      evaluation_interval: 1m
-      scrape_interval: 15s
+      evaluation_interval: 30s
+      scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
     rule_files:

--- a/config/monitoring/prometheus/config/prometheus.yml
+++ b/config/monitoring/prometheus/config/prometheus.yml
@@ -1,7 +1,7 @@
 global:
-  scrape_interval: 15s
+  scrape_interval: 30s
   scrape_timeout: 10s
-  evaluation_interval: 1m
+  evaluation_interval: 30s
   external_labels: {{ if eq (.Values.prometheus.externalLabels | len) 0 }}{}{{ end }}
     {{- range $k, $v := .Values.prometheus.externalLabels }}
     {{ $k }}: {{ $v | quote }}


### PR DESCRIPTION
This reverts commit 8b27b44
PR https://github.com/kubermatic/kubermatic/pull/1781

**What this PR does / why we need it**:
Those changes were intended for a test on cloud. Test outcome: No improvement

**Release note**:
```release-note
NONE
```
