### PR TITLE
loads seed cluster configuration properly

### DIFF
--- a/api/cmd/projects-migrator/main.go
+++ b/api/cmd/projects-migrator/main.go
@@ -75,7 +75,7 @@ func main() {
 
 			glog.V(2).Infof("Adding %s as seed cluster", ctxName)
 			kubeClient := kubernetes.NewForConfigOrDie(cfg)
-			kubermaticClient := kubermaticclientset.NewForConfigOrDie(ctx.config)
+			kubermaticClient := kubermaticclientset.NewForConfigOrDie(cfg)
 			clusterProviders = append(clusterProviders, &clusterProvider{fmt.Sprintf("seed/%s", ctxName), kubeClient, kubermaticClient})
 		}
 	}

--- a/api/cmd/rbac-generator/main.go
+++ b/api/cmd/rbac-generator/main.go
@@ -81,7 +81,7 @@ func main() {
 				glog.Fatal(err)
 			}
 			kubeInformerFactory := kuberinformers.NewSharedInformerFactory(kubeClient, time.Minute*5)
-			kubermaticClient := kubermaticclientset.NewForConfigOrDie(config)
+			kubermaticClient := kubermaticclientset.NewForConfigOrDie(cfg)
 			kubermaticInformerFactory := externalversions.NewSharedInformerFactory(kubermaticClient, time.Minute*5)
 			ctrlCtx.seedClusterProviders = append(ctrlCtx.seedClusterProviders, rbaccontroller.NewClusterProvider(fmt.Sprintf("seed/%s", ctxName), kubeClient, kubeInformerFactory, kubermaticClient, kubermaticInformerFactory))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: fixes seed cluster initialisation in both `projects-migrator` and `rbac-generator` applications

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
