### PR TITLE
removes ssh keys without an owner

### DIFF
--- a/api/cmd/projects-migrator/main.go
+++ b/api/cmd/projects-migrator/main.go
@@ -147,7 +147,7 @@ func removeKeysWithoutOwner(ctx migrationContext) error {
 	{
 		for _, keyToRemove := range keysWithoutOwner {
 			if !ctx.dryRun {
-				_, err := ctx.masterKubermaticClient.KubermaticV1().UserSSHKeies().Update(&keyToRemove)
+				err := ctx.masterKubermaticClient.KubermaticV1().UserSSHKeies().Delete(keyToRemove.Name, &metav1.DeleteOptions{})
 				if err != nil {
 					return err
 				}

--- a/api/cmd/projects-migrator/main.go
+++ b/api/cmd/projects-migrator/main.go
@@ -87,13 +87,13 @@ func main() {
 	//          for example on dev environment: user-lknc7, user-n45j9, user-z9s20j
 	err = removeDuplicatedUsers(ctx)
 	if err != nil {
-		glog.Errorf("phase 0 failed due to = %v", err)
+		glog.Fatalf("phase 0 failed due to = %v", err)
 	}
 
 	// phase 1: migrate existing cluster resources along with ssh keys they use to projects
 	err = migrateToProject(ctx)
 	if err != nil {
-		glog.Errorf("phase 1 failed due to = %v", err)
+		glog.Fatalf("phase 1 failed due to = %v", err)
 	}
 
 	// phase 2: migrate the remaining ssh keys to a project
@@ -103,7 +103,7 @@ func main() {
 	//          the project owner and were not used by running cluster (phase 1)
 	err = migrateRemainingSSHKeys(ctx)
 	if err != nil {
-		glog.Errorf("phase 2 failed due to %v", err)
+		glog.Fatalf("phase 2 failed due to %v", err)
 	}
 
 	// TODO:
@@ -114,11 +114,51 @@ func main() {
 	//         note that:
 	//         this step essentially breaks backward compatibility and prevents the old clients (dashboard) from finding the resources.
 
-	// TODO:
 	// phase 4 remove ssh keys without an owner
 	//
 	//         the keys that don't have an owner have their sshKey.Spec.Owner field empty
 	//         for example: key-8036218bef587f8230dad6426099da14-c7i4 and key-8036218bef587f8230dad6426099da14-wwk5 on dev env
+	err = removeKeysWithoutOwner(ctx)
+	if err != nil {
+		glog.Errorf("phase 4 failed due to %v", err)
+	}
+}
+
+func removeKeysWithoutOwner(ctx migrationContext) error {
+	glog.Info("\n")
+	glog.Infof("Running PHASE 4 ...")
+
+	keysWithoutOwner := []kubermaticv1.UserSSHKey{}
+	glog.Info("STEP 1: getting the list of keys that are owned by a project owner")
+	{
+		allKeys, err := ctx.masterKubermaticClient.KubermaticV1().UserSSHKeies().List(metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, key := range allKeys.Items {
+			if len(key.Spec.Owner) == 0 {
+				keysWithoutOwner = append(keysWithoutOwner, key)
+			}
+		}
+	}
+
+	glog.Info("STEP 2: removing the keys without an owner (if any)")
+	{
+		for _, keyToRemove := range keysWithoutOwner {
+			if !ctx.dryRun {
+				_, err := ctx.masterKubermaticClient.KubermaticV1().UserSSHKeies().Update(&keyToRemove)
+				if err != nil {
+					return err
+				}
+				glog.Infof("the ssh key = %s was removed", keyToRemove.Name)
+			} else {
+				glog.Infof("the ssh key = %s was NOT removed because dry-run option was requested", keyToRemove.Name)
+			}
+		}
+	}
+
+	return nil
 }
 
 //  migrateRemainingSSHKeys assigns the keys that are owned by the project owner


### PR DESCRIPTION
**What this PR does / why we need it**: removes ssh keys without an owner keys like that cannot be used or even listed in our system, thus they will be removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See also #1556 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
