### PR TITLE
rbac controller reads cluster resources only from seeds

### DIFF
--- a/api/cmd/rbac-generator/main.go
+++ b/api/cmd/rbac-generator/main.go
@@ -102,7 +102,7 @@ func main() {
 			// special case the current context/master is also a seed cluster
 			// we keep cluster resources also on master
 			if ctxName == clientcmdConfig.CurrentContext {
-				glog.V(2).Infof("Specail case adding %s (current context) also as seed cluster", ctxName)
+				glog.V(2).Infof("Special case adding %s (current context) also as seed cluster", ctxName)
 				clusterPrefix = rbaccontroller.SeedProviderPrefix
 				ctrlCtx.allClusterProviders = append(ctrlCtx.allClusterProviders, rbaccontroller.NewClusterProvider(fmt.Sprintf("%s/%s", clusterPrefix, ctxName), kubeClient, kubeInformerFactory, kubermaticClient, kubermaticInformerFactory))
 			}

--- a/api/cmd/rbac-generator/main.go
+++ b/api/cmd/rbac-generator/main.go
@@ -79,10 +79,6 @@ func main() {
 			if err != nil {
 				glog.Fatal(err)
 			}
-			if cfg.Host == config.Host && cfg.Username == config.Username && cfg.Password == config.Password {
-				glog.V(2).Infof("Skipping adding %s as a seed cluster. It is exactly the same as existing kubernetes master client", ctxName)
-				continue
-			}
 
 			glog.V(2).Infof("Adding %s as seed cluster", ctxName)
 			kubeClient, err := kubernetes.NewForConfig(cfg)

--- a/api/pkg/controller/rbac/cluster_provider.go
+++ b/api/pkg/controller/rbac/cluster_provider.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
+	// MasterProviderPrefix denotes prefix a master cluster has in its name
 	MasterProviderPrefix = "master"
-	SeedProviderPrefix   = "seed"
+	// SeedProviderPrefix denotes prefix a seed cluster has in its name
+	SeedProviderPrefix = "seed"
 )
 
 // ClusterProvider holds set of clients that allow for communication with the cluster and

--- a/api/pkg/controller/rbac/cluster_provider.go
+++ b/api/pkg/controller/rbac/cluster_provider.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	masterProviderName = "master"
+	MasterProviderPrefix = "master"
+	SeedProviderPrefix   = "seed"
 )
 
 // ClusterProvider holds set of clients that allow for communication with the cluster and

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -1,14 +1,15 @@
 package rbac
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
-	kubermaticsharedinformer "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
 	kubermaticsharedinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -18,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	rbacinformer "k8s.io/client-go/informers/rbac/v1"
 	"k8s.io/client-go/kubernetes"
 	rbaclister "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
