### PR TITLE
uses labels instead of OwnerReferences when migrating clusters

### DIFF
--- a/api/cmd/projects-migrator/main.go
+++ b/api/cmd/projects-migrator/main.go
@@ -248,7 +248,7 @@ func migrateRemainingSSHKeys(ctx migrationContext) error {
 			userName := isOwnedByUser(project.OwnerReferences)
 			if len(userName) > 0 {
 				if user, err := ctx.masterKubermaticClient.KubermaticV1().Users().Get(userName, metav1.GetOptions{}); err == nil {
-					projectOwnersTuple[userName] = projectOwnerTuple{project: project, owner: *user}
+					projectOwnersTuple[user.Spec.ID] = projectOwnerTuple{project: project, owner: *user}
 				}
 			} else {
 				return fmt.Errorf("project ID = %s, Name = %s doesn't have an owner", project.Name, project.Spec.Name)
@@ -509,7 +509,7 @@ func migrateToProject(ctx migrationContext) error {
 			if !ctx.dryRun {
 				_, err := ctx.masterKubermaticClient.KubermaticV1().Users().Update(&user)
 				if err != nil {
-					glog.Errorf("failed to update user (ID = %s) object, however we can continue because the user object will be updated by the \"rbac-controller\" anyway, err = %v", user.Spec.ID, err)
+					return fmt.Errorf("failed to update user (ID = %s) object, err = %v", user.Spec.ID, err)
 				}
 			} else {
 				glog.Infof("a project (ID = %s, Name = %s) for userID = %s was NOT added to the \"Spec.Projects\" field because dry-run option was requested", project.Name, project.Spec.Name, user.Spec.ID)


### PR DESCRIPTION
**What this PR does / why we need it**: adjusts the tool to use `labels` instead of `OwnerReferences` when migrating `cluster` resources. It turned out that we cannot use OwnerReferences because there is no referenced object on the seed clusters and the resource will be `gc'ed`.

**Special notes for your reviewer**: see for more https://github.com/kubermatic/kubermatic/pull/1839


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
