### PR TITLE
Fix nginx-ingress Prometheus config

### DIFF
--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -20,8 +20,8 @@ spec:
       labels:
         app: ingress-nginx
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '10254'
+        kubermatic/scrape: {{ .Values.nginx.prometheus.scrape | quote }}
+        kubermatic/scrape_port: {{ .Values.nginx.prometheus.port | quote }}
     spec:
     {{ if .Values.nginx.hostNetwork }}
       hostNetwork: true
@@ -82,7 +82,7 @@ spec:
                   fieldPath: metadata.namespace
           ports:
           - name: metrics
-            containerPort: 10254
+            containerPort: {{ .Values.nginx.prometheus.port }}
           - name: http
             containerPort: 80
           - name: https
@@ -91,7 +91,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.nginx.prometheus.port }}
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -101,7 +101,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.nginx.prometheus.port }}
               scheme: HTTP
             periodSeconds: 10
             successThreshold: 1

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       labels:
         app: ingress-nginx
+      annotations:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '10254'
     spec:

--- a/config/nginx-ingress-controller/templates/service.yaml
+++ b/config/nginx-ingress-controller/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   clusterIP: None
   ports:
   - name: metrics
-    port: 10254
+    port: {{ .Values.nginx.prometheus.port }}
     protocol: TCP
   selector:
     app: ingress-nginx

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -4,9 +4,6 @@ nginx:
   asDaemonSet: false
   replicas: 3
   ignoreMasterTaint: false
-  prometheus:
-    port: "10254"
-    scrape: "true"
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
     tag: 0.18.0

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -4,6 +4,9 @@ nginx:
   asDaemonSet: false
   replicas: 3
   ignoreMasterTaint: false
+  prometheus:
+    port: 10254
+    scrape: true
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
     tag: 0.18.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Somewhere in the last months, the nginx-ingress configuration was slowly morphed from using annotations to using configurable annotations (#636), to not using anything (#657 in which @guusvw had the [right idea](https://github.com/kubermatic/kubermatic/pull/657/files#r158278910) when asking why were removed) to using static labels (4 days ago in #1777). However, Prometheus expects the pods to have _annotations_ to properly build the target address for scraping their metrics. By just using labels, Prometheus cannot build the correct URL (noticeably the port) and fails to scrape any metrics.

This PR restores the old behaviour of using annotations for the scrape flag and port. It also uses the existing `prometheus.port` variable to build the Helm templates once again. The variables are not really meant to be changed (though it is safe to do so, as Prometheus will pick them up), but more as constants to not accidentally change a port somewhere without changing the others.

**Release note**:
```release-note monitoring
annotations will be used instead of labels for the nginx-ingress Prometheus configuration
```
