### PR TITLE
add in-cluster ClusterIP of the apiserver to its tls certificate

### DIFF
--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -109,6 +109,7 @@ func TestSecretV2CreatorsKeepAdditionalData(t *testing.T) {
 	cluster := &kubermaticv1.Cluster{}
 	cluster.Status.NamespaceName = "test-ns"
 	cluster.Address.IP = "1.2.3.4"
+	cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.10.10.0/24"}
 	dc := &provider.DatacenterMeta{}
 
 	keyPair, err := triple.NewCA("test-ca")

--- a/api/pkg/resources/apiserver/tls-serving-certificate.go
+++ b/api/pkg/resources/apiserver/tls-serving-certificate.go
@@ -46,6 +46,11 @@ func TLSServingCertificate(data *resources.TemplateData, existing *corev1.Secret
 		return nil, fmt.Errorf("failed to get external IP for cluster: %v", err)
 	}
 
+	inClusterIP, err := resources.InClusterApiserverIP(data.Cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the in-cluster ClusterIP for the apiserver: %v", err)
+	}
+
 	altNames := certutil.AltNames{
 		DNSNames: []string{
 			// ExternalName
@@ -70,6 +75,7 @@ func TLSServingCertificate(data *resources.TemplateData, existing *corev1.Secret
 			*apiserverExternalIP,
 			*apiserverInternalIP,
 			*externalIP,
+			*inClusterIP,
 		},
 	}
 

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -328,6 +328,22 @@ func UserClusterDNSResolverIP(cluster *kubermaticv1.Cluster) (string, error) {
 	return ip.String(), nil
 }
 
+// InClusterApiserverIP returns the first usable IP of the service cidr.
+// Its the in cluster IP for the apiserver
+func InClusterApiserverIP(cluster *kubermaticv1.Cluster) (*net.IP, error) {
+	if len(cluster.Spec.ClusterNetwork.Services.CIDRBlocks) == 0 {
+		return nil, errors.New("no service cidr defined")
+	}
+
+	block := cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0]
+	ip, _, err := net.ParseCIDR(block)
+	if err != nil {
+		return nil, fmt.Errorf("invalid service cidr %s", block)
+	}
+	ip[len(ip)-1] = ip[len(ip)-1] + 1
+	return &ip, nil
+}
+
 // UserClusterDNSPolicyAndConfig returns a DNSPolicy and DNSConfig to configure Pods to use user cluster DNS
 func UserClusterDNSPolicyAndConfig(d *TemplateData) (corev1.DNSPolicy, *corev1.PodDNSConfig, error) {
 	// DNSNone indicates that the pod should use empty DNS settings. DNS


### PR DESCRIPTION
**What this PR does / why we need it**:
Add in-cluster ClusterIP of the apiserver to its tls certificate.
It was missing and breaks new clusters.

**Release note**:
```release-note
NONE
```
