### PR TITLE
move cluster pod label handling into function

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -67,7 +67,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -64,7 +64,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -66,7 +66,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(resources.DNSResolverDeploymentName, data.Cluster.Name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(resources.DNSResolverDeploymentName, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get podlabels: %v", err)
 	}

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -57,7 +57,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(resources.EtcdStatefulSetName, data.Cluster.Name, volumes, baseLabels)
+	podLabels, err := data.GetPodTemplateLabels(resources.EtcdStatefulSetName, volumes, baseLabels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -49,7 +49,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -48,7 +48,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -61,7 +61,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -51,7 +51,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	set.Spec.ServiceName = resources.PrometheusServiceName
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, requiredBaseLabels)
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, requiredBaseLabels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -507,9 +507,8 @@ func UserClusterDNSPolicyAndConfig(d *TemplateData) (corev1.DNSPolicy, *corev1.P
 
 // GetPodTemplateLabels returns a set of labels for a Pod including the revisions of depending secrets and configmaps.
 // This will force pods being restarted as soon as one of the secrets/configmaps get updated.
-func (d *TemplateData) GetPodTemplateLabels(name, clusterName string, volumes []corev1.Volume, additionalLabels map[string]string) (map[string]string, error) {
-	podLabels := BaseAppLabel(name, additionalLabels)
-	podLabels["cluster"] = clusterName
+func (d *TemplateData) GetPodTemplateLabels(appName string, volumes []corev1.Volume, additionalLabels map[string]string) (map[string]string, error) {
+	podLabels := AppClusterLabel(appName, d.Cluster.Name, additionalLabels)
 
 	for _, v := range volumes {
 		if v.VolumeSource.Secret != nil {
@@ -540,6 +539,14 @@ func BaseAppLabel(name string, additionalLabels map[string]string) map[string]st
 		labels[k] = v
 	}
 	return labels
+}
+
+// AppClusterLabel returns the base app label + the cluster label. Additional labels can be included as well
+func AppClusterLabel(appName, clusterName string, additionalLabels map[string]string) map[string]string {
+	podLabels := BaseAppLabel(appName, additionalLabels)
+	podLabels["cluster"] = clusterName
+
+	return podLabels
 }
 
 // CertWillExpireSoon returns if the certificate will expire in the next 30 days

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -51,7 +51,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	volumes := getVolumes()
-	podLabels, err := data.GetPodTemplateLabels(name, data.Cluster.Name, volumes, nil)
+	podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod labels: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Move cluster pod label handling into function to enable reusage.

**Release note**:
```release-note
NONE
```
