### PR TITLE
Include cluster name as label

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -67,7 +67,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -64,7 +64,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -66,7 +66,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(resources.DNSResolverDeploymentName, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(resources.DNSResolverDeploymentName, data.Cluster.Name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get podlabels: %v", err)
 	}

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -57,7 +57,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(resources.EtcdStatefulSetName, volumes, baseLabels)
+	podLabels, err := data.GetPodTemplateLabels(resources.EtcdStatefulSetName, data.Cluster.Name, volumes, baseLabels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -49,7 +49,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -48,7 +48,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -61,7 +61,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -51,7 +51,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	set.Spec.ServiceName = resources.PrometheusServiceName
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, volumes, requiredBaseLabels)
+	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, requiredBaseLabels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -507,8 +507,9 @@ func UserClusterDNSPolicyAndConfig(d *TemplateData) (corev1.DNSPolicy, *corev1.P
 
 // GetPodTemplateLabels returns a set of labels for a Pod including the revisions of depending secrets and configmaps.
 // This will force pods being restarted as soon as one of the secrets/configmaps get updated.
-func (d *TemplateData) GetPodTemplateLabels(name string, volumes []corev1.Volume, additionalLabels map[string]string) (map[string]string, error) {
+func (d *TemplateData) GetPodTemplateLabels(name, clusterName string, volumes []corev1.Volume, additionalLabels map[string]string) (map[string]string, error) {
 	podLabels := BaseAppLabel(name, additionalLabels)
+	podLabels["cluster"] = clusterName
 
 	for _, v := range volumes {
 		if v.VolumeSource.Secret != nil {

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -51,7 +51,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -34,6 +34,7 @@ spec:
         app: apiserver
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         front-proxy-ca-secret-revision: "123456"
         kubelet-client-certificates-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -31,6 +31,7 @@ spec:
         app: controller-manager
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
         controllermanager-kubeconfig-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
         service-account-key-secret-revision: "123456"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: dns-resolver
         ca-secret-revision: "123456"
+        cluster: de-test-01
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -28,6 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kube-state-metrics
+        cluster: de-test-01
         kube-state-metrics-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -29,6 +29,7 @@ spec:
       creationTimestamp: null
       labels:
         app: machine-controller
+        cluster: de-test-01
         machinecontroller-kubeconfig-secret-revision: "123456"
     spec:
       containers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: openvpn-server
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-configs-configmap-revision: "123456"
         openvpn-server-certificates-secret-revision: "123456"
     spec:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: scheduler
         ca-secret-revision: "123456"
+        cluster: de-test-01
         openvpn-client-certificates-secret-revision: "123456"
         scheduler-kubeconfig-secret-revision: "123456"
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Include cluster name as label on every pod.
It enables to set proper antiAffinity rules - which will come as follow-up for all control plane components.

**Release note**:
```release-note
Include cluster name as label on each pod
```
