### PR TITLE
fix kubermatic-e2e after renames

### DIFF
--- a/api/cmd/kubermatic-e2e/e2e_test_runner.go
+++ b/api/cmd/kubermatic-e2e/e2e_test_runner.go
@@ -111,7 +111,7 @@ func (ctl *e2eTestRunner) run(ctx context.Context) error {
 		return err
 	}
 
-	clusterAdminRestConfig, err := ctl.clusterRestConfig(clusterKubeConfig, cluster.Name)
+	clusterAdminRestConfig, err := ctl.clusterRestConfig(clusterKubeConfig)
 	if err != nil {
 		return err
 	}
@@ -296,7 +296,7 @@ func (ctl *e2eTestRunner) createMachines(restConfig *rest.Config, dc provider.Da
 	return nil
 }
 
-func (ctl *e2eTestRunner) clusterRestConfig(cfg []byte, contextName string) (*rest.Config, error) {
+func (ctl *e2eTestRunner) clusterRestConfig(cfg []byte) (*rest.Config, error) {
 	clusterClientCfg, err := clientcmd.Load(cfg)
 	if err != nil {
 		return nil, err
@@ -304,7 +304,7 @@ func (ctl *e2eTestRunner) clusterRestConfig(cfg []byte, contextName string) (*re
 
 	return clientcmd.NewNonInteractiveClientConfig(
 		*clusterClientCfg,
-		contextName,
+		resources.KubeconfigDefaultContextKey,
 		&clientcmd.ConfigOverrides{},
 		nil,
 	).ClientConfig()


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix broken kubermatic-e2e test runs due to renames

```
F0904 13:32:02.185120      15 main.go:90] invalid configuration: [context was not found for specified context: e2e-test-runner-gqqp4, cluster has no server defined]
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
