### PR TITLE
uses labels instead of OwnerReferences for cluster resources

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -136,6 +136,8 @@ func main() {
 		kubermaticSeedClient := kubermaticclientset.NewForConfigOrDie(cfg)
 		kubermaticSeedInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticSeedClient, informerResyncPeriod)
 
+		defaultImpersonationClientForSeed := kubernetesprovider.NewKubermaticImpersonationClient(cfg)
+
 		clusterProviders[ctx] = kubernetesprovider.NewClusterProvider(
 			kubermaticSeedClient,
 			client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
@@ -144,7 +146,7 @@ func main() {
 			handler.IsAdmin,
 		)
 		newClusterProviders[ctx] = kubernetesprovider.NewRBACCompliantClusterProvider(
-			defaultImpersonationClient.CreateImpersonatedClientSet,
+			defaultImpersonationClientForSeed.CreateImpersonatedClientSet,
 			client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
 			kubermaticSeedInformerFactory.Kubermatic().V1().Clusters().Lister(),
 			workerName,

--- a/api/pkg/controller/rbac/sync_project_test.go
+++ b/api/pkg/controller/rbac/sync_project_test.go
@@ -596,6 +596,221 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 	}
 }
 
+// TestEnsureClusterResourcesCleanup test if cluster resources for the given
+// project were removed from all physical locations
+func TestEnsureClusterResourcesCleanup(t *testing.T) {
+	tests := []struct {
+		name               string
+		projectToSync      *kubermaticv1.Project
+		existingClustersOn map[string][]*kubermaticv1.Cluster
+		deletedClustersOn  map[string][]string
+	}{
+		// scenario 1
+		{
+			name:          "scenario 1: when a project is removed all cluster resources from all clusters (physical location) are also removed",
+			projectToSync: createProject("plan9", createUser("bob")),
+			existingClustersOn: map[string][]*kubermaticv1.Cluster{
+
+				// cluster resources that are on "a" physical location
+				"a": []*kubermaticv1.Cluster{
+
+					// cluster "abcd" that belongs to "thunderball" project
+					&kubermaticv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "abcd",
+							UID:  types.UID("abcdID"),
+							Labels: map[string]string{
+								kubermaticv1.ProjectIDLabelKey: "thunderball",
+							},
+						},
+						Spec:    kubermaticv1.ClusterSpec{},
+						Address: kubermaticv1.ClusterAddress{},
+						Status: kubermaticv1.ClusterStatus{
+							NamespaceName: "cluster-abcd",
+						},
+					},
+
+					// cluster "ab" that belongs to "plan9" project
+					&kubermaticv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ab",
+							UID:  types.UID("abID"),
+							Labels: map[string]string{
+								kubermaticv1.ProjectIDLabelKey: "plan9",
+							},
+						},
+						Spec:    kubermaticv1.ClusterSpec{},
+						Address: kubermaticv1.ClusterAddress{},
+						Status: kubermaticv1.ClusterStatus{
+							NamespaceName: "cluster-ab",
+						},
+					},
+				},
+
+				// cluster resources that are on "b" physical location
+				"b": []*kubermaticv1.Cluster{
+
+					// cluster "xyz" that belongs to "plan9" project
+					&kubermaticv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "xyz",
+							UID:  types.UID("xyzID"),
+							Labels: map[string]string{
+								kubermaticv1.ProjectIDLabelKey: "plan9",
+							},
+						},
+						Spec:    kubermaticv1.ClusterSpec{},
+						Address: kubermaticv1.ClusterAddress{},
+						Status: kubermaticv1.ClusterStatus{
+							NamespaceName: "cluster-xyz",
+						},
+					},
+
+					// cluster "zzz" that belongs to "plan9" project
+					&kubermaticv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "zzz",
+							UID:  types.UID("zzzID"),
+							Labels: map[string]string{
+								kubermaticv1.ProjectIDLabelKey: "plan9",
+							},
+						},
+						Spec:    kubermaticv1.ClusterSpec{},
+						Address: kubermaticv1.ClusterAddress{},
+						Status: kubermaticv1.ClusterStatus{
+							NamespaceName: "cluster-zzz",
+						},
+					},
+				},
+
+				// cluster resources that are on "c" physical location
+				"c": []*kubermaticv1.Cluster{
+
+					// cluster "cat" that belongs to "acme" project
+					&kubermaticv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cat",
+							UID:  types.UID("catID"),
+							Labels: map[string]string{
+								kubermaticv1.ProjectIDLabelKey: "acme",
+							},
+						},
+						Spec:    kubermaticv1.ClusterSpec{},
+						Address: kubermaticv1.ClusterAddress{},
+						Status: kubermaticv1.ClusterStatus{
+							NamespaceName: "cluster-cat",
+						},
+					},
+
+					// cluster "bat" that belongs to "acme" project
+					&kubermaticv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bat",
+							UID:  types.UID("batID"),
+							Labels: map[string]string{
+								kubermaticv1.ProjectIDLabelKey: "acme",
+							},
+						},
+						Spec:    kubermaticv1.ClusterSpec{},
+						Address: kubermaticv1.ClusterAddress{},
+						Status: kubermaticv1.ClusterStatus{
+							NamespaceName: "cluster-bat",
+						},
+					},
+				},
+			},
+			deletedClustersOn: map[string][]string{
+				"a": []string{"ab"},
+				"b": []string{"xyz", "zzz"},
+				"c": []string{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// prepare test data
+			getClusterProviderByName := func(name string, providers []*ClusterProvider) (*ClusterProvider, error) {
+				for _, provider := range providers {
+					if provider.providerName == name {
+						return provider, nil
+					}
+				}
+				return nil, fmt.Errorf("provider %s not found", name)
+			}
+			allClusterProviders := make([]*ClusterProvider, len(test.existingClustersOn))
+			{
+				index := 0
+				for providerName, clusterResources := range test.existingClustersOn {
+					kubermaticObjs := []runtime.Object{}
+					kubeObjs := []runtime.Object{}
+					clusterResourcesIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+					for _, clusterResource := range clusterResources {
+						err := clusterResourcesIndexer.Add(clusterResource)
+						if err != nil {
+							t.Fatal(err)
+						}
+						kubermaticObjs = append(kubermaticObjs, clusterResource)
+					}
+
+					fakeKubeClient := fake.NewSimpleClientset(kubeObjs...)
+					fakeKubeInformerFactory := kuberinformers.NewSharedInformerFactory(fakeKubeClient, time.Minute*5)
+					fakeKubermaticClient := kubermaticfakeclientset.NewSimpleClientset(kubermaticObjs...)
+					fakeProvider := NewClusterProvider(providerName, fakeKubeClient, fakeKubeInformerFactory, fakeKubermaticClient, nil)
+					fakeProvider.AddIndexerFor(clusterResourcesIndexer, schema.GroupVersionResource{Resource: kubermaticv1.ClusterResourceName})
+					allClusterProviders[index] = fakeProvider
+					index = index + 1
+				}
+			}
+			userIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			userLister := kubermaticv1lister.NewUserLister(userIndexer)
+			fakeKubermaticMasterClient := kubermaticfakeclientset.NewSimpleClientset(test.projectToSync)
+
+			// act
+			target := Controller{}
+			target.allClusterProviders = allClusterProviders
+			target.userLister = userLister
+			target.kubermaticMasterClient = fakeKubermaticMasterClient
+			err := target.ensureProjectCleanup(test.projectToSync)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// validate
+			if len(test.deletedClustersOn) != len(test.existingClustersOn) {
+				t.Fatalf("deletedClustersOn field is different than existingClusterOn in length, did you forget to update deletedClusterOn ?")
+			}
+			for providerName, deletedClusterResources := range test.deletedClustersOn {
+				provider, err := getClusterProviderByName(providerName, allClusterProviders)
+				if err != nil {
+					t.Fatalf("unable to validate deleted cluster resources because didn't find the provider %s", providerName)
+				}
+				fakeKubermaticClient, ok := provider.kubermaticClient.(*kubermaticfakeclientset.Clientset)
+				if !ok {
+					t.Fatalf("cannot cast kubermaticClient for provider %s", providerName)
+				}
+
+				if len(fakeKubermaticClient.Actions()) != len(deletedClusterResources) {
+					t.Fatalf("unexpected number of clusters were deleted, expected only %d, but got %d, for provider %s", len(deletedClusterResources), len(fakeKubermaticClient.Actions()), providerName)
+				}
+
+				for index, action := range fakeKubermaticClient.Actions() {
+					if !action.Matches("delete", "clusters") {
+						t.Fatalf("unexpected action %#v", action)
+					}
+					deleteAction, ok := action.(clienttesting.DeleteAction)
+					if !ok {
+						t.Fatalf("unexpected action %#v", action)
+					}
+					if deleteAction.GetName() != deletedClusterResources[index] {
+						t.Fatalf("wrong cluster has been deleted %s, expected %s", deleteAction.GetName(), deletedClusterResources[index])
+					}
+				}
+			}
+		})
+	}
+}
+
 // TestEnsureUserProjectCleanup extends TestEnsureProjectCleanup in a way
 // that also checks if the project being removed is removed from "Spec.Project" array for all users that belong the the project
 func TestEnsureUsersProjectCleanup(t *testing.T) {

--- a/api/pkg/controller/rbac/sync_resource_test.go
+++ b/api/pkg/controller/rbac/sync_resource_test.go
@@ -47,13 +47,8 @@ func TestEnsureDependantsRBACRole(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "abcd",
 						UID:  types.UID("abcdID"),
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
-								Kind:       kubermaticv1.ProjectKindName,
-								Name:       "thunderball",
-								UID:        "thunderballID",
-							},
+						Labels: map[string]string{
+							kubermaticv1.ProjectIDLabelKey: "thunderball",
 						},
 					},
 					Spec:    kubermaticv1.ClusterSpec{},
