### PR TITLE
add queue metrics

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -98,7 +98,7 @@ func New(
 	clusterInformer kubermaticv1informers.ClusterInformer) (*Controller, error) {
 
 	c := &Controller{
-		queue:              workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute), "Addon"),
+		queue:              workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute), "addon"),
 		metrics:            metrics,
 		addonVariables:     addonCtxVariables,
 		workerName:         workerName,

--- a/api/pkg/controller/addoninstaller/addoninstaller_controller.go
+++ b/api/pkg/controller/addoninstaller/addoninstaller_controller.go
@@ -63,7 +63,7 @@ func New(
 	clusterInformer kubermaticv1informers.ClusterInformer) (*Controller, error) {
 
 	c := &Controller{
-		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute), "cluster"),
+		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute), "addon_installer_cluster"),
 		metrics:          metrics,
 		workerName:       workerName,
 		defaultAddonList: defaultAddonList,

--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -143,7 +143,7 @@ func New(
 		backupContainerImage = DefaultBackupContainerImage
 	}
 	c := &Controller{
-		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Backup"),
+		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "backup_cluster"),
 		kubermaticClient:     kubermaticClient,
 		kubernetesClient:     kubernetesClient,
 		backupScheduleString: backupScheduleString,

--- a/api/pkg/controller/ipam/controller.go
+++ b/api/pkg/controller/ipam/controller.go
@@ -57,7 +57,7 @@ func NewController(client machineclientset.Interface, machineInformer machineinf
 		cidrRange:     networks,
 		client:        client,
 		machineLister: machineInformer.Lister(),
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "MachineQueue"),
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ipam_machine"),
 	}
 
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/api/pkg/controller/kubeletdnat/kubeletdnat_controller.go
+++ b/api/pkg/controller/kubeletdnat/kubeletdnat_controller.go
@@ -63,7 +63,7 @@ func NewController(
 	ctrl := &Controller{
 		client:                   client,
 		nodeLister:               nodeInformer.Lister(),
-		queue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "nodes"),
+		queue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kubetlet_dnat_node"),
 		nodeTranslationChainName: nodeTranslationChainName,
 		nodeAccessNetwork:        nodeAccessNetwork,
 		vpnInterface:             vpnInterface,

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -94,8 +94,8 @@ func New(
 	rbacClusterRoleBindingMasterInformer rbacinformer.ClusterRoleBindingInformer,
 	seedClusterProviders []*ClusterProvider) (*Controller, error) {
 	c := &Controller{
-		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "RBACGeneratorProject"),
-		projectResourcesQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "RBACGeneratorProjectResources"),
+		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project"),
+		projectResourcesQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project_resources"),
 		metrics:                metrics,
 		workerName:             workerName,
 		kubermaticMasterClient: kubermaticMasterClient,

--- a/api/pkg/controller/update/update_controller.go
+++ b/api/pkg/controller/update/update_controller.go
@@ -66,7 +66,7 @@ func New(
 	kubermaticClient kubermaticclientset.Interface,
 	clusterInformer kubermaticv1informers.ClusterInformer) (*Controller, error) {
 	c := &Controller{
-		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Update"),
+		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "update_cluster"),
 		metrics:          metrics,
 		workerName:       workerName,
 		kubermaticClient: kubermaticClient,

--- a/api/pkg/metrics/queue.go
+++ b/api/pkg/metrics/queue.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/util/workqueue/prometheus/prometheus.go
+// Package prometheus sets the workqueue DefaultMetricsFactory to produce
+// prometheus metrics. To use this package, you just have to import it.
+
+func init() {
+	workqueue.SetProvider(prometheusMetricsProvider{})
+}
+
+type prometheusMetricsProvider struct{}
+
+func (p prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	depth := prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: name,
+		Name:      "depth",
+		Help:      "Current depth of workqueue: " + name,
+	})
+	prometheus.MustRegister(depth)
+	return depth
+}
+
+func (p prometheusMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	adds := prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: name,
+		Name:      "adds",
+		Help:      "Total number of adds handled by workqueue: " + name,
+	})
+	prometheus.MustRegister(adds)
+	return adds
+}
+
+func (p prometheusMetricsProvider) NewLatencyMetric(name string) workqueue.SummaryMetric {
+	latency := prometheus.NewSummary(prometheus.SummaryOpts{
+		Subsystem: name,
+		Name:      "queue_latency",
+		Help:      "How long an item stays in workqueue" + name + " before being requested.",
+	})
+	prometheus.MustRegister(latency)
+	return latency
+}
+
+func (p prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.SummaryMetric {
+	workDuration := prometheus.NewSummary(prometheus.SummaryOpts{
+		Subsystem: name,
+		Name:      "work_duration",
+		Help:      "How long processing an item from workqueue" + name + " takes.",
+	})
+	prometheus.MustRegister(workDuration)
+	return workDuration
+}
+
+func (p prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	retries := prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: name,
+		Name:      "retries",
+		Help:      "Total number of retries handled by workqueue: " + name,
+	})
+	prometheus.MustRegister(retries)
+	return retries
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds workqueue metrics. To have insights into queue length & processing time.

I renamed the queue names as they get used as the subsystem for the metrics.
I named them according to the controller they are being used in & the struct they contain.

**Release note**:
```release-note
NONE
```