@@ -83,24 +83,25 @@ type projectResource struct {
 // managing RBAC roles for project's resources
 // The controller will also set proper ownership chain through OwnerReferences
 // so that whenever a project is deleted dependants object will be garbage collected.
-func New(
-	metrics *Metrics,
-	kubermaticMasterClient kubermaticclientset.Interface,
-	kubermaticMasterInformerFactory kubermaticsharedinformer.SharedInformerFactory,
-	kubeMasterClient kubernetes.Interface,
-	rbacClusterRoleMasterInformer rbacinformer.ClusterRoleInformer,
-	rbacClusterRoleBindingMasterInformer rbacinformer.ClusterRoleBindingInformer,
-	seedClusterProviders []*ClusterProvider) (*Controller, error) {
+func New(metrics *Metrics, allClusterProviders []*ClusterProvider) (*Controller, error) {
 	c := &Controller{
-		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project"),
-		projectResourcesQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project_resources"),
-		metrics:                metrics,
-		kubermaticMasterClient: kubermaticMasterClient,
-		kubeMasterClient:       kubeMasterClient,
-		seedClusterProviders:   seedClusterProviders,
+		projectQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project"),
+		projectResourcesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project_resources"),
+		metrics:               metrics,
 	}
 
-	projectInformer := kubermaticMasterInformerFactory.Kubermatic().V1().Projects()
+	var masterClusterProvider *ClusterProvider
+	for _, clusterProvider := range allClusterProviders {
+		if strings.HasPrefix(clusterProvider.providerName, MasterProviderPrefix) {
+			masterClusterProvider = clusterProvider
+			break
+		}
+	}
+	if masterClusterProvider == nil {
+		return nil, errors.New("cannot create controller because master cluster provider has not been found")
+	}
+
+	projectInformer := masterClusterProvider.kubermaticInformerFactory.Kubermatic().V1().Projects()
 	prometheus.MustRegister(metrics.Workers)
 
 	projectInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -129,13 +130,16 @@ func New(
 	})
 	c.projectLister = projectInformer.Lister()
 
-	userInformer := kubermaticMasterInformerFactory.Kubermatic().V1().Users()
+	userInformer := masterClusterProvider.kubermaticInformerFactory.Kubermatic().V1().Users()
 	c.userLister = userInformer.Lister()
 
-	c.userProjectBindingLister = kubermaticMasterInformerFactory.Kubermatic().V1().UserProjectBindings().Lister()
+	c.userProjectBindingLister = masterClusterProvider.kubermaticInformerFactory.Kubermatic().V1().UserProjectBindings().Lister()
 
-	c.rbacClusterRoleBindingMasterLister = rbacClusterRoleBindingMasterInformer.Lister()
-	c.rbacClusterRoleMasterLister = rbacClusterRoleMasterInformer.Lister()
+	c.rbacClusterRoleBindingMasterLister = masterClusterProvider.rbacClusterRoleBindingLister
+	c.rbacClusterRoleMasterLister = masterClusterProvider.rbacClusterRoleLister
+
+	c.kubeMasterClient = masterClusterProvider.kubeClient
+	c.kubermaticMasterClient = masterClusterProvider.kubermaticClient
 
 	// a list of dependent resources that we would like to watch/monitor
 	c.projectResources = []projectResource{
@@ -168,10 +172,15 @@ func New(
 		},
 	}
 
-	for _, clusterProvider := range seedClusterProviders {
+	for _, clusterProvider := range allClusterProviders {
+		glog.V(6).Infof("considering %s provider for resources", clusterProvider.providerName)
 		for _, resource := range c.projectResources {
-			if len(resource.destination) == 0 && clusterProvider.providerName != masterProviderName {
+			if len(resource.destination) == 0 && !strings.HasPrefix(clusterProvider.providerName, MasterProviderPrefix) {
 				glog.V(6).Infof("skipping adding a shared informer and indexer for a project's resource %q for provider %q, as it is meant only for the master cluster provider", resource.gvr.String(), clusterProvider.providerName)
+				continue
+			}
+			if resource.destination == destinationSeed && !strings.HasPrefix(clusterProvider.providerName, SeedProviderPrefix) {
+				glog.V(6).Infof("skipping adding a shared informer and indexer for a project's resource %q for provider %q, as it is meant only for the seed cluster provider", resource.gvr.String(), clusterProvider.providerName)
 				continue
 			}
 			informer, indexer, err := c.informerIndexerFor(clusterProvider.kubermaticInformerFactory, resource.gvr, resource.kind, clusterProvider)
@@ -180,6 +189,12 @@ func New(
 			}
 			clusterProvider.AddIndexerFor(indexer, resource.gvr)
 			c.projectResourcesInformers = append(c.projectResourcesInformers, informer)
+		}
+	}
+
+	for _, clusterProvider := range allClusterProviders {
+		if strings.HasPrefix(clusterProvider.providerName, SeedProviderPrefix) {
+			c.seedClusterProviders = append(c.seedClusterProviders, clusterProvider)
 		}
 	}
 

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -69,7 +69,6 @@ type Controller struct {
 	projectResourcesInformers []cache.Controller
 	projectResourcesQueue     workqueue.RateLimitingInterface
 
-	allClusterProviders  []*ClusterProvider
 	seedClusterProviders []*ClusterProvider
 	projectResources     []projectResource
 }
@@ -169,18 +168,7 @@ func New(
 		},
 	}
 
-	allClusterProviders := seedClusterProviders
-	allClusterProviders = append(allClusterProviders, &ClusterProvider{
-		providerName:                 masterProviderName,
-		kubeClient:                   kubeMasterClient,
-		kubermaticClient:             kubermaticMasterClient,
-		kubermaticInformerFactory:    kubermaticMasterInformerFactory,
-		rbacClusterRoleLister:        c.rbacClusterRoleMasterLister,
-		rbacClusterRoleBindingLister: c.rbacClusterRoleBindingMasterLister,
-	})
-	c.allClusterProviders = allClusterProviders
-
-	for _, clusterProvider := range allClusterProviders {
+	for _, clusterProvider := range seedClusterProviders {
 		for _, resource := range c.projectResources {
 			if len(resource.destination) == 0 && clusterProvider.providerName != masterProviderName {
 				glog.V(6).Infof("skipping adding a shared informer and indexer for a project's resource %q for provider %q, as it is meant only for the master cluster provider", resource.gvr.String(), clusterProvider.providerName)

--- a/api/pkg/controller/rbac/sync_project_test.go
+++ b/api/pkg/controller/rbac/sync_project_test.go
@@ -738,7 +738,7 @@ func TestEnsureClusterResourcesCleanup(t *testing.T) {
 				}
 				return nil, fmt.Errorf("provider %s not found", name)
 			}
-			allClusterProviders := make([]*ClusterProvider, len(test.existingClustersOn))
+			seedClusterProviders := make([]*ClusterProvider, len(test.existingClustersOn))
 			{
 				index := 0
 				for providerName, clusterResources := range test.existingClustersOn {
@@ -758,7 +758,7 @@ func TestEnsureClusterResourcesCleanup(t *testing.T) {
 					fakeKubermaticClient := kubermaticfakeclientset.NewSimpleClientset(kubermaticObjs...)
 					fakeProvider := NewClusterProvider(providerName, fakeKubeClient, fakeKubeInformerFactory, fakeKubermaticClient, nil)
 					fakeProvider.AddIndexerFor(clusterResourcesIndexer, schema.GroupVersionResource{Resource: kubermaticv1.ClusterResourceName})
-					allClusterProviders[index] = fakeProvider
+					seedClusterProviders[index] = fakeProvider
 					index = index + 1
 				}
 			}
@@ -768,7 +768,7 @@ func TestEnsureClusterResourcesCleanup(t *testing.T) {
 
 			// act
 			target := Controller{}
-			target.allClusterProviders = allClusterProviders
+			target.seedClusterProviders = seedClusterProviders
 			target.userLister = userLister
 			target.kubermaticMasterClient = fakeKubermaticMasterClient
 			err := target.ensureProjectCleanup(test.projectToSync)
@@ -781,7 +781,7 @@ func TestEnsureClusterResourcesCleanup(t *testing.T) {
 				t.Fatalf("deletedClustersOn field is different than existingClusterOn in length, did you forget to update deletedClusterOn ?")
 			}
 			for providerName, deletedClusterResources := range test.deletedClustersOn {
-				provider, err := getClusterProviderByName(providerName, allClusterProviders)
+				provider, err := getClusterProviderByName(providerName, seedClusterProviders)
 				if err != nil {
 					t.Fatalf("unable to validate deleted cluster resources because didn't find the provider %s", providerName)
 				}

--- a/api/pkg/controller/rbac/sync_project_test.go
+++ b/api/pkg/controller/rbac/sync_project_test.go
@@ -155,9 +155,9 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 	}{
 		// scenario 1
 		{
-			name:                     "Scenario 1: Proper set of RBAC Bindings for project's resources are created on \"master\" and seed clusters",
+			name:                     "Scenario 1: Proper set of RBAC Bindings for project's resources are created on master and seed clusters",
 			projectToSync:            "thunderball",
-			expectedActionsForMaster: []string{"create", "create", "create", "create"},
+			expectedActionsForMaster: []string{"create", "create"},
 			projectResourcesToSync: []projectResource{
 				{
 					gvr: schema.GroupVersionResource{
@@ -179,40 +179,6 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 				},
 			},
 			expectedClusterRoleBindingsForMaster: []*rbacv1.ClusterRoleBinding{
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:owners",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							APIGroup: rbacv1.GroupName,
-							Kind:     "Group",
-							Name:     "owners-thunderball",
-						},
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:owners",
-					},
-				},
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:editors",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							APIGroup: rbacv1.GroupName,
-							Kind:     "Group",
-							Name:     "editors-thunderball",
-						},
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:editors",
-					},
-				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:usersshkeies:owners",
@@ -303,11 +269,19 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 					kind:        kubermaticv1.ClusterKindName,
 					destination: destinationSeed,
 				},
+				{
+					gvr: schema.GroupVersionResource{
+						Group:    kubermaticv1.GroupName,
+						Version:  kubermaticv1.GroupVersion,
+						Resource: kubermaticv1.SSHKeyResourceName,
+					},
+					kind: kubermaticv1.SSHKeyKind,
+				},
 			},
 			existingClusterRoleBindingsForMaster: []*rbacv1.ClusterRoleBinding{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:owners",
+						Name: "kubermatic:usersshkeies:owners",
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -319,12 +293,12 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
 						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:owners",
+						Name:     "kubermatic:usersshkeies:owners",
 					},
 				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:editors",
+						Name: "kubermatic:usersshkeies:editors",
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -336,14 +310,14 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
 						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:editors",
+						Name:     "kubermatic:usersshkeies:editors",
 					},
 				},
 			},
 			expectedClusterRoleBindingsForMaster: []*rbacv1.ClusterRoleBinding{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:owners",
+						Name: "kubermatic:usersshkeies:owners",
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -361,12 +335,12 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
 						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:owners",
+						Name:     "kubermatic:usersshkeies:owners",
 					},
 				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:editors",
+						Name: "kubermatic:usersshkeies:editors",
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -384,7 +358,7 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
 						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:editors",
+						Name:     "kubermatic:usersshkeies:editors",
 					},
 				},
 			},
