### PR TITLE
Revert "Update machine-controller to v0.7.19 (#1914)"

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -654,7 +654,7 @@
   revision = "7cafcd837844e784b526369c9bce262804aebc60"
 
 [[projects]]
-  digest = "1:789715b763918c380d0a9c76fcd04e0d355c0cbe364a909aaec47149298d6485"
+  digest = "1:a9df415b82688898337aa6f2deaeb0334a08815ee506b3850770793985821a39"
   name = "github.com/kubermatic/machine-controller"
   packages = [
     "pkg/client/clientset/versioned",
@@ -690,8 +690,8 @@
     "pkg/userdata/ubuntu",
   ]
   pruneopts = "NUT"
-  revision = "3d36061083caf0d166ec6dc2625dbfd48b58a13a"
-  version = "v0.7.19"
+  revision = "5c11b45346a6e22b6a3a0538a3d568c48da342bc"
+  version = "v0.7.18"
 
 [[projects]]
   digest = "1:35e5598ba3bc950039e13d91958ce37f675264735907cada569d11b243e5cacb"

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -109,7 +109,7 @@ required = [
 
 [[constraint]]
   name = "github.com/kubermatic/machine-controller"
-  version = "v0.7.19"
+  version = "v0.7.18"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -16,7 +16,7 @@ import (
 const (
 	name = "machine-controller"
 
-	tag = "v0.7.19"
+	tag = "v0.7.18"
 )
 
 // Deployment returns the machine-controller Deployment

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.19
+        image: docker.io/kubermatic/machine-controller:v0.7.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/cloud/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/cloud/provider.go
@@ -31,12 +31,6 @@ type Provider interface {
 	// This will always be called on machine deletion, the implemention must check if there is actually
 	// something to delete and just do nothing if there isn't
 	Delete(machine *v1alpha1.Machine, update MachineUpdater) error
-
-	// MachineMetricsLabels returns labels used for the Prometheus metrics
-	// about created machines, e.g. instance type, instance size, region
-	// or whatever the provider deems interesting. Should always return
-	// a "size" label.
-	MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]string, error)
 }
 
 // MachineUpdater defines a function to persist an update to a machine

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/common/ssh/ssh.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/common/ssh/ssh.go
@@ -12,17 +12,17 @@ import (
 
 const privateRSAKeyBitSize = 4096
 
-// Pubkey is only used to create temporary keypairs, thus we
+// We only use this to create temporary keypairs, thus we
 // do not need the Private key
 // The reason for not hardcoding a random public key is that
 // it would look like a backdoor
-type Pubkey struct {
+type SSHPubkey struct {
 	Name           string
 	PublicKey      string
 	FingerprintMD5 string
 }
 
-func NewKey() (*Pubkey, error) {
+func NewSSHKey() (*SSHPubkey, error) {
 	tmpRSAKeyPair, err := rsa.GenerateKey(rand.Reader, privateRSAKeyBitSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private RSA key: %v", err)
@@ -37,7 +37,7 @@ func NewKey() (*Pubkey, error) {
 		return nil, fmt.Errorf("failed to generate ssh public key: %v", err)
 	}
 
-	return &Pubkey{
+	return &SSHPubkey{
 		Name:           uuid.New(),
 		PublicKey:      string(ssh.MarshalAuthorizedKey(pubKey)),
 		FingerprintMD5: ssh.FingerprintLegacyMD5(pubKey),

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws/provider.go
@@ -87,26 +87,25 @@ var (
 			"us-west-1":      "ami-7d81bb1d",
 			"us-west-2":      "ami-c167bdb9",
 		},
-		// for region in $(aws ec2 describe-regions  | jq '.Regions[].RegionName' --raw-output); do
-		//   IMAGE="$(aws ec2 --region "$region" describe-images --filters Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server* --output json | jq '.Images | sort_by(.CreationDate) | reverse | .[0].ImageId' --raw-output)"
-		//   echo "\"$region\": \"$IMAGE\","
-		// done
 		providerconfig.OperatingSystemUbuntu: {
-			"ap-south-1":     "ami-004ae4f94341b595d",
-			"eu-west-3":      "ami-0f230b076c11618ab",
-			"eu-west-2":      "ami-54d12433",
-			"eu-west-1":      "ami-0bd5ae06b6779872a",
-			"ap-northeast-2": "ami-0cffb4e3f8f2c7ca2",
-			"ap-northeast-1": "ami-18a8d1f5",
-			"sa-east-1":      "ami-0ba619c9d7a85181f",
-			"ca-central-1":   "ami-4875f82c",
-			"ap-southeast-1": "ami-02717f13071669929",
-			"ap-southeast-2": "ami-3b288859",
-			"eu-central-1":   "ami-f3bcb218",
-			"us-east-1":      "ami-920b10ed",
-			"us-east-2":      "ami-03bd56e7bb2f24c5d",
-			"us-west-1":      "ami-f36b8490",
-			"us-west-2":      "ami-349fb84c",
+			"ap-northeast-1": "ami-42ca4724",
+			"ap-south-1":     "ami-84dc94eb",
+			"ap-southeast-1": "ami-29aece55",
+			"ca-central-1":   "ami-b0c67cd4",
+			"eu-central-1":   "ami-13b8337c",
+			"eu-west-1":      "ami-63b0341a",
+			"sa-east-1":      "ami-8181c7ed",
+			"us-east-1":      "ami-3dec9947",
+			"us-west-1":      "ami-1a17137a",
+			"cn-north-1":     "ami-fc25f791",
+			"cn-northwest-1": "ami-e5b0a587",
+			"us-gov-west-1":  "ami-6261ee03",
+			"ap-northeast-2": "ami-5027813e",
+			"ap-southeast-2": "ami-9b8076f9",
+			"eu-west-2":      "ami-22415846",
+			"us-east-2":      "ami-597d553c",
+			"us-west-2":      "ami-a2e544da",
+			"eu-west-3":      "ami-794bfc04",
 		},
 		providerconfig.OperatingSystemCentOS: {
 			"ap-northeast-1": "ami-25bd2743",
@@ -714,20 +713,6 @@ func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
 
 func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, name string, err error) {
 	return "", "aws", nil
-}
-
-func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]string, error) {
-	labels := make(map[string]string)
-
-	c, _, err := p.getConfig(machine.Spec.ProviderConfig)
-	if err == nil {
-		labels["size"] = c.InstanceType
-		labels["region"] = c.Region
-		labels["az"] = c.AvailabilityZone
-		labels["ami"] = c.AMI
-	}
-
-	return labels, err
 }
 
 type awsInstance struct {

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure/create_delete_resources.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure/create_delete_resources.go
@@ -29,9 +29,7 @@ func deleteInterfacesByMachineUID(ctx context.Context, c *config, machineUID typ
 
 	for list.NotDone() {
 		allInterfaces = append(allInterfaces, list.Values()...)
-		if err = list.Next(); err != nil {
-			return fmt.Errorf("failed to iterate the result list: %s", err)
-		}
+		list.Next()
 	}
 
 	for _, iface := range allInterfaces {
@@ -68,9 +66,7 @@ func deleteIPAddressesByMachineUID(ctx context.Context, c *config, machineUID ty
 
 	for list.NotDone() {
 		allIPs = append(allIPs, list.Values()...)
-		if err = list.Next(); err != nil {
-			return fmt.Errorf("failed to iterate the result list: %s", err)
-		}
+		list.Next()
 	}
 
 	for _, ip := range allIPs {
@@ -104,9 +100,7 @@ func deleteVMsByMachineUID(ctx context.Context, c *config, machineUID types.UID)
 
 	for list.NotDone() {
 		allServers = append(allServers, list.Values()...)
-		if err = list.Next(); err != nil {
-			return fmt.Errorf("failed to iterate the result list: %s", err)
-		}
+		list.Next()
 	}
 
 	for _, vm := range allServers {
@@ -140,9 +134,7 @@ func deleteDisksByMachineUID(ctx context.Context, c *config, machineUID types.UI
 
 	for list.NotDone() {
 		allDisks = append(allDisks, list.Values()...)
-		if err = list.Next(); err != nil {
-			return fmt.Errorf("failed to iterate the result list: %s", err)
-		}
+		list.Next()
 	}
 
 	for _, disk := range allDisks {

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure/provider.go
@@ -335,7 +335,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	}
 
 	// We genete a random SSH key, since Azure won't let us create a VM without an SSH key or a password
-	key, err := ssh.NewKey()
+	key, err := ssh.NewSSHKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ssh key: %v", err)
 	}
@@ -382,7 +382,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 			NetworkProfile: &compute.NetworkProfile{
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
-						ID: iface.ID,
+						ID:                                  iface.ID,
 						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: to.BoolPtr(true)},
 					},
 				},
@@ -533,9 +533,7 @@ func getVMByUID(ctx context.Context, c *config, uid types.UID) (*compute.Virtual
 
 	for list.NotDone() {
 		allServers = append(allServers, list.Values()...)
-		if err = list.Next(); err != nil {
-			return nil, fmt.Errorf("failed to iterate the result list: %s", err)
-		}
+		list.Next()
 	}
 
 	for _, vm := range allServers {
@@ -715,17 +713,9 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	}
 
 	_, err = getOSImageReference(providerCfg.OperatingSystem)
-	return nil
-}
-
-func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]string, error) {
-	labels := make(map[string]string)
-
-	c, _, err := p.getConfig(machine.Spec.ProviderConfig)
-	if err == nil {
-		labels["size"] = c.VMSize
-		labels["location"] = c.Location
+	if err != nil {
+		return err
 	}
 
-	return labels, err
+	return nil
 }

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+const privateRSAKeyBitSize = 4096
+
 type provider struct {
 	configVarResolver *providerconfig.ConfigVarResolver
 }
@@ -76,7 +78,7 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 func getSlugForOS(os providerconfig.OperatingSystem) (string, error) {
 	switch os {
 	case providerconfig.OperatingSystemUbuntu:
-		return "ubuntu-18-04-x64", nil
+		return "ubuntu-16-04-x64", nil
 	case providerconfig.OperatingSystemCoreos:
 		return "coreos-stable", nil
 	case providerconfig.OperatingSystemCentOS:
@@ -229,7 +231,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 // digital ocean because it is not possible to create a droplet without ssh key assigned
 // this method returns an error if the key already exists
 func uploadRandomSSHPublicKey(ctx context.Context, service godo.KeysService) (string, error) {
-	sshkey, err := ssh.NewKey()
+	sshkey, err := ssh.NewSSHKey()
 	if err != nil {
 		return "", fmt.Errorf("failed to generate ssh key: %v", err)
 	}
@@ -381,18 +383,6 @@ func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
 
 func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, name string, err error) {
 	return "", "", nil
-}
-
-func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]string, error) {
-	labels := make(map[string]string)
-
-	c, _, err := p.getConfig(machine.Spec.ProviderConfig)
-	if err == nil {
-		labels["size"] = c.Size
-		labels["region"] = c.Region
-	}
-
-	return labels, err
 }
 
 type doInstance struct {

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/hetzner/provider.go
@@ -47,7 +47,7 @@ type Config struct {
 func getNameForOS(os providerconfig.OperatingSystem) (string, error) {
 	switch os {
 	case providerconfig.OperatingSystemUbuntu:
-		return "ubuntu-18.04", nil
+		return "ubuntu-16.04", nil
 	case providerconfig.OperatingSystemCentOS:
 		return "centos-7", nil
 	}
@@ -180,7 +180,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, use
 		return nil, hzErrorToTerminalError(err, "failed to get server type")
 	}
 
-	sshkey, err := ssh.NewKey()
+	sshkey, err := ssh.NewSSHKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ssh key: %v", err)
 	}
@@ -272,19 +272,6 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 	return "", "", nil
 }
 
-func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]string, error) {
-	labels := make(map[string]string)
-
-	c, _, err := p.getConfig(machine.Spec.ProviderConfig)
-	if err == nil {
-		labels["size"] = c.ServerType
-		labels["dc"] = c.Datacenter
-		labels["location"] = c.Location
-	}
-
-	return labels, err
-}
-
 type hetznerServer struct {
 	server *hcloud.Server
 }
@@ -306,8 +293,8 @@ func (s *hetznerServer) Addresses() []string {
 	return append(addresses, s.server.PublicNet.IPv4.IP.String(), s.server.PublicNet.IPv6.IP.String())
 }
 
-func (s *hetznerServer) Status() instance.Status {
-	switch s.server.Status {
+func (d *hetznerServer) Status() instance.Status {
+	switch d.server.Status {
 	case hcloud.ServerStatusInitializing:
 		return instance.StatusCreating
 	case hcloud.ServerStatusRunning:

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/helper.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/helper.go
@@ -382,30 +382,30 @@ func getDefaultNetwork(client *gophercloud.ProviderClient, region string) (*osne
 	}
 	if len(networks) == 1 {
 		return &networks[0], nil
-	}
-
-	// Networks without subnets can't be used, try finding a default by excluding them
-	// However the network object itself still contains the subnet, the only difference
-	// is that the subnet can not be retrieved by itself
-	var candidates []osnetworks.Network
-NetworkLoop:
-	for _, network := range networks {
-		for _, subnet := range network.Subnets {
-			_, err := getSubnet(client, region, subnet)
-			if err == errNotFound {
-				continue
-			} else if err != nil {
-				return nil, err
+	} else {
+		// Networks without subnets can't be used, try finding a default by excluding them
+		// However the network object itself still contains the subnet, the only difference
+		// is that the subnet can not be retrieved by itself
+		var candidates []osnetworks.Network
+	NetworkLoop:
+		for _, network := range networks {
+			for _, subnet := range network.Subnets {
+				_, err := getSubnet(client, region, subnet)
+				if err == errNotFound {
+					continue
+				} else if err != nil {
+					return nil, err
+				}
+				candidates = append(candidates, network)
+				continue NetworkLoop
 			}
-			candidates = append(candidates, network)
-			continue NetworkLoop
+		}
+		if len(candidates) == 1 {
+			return &candidates[0], nil
 		}
 	}
-	if len(candidates) == 1 {
-		return &candidates[0], nil
-	}
 
-	return nil, fmt.Errorf("%d candidate networks found", len(candidates))
+	return nil, nil
 }
 
 func getDefaultSubnet(client *gophercloud.ProviderClient, network *osnetworks.Network, region string) (*string, error) {

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/provider.go
@@ -224,7 +224,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 			changed = true
 			rawConfig.Region.Value = regions[0].ID
 		} else {
-			return spec, changed, fmt.Errorf("could not default region because got '%v' results", len(regions))
+			return spec, changed, fmt.Errorf("could not default region because got '%v' results!", len(regions))
 		}
 	}
 
@@ -426,8 +426,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, use
 
 	var server serverWithExt
 	err = osservers.Create(computeClient, keypairs.CreateOptsExt{
-		CreateOptsBuilder: serverOpts,
-		KeyName:           "",
+		serverOpts,
+		"",
 	}).ExtractInto(&server)
 	if err != nil {
 		return nil, osErrorToTerminalError(err, "failed to create server")
@@ -555,19 +555,6 @@ tenant-name = "%s"
 region = "%s"
 `, c.IdentityEndpoint, c.Username, c.Password, c.DomainName, c.TenantName, c.Region)
 	return config, "openstack", nil
-}
-
-func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]string, error) {
-	labels := make(map[string]string)
-
-	c, _, _, err := p.getConfig(machine.Spec.ProviderConfig)
-	if err == nil {
-		labels["size"] = c.Flavor
-		labels["image"] = c.Image
-		labels["region"] = c.Region
-	}
-
-	return labels, err
 }
 
 type serverWithExt struct {

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/providerconfig/types.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/providerconfig/types.go
@@ -67,8 +67,7 @@ type Config struct {
 	OverwriteCloudConfig *string `json:"overwriteCloudConfig,omitempty"`
 }
 
-// GlobaObjectKeySelector is needed as we can not use v1.SecretKeySelector
-// because it is not cross namespace
+// We can not use v1.SecretKeySelector because it is not cross namespace
 type GlobaObjectKeySelector struct {
 	v1.ObjectReference `json:",inline"`
 	Key                string `json:"key"`
@@ -88,7 +87,6 @@ type ConfigVarString struct {
 // causing a recursion
 type configVarStringWithoutUnmarshaller ConfigVarString
 
-// MarshalJSON converts a configVarString to its JSON form, ompitting empty strings.
 // This is done to not have the json object cluttered with empty strings
 // This will eventually hopefully be resolved within golang itself
 // https://github.com/golang/go/issues/11939
@@ -167,7 +165,6 @@ type ConfigVarBool struct {
 
 type configVarBoolWithoutUnmarshaller ConfigVarBool
 
-// MarshalJSON encodes the configVarBool, omitting empty strings
 // This is done to not have the json object cluttered with empty strings
 // This will eventually hopefully be resolved within golang itself
 // https://github.com/golang/go/issues/11939
@@ -250,7 +247,7 @@ func (configVarResolver *ConfigVarResolver) GetConfigVarStringValue(configVar Co
 		if val, ok := secret.Data[configVar.SecretKeyRef.Key]; ok {
 			return string(val), nil
 		}
-		return "", fmt.Errorf("secret '%s' in namespace '%s' has no key '%s'", configVar.SecretKeyRef.Name, configVar.SecretKeyRef.Namespace, configVar.SecretKeyRef.Key)
+		return "", fmt.Errorf("secret '%s' in namespace '%s' has no key '%s'!", configVar.SecretKeyRef.Name, configVar.SecretKeyRef.Namespace, configVar.SecretKeyRef.Key)
 	}
 
 	// We need all three of these to fetch and use a configmap
@@ -262,13 +259,13 @@ func (configVarResolver *ConfigVarResolver) GetConfigVarStringValue(configVar Co
 		if val, ok := configMap.Data[configVar.ConfigMapKeyRef.Key]; ok {
 			return string(val), nil
 		}
-		return "", fmt.Errorf("configmap '%s' in namespace '%s' has no key '%s'", configVar.ConfigMapKeyRef.Name, configVar.ConfigMapKeyRef.Namespace, configVar.ConfigMapKeyRef.Key)
+		return "", fmt.Errorf("configmap '%s' in namespace '%s' has no key '%s'!", configVar.ConfigMapKeyRef.Name, configVar.ConfigMapKeyRef.Namespace, configVar.ConfigMapKeyRef.Key)
 	}
 
 	return configVar.Value, nil
 }
 
-// GetConfigVarStringValueOrEnv tries to get the value from ConfigVarString, when it fails, it falls back to
+// GetConfigVarStringValueOrEvn tries to get the value from ConfigVarString, when it fails, it falls back to
 // getting the value from an environment variable specified by envVarName parameter
 func (configVarResolver *ConfigVarResolver) GetConfigVarStringValueOrEnv(configVar ConfigVarString, envVarName string) (string, error) {
 	cfgVar, err := configVarResolver.GetConfigVarStringValue(configVar)

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/centos/userdata.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/centos/userdata.go
@@ -146,7 +146,6 @@ func (p Provider) UserData(
 		ClusterDNSIPs     []net.IP
 		KubeadmCACertHash string
 		ServerAddr        string
-		JournaldMaxSize   string
 	}{
 		MachineSpec:       spec,
 		ProviderConfig:    pconfig,
@@ -159,7 +158,6 @@ func (p Provider) UserData(
 		ClusterDNSIPs:     clusterDNSIPs,
 		KubeadmCACertHash: kubeadmCACertHash,
 		ServerAddr:        serverAddr,
-		JournaldMaxSize:   userdatahelper.JournaldMaxUse,
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -187,11 +185,6 @@ ssh_authorized_keys:
 {{- end }}
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
-  content: |
-    [Journal]
-    SystemMaxUse={{ .JournaldMaxSize }}
-
 - path: "/etc/sysctl.d/k8s.conf"
   content: |
     net.bridge.bridge-nf-call-ip6tables = 1

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/coreos/userdata.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/coreos/userdata.go
@@ -118,7 +118,6 @@ func (p Provider) UserData(
 		HyperkubeImageTag string
 		ClusterDNSIPs     []net.IP
 		KubernetesCACert  string
-		JournaldMaxSize   string
 	}{
 		MachineSpec:       spec,
 		ProviderConfig:    pconfig,
@@ -129,7 +128,6 @@ func (p Provider) UserData(
 		HyperkubeImageTag: fmt.Sprintf("v%s", kubeletVersion.String()),
 		ClusterDNSIPs:     clusterDNSIPs,
 		KubernetesCACert:  kubernetesCACert,
-		JournaldMaxSize:   userdatahelper.JournaldMaxUse,
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -264,14 +262,6 @@ systemd:
 
 storage:
   files:
-    - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Journal]
-          SystemMaxUse={{ .JournaldMaxSize }}
-
     - path: /etc/sysctl.d/k8s.conf
       filesystem: root
       mode: 0644

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/helper.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/helper.go
@@ -11,38 +11,32 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-const (
-	// JournaldMaxUse defines the maximum space that journalD logs can occupy.
-	// https://www.freedesktop.org/software/systemd/man/journald.conf.html#SystemMaxUse=
-	JournaldMaxUse = "5G"
-)
-
 func GetServerAddressFromKubeconfig(kubeconfig *clientcmdapi.Config) (string, error) {
 	if len(kubeconfig.Clusters) != 1 {
-		return "", fmt.Errorf("kubeconfig does not contain exactly one cluster, can not extract server address")
+		return "", fmt.Errorf("kubeconfig does not contain exactly one cluster, can not extract server address...")
 	}
 	// Clusters is a map so we have to use range here
 	for _, clusterConfig := range kubeconfig.Clusters {
 		return strings.Replace(clusterConfig.Server, "https://", "", -1), nil
 	}
 
-	return "", fmt.Errorf("no server address found")
+	return "", fmt.Errorf("no server address found!")
 
 }
 
 func GetCACert(kubeconfig *clientcmdapi.Config) (string, error) {
 	if len(kubeconfig.Clusters) != 1 {
-		return "", fmt.Errorf("kubeconfig does not contain exactly one cluster, can not extract server address")
+		return "", fmt.Errorf("kubeconfig does not contain exactly one cluster, can not extract server address...")
 	}
 	// Clusters is a map so we have to use range here
 	for _, clusterConfig := range kubeconfig.Clusters {
 		return string(clusterConfig.CertificateAuthorityData), nil
 	}
 
-	return "", fmt.Errorf("no CACert found")
+	return "", fmt.Errorf("no CACert found!")
 }
 
-// GetKubeadmCACertHash returns a sha256sum of the Certificates RawSubjectPublicKeyInfo
+// Returns a sha256sum of the Certificates RawSubjectPublicKeyInfo
 func GetKubeadmCACertHash(kubeconfig *clientcmdapi.Config) (string, error) {
 	cacert, err := GetCACert(kubeconfig)
 	if err != nil {
@@ -63,7 +57,7 @@ func GetKubeadmCACertHash(kubeconfig *clientcmdapi.Config) (string, error) {
 
 func GetTokenFromKubeconfig(kubeconfig *clientcmdapi.Config) (string, error) {
 	if len(kubeconfig.AuthInfos) != 1 {
-		return "", fmt.Errorf("kubeconfig does not contain exactly one token, can not extract token")
+		return "", fmt.Errorf("kubeconfig does not contain exactly one token, can not extract token...")
 	}
 
 	for _, authInfo := range kubeconfig.AuthInfos {
@@ -73,7 +67,6 @@ func GetTokenFromKubeconfig(kubeconfig *clientcmdapi.Config) (string, error) {
 	return "", fmt.Errorf("no token found in kubeconfig")
 }
 
-// StringifyKubeconfig marshals a kubeconfig to its text form
 func StringifyKubeconfig(kubeconfig *clientcmdapi.Config) (string, error) {
 	kubeconfigBytes, err := clientcmd.Write(*kubeconfig)
 	if err != nil {

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/ubuntu/docker.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/ubuntu/docker.go
@@ -75,5 +75,5 @@ func getDockerInstallCandidate(desiredVersion string) (pkg string, version strin
 		}
 	}
 
-	return "", "", errNoInstallCandidateAvailable
+	return "", "", NoInstallCandidateAvailableErr
 }


### PR DESCRIPTION
This reverts commit f7154c5905b9a08bf36c2c2820e1a2328ab55811, which updated to the `v0.7.19` release of machine-controller, implementing partial upgrade to Ubuntu Bionic.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NOTE
```
