### PR TITLE
Enable etcd auto compaction

### DIFF
--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -348,6 +348,7 @@ exec /usr/local/bin/etcd \
     --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
     --client-cert-auth \
     --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-    --key-file /etc/etcd/pki/tls/etcd-tls.key
+    --key-file /etc/etcd/pki/tls/etcd-tls.key \
+    --auto-compaction-retention=8
 `
 )

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -71,7 +71,8 @@ exec /usr/local/bin/etcd \
     --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
     --client-cert-auth \
     --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-    --key-file /etc/etcd/pki/tls/etcd-tls.key
+    --key-file /etc/etcd/pki/tls/etcd-tls.key \
+    --auto-compaction-retention=8
 `
 
 	migration = `export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2379"
@@ -141,6 +142,7 @@ exec /usr/local/bin/etcd \
     --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
     --client-cert-auth \
     --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-    --key-file /etc/etcd/pki/tls/etcd-tls.key
+    --key-file /etc/etcd/pki/tls/etcd-tls.key \
+    --auto-compaction-retention=8
 `
 )

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
@@ -65,7 +65,8 @@ spec:
               --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
               --client-cert-auth \
               --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
-              --key-file /etc/etcd/pki/tls/etcd-tls.key
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable etcd auto compaction as its disabled by default but it is recommended maintenance.
The value 8 comes from the defaults from kube-spray: https://github.com/kubernetes-incubator/kubespray/blob/6e7100f2838f8c85e98af284a7a2ba86a536cb43/roles/etcd/defaults/main.yml#L58

**Release note**:
```release-note
Enable etcd auto-compaction
```