@@ -820,200 +794,6 @@ func TestEnsureClusterResourcesCleanup(t *testing.T) {
 	}
 }
 
-// TestEnsureUserProjectCleanup extends TestEnsureProjectCleanup in a way
-// that also checks if the project being removed is removed from "Spec.Project" array for all users that belong the the project
-func TestEnsureUsersProjectCleanup(t *testing.T) {
-	tests := []struct {
-		name            string
-		projectToSync   *kubermaticv1.Project
-		existingUsers   []*kubermaticv1.User
-		expectedActions []string
-		expectedUsers   []*kubermaticv1.User
-	}{
-		// scenario 1
-		{
-			name:          "Scenario 1: bob's projects entries are updated when the project he belongs to is removed",
-			projectToSync: createProject("plan9", createUser("bob")),
-			existingUsers: []*kubermaticv1.User{
-				&kubermaticv1.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bob",
-					},
-					Spec: kubermaticv1.UserSpec{
-						Name:  "bob",
-						Email: "bob@acme.com",
-						Projects: []kubermaticv1.ProjectGroup{
-							{
-								Group: "editors-myFirstProjectName",
-								Name:  "myFirstProjectName",
-							},
-							{
-								Group: "owners-plan9",
-								Name:  "plan9",
-							},
-							{
-								Group: "editors-myThirdProjectInternalName",
-								Name:  "myThirdProjectInternalName",
-							},
-						},
-					},
-				},
-			},
-			expectedActions: []string{"update", "update"},
-			expectedUsers: []*kubermaticv1.User{
-				&kubermaticv1.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bob",
-					},
-					Spec: kubermaticv1.UserSpec{
-						Name:  "bob",
-						Email: "bob@acme.com",
-						Projects: []kubermaticv1.ProjectGroup{
-							{
-								Group: "editors-myFirstProjectName",
-								Name:  "myFirstProjectName",
-							},
-							{
-								Group: "editors-myThirdProjectInternalName",
-								Name:  "myThirdProjectInternalName",
-							},
-						},
-					},
-				},
-			},
-		},
-
-		// scenario 2
-		{
-			name:          "Scenario 2: only bob's projects entries are updated when the project he belongs to is removed",
-			projectToSync: createProject("plan9", createUser("bob")),
-			existingUsers: []*kubermaticv1.User{
-				&kubermaticv1.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bob",
-					},
-					Spec: kubermaticv1.UserSpec{
-						Name:  "bob",
-						Email: "bob@acme.com",
-						Projects: []kubermaticv1.ProjectGroup{
-							{
-								Group: "editors-plan9",
-								Name:  "plan9",
-							},
-						},
-					},
-				},
-
-				&kubermaticv1.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "alice",
-					},
-					Spec: kubermaticv1.UserSpec{
-						Name:  "alice",
-						Email: "alice@acme.com",
-						Projects: []kubermaticv1.ProjectGroup{
-							{
-								Group: "editors-placeX",
-								Name:  "placeX",
-							},
-						},
-					},
-				},
-			},
-			expectedActions: []string{"update", "update"},
-			expectedUsers: []*kubermaticv1.User{
-				&kubermaticv1.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bob",
-					},
-					Spec: kubermaticv1.UserSpec{
-						Name:     "bob",
-						Email:    "bob@acme.com",
-						Projects: []kubermaticv1.ProjectGroup{},
-					},
-				},
-				&kubermaticv1.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "alice",
-					},
-					Spec: kubermaticv1.UserSpec{
-						Name:  "alice",
-						Email: "alice@acme.com",
-						Projects: []kubermaticv1.ProjectGroup{
-							{
-								Group: "editors-placeX",
-								Name:  "placeX",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// setup the test scenario
-			kubermaticObjs := []runtime.Object{}
-			projectIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			if test.projectToSync != nil {
-				err := projectIndexer.Add(test.projectToSync)
-				if err != nil {
-					t.Fatal(err)
-				}
-				kubermaticObjs = append(kubermaticObjs, test.projectToSync)
-			}
-			projectLister := kubermaticv1lister.NewProjectLister(projectIndexer)
-
-			userIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			for _, existingUser := range test.existingUsers {
-				err := userIndexer.Add(existingUser)
-				if err != nil {
-					t.Fatal(err)
-				}
-				kubermaticObjs = append(kubermaticObjs, existingUser)
-			}
-			userLister := kubermaticv1lister.NewUserLister(userIndexer)
-			fakeKubermaticClient := kubermaticfakeclientset.NewSimpleClientset(kubermaticObjs...)
-
-			// act
-			target := Controller{}
-			target.kubermaticMasterClient = fakeKubermaticClient
-			target.projectLister = projectLister
-			target.userLister = userLister
-			err := target.ensureProjectCleanup(test.projectToSync)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// validate
-			actualActions := fakeKubermaticClient.Actions()
-			if len(test.expectedActions) != len(actualActions) {
-				t.Fatalf("expected to get exactly %d actions but got %d, actions = %v", len(test.expectedActions), len(actualActions), actualActions)
-			}
-
-			// verifiedActions is equal to one because the last update action is updating the project
-			// not the users and this is something we don't want to validate
-			verifiedActions := 1
-			for index, actualAction := range actualActions {
-				if actualAction.Matches(test.expectedActions[index], "users") {
-					updateAction, ok := actualAction.(clienttesting.CreateAction)
-					if !ok {
-						t.Fatalf("cannot cast actualAction to CreateActon")
-					}
-					updatedUser := updateAction.GetObject().(*kubermaticv1.User)
-					if !equality.Semantic.DeepEqual(updatedUser, test.expectedUsers[index]) {
-						t.Fatalf("%v", diff.ObjectDiff(updatedUser, test.expectedUsers[index]))
-					}
-					verifiedActions = verifiedActions + 1
-				}
-			}
-			if verifiedActions != len(test.expectedActions) {
-				t.Fatalf("expected to verify %d actions but only %d were verified", verifiedActions, len(test.expectedActions))
-			}
-		})
-	}
-}
-
 func TestEnsureProjectCleanup(t *testing.T) {
 	tests := []struct {
 		name                                 string
@@ -1043,36 +823,44 @@ func TestEnsureProjectCleanup(t *testing.T) {
 					kind:        kubermaticv1.ClusterKindName,
 					destination: destinationSeed,
 				},
+				{
+					gvr: schema.GroupVersionResource{
+						Group:    kubermaticv1.GroupName,
+						Version:  kubermaticv1.GroupVersion,
+						Resource: kubermaticv1.SSHKeyResourceName,
+					},
+					kind: kubermaticv1.SSHKeyKind,
+				},
 			},
 			expectedActionsForMaster: []string{"get", "update", "get", "update"},
 			expectedClusterRoleBindingsForMaster: []*rbacv1.ClusterRoleBinding{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:owners",
+						Name: "kubermatic:usersshkeies:owners",
 					},
 					Subjects: []rbacv1.Subject{},
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
 						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:owners",
+						Name:     "kubermatic:usersshkeies:owners",
 					},
 				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:editors",
