### PR TITLE
check if the key already belongs to a project

### DIFF
--- a/api/cmd/projects-migrator/main.go
+++ b/api/cmd/projects-migrator/main.go
@@ -270,6 +270,10 @@ func migrateRemainingSSHKeys(ctx migrationContext) error {
 				glog.Warningf("the key ID = %s, Name = %s doesn't have an owner", key.Name, key.Spec.Name)
 				continue
 			}
+			if projectName := isOwnedByProject(key.GetOwnerReferences(), nil); len(projectName) > 0 {
+				glog.V(2).Infof("skipping the key ID = %s, Name = %s, already belongs to the project %s", key.Name, key.Spec.Name, projectName)
+				continue
+			}
 			if projectOwner, ok := projectOwnersTuple[key.Spec.Owner]; ok {
 				keysProjectTuple = append(keysProjectTuple, keyProjectTuple{key: key, project: projectOwner.project})
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**: adds additional check for migrateRemainingSSHKeys phase
that will check if the key has been already added to the project.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
