### PR TITLE
deploys project-migrator tool as an init container of rbac-generator

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,6 +1,6 @@
 REPO=kubermatic/api
 GO?=go
-CMD=kubermatic-api kubermatic-controller-manager kubermatic-controller-manager-cleanup image-loader rbac-generator s3-storeuploader kubermatic-e2e s3-exporter ipam-controller
+CMD=kubermatic-api kubermatic-controller-manager kubermatic-controller-manager-cleanup image-loader rbac-generator s3-storeuploader kubermatic-e2e s3-exporter ipam-controller projects-migrator
 GOBUILDFLAGS += -v
 GITTAG=$(shell git describe --tags --always)
 TAGS?=$(GITTAG)

--- a/config/kubermatic/master/templates/kubermatic-rbac-generator-dep.yaml
+++ b/config/kubermatic/master/templates/kubermatic-rbac-generator-dep.yaml
@@ -14,6 +14,21 @@ spec:
       labels:
         app: rbac-generator
     spec:
+      initContainers:
+      - name: projects-migrator
+        image: '{{.Values.kubermatic.rbac.image.repository}}:{{.Values.kubermatic.rbac.image.tag}}'
+        imagePullPolicy: {{.Values.kubermatic.rbac.image.pullPolicy}}
+        command:
+        - projects-migrator
+        args:
+        - -v=3
+        - -logtostderr
+        - -kubeconfig=/opt/.kube/kubeconfig
+        - -dry-run=false
+        volumeMounts:
+          - name: kubeconfigwithseeds
+            mountPath: "/opt/.kube/"
+            readOnly: true
       containers:
       - name: rbac-generator
         command:


### PR DESCRIPTION
**What this PR does / why we need it**: deploys `project-migrator` tool as an init container of `rbac-generator`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1556


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Old clusters will be automatically migrated to each user's default project
```