+						Name: "kubermatic:usersshkeies:editors",
 					},
 					Subjects: []rbacv1.Subject{},
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
 						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:editors",
+						Name:     "kubermatic:usersshkeies:editors",
 					},
 				},
 			},
 			existingClusterRoleBindingsForMaster: []*rbacv1.ClusterRoleBinding{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:owners",
+						Name: "kubermatic:usersshkeies:owners",
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -1084,12 +872,12 @@ func TestEnsureProjectCleanup(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
 						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:owners",
+						Name:     "kubermatic:usersshkeies:owners",
 					},
 				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:editors",
+						Name: "kubermatic:usersshkeies:editors",
 					},
 					Subjects: []rbacv1.Subject{
 						{
@@ -1101,7 +889,7 @@ func TestEnsureProjectCleanup(t *testing.T) {
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
 						Kind:     "ClusterRole",
-						Name:     "kubermatic:clusters:editors",
+						Name:     "kubermatic:usersshkeies:editors",
 					},
 				},
 			},
@@ -1206,9 +994,11 @@ func TestEnsureProjectCleanup(t *testing.T) {
 				for _, existingClusterRoleBinding := range test.existingClusterRoleBindingsForSeeds {
 					objs = append(objs, existingClusterRoleBinding)
 				}
+				clusterResourcesIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 				fakeSeedKubeClient := fake.NewSimpleClientset(objs...)
 				fakeKubeInformerFactory := kuberinformers.NewSharedInformerFactory(fakeSeedKubeClient, time.Minute*5)
 				fakeProvider := NewClusterProvider(strconv.Itoa(i), fakeSeedKubeClient, fakeKubeInformerFactory, nil, nil)
+				fakeProvider.AddIndexerFor(clusterResourcesIndexer, schema.GroupVersionResource{Resource: kubermaticv1.ClusterResourceName})
 				seedClusterProviders[i] = fakeProvider
 			}
 
