### PR TITLE
stops the migration app when duplicates for users were detected

### DIFF
--- a/api/cmd/projects-migrator/main.go
+++ b/api/cmd/projects-migrator/main.go
@@ -551,6 +551,10 @@ func getAllClusters(ctx migrationContext) (map[string]map[string]*clustersProvid
 	// helper is a helper method that adds the given cluster to the list of clusters
 	// grouped by the user's ID and physical location
 	helper := func(cluster kubermaticv1.Cluster, provider *clusterProvider) {
+		if val, ok := cluster.Labels["user"]; !ok || len(val) == 0 {
+			glog.Warningf("the cluster ID = %s, Name = %s doesn't have an owner (this might be okay, e2e tests ?)", cluster.Name, cluster.Spec.HumanReadableName)
+				return
+		}
 		userClustersMap := clustersToAdoptByUserID[cluster.Labels["user"]]
 
 		if userClustersMap == nil {


### PR DESCRIPTION
**What this PR does / why we need it**: the migration tool will stop when it detects duplicates for users, as this means that our API server is faulty and we need to provide a fix. Once we have the fix we can run the migration tool with `rm-dup-users=true` flag, this flag tell the tool to only remove duplicates and exit

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See also #1556

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
