### PR TITLE
Escape quotation marks in the openstack cloud config

### DIFF
--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/provider.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -545,6 +546,9 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 		return "", "", fmt.Errorf("failed to parse config: %v", err)
 	}
 
+	// Quotation marks in passwords are allowed and must be escaped to not break
+	// the cloud-config
+	var replacer = strings.NewReplacer("\"", "\\\"")
 	config = fmt.Sprintf(`
 [Global]
 auth-url = "%s"
@@ -553,7 +557,7 @@ password = "%s"
 domain-name="%s"
 tenant-name = "%s"
 region = "%s"
-`, c.IdentityEndpoint, c.Username, c.Password, c.DomainName, c.TenantName, c.Region)
+`, c.IdentityEndpoint, c.Username, replacer.Replace(c.Password), c.DomainName, c.TenantName, c.Region)
 	return config, "openstack", nil
 }
 


### PR DESCRIPTION
As quotation marks may be part of the password in the cloud config,
these must be escaped in order to let the quoted string be correct.
This commit addresses this issue.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1905 

**Special notes for your reviewer**:
As I'm quite new to golang there might be a more performant/better solution to this. This might affect other cloud providers aswell.