@@ -1661,6 +1451,7 @@ func TestEnsureProjectClusterRBACRoleBindingForNamedResource(t *testing.T) {
 		})
 	}
 }
+
 func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 	tests := []struct {
 		name                          string
@@ -1674,7 +1465,7 @@ func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 		// scenario 1
 		{
 			name:                     "Scenario 1: Proper set of RBAC Roles for project's resources are created on \"master\" and seed clusters",
-			expectedActionsForMaster: []string{"create", "create", "create", "create"},
+			expectedActionsForMaster: []string{"create", "create"},
 			expectedActionsForSeeds:  []string{"create", "create"},
 			seedClusters:             2,
 			projectResourcesToSync: []projectResource{
@@ -1739,32 +1530,6 @@ func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 			},
 
 			expectedClusterRolesForMaster: []*rbacv1.ClusterRole{
-				&rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:owners",
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							APIGroups: []string{kubermaticv1.SchemeGroupVersion.Group},
-							Resources: []string{"clusters"},
-							Verbs:     []string{"create"},
-						},
-					},
-				},
-
-				&rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubermatic:clusters:editors",
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							APIGroups: []string{kubermaticv1.SchemeGroupVersion.Group},
-							Resources: []string{"clusters"},
-							Verbs:     []string{"create"},
-						},
-					},
-				},
-
 				&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kubermatic:usersshkeies:owners",

--- a/api/pkg/controller/rbac/sync_resource.go
+++ b/api/pkg/controller/rbac/sync_resource.go
@@ -41,12 +41,12 @@ func (c *Controller) syncProjectResource(item *projectResourceQueueItem) error {
 	}
 
 	if err := c.ensureClusterRBACRoleForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.rbacClusterRoleLister); err != nil {
-		err = fmt.Errorf("failed to sync cluster RBAC Role for %s resource for %s cluster provider", item.gvr.String(), item.clusterProvider.providerName)
+		err = fmt.Errorf("failed to sync cluster RBAC Role for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
 		return err
 	}
 	err := c.ensureClusterRBACRoleBindingForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.rbacClusterRoleBindingLister)
 	if err != nil {
-		err = fmt.Errorf("failed to sync cluster RBAC Role Binding for %s resource for %s cluster provider", item.gvr.String(), item.clusterProvider.providerName)
+		err = fmt.Errorf("failed to sync cluster RBAC Role Binding for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
 	}
 	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**: changes the assumption I made in `rbac` controller about where to find cluster resources. It turned out that those resources are only on seed clusters (physical location)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: #2024 

**Special notes for your reviewer**:
https://github.com/kubermatic/kubermatic/issues/1195

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
