### PR TITLE
OpenVPN client: fix incorrect comment / remove owner-ref.

### DIFF
--- a/api/pkg/resources/openvpn/configmap.go
+++ b/api/pkg/resources/openvpn/configmap.go
@@ -68,7 +68,7 @@ func ServerClientConfigsConfigMap(data *resources.TemplateData, existing *corev1
 	return cm, nil
 }
 
-// ClientConfigConfigMap returns a ConfigMap containing the ClientConfig for the OpenVPN server. It lives inside the seed-cluster
+// ClientConfigConfigMap returns a ConfigMap containing the config for the OpenVPN client. It lives inside the user-cluster
 func ClientConfigConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	var cm *corev1.ConfigMap
 	if existing != nil {
@@ -82,7 +82,6 @@ func ClientConfigConfigMap(data *resources.TemplateData, existing *corev1.Config
 
 	cm.Name = resources.OpenVPNClientConfigConfigMapName
 	cm.Namespace = metav1.NamespaceSystem
-	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	cm.Labels = resources.BaseAppLabel(name, nil)
 
 	openvpnSvc, err := data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get(resources.OpenVPNServerServiceName)


### PR DESCRIPTION
This code is for generating the ConfigMap in the user-cluster, which
provides configuration to the user-cluster vpn-client.
This Commit fixes the comment and also removes the owner-reference.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
