### PR TITLE
fix image pull secret for the nodeport-proxy chart

### DIFF
--- a/config/nodeport-proxy/templates/quay-secret.yaml
+++ b/config/nodeport-proxy/templates/quay-secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: quay
 data:
-  .dockerconfigjson: {{ .Values.kubermatic.quay.secret }}
+  .dockerconfigjson: {{ .Values.kubermatic.imagePullSecretData }}
 type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
**What this PR does / why we need it**:
fix image pull secret for the nodeport-proxy chart.
Broken as we changed the format in https://github.com/kubermatic/kubermatic/pull/1877

**Release note**:
```release-note
NONE
```
