### PR TITLE
Fix: scrape annotations in s3-exporter must not be labels but annotations

### DIFF
--- a/config/kubermatic/templates/s3-exporter-dep.yaml
+++ b/config/kubermatic/templates/s3-exporter-dep.yaml
@@ -45,6 +45,7 @@ spec:
     metadata:
       labels:
         app: s3-exporter
+      annotations:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '9340'
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**: Fix: scrape annotations must not be labels but annotations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```
