### PR TITLE
enables the project's migration tool

### DIFF
--- a/config/kubermatic/master/templates/kubermatic-rbac-generator-dep.yaml
+++ b/config/kubermatic/master/templates/kubermatic-rbac-generator-dep.yaml
@@ -24,6 +24,7 @@ spec:
         - -v=3
         - -logtostderr
         - -kubeconfig=/opt/.kube/kubeconfig
+        - -dry-run=false
         volumeMounts:
           - name: kubeconfigwithseeds
             mountPath: "/opt/.kube/"


### PR DESCRIPTION
**What this PR does / why we need it**: enables the project's migration tool by default the tool runs in "dry" mode and doesn't persist the changes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
