### PR TITLE
fixes flaky TestEnsureClusterResourcesCleanup test

### DIFF
--- a/api/pkg/controller/rbac/sync_project_test.go
+++ b/api/pkg/controller/rbac/sync_project_test.go
@@ -794,7 +794,7 @@ func TestEnsureClusterResourcesCleanup(t *testing.T) {
 					t.Fatalf("unexpected number of clusters were deleted, expected only %d, but got %d, for provider %s", len(deletedClusterResources), len(fakeKubermaticClient.Actions()), providerName)
 				}
 
-				for index, action := range fakeKubermaticClient.Actions() {
+				for _, action := range fakeKubermaticClient.Actions() {
 					if !action.Matches("delete", "clusters") {
 						t.Fatalf("unexpected action %#v", action)
 					}
@@ -802,8 +802,17 @@ func TestEnsureClusterResourcesCleanup(t *testing.T) {
 					if !ok {
 						t.Fatalf("unexpected action %#v", action)
 					}
-					if deleteAction.GetName() != deletedClusterResources[index] {
-						t.Fatalf("wrong cluster has been deleted %s, expected %s", deleteAction.GetName(), deletedClusterResources[index])
+
+					foundDeletedResourceOnTheList := false
+					for _, deletedClusterResource := range deletedClusterResources {
+						if deleteAction.GetName() == deletedClusterResource {
+							foundDeletedResourceOnTheList = true
+							break
+						}
+
+					}
+					if !foundDeletedResourceOnTheList {
+						t.Fatalf("wrong cluster has been deleted %s, the cluster is not on the list  %v", deleteAction.GetName(), deletedClusterResources)
 					}
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**: fixes flaky TestEnsureClusterResourcesCleanup test, the list of clusters that were deleted is not stable thus instead of checking at the index position check if the cluster is on the list of clusters that are expected to be deleted.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
