### PR TITLE
replace secret copying with loading from file for ImagePullSecret

### DIFF
--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -87,9 +87,9 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		return nil, err
 	}
 
-	imagePullSecret, err := ioutil.ReadFile(ctrlCtx.runOptions.imagePullSecretFile)
+	dockerPullConfigJSON, err := ioutil.ReadFile(ctrlCtx.runOptions.dockerPullConfigJSONFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load ImagePullSecret from %s: %v", ctrlCtx.runOptions.imagePullSecretFile, err)
+		return nil, fmt.Errorf("failed to load ImagePullSecret from %s: %v", ctrlCtx.runOptions.dockerPullConfigJSONFile, err)
 	}
 
 	cps := cloud.Providers(dcs)
@@ -109,7 +109,7 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.runOptions.etcdDiskSize,
 		ctrlCtx.runOptions.inClusterPrometheusRulesFile,
 		ctrlCtx.runOptions.inClusterPrometheusDisableDefaultRules,
-		imagePullSecret,
+		dockerPullConfigJSON,
 
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		ctrlCtx.kubeInformerFactory.Core().V1().Namespaces(),

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -87,6 +87,11 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		return nil, err
 	}
 
+	imagePullSecret, err := ioutil.ReadFile(ctrlCtx.runOptions.imagePullSecretFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load ImagePullSecret from %s: %v", ctrlCtx.runOptions.imagePullSecretFile, err)
+	}
+
 	cps := cloud.Providers(dcs)
 
 	return cluster.NewController(
@@ -104,6 +109,7 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.runOptions.etcdDiskSize,
 		ctrlCtx.runOptions.inClusterPrometheusRulesFile,
 		ctrlCtx.runOptions.inClusterPrometheusDisableDefaultRules,
+		imagePullSecret,
 
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		ctrlCtx.kubeInformerFactory.Core().V1().Namespaces(),

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -61,7 +61,7 @@ type controllerRunOptions struct {
 	etcdDiskSize                           string
 	inClusterPrometheusRulesFile           string
 	inClusterPrometheusDisableDefaultRules bool
-	imagePullSecretFile                    string
+	dockerPullConfigJSONFile               string
 }
 
 type controllerContext struct {
@@ -102,7 +102,7 @@ func main() {
 	flag.StringVar(&runOp.etcdDiskSize, "etcd-disk-size", "5Gi", "Size for the etcd PV's. Only applies to new clusters.")
 	flag.StringVar(&runOp.inClusterPrometheusRulesFile, "in-cluster-prometheus-rules-file", "", "The file containing the alerting rules for the prometheus running in the cluster-foo namespaces.")
 	flag.BoolVar(&runOp.inClusterPrometheusDisableDefaultRules, "in-cluster-prometheus-disable-default-rules", false, "A flag indicating whether the default rules for the prometheus running in the cluster-foo namespaces should be deployed.")
-	flag.StringVar(&runOp.imagePullSecretFile, "image-pull-secret", "config.json", "The file containing the docker auth config.")
+	flag.StringVar(&runOp.dockerPullConfigJSONFile, "docker-pull-config-json-file", "config.json", "The file containing the docker auth config.")
 	flag.Parse()
 
 	if runOp.masterResources == "" {
@@ -121,7 +121,7 @@ func main() {
 		glog.Fatal("backup-container is undefined")
 	}
 
-	if runOp.imagePullSecretFile == "" {
+	if runOp.dockerPullConfigJSONFile == "" {
 		glog.Fatal("image-pull-secret is undefined")
 	}
 

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -61,6 +61,7 @@ type controllerRunOptions struct {
 	etcdDiskSize                           string
 	inClusterPrometheusRulesFile           string
 	inClusterPrometheusDisableDefaultRules bool
+	imagePullSecretFile                    string
 }
 
 type controllerContext struct {
@@ -101,6 +102,7 @@ func main() {
 	flag.StringVar(&runOp.etcdDiskSize, "etcd-disk-size", "5Gi", "Size for the etcd PV's. Only applies to new clusters.")
 	flag.StringVar(&runOp.inClusterPrometheusRulesFile, "in-cluster-prometheus-rules-file", "", "The file containing the alerting rules for the prometheus running in the cluster-foo namespaces.")
 	flag.BoolVar(&runOp.inClusterPrometheusDisableDefaultRules, "in-cluster-prometheus-disable-default-rules", false, "A flag indicating whether the default rules for the prometheus running in the cluster-foo namespaces should be deployed.")
+	flag.StringVar(&runOp.imagePullSecretFile, "image-pull-secret", "config.json", "The file containing the docker auth config.")
 	flag.Parse()
 
 	if runOp.masterResources == "" {
@@ -117,6 +119,10 @@ func main() {
 
 	if runOp.backupContainerFile == "" {
 		glog.Fatal("backup-container is undefined")
+	}
+
+	if runOp.imagePullSecretFile == "" {
+		glog.Fatal("image-pull-secret is undefined")
 	}
 
 	// Validate etcd disk size

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -21,5 +21,6 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -external-url=dev.kubermatic.io \
   -backup-container=../config/kubermatic/static/backup-container.yaml \
   -cleanup-container=../config/kubermatic/static/cleanup-container.yaml \
+  -image-pull-secret=../../secrets/seed-clusters/dev.kubermatic.io/.dockerconfigjson \
   -logtostderr=1 \
   -v=6 $@

--- a/api/pkg/controller/cluster/auth.go
+++ b/api/pkg/controller/cluster/auth.go
@@ -61,26 +61,6 @@ func (cc *Controller) createCASecret(commonName string, c *kubermaticv1.Cluster)
 	}, nil
 }
 
-func (cc *Controller) getImagePullSecret(c *kubermaticv1.Cluster, existingSecret *corev1.Secret) (*corev1.Secret, string, error) {
-	cacheCfgSecret, err := cc.secretLister.Secrets(resources.KubermaticNamespaceName).Get(resources.ImagePullSecretName)
-	if err != nil {
-		return nil, "", fmt.Errorf("couldn't retrieve dockercfg from kubermatic ns: %v", err)
-	}
-	cfgSecret := cacheCfgSecret.DeepCopy()
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations:     map[string]string{},
-			Labels:          map[string]string{},
-			OwnerReferences: []metav1.OwnerReference{cc.getOwnerRefForCluster(c)},
-		},
-		Type: corev1.SecretTypeDockerConfigJson,
-		Data: cfgSecret.Data,
-	}
-
-	return cc.secretWithJSON(secret)
-}
-
 func (cc *Controller) getRootCACertSecret(c *kubermaticv1.Cluster, existingSecret *corev1.Secret) (*corev1.Secret, string, error) {
 	if existingSecret == nil {
 		data, err := cc.createCASecret(fmt.Sprintf("root-ca.%s.%s.%s", c.Name, cc.dc, cc.externalURL), c)

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -60,6 +60,7 @@ type Controller struct {
 	etcdDiskSize                           resource.Quantity
 	inClusterPrometheusRulesFile           string
 	inClusterPrometheusDisableDefaultRules bool
+	imagePullSecretData                    []byte
 
 	clusterLister             kubermaticv1lister.ClusterLister
 	namespaceLister           corev1lister.NamespaceLister
@@ -93,6 +94,7 @@ func NewController(
 	etcdDiskSize string,
 	inClusterPrometheusRulesFile string,
 	inClusterPrometheusDisableDefaultRules bool,
+	imagePullSecretData []byte,
 
 	clusterInformer kubermaticv1informers.ClusterInformer,
 	namespaceInformer corev1informers.NamespaceInformer,
@@ -121,6 +123,7 @@ func NewController(
 		etcdDiskSize:                           resource.MustParse(etcdDiskSize),
 		inClusterPrometheusRulesFile:           inClusterPrometheusRulesFile,
 		inClusterPrometheusDisableDefaultRules: inClusterPrometheusDisableDefaultRules,
+		imagePullSecretData:                    imagePullSecretData,
 
 		externalURL: externalURL,
 		workerName:  workerName,

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -60,7 +60,7 @@ type Controller struct {
 	etcdDiskSize                           resource.Quantity
 	inClusterPrometheusRulesFile           string
 	inClusterPrometheusDisableDefaultRules bool
-	imagePullSecretData                    []byte
+	dockerPullConfigJSON                   []byte
 
 	clusterLister             kubermaticv1lister.ClusterLister
 	namespaceLister           corev1lister.NamespaceLister
@@ -94,7 +94,7 @@ func NewController(
 	etcdDiskSize string,
 	inClusterPrometheusRulesFile string,
 	inClusterPrometheusDisableDefaultRules bool,
-	imagePullSecretData []byte,
+	dockerPullConfigJSON []byte,
 
 	clusterInformer kubermaticv1informers.ClusterInformer,
 	namespaceInformer corev1informers.NamespaceInformer,
@@ -123,7 +123,7 @@ func NewController(
 		etcdDiskSize:                           resource.MustParse(etcdDiskSize),
 		inClusterPrometheusRulesFile:           inClusterPrometheusRulesFile,
 		inClusterPrometheusDisableDefaultRules: inClusterPrometheusDisableDefaultRules,
-		imagePullSecretData:                    imagePullSecretData,
+		dockerPullConfigJSON:                   dockerPullConfigJSON,
 
 		externalURL: externalURL,
 		workerName:  workerName,

--- a/api/pkg/controller/cluster/cluster_controller_test.go
+++ b/api/pkg/controller/cluster/cluster_controller_test.go
@@ -46,6 +46,7 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		"5Gi",
 		"",
 		false,
+		[]byte{},
 
 		kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		kubeInformerFactory.Core().V1().Namespaces(),

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -568,9 +568,9 @@ func (cc *Controller) ensureDeployments(c *kubermaticv1.Cluster) error {
 }
 
 // GetSecretCreators returns all SecretCreators that are currently in use
-func GetSecretCreators(imagePullSecretData []byte) map[string]resources.SecretCreator {
+func GetSecretCreators(dockerPullConfigJSON []byte) map[string]resources.SecretCreator {
 	return map[string]resources.SecretCreator{
-		resources.ImagePullSecretName:                            resources.ImagePullSecretCreator(resources.ImagePullSecretName, imagePullSecretData),
+		resources.ImagePullSecretName:                            resources.ImagePullSecretCreator(resources.ImagePullSecretName, dockerPullConfigJSON),
 		resources.EtcdTLSCertificateSecretName:                   etcd.TLSCertificate,
 		resources.ApiserverEtcdClientCertificateSecretName:       apiserver.EtcdClientCertificate,
 		resources.ServiceAccountKeySecretName:                    apiserver.ServiceAccountKey,
@@ -579,7 +579,7 @@ func GetSecretCreators(imagePullSecretData []byte) map[string]resources.SecretCr
 }
 
 func (cc *Controller) ensureSecretsV2(c *kubermaticv1.Cluster) error {
-	creators := GetSecretCreators(cc.imagePullSecretData)
+	creators := GetSecretCreators(cc.dockerPullConfigJSON)
 
 	data, err := cc.getClusterTemplateData(c)
 	if err != nil {

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -195,7 +195,6 @@ func (cc *Controller) ensureSecrets(c *kubermaticv1.Cluster) error {
 		{resources.TokensSecretName, cc.getTokenUsersSecret},
 		{resources.OpenVPNServerCertificatesSecretName, cc.getOpenVPNServerCertificates},
 		{resources.OpenVPNClientCertificatesSecretName, cc.getOpenVPNInternalClientCertificates},
-		{resources.ImagePullSecretName, cc.getImagePullSecret},
 	}
 
 	if len(c.Spec.MachineNetworks) > 0 {
@@ -569,8 +568,9 @@ func (cc *Controller) ensureDeployments(c *kubermaticv1.Cluster) error {
 }
 
 // GetSecretCreators returns all SecretCreators that are currently in use
-func GetSecretCreators() map[string]resources.SecretCreator {
+func GetSecretCreators(imagePullSecretData []byte) map[string]resources.SecretCreator {
 	return map[string]resources.SecretCreator{
+		resources.ImagePullSecretName:                            resources.ImagePullSecretCreator(resources.ImagePullSecretName, imagePullSecretData),
 		resources.EtcdTLSCertificateSecretName:                   etcd.TLSCertificate,
 		resources.ApiserverEtcdClientCertificateSecretName:       apiserver.EtcdClientCertificate,
 		resources.ServiceAccountKeySecretName:                    apiserver.ServiceAccountKey,
@@ -579,7 +579,7 @@ func GetSecretCreators() map[string]resources.SecretCreator {
 }
 
 func (cc *Controller) ensureSecretsV2(c *kubermaticv1.Cluster) error {
-	creators := GetSecretCreators()
+	creators := GetSecretCreators(cc.imagePullSecretData)
 
 	data, err := cc.getClusterTemplateData(c)
 	if err != nil {

--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -157,7 +157,7 @@ func TestSecretV2CreatorsKeepAdditionalData(t *testing.T) {
 		ServiceLister: serviceLister,
 	}
 
-	for name, create := range GetSecretCreators() {
+	for name, create := range GetSecretCreators([]byte{}) {
 		existing := &corev1.Secret{
 			Data: map[string][]byte{"Test": []byte("Data")},
 		}

--- a/api/pkg/resources/imagepullsecret.go
+++ b/api/pkg/resources/imagepullsecret.go
@@ -1,0 +1,31 @@
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ImagePullSecretCreator returns a creator function to create a ImagePullSecret
+func ImagePullSecretCreator(name string, authData []byte) func(data *TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+	return func(data *TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+		var secret *corev1.Secret
+		if existing != nil {
+			secret = existing
+		} else {
+			secret = &corev1.Secret{}
+		}
+
+		secret.Name = name
+		secret.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
+
+		secret.Type = corev1.SecretTypeDockerConfigJson
+
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+
+		secret.Data[corev1.DockerConfigJsonKey] = authData
+
+		return secret, nil
+	}
+}

--- a/api/pkg/resources/imagepullsecret.go
+++ b/api/pkg/resources/imagepullsecret.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ImagePullSecretCreator returns a creator function to create a ImagePullSecret
-func ImagePullSecretCreator(name string, authData []byte) func(data *TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func ImagePullSecretCreator(name string, dockerPullConfigJSON []byte) func(data *TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
 	return func(data *TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
 		var secret *corev1.Secret
 		if existing != nil {
@@ -24,7 +24,7 @@ func ImagePullSecretCreator(name string, authData []byte) func(data *TemplateDat
 			secret.Data = map[string][]byte{}
 		}
 
-		secret.Data[corev1.DockerConfigJsonKey] = authData
+		secret.Data[corev1.DockerConfigJsonKey] = dockerPullConfigJSON
 
 		return secret, nil
 	}

--- a/config/kubermatic/templates/dockercfg-secret.yaml
+++ b/config/kubermatic/templates/dockercfg-secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: dockercfg
 data:
-  .dockerconfigjson: {{ .Values.kubermatic.docker.secret }}
+  .dockerconfigjson: {{ .Values.kubermatic.imagePullSecretData }}
 type: kubernetes.io/dockerconfigjson

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -15,6 +15,7 @@ spec:
         checksum/master-files: {{ include (print $.Template.BasePath "/master-files-secret.yaml") . | sha256sum }}
         checksum/datecenters: {{ include (print $.Template.BasePath "/datacenter-yaml-secret.yaml") . | sha256sum }}
         checksum/backup-container-configmap: {{ include (print $.Template.BasePath "/backup-container-configmap.yaml") . | sha256sum }}
+        checksum/dockercfg: {{ include (print $.Template.BasePath "/dockercfg-secret.yaml") . | sha256sum }}
     spec:
       serviceAccountName: kubermatic
       initContainers:

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -55,7 +55,7 @@ spec:
           - -addons-path=/opt/addons
           - -backup-container=/opt/backup/store-container.yaml
           - -cleanup-container=/opt/backup/cleanup-container.yaml
-          - -image-pull-secret=/opt/docker/.dockerconfigjson
+          - -docker-pull-config-json-file=/opt/docker/.dockerconfigjson
           {{- if .Values.kubermatic.clusterNamespacePrometheus.disableDefaultRules }}
           - -in-cluster-prometheus-disable-default-rules=true
           {{- end }}

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -55,6 +55,7 @@ spec:
           - -addons-path=/opt/addons
           - -backup-container=/opt/backup/store-container.yaml
           - -cleanup-container=/opt/backup/cleanup-container.yaml
+          - -image-pull-secret=/opt/docker/.dockerconfigjson
           {{- if .Values.kubermatic.clusterNamespacePrometheus.disableDefaultRules }}
           - -in-cluster-prometheus-disable-default-rules=true
           {{- end }}
@@ -80,6 +81,9 @@ spec:
             - name: backup-container
               mountPath: "/opt/backup/"
               readOnly: true
+            - name: dockercfg
+              mountPath: "/opt/docker/"
+              readOnly: true
             {{- if .Values.kubermatic.clusterNamespacePrometheus.rules }}
             - name: in-cluster-prometheus-rules-file
               mountPath: "/opt/incluster-prometheus/"
@@ -94,7 +98,6 @@ spec:
               cpu: "200m"
       imagePullSecrets:
         - name: dockercfg
-        - name: quay
       tolerations:
       - key: "only_critical"
         operator: "Equal"
@@ -122,6 +125,9 @@ spec:
         - name: backup-container
           configMap:
             name: backup-container
+        - name: dockercfg
+          secret:
+            secretName: dockercfg
         {{- if .Values.kubermatic.clusterNamespacePrometheus.rules }}
         - name: in-cluster-prometheus-rules-file
           configMap:

--- a/config/kubermatic/templates/quay-secret.yaml
+++ b/config/kubermatic/templates/quay-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: quay
-data:
-  .dockerconfigjson: {{ .Values.kubermatic.quay.secret }}
-type: kubernetes.io/dockerconfigjson

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -1,10 +1,6 @@
 kubermatic:
-  docker:
-    # the base64 encoded docker authentication token
-    secret: ""
-  quay:
-    # the base64 encoded quay.io authentication token
-    secret: ""
+  # the base64 encoded docker/quay authentication json file
+  imagePullSecretData: ""
   auth:
     # the full path to the openid connect token issuer. For example 'https://dev.kubermatic.io/dex'
     tokenIssuer: ""
@@ -125,4 +121,3 @@ kubermatic:
 #          labels:
 #            severity: warning
   clusterNamespacePrometheus: {}
-  


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the way we handle ImagePullSecrets for user-clusters.
In the old way, we copied a Secret from the Kubermatic namespace.
Though this worked, it required the initial ImagePullSecret to exist already inside `kubermatic` namespace within the cluster.

This approach will load the ImagePullSecret from a file, specified via a flag.
The Kubermatic Helm chart got modified to mount the already existing ImagePullSecret to the kubermatic-controller-manager.

Also this PR will combine the existing ImagePullSecrets for Quay.io & Docker-Hub.

If this PR got approved, a second PR for the Secrets repository will be opened.

**Release note**:
```release-note
Combine ImagePullSecrets im the Kubermatic chart.
```
