### PR TITLE
Monitor and alert on backups

### DIFF
--- a/config/backup/ark/templates/deployment.yaml
+++ b/config/backup/ark/templates/deployment.yaml
@@ -12,7 +12,11 @@ spec:
       labels:
         name: ark-server
       annotations:
-{{ toYaml .Values.ark.podAnnotations | indent 8 }}
+        kubermatic/scrape: "true"
+        kubermatic/scrape_port: "8085"
+{{- with .Values.ark.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       restartPolicy: Always
       containers:
@@ -48,6 +52,10 @@ spec:
             - name: gcp-credentials
               mountPath: /credentials/gcp
           {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8085
+              protocol: TCP
       volumes:
         - name: plugins
           emptyDir: {}

--- a/config/backup/ark/templates/secrets.yaml
+++ b/config/backup/ark/templates/secrets.yaml
@@ -1,4 +1,5 @@
-{{- with .Values.ark.credentials.restic }}
+{{- with .Values.ark.credentials }}
+{{- with .restic }}
 {{- with .password }}
 ---
 # This secret contains the password with which restic is encrypting all
@@ -14,7 +15,7 @@ data:
 {{- end }}
 {{- end }}
 
-{{- with .Values.ark.credentials.aws }}
+{{- with .aws }}
 ---
 apiVersion: v1
 kind: Secret
@@ -25,7 +26,7 @@ data:
   creds: {{ (printf "[default]\naws_access_key_id=%s\naws_secret_access_key=%s\n" .accessKey .secretKey) | b64enc | quote }}
 {{- end }}
 
-{{- with .Values.ark.credentials.gcp }}
+{{- with .gcp }}
 ---
 apiVersion: v1
 kind: Secret
@@ -36,7 +37,7 @@ data:
   creds: {{ .serviceKey | b64enc | quote }}
 {{- end }}
 
-{{- with .Values.ark.credentials.azure }}
+{{- with .azure }}
 ---
 apiVersion: v1
 kind: Secret
@@ -46,5 +47,6 @@ type: Opaque
 data:
 {{- range $key, $value := . }}
   {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/config/monitoring/prometheus/jsonnet/alerts/ark.libsonnet
+++ b/config/monitoring/prometheus/jsonnet/alerts/ark.libsonnet
@@ -1,0 +1,32 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'ark',
+        rules: [
+          {
+            alert: 'ArkBackupTakesTooLong',
+            expr: '(ark_backup_attempt_total - ark_backup_success_total) > 0',
+            'for': '60m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Backup schedule {{ $labels.schedule }} has been taking more than 60min already.',
+            },
+          },
+          {
+            alert: 'ArkNoRecentBackup',
+            expr: 'changes(ark_backup_success_total[25h]) < 1', // 25 hours to allow for one hour backup runtime
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'There has not been a successful backup for schedule {{ $labels.schedule }} in the last 24 hours.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
+++ b/config/monitoring/prometheus/jsonnet/prometheus.jsonnet
@@ -1,4 +1,6 @@
+(import './alerts/ark.libsonnet') +
 (import './alerts/kubermatic.libsonnet') +
+(import './alerts/machine-controller.libsonnet') +
 (import 'kubernetes-mixin/mixin.libsonnet') +
 (import 'prometheus/mixin.libsonnet') +
 (import 'node_exporter/mixin.libsonnet') +

--- a/config/monitoring/prometheus/rules/rules.yaml
+++ b/config/monitoring/prometheus/rules/rules.yaml
@@ -296,6 +296,23 @@
          irate(node_network_transmit_drop{app="node-exporter",device=~"eth[0-9]+"}[1m]))
       )
     "record": "instance:node_net_saturation:sum_irate"
+- "name": "ark"
+  "rules":
+  - "alert": "ArkBackupTakesTooLong"
+    "annotations":
+      "message": "Backup schedule {{ $labels.schedule }} has been taking more than 60min already."
+      "runbook_url": "https://docs.kubermatic.io/monitoring/runbook/#alert-arkbackuptakestoolong"
+    "expr": "(ark_backup_attempt_total - ark_backup_success_total) > 0"
+    "for": "60m"
+    "labels":
+      "severity": "warning"
+  - "alert": "ArkNoRecentBackup"
+    "annotations":
+      "message": "There has not been a successful backup for schedule {{ $labels.schedule }} in the last 24 hours."
+      "runbook_url": "https://docs.kubermatic.io/monitoring/runbook/#alert-arknorecentbackup"
+    "expr": "changes(ark_backup_success_total[25h]) < 1"
+    "labels":
+      "severity": "warning"
 - "name": "kubermatic"
   "rules":
   - "alert": "KubermaticTooManyUnhandledErrors"
@@ -312,6 +329,25 @@
       "message": "Cluster {{ $labels.cluster }} is stuck in deletion for more than 30min."
       "runbook_url": "https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticclusterdeletiontakestoolong"
     "expr": "(time() - kubermatic_cluster_deleted) > 30*60"
+    "for": "0m"
+    "labels":
+      "severity": "warning"
+- "name": "machine-controller"
+  "rules":
+  - "alert": "MachineControllerTooManyErrors"
+    "annotations":
+      "message": "Machine Controller in {{ $labels.namespace }} has too many errors in its loop."
+      "runbook_url": "https://docs.kubermatic.io/monitoring/runbook/#alert-machinecontrollertoomanyerrors"
+    "expr": |
+      sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+    "for": "10m"
+    "labels":
+      "severity": "warning"
+  - "alert": "MachineControllerMachineDeletionTakesTooLong"
+    "annotations":
+      "message": "Machine {{ $labels.machine }} of cluster {{ $labels.cluster }} is stuck in deletion for more than 30min."
+      "runbook_url": "https://docs.kubermatic.io/monitoring/runbook/#alert-machinecontrollermachinedeletiontakestoolong"
+    "expr": "(time() - machine_controller_machine_deleted) > 30*60"
     "for": "0m"
     "labels":
       "severity": "warning"


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes Prometheus scrape Ark and ingest its metrics. Based on those, we now also have very basic alerts, assuming that backups run at least daily and are defined based on Ark's own schedules (non-scheduled backups will have no `schedule` label in the metrics and yield somewhat akward alert message).

**Which issue(s) this PR fixes**:
Fixes #1896

**Release note**:
```release-note
NONE
```
