### PR TITLE
changes the way api lists cluster resources

### DIFF
--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -1345,15 +1345,8 @@ func TestListClusters(t *testing.T) {
 			ExistingClusters: []*kubermaticv1.Cluster{
 				&kubermaticv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "InternalNameOfTheObject",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8s.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       "myProjectInternalName",
-							},
-						},
+						Name:   "InternalNameOfTheObject",
+						Labels: map[string]string{"project-id": "myProjectInternalName"},
 						CreationTimestamp: func() metav1.Time {
 							const longForm = "Jan 2, 2006 at 3:04pm (MST)"
 							creationTime, err := time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
@@ -1375,15 +1368,8 @@ func TestListClusters(t *testing.T) {
 				},
 				&kubermaticv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "InternalNameOfTheObject_Second",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "kubermatic.k8s.io/v1",
-								Kind:       "Project",
-								UID:        "",
-								Name:       "myProjectInternalName",
-							},
-						},
+						Name:   "InternalNameOfTheObject_Second",
+						Labels: map[string]string{"project-id": "myProjectInternalName"},
 						CreationTimestamp: func() metav1.Time {
 							const longForm = "Jan 2, 2006 at 3:04pm (MST)"
 							creationTime, err := time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")

--- a/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
+++ b/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
@@ -108,13 +108,6 @@ func (p *RBACCompliantClusterProvider) List(project *kubermaticapiv1.Project, op
 
 	projectClusters := []*kubermaticapiv1.Cluster{}
 	for _, cluster := range clusters {
-		// TODO: remove reading OwnerReferences after migration
-		owners := cluster.GetOwnerReferences()
-		for _, owner := range owners {
-			if owner.APIVersion == kubermaticapiv1.SchemeGroupVersion.String() && owner.Kind == kubermaticapiv1.ProjectKindName && owner.Name == project.Name {
-				projectClusters = append(projectClusters, cluster)
-			}
-		}
 		if clusterProject := cluster.GetLabels()[kubermaticapiv1.ProjectIDLabelKey]; clusterProject == project.Name {
 			projectClusters = append(projectClusters, cluster)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: since we use labels not OwnerReferences to attach a cluster to the given project and we migrated all existing resources there is no need to look up by OwnerRef in API when listing cluster resources for a project.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
