### PR TITLE
unbreak hack/run-controller.sh (flag name changed)

### DIFF
--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -122,7 +122,7 @@ func main() {
 	}
 
 	if runOp.dockerPullConfigJSONFile == "" {
-		glog.Fatal("image-pull-secret is undefined")
+		glog.Fatal("docker-pull-config-json-file is undefined")
 	}
 
 	// Validate etcd disk size

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -21,6 +21,6 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -external-url=dev.kubermatic.io \
   -backup-container=../config/kubermatic/static/backup-container.yaml \
   -cleanup-container=../config/kubermatic/static/cleanup-container.yaml \
-  -image-pull-secret=../../secrets/seed-clusters/dev.kubermatic.io/.dockerconfigjson \
+  -docker-pull-config-json-file=../../secrets/seed-clusters/dev.kubermatic.io/.dockerconfigjson \
   -logtostderr=1 \
   -v=6 $@


### PR DESCRIPTION
Flag ` -docker-pull-config-json-file` was still `-image-pull-secret` in log and hack-script.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