@@ -213,6 +208,184 @@ func TestEnsureDependantsRBACRole(t *testing.T) {
 		},
 
 		// scenario 2
+		{
+			name:            "scenario 2: a proper set of RBAC Role/Binding is generated for an ssh key",
+			expectedActions: []string{"create", "create", "create", "create", "create", "create"},
+			existingProject: createProject("thunderball", createUser("James Bond")),
+
+			dependantToSync: &projectResourceQueueItem{
+				gvr: schema.GroupVersionResource{
+					Group:    kubermaticv1.SchemeGroupVersion.Group,
+					Version:  kubermaticv1.SchemeGroupVersion.Version,
+					Resource: kubermaticv1.SSHKeyResourceName,
+				},
+				kind: kubermaticv1.SSHKeyKind,
+				metaObject: &kubermaticv1.UserSSHKey{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "abcd",
+						UID:  types.UID("abcdID"),
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID",
+							},
+						},
+					},
+					Spec: kubermaticv1.SSHKeySpec{},
+				},
+			},
+
+			expectedClusterRoles: []*rbacv1.ClusterRole{
+				&rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:usersshkey-abcd:owners-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.SSHKeyKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{kubermaticv1.SSHKeyResourceName},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+
+				&rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:usersshkey-abcd:editors-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.SSHKeyKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{kubermaticv1.SSHKeyResourceName},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+				&rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:usersshkey-abcd:viewers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.SSHKeyKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{kubermaticv1.SSHKeyResourceName},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get"},
+						},
+					},
+				},
+			},
+
+			expectedClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:usersshkey-abcd:owners-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.SSHKeyKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "owners-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:usersshkey-abcd:owners-thunderball",
+					},
+				},
+
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:usersshkey-abcd:editors-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.SSHKeyKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "editors-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:usersshkey-abcd:editors-thunderball",
+					},
+				},
+
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:usersshkey-abcd:viewers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.SSHKeyKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "viewers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:usersshkey-abcd:viewers-thunderball",
+					},
+				},
+			},
+		},
+
+		// scenario 3
 		//
 		// TODO: uncomment this when existing object are migrated to projects
 		//       see: https://github.com/kubermatic/kubermatic/issues/1219
@@ -259,7 +432,6 @@ func TestEnsureDependantsRBACRole(t *testing.T) {
 				}
 				kubermaticObjs = append(kubermaticObjs, test.existingProject)
 			}
-			//projectLister := kubermaticv1lister.NewProjectLister(projectIndexer)
 
 			objs := []runtime.Object{}
 			clusterRoleIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -39,6 +39,7 @@ const (
 
 const (
 	WorkerNameLabelKey = "worker-name"
+	ProjectIDLabelKey  = "project-id"
 )
 
 //+genclient


### PR DESCRIPTION
**What this PR does / why we need it**: Changes how cluster resources are attached to the given project. Cluster resources are on seed clusters and as we don't store information on project resources there we cannot use OwnerReferences. In general, if the object pointed in the OwnerReferences doesn't exist then the child object will be garbaged collected by k8s.


**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
