### PR TITLE
fix image pull secret for the kubermatic master chart

### DIFF
--- a/config/kubermatic/master/templates/dockerregistry-secret.yaml
+++ b/config/kubermatic/master/templates/dockerregistry-secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: dockerregistry
 data:
-  .dockerconfigjson: {{ .Values.kubermatic.docker.secret }}
+  .dockerconfigjson: {{ .Values.kubermatic.imagePullSecretData }}
 type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
**What this PR does / why we need it**:
fix image pull secret for the kubermatic master chart.
Broken as we changed the format in https://github.com/kubermatic/kubermatic/pull/1877

**Release note**:
```release-note
NONE
```
