### PR TITLE
Use data providers in creators

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
@@ -334,13 +335,22 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 	kubeInformerFactory.Start(stopChannel)
 	kubeInformerFactory.WaitForCacheSync(stopChannel)
 
-	return &resources.TemplateData{
-		DC:                &provider.DatacenterMeta{},
-		SecretLister:      secretLister,
-		ServiceLister:     serviceLister,
-		ConfigMapLister:   configMapLister,
-		NodeAccessNetwork: "192.0.2.0/24",
-		Cluster:           fakeCluster}, nil
+	return resources.NewTemplateData(
+		fakeCluster,
+		&provider.DatacenterMeta{},
+		"",
+		secretLister,
+		configMapLister,
+		serviceLister,
+		"",
+		"",
+		"192.0.2.0/24",
+		resource.Quantity{},
+		"",
+		false,
+		false,
+		"",
+		nil), nil
 }
 
 func createNamedSecrets(secretNames []string) *corev1.SecretList {

--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -84,11 +85,7 @@ func TestConfigMapCreatorsKeepAdditionalData(t *testing.T) {
 	cluster.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"10.10.0.0/8"}
 	cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.11.0.0/8"}
 	dc := &provider.DatacenterMeta{}
-	templateData := &resources.TemplateData{
-		Cluster:           cluster,
-		DC:                dc,
-		NodeAccessNetwork: "10.12.0.0/8",
-	}
+	templateData := resources.NewTemplateData(cluster, dc, "", nil, nil, nil, "", "", "10.12.0.0/8", resource.Quantity{}, "", false, false, "", nil)
 
 	for _, create := range GetConfigMapCreators() {
 		existing := &corev1.ConfigMap{
@@ -166,12 +163,7 @@ func TestSecretV2CreatorsKeepAdditionalData(t *testing.T) {
 	}
 	serviceLister := listerscorev1.NewServiceLister(serviceIndexer)
 
-	templateData := &resources.TemplateData{
-		Cluster:       cluster,
-		DC:            dc,
-		SecretLister:  secretLister,
-		ServiceLister: serviceLister,
-	}
+	templateData := resources.NewTemplateData(cluster, dc, "", secretLister, nil, serviceLister, "", "", "", resource.Quantity{}, "", false, false, "", nil)
 
 	for _, op := range GetSecretCreatorOperations([]byte{}) {
 		existing := &corev1.Secret{

--- a/api/pkg/resources/apiserver/deployment_test.go
+++ b/api/pkg/resources/apiserver/deployment_test.go
@@ -5,6 +5,8 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestGetAdmissionControlFlags(t *testing.T) {
@@ -35,11 +37,10 @@ func TestGetAdmissionControlFlags(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		templateData := resources.TemplateData{}
-		templateData.Cluster = &kubermaticv1.Cluster{}
-		templateData.Cluster.Spec.Version = test.kubernetesVersion
+		templateData := resources.NewTemplateData(&kubermaticv1.Cluster{}, nil, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", false, false, "", nil)
+		templateData.Cluster().Spec.Version = test.kubernetesVersion
 
-		admissionControlFlagName, admissionControlFlagValue := getAdmissionControlFlags(&templateData)
+		admissionControlFlagName, admissionControlFlagValue := getAdmissionControlFlags(templateData)
 		if admissionControlFlagName != test.expectedAdmissionControlFlagName {
 			t.Errorf("Expected admission control flag name to be %s but was %s", test.expectedAdmissionControlFlagName, admissionControlFlagName)
 		}

--- a/api/pkg/resources/apiserver/etcd-client-certificate.go
+++ b/api/pkg/resources/apiserver/etcd-client-certificate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // EtcdClientCertificate returns a secret with the client certificate for authenticating against etcd
-func EtcdClientCertificate(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func EtcdClientCertificate(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	return certificates.GetClientCertificateCreator(
 		resources.ApiserverEtcdClientCertificateSecretName,
 		"apiserver",

--- a/api/pkg/resources/apiserver/frontproxy-client-certificate.go
+++ b/api/pkg/resources/apiserver/frontproxy-client-certificate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // FrontProxyClientCertificate returns a secret with the client certificate for authenticating against extension apiserver
-func FrontProxyClientCertificate(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func FrontProxyClientCertificate(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	return certificates.GetClientCertificateCreator(
 		resources.ApiserverFrontProxyClientCertificateSecretName,
 		"apiserver-aggregator",

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -9,7 +9,7 @@ import (
 )
 
 // IsRunningInitContainer returns a init container which will wait until the apiserver is reachable via its ClusterIP
-func IsRunningInitContainer(data *resources.TemplateData) (*corev1.Container, error) {
+func IsRunningInitContainer(data resources.DeploymentDataProvider) (*corev1.Container, error) {
 	// get clusterIP of apiserver
 	url, err := data.InClusterApiserverURL()
 	if err != nil {

--- a/api/pkg/resources/apiserver/kubelet-client-certificate.go
+++ b/api/pkg/resources/apiserver/kubelet-client-certificate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // KubeletClientCertificate returns a secret with the client certificate for the apiserver -> kubelet connection.
-func KubeletClientCertificate(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func KubeletClientCertificate(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	return certificates.GetClientCertificateCreator(
 		resources.KubeletClientCertificatesSecretName,
 		"kube-apiserver-kubelet-client",

--- a/api/pkg/resources/apiserver/service-account-key.go
+++ b/api/pkg/resources/apiserver/service-account-key.go
@@ -13,11 +13,9 @@ import (
 )
 
 // ServiceAccountKey returns a secret with the ServiceAccount key
-func ServiceAccountKey(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
-	var se *corev1.Secret
-	if existing != nil {
-		se = existing
-	} else {
+func ServiceAccountKey(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
+	se := existing
+	if se == nil {
 		se = &corev1.Secret{}
 	}
 

--- a/api/pkg/resources/apiserver/service.go
+++ b/api/pkg/resources/apiserver/service.go
@@ -9,11 +9,9 @@ import (
 )
 
 // Service returns the internal service for the apiserver
-func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
-	var se *corev1.Service
-	if existing != nil {
-		se = existing
-	} else {
+func Service(data resources.ServiceDataProvider, existing *corev1.Service) (*corev1.Service, error) {
+	se := existing
+	if se == nil {
 		se = &corev1.Service{}
 	}
 
@@ -38,7 +36,7 @@ func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Se
 }
 
 // ExternalService returns the internal service for the apiserver
-func ExternalService(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
+func ExternalService(data resources.ServiceDataProvider, existing *corev1.Service) (*corev1.Service, error) {
 	var se *corev1.Service
 	if existing != nil {
 		se = existing

--- a/api/pkg/resources/apiserver/tls-serving-certificate.go
+++ b/api/pkg/resources/apiserver/tls-serving-certificate.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TLSServingCertificate returns a secret with the apiserver tls certificate used to serve https
-func TLSServingCertificate(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func TLSServingCertificate(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	var se *corev1.Secret
 	if existing != nil {
 		se = existing
@@ -38,7 +38,7 @@ func TLSServingCertificate(data *resources.TemplateData, existing *corev1.Secret
 		return nil, fmt.Errorf("failed to get external IP for cluster: %v", err)
 	}
 
-	inClusterIP, err := resources.InClusterApiserverIP(data.Cluster)
+	inClusterIP, err := resources.InClusterApiserverIP(data.Cluster())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the in-cluster ClusterIP for the apiserver: %v", err)
 	}
@@ -46,22 +46,22 @@ func TLSServingCertificate(data *resources.TemplateData, existing *corev1.Secret
 	altNames := certutil.AltNames{
 		DNSNames: []string{
 			// ExternalName
-			data.Cluster.Address.ExternalName,
+			data.Cluster().Address.ExternalName,
 			// User facing
 			"kubernetes",
 			"kubernetes.default",
 			"kubernetes.default.svc",
-			fmt.Sprintf("kubernetes.default.svc.%s", data.Cluster.Spec.ClusterNetwork.DNSDomain),
+			fmt.Sprintf("kubernetes.default.svc.%s", data.Cluster().Spec.ClusterNetwork.DNSDomain),
 			// Internal - apiserver-external
 			resources.ApiserverExternalServiceName,
-			fmt.Sprintf("%s.%s", resources.ApiserverExternalServiceName, data.Cluster.Status.NamespaceName),
-			fmt.Sprintf("%s.%s.svc", resources.ApiserverExternalServiceName, data.Cluster.Status.NamespaceName),
-			fmt.Sprintf("%s.%s.svc.cluster.local", resources.ApiserverExternalServiceName, data.Cluster.Status.NamespaceName),
+			fmt.Sprintf("%s.%s", resources.ApiserverExternalServiceName, data.Cluster().Status.NamespaceName),
+			fmt.Sprintf("%s.%s.svc", resources.ApiserverExternalServiceName, data.Cluster().Status.NamespaceName),
+			fmt.Sprintf("%s.%s.svc.cluster.local", resources.ApiserverExternalServiceName, data.Cluster().Status.NamespaceName),
 			// Internal - apiserver
 			resources.ApiserverInternalServiceName,
-			fmt.Sprintf("%s.%s", resources.ApiserverInternalServiceName, data.Cluster.Status.NamespaceName),
-			fmt.Sprintf("%s.%s.svc", resources.ApiserverInternalServiceName, data.Cluster.Status.NamespaceName),
-			fmt.Sprintf("%s.%s.svc.cluster.local", resources.ApiserverInternalServiceName, data.Cluster.Status.NamespaceName),
+			fmt.Sprintf("%s.%s", resources.ApiserverInternalServiceName, data.Cluster().Status.NamespaceName),
+			fmt.Sprintf("%s.%s.svc", resources.ApiserverInternalServiceName, data.Cluster().Status.NamespaceName),
+			fmt.Sprintf("%s.%s.svc.cluster.local", resources.ApiserverInternalServiceName, data.Cluster().Status.NamespaceName),
 		},
 		IPs: []net.IP{
 			*externalIP,

--- a/api/pkg/resources/apiserver/token-users.go
+++ b/api/pkg/resources/apiserver/token-users.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TokenUsers returns a secret containing the tokens csv
-func TokenUsers(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func TokenUsers(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	var se *corev1.Secret
 	if existing != nil {
 		se = existing
@@ -29,7 +29,7 @@ func TokenUsers(data *resources.TemplateData, existing *corev1.Secret) (*corev1.
 	buffer := &bytes.Buffer{}
 	writer := csv.NewWriter(buffer)
 
-	if err := writer.Write([]string{data.Cluster.Address.AdminToken, "admin", "10000", "system:masters"}); err != nil {
+	if err := writer.Write([]string{data.Cluster().Address.AdminToken, "admin", "10000", "system:masters"}); err != nil {
 		return nil, err
 	}
 	writer.Flush()

--- a/api/pkg/resources/certificates/root-ca.go
+++ b/api/pkg/resources/certificates/root-ca.go
@@ -12,8 +12,8 @@ import (
 )
 
 // GetCACreator returns a function to create a secret containing a CA with the specified name
-func getCACreator(name, commonName string) func(*resources.TemplateData, *corev1.Secret) (*corev1.Secret, error) {
-	return func(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func getCACreator(name, commonName string) func(resources.SecretDataProvider, *corev1.Secret) (*corev1.Secret, error) {
+	return func(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 		var se *corev1.Secret
 		if existing != nil {
 			se = existing
@@ -44,14 +44,14 @@ func getCACreator(name, commonName string) func(*resources.TemplateData, *corev1
 }
 
 // RootCA returns a function to create a secret with the root ca
-func RootCA(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
-	create := getCACreator(resources.CASecretName, fmt.Sprintf("root-ca.%s", data.Cluster.Address.ExternalName))
+func RootCA(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
+	create := getCACreator(resources.CASecretName, fmt.Sprintf("root-ca.%s", data.Cluster().Address.ExternalName))
 
 	return create(data, existing)
 }
 
 // FrontProxyCA returns a function to create a secret with front proxy ca
-func FrontProxyCA(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func FrontProxyCA(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	create := getCACreator(resources.FrontProxyCASecretName, resources.FrontProxyCASecretName)
 
 	return create(data, existing)

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -17,7 +17,7 @@ const (
 )
 
 // ConfigMap returns a ConfigMap containing the cloud-config for the supplied data
-func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+func ConfigMap(data resources.ConfigMapDataProvider, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	var cm *corev1.ConfigMap
 	if existing != nil {
 		cm = existing
@@ -43,7 +43,7 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
 }
 
 // CloudConfig returns the cloud-config for the supplied data
-func CloudConfig(data *resources.TemplateData) (string, error) {
+func CloudConfig(data resources.ConfigMapDataProvider) (string, error) {
 	configBuffer := bytes.Buffer{}
 	configTpl, err := template.New("base").Funcs(sprig.TxtFuncMap()).Parse(config)
 	if err != nil {

--- a/api/pkg/resources/controllermanager/clusterrolebinding.go
+++ b/api/pkg/resources/controllermanager/clusterrolebinding.go
@@ -7,7 +7,7 @@ import (
 )
 
 // AdminClusterRoleBinding allows just everything.
-func AdminClusterRoleBinding(data *resources.TemplateData, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+func AdminClusterRoleBinding(_ resources.ClusterRoleBindingDataProvider, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 	var crb *rbacv1.ClusterRoleBinding
 	if existing != nil {
 		crb = existing

--- a/api/pkg/resources/controllermanager/rolebinding.go
+++ b/api/pkg/resources/controllermanager/rolebinding.go
@@ -9,13 +9,13 @@ import (
 
 // SystemBootstrapSignerRoleBinding returns the RoleBinding for the bootstrapping in controller-manager.
 // It has to be put into the user-cluster.
-func SystemBootstrapSignerRoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+func SystemBootstrapSignerRoleBinding(_ resources.RoleBindingDataProvider, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 	return createRoleBinding(existing, metav1.NamespaceSystem, "system:controller:bootstrap-signer")
 }
 
 // PublicBootstrapSignerRoleBinding returns the RoleBinding for the bootstrapping reader in controller-manager.
 // It has to be put into the user-cluster.
-func PublicBootstrapSignerRoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+func PublicBootstrapSignerRoleBinding(_ resources.RoleBindingDataProvider, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 	return createRoleBinding(existing, metav1.NamespacePublic, "system:controller:bootstrap-signer")
 }
 

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -19,30 +19,103 @@ import (
 
 // TemplateData is a group of data required for template generation
 type TemplateData struct {
-	Cluster                                          *kubermaticv1.Cluster
-	DC                                               *provider.DatacenterMeta
+	cluster                                          *kubermaticv1.Cluster
+	dC                                               *provider.DatacenterMeta
 	SeedDC                                           string
 	SecretLister                                     corev1lister.SecretLister
-	ConfigMapLister                                  corev1lister.ConfigMapLister
-	ServiceLister                                    corev1lister.ServiceLister
+	configMapLister                                  corev1lister.ConfigMapLister
+	serviceLister                                    corev1lister.ServiceLister
 	OverwriteRegistry                                string
-	NodePortRange                                    string
-	NodeAccessNetwork                                string
-	EtcdDiskSize                                     resource.Quantity
-	InClusterPrometheusRulesFile                     string
-	InClusterPrometheusDisableDefaultRules           bool
-	InClusterPrometheusDisableDefaultScrapingConfigs bool
-	InClusterPrometheusScrapingConfigsFile           string
+	nodePortRange                                    string
+	nodeAccessNetwork                                string
+	etcdDiskSize                                     resource.Quantity
+	inClusterPrometheusRulesFile                     string
+	inClusterPrometheusDisableDefaultRules           bool
+	inClusterPrometheusDisableDefaultScrapingConfigs bool
+	inClusterPrometheusScrapingConfigsFile           string
 	DockerPullConfigJSON                             []byte
+}
+
+// TemplateData returns data for templating
+func (d *TemplateData) TemplateData() interface{} {
+	return d
 }
 
 // UserClusterData groups data required for resource creation in user-cluster
 type UserClusterData struct {
+	configMapLister corev1lister.ConfigMapLister
+	serviceLister   corev1lister.ServiceLister
 }
 
-// RoleDataProvider provides data about roles
+// RoleDataProvider provides data
 type RoleDataProvider interface {
 	GetClusterRef() metav1.OwnerReference
+}
+
+// RoleBindingDataProvider provides data
+type RoleBindingDataProvider interface {
+	GetClusterRef() metav1.OwnerReference
+	Cluster() *kubermaticv1.Cluster
+}
+
+// ClusterRoleDataProvider provides data
+type ClusterRoleDataProvider interface {
+	GetClusterRef() metav1.OwnerReference
+}
+
+// ClusterRoleBindingDataProvider provides data
+type ClusterRoleBindingDataProvider interface {
+	GetClusterRef() metav1.OwnerReference
+}
+
+// ConfigMapDataProvider provides data
+type ConfigMapDataProvider interface {
+	GetClusterRef() metav1.OwnerReference
+	Cluster() *kubermaticv1.Cluster
+	TemplateData() interface{}
+	ServiceLister() corev1lister.ServiceLister
+	NodeAccessNetwork() string
+	InClusterPrometheusRulesFile() string
+	InClusterPrometheusScrapingConfigsFile() string
+	InClusterPrometheusDisableDefaultRules() bool
+	InClusterPrometheusDisableDefaultScrapingConfigs() bool
+}
+
+// SecretDataProvider provides data
+type SecretDataProvider interface {
+	GetClusterRef() metav1.OwnerReference
+	InClusterApiserverURL() (*url.URL, error)
+	GetFrontProxyCA() (*triple.KeyPair, error)
+	GetRootCA() (*triple.KeyPair, error)
+	ExternalIP() (*net.IP, error)
+	Cluster() *kubermaticv1.Cluster
+}
+
+// ServiceDataProvider provides data
+type ServiceDataProvider interface {
+	GetClusterRef() metav1.OwnerReference
+	Cluster() *kubermaticv1.Cluster
+}
+
+// DeploymentDataProvider provides data
+type DeploymentDataProvider interface {
+	GetClusterRef() metav1.OwnerReference
+	ClusterIPByServiceName(name string) (string, error)
+	GetApiserverExternalNodePort() (int32, error)
+	EtcdDiskSize() resource.Quantity
+	NodeAccessNetwork() string
+	NodePortRange() string
+	ServiceLister() corev1lister.ServiceLister
+	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
+	InClusterApiserverURL() (*url.URL, error)
+	ImageRegistry(string) string
+	Cluster() *kubermaticv1.Cluster
+	DC() *provider.DatacenterMeta
+}
+
+// StatefulSetDataProvider provides data
+type StatefulSetDataProvider interface {
+	DeploymentDataProvider
 }
 
 // NewTemplateData returns an instance of TemplateData
@@ -63,34 +136,99 @@ func NewTemplateData(
 	inClusterPrometheusScrapingConfigsFile string,
 	dockerPullConfigJSON []byte) *TemplateData {
 	return &TemplateData{
-		Cluster:                                cluster,
-		DC:                                     dc,
+		cluster:                                cluster,
+		dC:                                     dc,
 		SeedDC:                                 seedDatacenter,
-		ConfigMapLister:                        configMapLister,
+		configMapLister:                        configMapLister,
 		SecretLister:                           secretLister,
-		ServiceLister:                          serviceLister,
+		serviceLister:                          serviceLister,
 		OverwriteRegistry:                      overwriteRegistry,
-		NodePortRange:                          nodePortRange,
-		NodeAccessNetwork:                      nodeAccessNetwork,
-		EtcdDiskSize:                           etcdDiskSize,
-		InClusterPrometheusRulesFile:           inClusterPrometheusRulesFile,
-		InClusterPrometheusDisableDefaultRules: inClusterPrometheusDisableDefaultRules,
-		InClusterPrometheusDisableDefaultScrapingConfigs: inClusterPrometheusDisableDefaultScrapingConfigs,
-		InClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
+		nodePortRange:                          nodePortRange,
+		nodeAccessNetwork:                      nodeAccessNetwork,
+		etcdDiskSize:                           etcdDiskSize,
+		inClusterPrometheusRulesFile:           inClusterPrometheusRulesFile,
+		inClusterPrometheusDisableDefaultRules: inClusterPrometheusDisableDefaultRules,
+		inClusterPrometheusDisableDefaultScrapingConfigs: inClusterPrometheusDisableDefaultScrapingConfigs,
+		inClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
 		DockerPullConfigJSON:                             dockerPullConfigJSON,
+	}
+}
+
+// Cluster returns the cluster
+func (d *TemplateData) Cluster() *kubermaticv1.Cluster {
+	return d.cluster
+}
+
+// DC returns the dC
+func (d *TemplateData) DC() *provider.DatacenterMeta {
+	return d.dC
+}
+
+// ServiceLister returns the serviceLister
+func (d *TemplateData) ServiceLister() corev1lister.ServiceLister {
+	return d.serviceLister
+}
+
+// ConfigMapLister returns the configMapLister
+func (d *TemplateData) ConfigMapLister() corev1lister.ConfigMapLister {
+	return d.configMapLister
+}
+
+// EtcdDiskSize returns the etcd disk size
+func (d *TemplateData) EtcdDiskSize() resource.Quantity {
+	return d.etcdDiskSize
+}
+
+// InClusterPrometheusRulesFile returns inClusterPrometheusRulesFile
+func (d *TemplateData) InClusterPrometheusRulesFile() string {
+	return d.inClusterPrometheusRulesFile
+}
+
+// InClusterPrometheusDisableDefaultRules returns whether to disable default rules
+func (d *TemplateData) InClusterPrometheusDisableDefaultRules() bool {
+	return d.inClusterPrometheusDisableDefaultRules
+}
+
+// InClusterPrometheusDisableDefaultScrapingConfigs returns whether to disable default scrape configs
+func (d *TemplateData) InClusterPrometheusDisableDefaultScrapingConfigs() bool {
+	return d.inClusterPrometheusDisableDefaultScrapingConfigs
+}
+
+// InClusterPrometheusScrapingConfigsFile returns inClusterPrometheusScrapingConfigsFile
+func (d *TemplateData) InClusterPrometheusScrapingConfigsFile() string {
+	return d.inClusterPrometheusScrapingConfigsFile
+}
+
+// NodeAccessNetwork returns the node access network
+func (d *TemplateData) NodeAccessNetwork() string {
+	return d.nodeAccessNetwork
+}
+
+// NodePortRange returns the node access network
+func (d *TemplateData) NodePortRange() string {
+	return d.nodePortRange
+}
+
+// NewUserClusterData returns an instance of UserClusterData
+func NewUserClusterData(
+	configMapLister corev1lister.ConfigMapLister,
+	serviceLister corev1lister.ServiceLister) *UserClusterData {
+	return &UserClusterData{
+		configMapLister: configMapLister,
+		serviceLister:   serviceLister,
 	}
 }
 
 // GetClusterRef returns a instance of a OwnerReference for the Cluster in the TemplateData
 func (d *TemplateData) GetClusterRef() metav1.OwnerReference {
-	return GetClusterRef(d.Cluster)
+	return GetClusterRef(d.cluster)
 }
 
 // ExternalIP returns the external facing IP or an error if no IP exists
 func (d *TemplateData) ExternalIP() (*net.IP, error) {
-	ip := net.ParseIP(d.Cluster.Address.IP)
+	ip := net.ParseIP(d.cluster.Address.IP)
 	if ip == nil {
-		return nil, fmt.Errorf("failed to create a net.IP object from the external cluster IP '%s'", d.Cluster.Address.IP)
+		return nil, fmt.Errorf("failed to create a net.IP object from the external cluster IP '%s'", d.cluster.Address.IP)
 	}
 	return &ip, nil
 }
@@ -100,19 +238,19 @@ func (d *TemplateData) ExternalIP() (*net.IP, error) {
 // `Cluster.Status.NamespaceName`. When ClusterIP fails to parse
 // as valid IP address, an error is returned.
 func (d *TemplateData) ClusterIPByServiceName(name string) (string, error) {
-	service, err := d.ServiceLister.Services(d.Cluster.Status.NamespaceName).Get(name)
+	service, err := d.serviceLister.Services(d.cluster.Status.NamespaceName).Get(name)
 	if err != nil {
-		return "", fmt.Errorf("could not get service %s from lister for cluster %s: %v", name, d.Cluster.Name, err)
+		return "", fmt.Errorf("could not get service %s from lister for cluster %s: %v", name, d.cluster.Name, err)
 	}
 	if net.ParseIP(service.Spec.ClusterIP) == nil {
-		return "", fmt.Errorf("service %s in cluster %s has no valid cluster ip (\"%s\"): %v", name, d.Cluster.Name, service.Spec.ClusterIP, err)
+		return "", fmt.Errorf("service %s in cluster %s has no valid cluster ip (\"%s\"): %v", name, d.cluster.Name, service.Spec.ClusterIP, err)
 	}
 	return service.Spec.ClusterIP, nil
 }
 
 // ProviderName returns the name of the clusters providerName
 func (d *TemplateData) ProviderName() string {
-	p, err := provider.ClusterCloudProviderName(d.Cluster.Spec.Cloud)
+	p, err := provider.ClusterCloudProviderName(d.cluster.Spec.Cloud)
 	if err != nil {
 		glog.V(0).Infof("could not identify cloud provider: %v", err)
 	}
@@ -121,7 +259,7 @@ func (d *TemplateData) ProviderName() string {
 
 // GetApiserverExternalNodePort returns the nodeport of the external apiserver service
 func (d *TemplateData) GetApiserverExternalNodePort() (int32, error) {
-	s, err := d.ServiceLister.Services(d.Cluster.Status.NamespaceName).Get(ApiserverExternalServiceName)
+	s, err := d.serviceLister.Services(d.cluster.Status.NamespaceName).Get(ApiserverExternalServiceName)
 	if err != nil {
 
 		return 0, fmt.Errorf("failed to get NodePort for external apiserver service: %v", err)
@@ -134,16 +272,16 @@ func (d *TemplateData) GetApiserverExternalNodePort() (int32, error) {
 // and returns them joined by a `:`.
 // Service lookup happens within `Cluster.Status.NamespaceName`.
 func (d *TemplateData) InClusterApiserverURL() (*url.URL, error) {
-	service, err := d.ServiceLister.Services(d.Cluster.Status.NamespaceName).Get(ApiserverExternalServiceName)
+	service, err := d.serviceLister.Services(d.Cluster().Status.NamespaceName).Get(ApiserverExternalServiceName)
 	if err != nil {
-		return nil, fmt.Errorf("could not get service %s from lister for cluster %s: %v", ApiserverExternalServiceName, d.Cluster.Name, err)
+		return nil, fmt.Errorf("could not get service %s from lister for cluster %s: %v", ApiserverExternalServiceName, d.Cluster().Name, err)
 	}
 
 	if len(service.Spec.Ports) != 1 {
 		return nil, errors.New("apiserver service does not have exactly one port")
 	}
 
-	return url.Parse(fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", ApiserverExternalServiceName, d.Cluster.Status.NamespaceName, service.Spec.Ports[0].NodePort))
+	return url.Parse(fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", ApiserverExternalServiceName, d.Cluster().Status.NamespaceName, service.Spec.Ports[0].NodePort))
 }
 
 // ImageRegistry returns the image registry to use or the passed in default if no override is specified
@@ -156,28 +294,28 @@ func (d *TemplateData) ImageRegistry(defaultRegistry string) string {
 
 // GetRootCA returns the root CA of the cluster
 func (d *TemplateData) GetRootCA() (*triple.KeyPair, error) {
-	return GetClusterRootCA(d.Cluster, d.SecretLister)
+	return GetClusterRootCA(d.cluster, d.SecretLister)
 }
 
 // GetFrontProxyCA returns the root CA of the cluster
 func (d *TemplateData) GetFrontProxyCA() (*triple.KeyPair, error) {
-	return GetClusterFrontProxyCA(d.Cluster, d.SecretLister)
+	return GetClusterFrontProxyCA(d.cluster, d.SecretLister)
 }
 
 // SecretRevision returns the resource version of the secret specified by name. A empty string will be returned in case of an error
 func (d *TemplateData) SecretRevision(name string) (string, error) {
-	secret, err := d.SecretLister.Secrets(d.Cluster.Status.NamespaceName).Get(name)
+	secret, err := d.SecretLister.Secrets(d.cluster.Status.NamespaceName).Get(name)
 	if err != nil {
-		return "", fmt.Errorf("could not get secret %s from lister for cluster %s: %v", name, d.Cluster.Name, err)
+		return "", fmt.Errorf("could not get secret %s from lister for cluster %s: %v", name, d.cluster.Name, err)
 	}
 	return secret.ResourceVersion, nil
 }
 
 // ConfigMapRevision returns the resource version of the configmap specified by name. A empty string will be returned in case of an error
 func (d *TemplateData) ConfigMapRevision(name string) (string, error) {
-	cm, err := d.ConfigMapLister.ConfigMaps(d.Cluster.Status.NamespaceName).Get(name)
+	cm, err := d.ConfigMapLister().ConfigMaps(d.cluster.Status.NamespaceName).Get(name)
 	if err != nil {
-		return "", fmt.Errorf("could not get configmap %s from lister for cluster %s: %v", name, d.Cluster.Name, err)
+		return "", fmt.Errorf("could not get configmap %s from lister for cluster %s: %v", name, d.cluster.Name, err)
 	}
 	return cm.ResourceVersion, nil
 }
@@ -185,7 +323,7 @@ func (d *TemplateData) ConfigMapRevision(name string) (string, error) {
 // GetPodTemplateLabels returns a set of labels for a Pod including the revisions of depending secrets and configmaps.
 // This will force pods being restarted as soon as one of the secrets/configmaps get updated.
 func (d *TemplateData) GetPodTemplateLabels(appName string, volumes []corev1.Volume, additionalLabels map[string]string) (map[string]string, error) {
-	podLabels := AppClusterLabel(appName, d.Cluster.Name, additionalLabels)
+	podLabels := AppClusterLabel(appName, d.cluster.Name, additionalLabels)
 
 	for _, v := range volumes {
 		if v.VolumeSource.Secret != nil {
@@ -207,7 +345,87 @@ func (d *TemplateData) GetPodTemplateLabels(appName string, volumes []corev1.Vol
 	return podLabels, nil
 }
 
-// GetClusterRef returns a instance of a OwnerReference for the Cluster in the TemplateData
+// ServiceLister returns the serviceLister
+func (d *UserClusterData) ServiceLister() corev1lister.ServiceLister {
+	return d.serviceLister
+}
+
+// ConfigMapLister returns the configMapLister
+func (d *UserClusterData) ConfigMapLister() corev1lister.ConfigMapLister {
+	return d.configMapLister
+}
+
+// GetClusterRef panics
 func (d *UserClusterData) GetClusterRef() metav1.OwnerReference {
 	panic("GetClusterRef not implemented for UserClusterData")
+}
+
+// ImageRegistry panics
+func (d *UserClusterData) ImageRegistry(defaultRegistry string) string {
+	panic("ImageRegistry not implemented for UserClusterData")
+}
+
+// GetPodTemplateLabels panics
+func (d *UserClusterData) GetPodTemplateLabels(_ string, _ []corev1.Volume, _ map[string]string) (map[string]string, error) {
+	panic("GetPodTemplateLabels not implemented for UserClusterData")
+}
+
+// NodeAccessNetwork panics
+func (d *UserClusterData) NodeAccessNetwork() string {
+	panic("NodeAccessNetwork not implemented for UserClusterData")
+}
+
+// GetApiserverExternalNodePort panics
+func (d *UserClusterData) GetApiserverExternalNodePort() (int32, error) {
+	panic("GetApiserverExternalNodePort not implemented for UserClusterData")
+}
+
+// ClusterIPByServiceName panics
+func (d *UserClusterData) ClusterIPByServiceName(name string) (string, error) {
+	panic("ClusterIPByServiceName not implemented for UserClusterData")
+}
+
+// InClusterApiserverURL panics
+func (d *UserClusterData) InClusterApiserverURL() (*url.URL, error) {
+	panic("InClusterApiserverURL not implemented for UserClusterData")
+}
+
+// GetFrontProxyCA panics
+func (d *UserClusterData) GetFrontProxyCA() (*triple.KeyPair, error) {
+	panic("GetFrontProxyCA not implemented for UserClusterData")
+}
+
+// ExternalIP panics
+func (d *UserClusterData) ExternalIP() (*net.IP, error) {
+	panic("ExternalIP not implemented for UserClusterData")
+}
+
+// TemplateData returns data for templating
+func (d *UserClusterData) TemplateData() interface{} {
+	return d
+}
+
+// InClusterPrometheusRulesFile panics
+func (d *UserClusterData) InClusterPrometheusRulesFile() string {
+	panic("InClusterPrometheusRulesFile not implemented for UserClusterData")
+}
+
+// InClusterPrometheusScrapingConfigsFile returns inClusterPrometheusScrapingConfigsFile
+func (d *UserClusterData) InClusterPrometheusScrapingConfigsFile() string {
+	panic("InClusterPrometheusScrapingConfigsFile not implemented for UserClusterData")
+}
+
+// InClusterPrometheusDisableDefaultRules panics
+func (d *UserClusterData) InClusterPrometheusDisableDefaultRules() bool {
+	panic("InClusterPrometheusDisableDefaultRules not implemented for UserClusterData")
+}
+
+// InClusterPrometheusDisableDefaultScrapingConfigs panics
+func (d *UserClusterData) InClusterPrometheusDisableDefaultScrapingConfigs() bool {
+	panic("InClusterPrometheusDisableDefaultScrapingConfigs not implemented for UserClusterData")
+}
+
+// Cluster panics
+func (d *UserClusterData) Cluster() *kubermaticv1.Cluster {
+	panic("Cluster not implemented for UserClusterData")
 }

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -36,6 +36,15 @@ type TemplateData struct {
 	DockerPullConfigJSON                             []byte
 }
 
+// UserClusterData groups data required for resource creation in user-cluster
+type UserClusterData struct {
+}
+
+// RoleDataProvider provides data about roles
+type RoleDataProvider interface {
+	GetClusterRef() metav1.OwnerReference
+}
+
 // NewTemplateData returns an instance of TemplateData
 func NewTemplateData(
 	cluster *kubermaticv1.Cluster,
@@ -196,4 +205,9 @@ func (d *TemplateData) GetPodTemplateLabels(appName string, volumes []corev1.Vol
 	}
 
 	return podLabels, nil
+}
+
+// GetClusterRef returns a instance of a OwnerReference for the Cluster in the TemplateData
+func (d *UserClusterData) GetClusterRef() metav1.OwnerReference {
+	panic("GetClusterRef not implemented for UserClusterData")
 }

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -14,14 +14,14 @@ import (
 )
 
 // Service returns the service for the dns resolver
-func Service(_ *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
-	var svc *corev1.Service
-	if existing != nil {
-		svc = existing
-	} else {
+func Service(data resources.ServiceDataProvider, existing *corev1.Service) (*corev1.Service, error) {
+	svc := existing
+	if svc == nil {
 		svc = &corev1.Service{}
 	}
+
 	svc.Name = resources.DNSResolverServiceName
+	svc.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	svc.Spec.Selector = map[string]string{
 		resources.AppLabelKey: resources.DNSResolverDeploymentName,
 	}
@@ -38,11 +38,9 @@ func Service(_ *resources.TemplateData, existing *corev1.Service) (*corev1.Servi
 }
 
 // Deployment returns the deployment for the dns resolver
-func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
-	var dep *appsv1.Deployment
-	if existing != nil {
-		dep = existing
-	} else {
+func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
+	dep := existing
+	if dep == nil {
 		dep = &appsv1.Deployment{}
 	}
 
@@ -131,7 +129,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 
 	dep.Spec.Template.Spec.Volumes = volumes
 
-	dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(resources.DNSResolverDeploymentName, data.Cluster.Name, nil))
+	dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(resources.DNSResolverDeploymentName, data.Cluster().Name, nil))
 
 	return dep, nil
 }
@@ -176,24 +174,22 @@ func getVolumes() []corev1.Volume {
 }
 
 // ConfigMap returns a ConfigMap containing the cloud-config for the supplied data
-func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	var cm *corev1.ConfigMap
-	if existing != nil {
-		cm = existing
-	} else {
+func ConfigMap(data resources.ConfigMapDataProvider, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	cm := existing
+	if cm == nil {
 		cm = &corev1.ConfigMap{}
 	}
 	if cm.Data == nil {
 		cm.Data = map[string]string{}
 	}
 
-	dnsIP, err := resources.UserClusterDNSResolverIP(data.Cluster)
+	dnsIP, err := resources.UserClusterDNSResolverIP(data.Cluster())
 	if err != nil {
 		return nil, err
 	}
 	cm.Name = resources.DNSResolverConfigMapName
 	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	seedClusterNamespaceDNS := fmt.Sprintf("%s.svc.cluster.local.", data.Cluster.Status.NamespaceName)
+	seedClusterNamespaceDNS := fmt.Sprintf("%s.svc.cluster.local.", data.Cluster().Status.NamespaceName)
 	cm.Data["Corefile"] = fmt.Sprintf(`
 %s {
     forward . /etc/resolv.conf
@@ -208,7 +204,7 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
   errors
   health
 }
-`, seedClusterNamespaceDNS, data.Cluster.Spec.ClusterNetwork.DNSDomain, dnsIP)
+`, seedClusterNamespaceDNS, data.Cluster().Spec.ClusterNetwork.DNSDomain, dnsIP)
 
 	return cm, nil
 }

--- a/api/pkg/resources/ensure.go
+++ b/api/pkg/resources/ensure.go
@@ -11,7 +11,7 @@ import (
 
 // EnsureRole will create the role with the passed create function & create or update it if necessary.
 // To check if its necessary it will do a lookup of the resource at the lister & compare the existing Role with the created one
-func EnsureRole(data *TemplateData, create RoleCreator, roleLister rbacv1lister.RoleNamespaceLister, roleClient rbacv1client.RoleInterface) error {
+func EnsureRole(data RoleDataProvider, create RoleCreator, roleLister rbacv1lister.RoleNamespaceLister, roleClient rbacv1client.RoleInterface) error {
 	var existing *rbacv1.Role
 	role, err := create(data, nil)
 	if err != nil {

--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -81,7 +81,7 @@ func defraggerCommand(data *resources.TemplateData) ([]string, error) {
 
 	tplData := defraggerCommandTplData{
 		ServiceName: resources.EtcdServiceName,
-		Namespace:   data.Cluster.Status.NamespaceName,
+		Namespace:   data.Cluster().Status.NamespaceName,
 		CACertFile:  resources.CACertSecretKey,
 		CertFile:    resources.ApiserverEtcdClientCertificateCertSecretKey,
 		KeyFile:     resources.ApiserverEtcdClientCertificateKeySecretKey,

--- a/api/pkg/resources/etcd/etcdservices.go
+++ b/api/pkg/resources/etcd/etcdservices.go
@@ -11,11 +11,9 @@ import (
 )
 
 // Service returns a service for the etcd StatefulSet
-func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
-	var se *corev1.Service
-	if existing != nil {
-		se = existing
-	} else {
+func Service(data resources.ServiceDataProvider, existing *corev1.Service) (*corev1.Service, error) {
+	se := existing
+	if se == nil {
 		se = &corev1.Service{}
 	}
 
@@ -27,7 +25,7 @@ func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Se
 	se.Spec.ClusterIP = "None"
 	se.Spec.Selector = map[string]string{
 		resources.AppLabelKey: name,
-		"cluster":             data.Cluster.Name,
+		"cluster":             data.Cluster().Name,
 	}
 	se.Spec.Ports = []corev1.ServicePort{
 		{

--- a/api/pkg/resources/etcd/pdb.go
+++ b/api/pkg/resources/etcd/pdb.go
@@ -23,7 +23,7 @@ func PodDisruptionBudget(data *resources.TemplateData, existing *policyv1beta1.P
 	minAvailable := intstr.FromInt((resources.EtcdClusterSize / 2) + 1)
 	pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: getBasePodLabels(data),
+			MatchLabels: getBasePodLabels(data.Cluster()),
 		},
 		MinAvailable: &minAvailable,
 	}

--- a/api/pkg/resources/etcd/tls-serving-certificate.go
+++ b/api/pkg/resources/etcd/tls-serving-certificate.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TLSCertificate returns a secret with the etcd tls certificate
-func TLSCertificate(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func TLSCertificate(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	var se *corev1.Secret
 	if existing != nil {
 		se = existing
@@ -44,7 +44,7 @@ func TLSCertificate(data *resources.TemplateData, existing *corev1.Secret) (*cor
 		altNames.DNSNames = append(altNames.DNSNames, podName)
 
 		// Pod DNS name
-		absolutePodDNSName := fmt.Sprintf("etcd-%d.%s.%s.svc.cluster.local", i, resources.EtcdServiceName, data.Cluster.Status.NamespaceName)
+		absolutePodDNSName := fmt.Sprintf("etcd-%d.%s.%s.svc.cluster.local", i, resources.EtcdServiceName, data.Cluster().Status.NamespaceName)
 		altNames.DNSNames = append(altNames.DNSNames, absolutePodDNSName)
 	}
 

--- a/api/pkg/resources/imagepullsecret.go
+++ b/api/pkg/resources/imagepullsecret.go
@@ -6,8 +6,8 @@ import (
 )
 
 // ImagePullSecretCreator returns a creator function to create a ImagePullSecret
-func ImagePullSecretCreator(name string, dockerPullConfigJSON []byte) func(data *TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
-	return func(data *TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func ImagePullSecretCreator(name string, dockerPullConfigJSON []byte) func(data SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
+	return func(data SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 		var secret *corev1.Secret
 		if existing != nil {
 			secret = existing

--- a/api/pkg/resources/ipamcontroller/clusterRole.go
+++ b/api/pkg/resources/ipamcontroller/clusterRole.go
@@ -7,11 +7,9 @@ import (
 )
 
 // ClusterRole returns a cluster role for the ipam controller
-func ClusterRole(data *resources.TemplateData, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-	var r *rbacv1.ClusterRole
-	if existing != nil {
-		r = existing
-	} else {
+func ClusterRole(_ resources.ClusterRoleDataProvider, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	r := existing
+	if r == nil {
 		r = &rbacv1.ClusterRole{}
 	}
 

--- a/api/pkg/resources/ipamcontroller/clusterRoleBinding.go
+++ b/api/pkg/resources/ipamcontroller/clusterRoleBinding.go
@@ -10,7 +10,7 @@ import (
 
 // ClusterRoleBinding returns a ClusterRoleBinding for the ipam-controller.
 // It has to be put into the user-cluster.
-func ClusterRoleBinding(data *resources.TemplateData, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+func ClusterRoleBinding(_ resources.ClusterRoleBindingDataProvider, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 	return createClusterRoleBinding(existing, "controller",
 		resources.IPAMControllerClusterRoleName, rbacv1.Subject{
 			Kind:     "User",

--- a/api/pkg/resources/ipamcontroller/deployment.go
+++ b/api/pkg/resources/ipamcontroller/deployment.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Deployment returns the ipamcontroller deployment
-func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
+func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
 	var dep *appsv1.Deployment
 	if existing != nil {
 		dep = existing
@@ -97,11 +97,11 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	return dep, nil
 }
 
-func getNetworkArgs(data *resources.TemplateData) []string {
-	networkFlags := make([]string, len(data.Cluster.Spec.MachineNetworks)*2)
+func getNetworkArgs(data resources.DeploymentDataProvider) []string {
+	networkFlags := make([]string, len(data.Cluster().Spec.MachineNetworks)*2)
 	i := 0
 
-	for _, n := range data.Cluster.Spec.MachineNetworks {
+	for _, n := range data.Cluster().Spec.MachineNetworks {
 		networkFlags[i] = "--network"
 		i++
 		networkFlags[i] = fmt.Sprintf("%s,%s,%s", n.CIDR, n.Gateway, strings.Join(n.DNSServers, ","))

--- a/api/pkg/resources/kubestatemetrics/clusterrole.go
+++ b/api/pkg/resources/kubestatemetrics/clusterrole.go
@@ -7,11 +7,9 @@ import (
 )
 
 // ClusterRole returns a cluster role for kube-state-metrics
-func ClusterRole(_ *resources.TemplateData, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-	var r *rbacv1.ClusterRole
-	if existing != nil {
-		r = existing
-	} else {
+func ClusterRole(_ resources.ClusterRoleDataProvider, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	r := existing
+	if r == nil {
 		r = &rbacv1.ClusterRole{}
 	}
 

--- a/api/pkg/resources/kubestatemetrics/clusterrolebinding.go
+++ b/api/pkg/resources/kubestatemetrics/clusterrolebinding.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ClusterRoleBinding returns the ClusterRoleBinding required for Kube-State-Metrics
-func ClusterRoleBinding(_ *resources.TemplateData, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+func ClusterRoleBinding(_ resources.ClusterRoleBindingDataProvider, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 	var crb *rbacv1.ClusterRoleBinding
 	if existing != nil {
 		crb = existing

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -33,7 +33,7 @@ const (
 )
 
 // Deployment returns the kube-state-metrics Deployment
-func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
+func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
 	var dep *appsv1.Deployment
 	if existing != nil {
 		dep = existing

--- a/api/pkg/resources/machine/machine.go
+++ b/api/pkg/resources/machine/machine.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/userdata/coreos"
 	"github.com/kubermatic/machine-controller/pkg/userdata/ubuntu"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -70,7 +71,7 @@ func Machine(c *kubermaticv1.Cluster, node *apiv2.Node, dc provider.DatacenterMe
 		// We use OverwriteCloudConfig for Vsphere to ensure we always
 		// use the credentials passed in via frontend for the cloud-provider
 		// functionality
-		templateData := &resources.TemplateData{Cluster: c, DC: &dc}
+		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", false, false, "", nil)
 		overwriteCloudConfig, err := cloudconfig.CloudConfig(templateData)
 		if err != nil {
 			return nil, err

--- a/api/pkg/resources/machinecontroller/clusterrole.go
+++ b/api/pkg/resources/machinecontroller/clusterrole.go
@@ -7,11 +7,9 @@ import (
 )
 
 // ClusterRole returns a cluster role for the machine controller (user-cluster)
-func ClusterRole(data *resources.TemplateData, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-	var r *rbacv1.ClusterRole
-	if existing != nil {
-		r = existing
-	} else {
+func ClusterRole(_ resources.ClusterRoleDataProvider, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	r := existing
+	if r == nil {
 		r = &rbacv1.ClusterRole{}
 	}
 

--- a/api/pkg/resources/machinecontroller/clusterrolebinding.go
+++ b/api/pkg/resources/machinecontroller/clusterrolebinding.go
@@ -10,7 +10,7 @@ import (
 
 // ClusterRoleBinding returns a ClusterRoleBinding for the machine-controller.
 // It has to be put into the user-cluster.
-func ClusterRoleBinding(data *resources.TemplateData, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+func ClusterRoleBinding(_ resources.ClusterRoleBindingDataProvider, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 	// TemplateData actually not needed, no ownerrefs set in user-cluster
 	return createClusterRoleBinding(existing, "controller",
 		resources.MachineControllerClusterRoleName, rbacv1.Subject{
@@ -22,7 +22,7 @@ func ClusterRoleBinding(data *resources.TemplateData, existing *rbacv1.ClusterRo
 
 // NodeBootstrapperClusterRoleBinding returns a ClusterRoleBinding for the machine-controller.
 // It has to be put into the user-cluster.
-func NodeBootstrapperClusterRoleBinding(data *resources.TemplateData, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+func NodeBootstrapperClusterRoleBinding(_ resources.ClusterRoleBindingDataProvider, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 	return createClusterRoleBinding(existing, "kubelet-bootstrap",
 		"system:node-bootstrapper", rbacv1.Subject{
 			Kind:     "Group",
@@ -33,7 +33,7 @@ func NodeBootstrapperClusterRoleBinding(data *resources.TemplateData, existing *
 
 // NodeSignerClusterRoleBinding returns a ClusterRoleBinding for the machine-controller.
 // It has to be put into the user-cluster.
-func NodeSignerClusterRoleBinding(data *resources.TemplateData, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+func NodeSignerClusterRoleBinding(_ resources.ClusterRoleBindingDataProvider, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 	return createClusterRoleBinding(existing, "node-signer",
 		"system:certificates.k8s.io:certificatesigningrequests:nodeclient", rbacv1.Subject{
 			Kind:     "Group",
@@ -43,10 +43,8 @@ func NodeSignerClusterRoleBinding(data *resources.TemplateData, existing *rbacv1
 }
 
 func createClusterRoleBinding(existing *rbacv1.ClusterRoleBinding, crbSuffix, cRoleRef string, subj rbacv1.Subject) (*rbacv1.ClusterRoleBinding, error) {
-	var crb *rbacv1.ClusterRoleBinding
-	if existing != nil {
-		crb = existing
-	} else {
+	crb := existing
+	if crb == nil {
 		crb = &rbacv1.ClusterRoleBinding{}
 	}
 

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -20,7 +20,7 @@ const (
 )
 
 // Deployment returns the machine-controller Deployment
-func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
+func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
 	var dep *appsv1.Deployment
 	if existing != nil {
 		dep = existing
@@ -72,7 +72,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
 
-	clusterDNSIP, err := resources.UserClusterDNSResolverIP(data.Cluster)
+	clusterDNSIP, err := resources.UserClusterDNSResolverIP(data.Cluster())
 	if err != nil {
 		return nil, err
 	}
@@ -146,29 +146,29 @@ func getVolumes() []corev1.Volume {
 	}
 }
 
-func getEnvVars(data *resources.TemplateData) []corev1.EnvVar {
+func getEnvVars(data resources.DeploymentDataProvider) []corev1.EnvVar {
 	var vars []corev1.EnvVar
-	if data.Cluster.Spec.Cloud.AWS != nil {
-		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: data.Cluster.Spec.Cloud.AWS.AccessKeyID})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: data.Cluster.Spec.Cloud.AWS.SecretAccessKey})
+	if data.Cluster().Spec.Cloud.AWS != nil {
+		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: data.Cluster().Spec.Cloud.AWS.AccessKeyID})
+		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: data.Cluster().Spec.Cloud.AWS.SecretAccessKey})
 	}
-	if data.Cluster.Spec.Cloud.Openstack != nil {
-		vars = append(vars, corev1.EnvVar{Name: "OS_AUTH_URL", Value: data.DC.Spec.Openstack.AuthURL})
-		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", Value: data.Cluster.Spec.Cloud.Openstack.Username})
-		vars = append(vars, corev1.EnvVar{Name: "OS_PASSWORD", Value: data.Cluster.Spec.Cloud.Openstack.Password})
-		vars = append(vars, corev1.EnvVar{Name: "OS_DOMAIN_NAME", Value: data.Cluster.Spec.Cloud.Openstack.Domain})
-		vars = append(vars, corev1.EnvVar{Name: "OS_TENANT_NAME", Value: data.Cluster.Spec.Cloud.Openstack.Tenant})
+	if data.Cluster().Spec.Cloud.Openstack != nil {
+		vars = append(vars, corev1.EnvVar{Name: "OS_AUTH_URL", Value: data.DC().Spec.Openstack.AuthURL})
+		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", Value: data.Cluster().Spec.Cloud.Openstack.Username})
+		vars = append(vars, corev1.EnvVar{Name: "OS_PASSWORD", Value: data.Cluster().Spec.Cloud.Openstack.Password})
+		vars = append(vars, corev1.EnvVar{Name: "OS_DOMAIN_NAME", Value: data.Cluster().Spec.Cloud.Openstack.Domain})
+		vars = append(vars, corev1.EnvVar{Name: "OS_TENANT_NAME", Value: data.Cluster().Spec.Cloud.Openstack.Tenant})
 	}
-	if data.Cluster.Spec.Cloud.Hetzner != nil {
-		vars = append(vars, corev1.EnvVar{Name: "HZ_TOKEN", Value: data.Cluster.Spec.Cloud.Hetzner.Token})
+	if data.Cluster().Spec.Cloud.Hetzner != nil {
+		vars = append(vars, corev1.EnvVar{Name: "HZ_TOKEN", Value: data.Cluster().Spec.Cloud.Hetzner.Token})
 	}
-	if data.Cluster.Spec.Cloud.Digitalocean != nil {
-		vars = append(vars, corev1.EnvVar{Name: "DO_TOKEN", Value: data.Cluster.Spec.Cloud.Digitalocean.Token})
+	if data.Cluster().Spec.Cloud.Digitalocean != nil {
+		vars = append(vars, corev1.EnvVar{Name: "DO_TOKEN", Value: data.Cluster().Spec.Cloud.Digitalocean.Token})
 	}
-	if data.Cluster.Spec.Cloud.VSphere != nil {
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_ADDRESS", Value: data.DC.Spec.VSphere.Endpoint})
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", Value: data.Cluster.Spec.Cloud.VSphere.InfraManagementUser.Username})
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", Value: data.Cluster.Spec.Cloud.VSphere.InfraManagementUser.Password})
+	if data.Cluster().Spec.Cloud.VSphere != nil {
+		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_ADDRESS", Value: data.DC().Spec.VSphere.Endpoint})
+		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", Value: data.Cluster().Spec.Cloud.VSphere.InfraManagementUser.Username})
+		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", Value: data.Cluster().Spec.Cloud.VSphere.InfraManagementUser.Password})
 	}
 	return vars
 }

--- a/api/pkg/resources/machinecontroller/role.go
+++ b/api/pkg/resources/machinecontroller/role.go
@@ -9,7 +9,7 @@ import (
 
 // KubeSystemRole returns a role for the machine controller. This
 // role has to be put in the user-cluster and carries a namespace.
-func KubeSystemRole(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv1.Role, error) {
+func KubeSystemRole(data resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
 	var r *rbacv1.Role
 	if existing != nil {
 		r = existing
@@ -54,7 +54,7 @@ func KubeSystemRole(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv
 
 // KubePublicRole returns a role for the machine controller. This
 // role has to be put in the user-cluster and carries a namespace.
-func KubePublicRole(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv1.Role, error) {
+func KubePublicRole(data resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
 	var r *rbacv1.Role
 	if existing != nil {
 		r = existing
@@ -82,7 +82,7 @@ func KubePublicRole(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv
 
 // Role returns a role for the machine controller. This
 // role has to be put in the user-cluster and carries a namespace.
-func Role(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv1.Role, error) {
+func Role(data resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
 	var r *rbacv1.Role
 	if existing != nil {
 		r = existing

--- a/api/pkg/resources/machinecontroller/rolebinding.go
+++ b/api/pkg/resources/machinecontroller/rolebinding.go
@@ -9,20 +9,20 @@ import (
 
 // DefaultRoleBinding returns the RoleBinding for the machine-controller.
 // It has to be put into the user-cluster.
-func DefaultRoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-	// TemplateData actually not needed, no ownerrefs set in user-cluster
+func DefaultRoleBinding(_ resources.RoleBindingDataProvider, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+	// RoleBindingDataProvider actually not needed, no ownerrefs set in user-cluster
 	return createRoleBinding(existing, metav1.NamespaceDefault)
 }
 
 // KubeSystemRoleBinding returns the RoleBinding for the machine-controller in kube-system ns.
 // It has to be put into the user-cluster.
-func KubeSystemRoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+func KubeSystemRoleBinding(_ resources.RoleBindingDataProvider, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 	return createRoleBinding(existing, metav1.NamespaceSystem)
 }
 
 // KubePublicRoleBinding returns the RoleBinding for the machine-controller in kube-public ns.
 // It has to be put into the user-cluster.
-func KubePublicRoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+func KubePublicRoleBinding(_ resources.RoleBindingDataProvider, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 	return createRoleBinding(existing, metav1.NamespacePublic)
 }
 

--- a/api/pkg/resources/openvpn/configmap.go
+++ b/api/pkg/resources/openvpn/configmap.go
@@ -12,11 +12,9 @@ import (
 )
 
 // ServerClientConfigsConfigMap returns a ConfigMap containing the ClientConfig for the OpenVPN server. It lives inside the seed-cluster
-func ServerClientConfigsConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	var cm *corev1.ConfigMap
-	if existing != nil {
-		cm = existing
-	} else {
+func ServerClientConfigsConfigMap(data resources.ConfigMapDataProvider, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	cm := existing
+	if cm == nil {
 		cm = &corev1.ConfigMap{}
 	}
 	if cm.Data == nil {
@@ -30,10 +28,10 @@ func ServerClientConfigsConfigMap(data *resources.TemplateData, existing *corev1
 	var iroutes []string
 
 	// iroute for pod network
-	if len(data.Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks) < 1 {
+	if len(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks) < 1 {
 		return nil, fmt.Errorf("cluster.Spec.ClusterNetwork.Pods.CIDRBlocks must contain at least one entry")
 	}
-	_, podNet, err := net.ParseCIDR(data.Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+	_, podNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks[0])
 	if err != nil {
 		return nil, err
 	}
@@ -42,10 +40,10 @@ func ServerClientConfigsConfigMap(data *resources.TemplateData, existing *corev1
 		net.IP(podNet.Mask).String()))
 
 	// iroute for service network
-	if len(data.Cluster.Spec.ClusterNetwork.Services.CIDRBlocks) < 1 {
+	if len(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks) < 1 {
 		return nil, fmt.Errorf("cluster.Spec.ClusterNetwork.Services.CIDRBlocks must contain at least one entry")
 	}
-	_, serviceNet, err := net.ParseCIDR(data.Cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0])
+	_, serviceNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks[0])
 	if err != nil {
 		return nil, err
 	}
@@ -53,9 +51,9 @@ func ServerClientConfigsConfigMap(data *resources.TemplateData, existing *corev1
 		serviceNet.IP.String(),
 		net.IP(serviceNet.Mask).String()))
 
-	_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork)
+	_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork())
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork, err)
+		return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork(), err)
 	}
 	iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
 		nodeAccessNetwork.IP.String(),
@@ -69,11 +67,9 @@ func ServerClientConfigsConfigMap(data *resources.TemplateData, existing *corev1
 }
 
 // ClientConfigConfigMap returns a ConfigMap containing the config for the OpenVPN client. It lives inside the user-cluster
-func ClientConfigConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	var cm *corev1.ConfigMap
-	if existing != nil {
-		cm = existing
-	} else {
+func ClientConfigConfigMap(data resources.ConfigMapDataProvider, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	cm := existing
+	if cm == nil {
 		cm = &corev1.ConfigMap{}
 	}
 	if cm.Data == nil {
@@ -84,7 +80,7 @@ func ClientConfigConfigMap(data *resources.TemplateData, existing *corev1.Config
 	cm.Namespace = metav1.NamespaceSystem
 	cm.Labels = resources.BaseAppLabel(name, nil)
 
-	openvpnSvc, err := data.ServiceLister.Services(data.Cluster.Status.NamespaceName).Get(resources.OpenVPNServerServiceName)
+	openvpnSvc, err := data.ServiceLister().Services(data.Cluster().Status.NamespaceName).Get(resources.OpenVPNServerServiceName)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +104,7 @@ keysize 256
 status /run/openvpn-status
 up '/bin/sh -c "/sbin/iptables -t nat -I POSTROUTING -s 10.20.0.0/24 -j MASQUERADE"'
 log /dev/stdout
-`, data.Cluster.Address.ExternalName, openvpnSvc.Spec.Ports[0].NodePort)
+`, data.Cluster().Address.ExternalName, openvpnSvc.Spec.Ports[0].NodePort)
 
 	cm.Data["config"] = config
 

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -30,7 +30,7 @@ const (
 )
 
 // Deployment returns the kubernetes Controller-Manager Deployment
-func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
+func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployment) (*appsv1.Deployment, error) {
 	var dep *appsv1.Deployment
 	if existing != nil {
 		dep = existing
@@ -70,12 +70,12 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		Labels: podLabels,
 	}
 
-	_, podNet, err := net.ParseCIDR(data.Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+	_, podNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks[0])
 	if err != nil {
 		return nil, err
 	}
 
-	_, serviceNet, err := net.ParseCIDR(data.Cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0])
+	_, serviceNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks[0])
 	if err != nil {
 		return nil, err
 	}
@@ -89,9 +89,9 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 
 	// node access network route
-	_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork)
+	_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork())
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork, err)
+		return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork(), err)
 	}
 	pushRoutes = append(pushRoutes, []string{
 		"--push", fmt.Sprintf("route %s %s", nodeAccessNetwork.IP.String(), net.IP(nodeAccessNetwork.Mask).String()),

--- a/api/pkg/resources/openvpn/internal-client-certificate.go
+++ b/api/pkg/resources/openvpn/internal-client-certificate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // InternalClientCertificate returns a secret with a client certificate for the openvpn clients in the seed-cluster.
-func InternalClientCertificate(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func InternalClientCertificate(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	return certificates.GetClientCertificateCreator(
 		resources.OpenVPNClientCertificatesSecretName,
 		"internal-client",

--- a/api/pkg/resources/openvpn/server-certificate.go
+++ b/api/pkg/resources/openvpn/server-certificate.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TLSServingCertificate returns a secret with the openvpn server tls certificate
-func TLSServingCertificate(data *resources.TemplateData, existing *corev1.Secret) (*corev1.Secret, error) {
+func TLSServingCertificate(data resources.SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error) {
 	var se *corev1.Secret
 	if existing != nil {
 		se = existing

--- a/api/pkg/resources/openvpn/service.go
+++ b/api/pkg/resources/openvpn/service.go
@@ -8,12 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// Service returns a service for the prometheus
-func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
-	var se *corev1.Service
-	if existing != nil {
-		se = existing
-	} else {
+// Service returns the service of the openvpn server
+func Service(data resources.ServiceDataProvider, existing *corev1.Service) (*corev1.Service, error) {
+	se := existing
+	if se == nil {
 		se = &corev1.Service{}
 	}
 

--- a/api/pkg/resources/prometheus/role.go
+++ b/api/pkg/resources/prometheus/role.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Role returns a role for the prometheus
-func Role(data *resources.TemplateData, existing *rbacv1.Role) (*rbacv1.Role, error) {
+func Role(data resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
 	var r *rbacv1.Role
 	if existing != nil {
 		r = existing

--- a/api/pkg/resources/prometheus/rolebinding.go
+++ b/api/pkg/resources/prometheus/rolebinding.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RoleBinding returns the RoleBinding for the prometheus
-func RoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+func RoleBinding(data resources.RoleBindingDataProvider, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 	var rb *rbacv1.RoleBinding
 	if existing != nil {
 		rb = existing
@@ -29,7 +29,7 @@ func RoleBinding(data *resources.TemplateData, existing *rbacv1.RoleBinding) (*r
 		{
 			Kind:      "ServiceAccount",
 			Name:      resources.PrometheusServiceAccountName,
-			Namespace: data.Cluster.Status.NamespaceName,
+			Namespace: data.Cluster().Status.NamespaceName,
 		},
 	}
 	return rb, nil

--- a/api/pkg/resources/prometheus/service.go
+++ b/api/pkg/resources/prometheus/service.go
@@ -9,11 +9,9 @@ import (
 )
 
 // Service returns a service for the prometheus
-func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
-	var se *corev1.Service
-	if existing != nil {
-		se = existing
-	} else {
+func Service(data resources.ServiceDataProvider, existing *corev1.Service) (*corev1.Service, error) {
+	se := existing
+	if se == nil {
 		se = &corev1.Service{}
 	}
 
@@ -26,7 +24,7 @@ func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Se
 	se.Spec.ClusterIP = "None"
 	se.Spec.Selector = map[string]string{
 		resources.AppLabelKey: "prometheus",
-		"cluster":             data.Cluster.Name,
+		"cluster":             data.Cluster().Name,
 	}
 	se.Spec.Ports = []corev1.ServicePort{
 		{

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -29,7 +29,7 @@ var (
 )
 
 // StatefulSet returns the prometheus StatefulSet
-func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
+func StatefulSet(data resources.StatefulSetDataProvider, existing *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 	var set *appsv1.StatefulSet
 	if existing != nil {
 		set = existing
@@ -40,7 +40,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	set.Name = resources.PrometheusStatefulSetName
 	set.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 
-	requiredBaseLabels := map[string]string{"cluster": data.Cluster.Name}
+	requiredBaseLabels := map[string]string{"cluster": data.Cluster().Name}
 	set.Labels = resources.BaseAppLabel(name, requiredBaseLabels)
 	set.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: resources.BaseAppLabel(name, requiredBaseLabels),

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -261,31 +261,31 @@ const (
 )
 
 // ConfigMapCreator defines an interface to create/update ConfigMap's
-type ConfigMapCreator = func(data *TemplateData, existing *corev1.ConfigMap) (*corev1.ConfigMap, error)
+type ConfigMapCreator = func(data ConfigMapDataProvider, existing *corev1.ConfigMap) (*corev1.ConfigMap, error)
 
 // SecretCreator defines an interface to create/update Secret's
-type SecretCreator = func(data *TemplateData, existing *corev1.Secret) (*corev1.Secret, error)
+type SecretCreator = func(data SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error)
 
 // StatefulSetCreator defines an interface to create/update StatefulSet
-type StatefulSetCreator = func(data *TemplateData, existing *appsv1.StatefulSet) (*appsv1.StatefulSet, error)
+type StatefulSetCreator = func(data StatefulSetDataProvider, existing *appsv1.StatefulSet) (*appsv1.StatefulSet, error)
 
 // ServiceCreator defines an interface to create/update Services
-type ServiceCreator = func(data *TemplateData, existing *corev1.Service) (*corev1.Service, error)
+type ServiceCreator = func(data ServiceDataProvider, existing *corev1.Service) (*corev1.Service, error)
 
 // RoleCreator defines an interface to create/update RBAC Roles
 type RoleCreator = func(data RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error)
 
 // RoleBindingCreator defines an interface to create/update RBAC RoleBinding's
-type RoleBindingCreator = func(data *TemplateData, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error)
+type RoleBindingCreator = func(data RoleBindingDataProvider, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error)
 
 // ClusterRoleCreator defines an interface to create/update RBAC ClusterRoles
-type ClusterRoleCreator = func(data *TemplateData, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error)
+type ClusterRoleCreator = func(data ClusterRoleDataProvider, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error)
 
 // ClusterRoleBindingCreator defines an interface to create/update RBAC ClusterRoleBinding's
-type ClusterRoleBindingCreator = func(data *TemplateData, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error)
+type ClusterRoleBindingCreator = func(data ClusterRoleBindingDataProvider, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error)
 
 // DeploymentCreator defines an interface to create/update Deployment's
-type DeploymentCreator = func(data *TemplateData, existing *appsv1.Deployment) (*appsv1.Deployment, error)
+type DeploymentCreator = func(data DeploymentDataProvider, existing *appsv1.Deployment) (*appsv1.Deployment, error)
 
 // InitializerConfigurationCreator defines an interface to create/update InitializerConfigurations
 type InitializerConfigurationCreator = func(data *TemplateData, existing *admissionv1alpha1.InitializerConfiguration) (*admissionv1alpha1.InitializerConfiguration, error)
@@ -356,7 +356,7 @@ func InClusterApiserverIP(cluster *kubermaticv1.Cluster) (*net.IP, error) {
 }
 
 // UserClusterDNSPolicyAndConfig returns a DNSPolicy and DNSConfig to configure Pods to use user cluster DNS
-func UserClusterDNSPolicyAndConfig(d *TemplateData) (corev1.DNSPolicy, *corev1.PodDNSConfig, error) {
+func UserClusterDNSPolicyAndConfig(d DeploymentDataProvider) (corev1.DNSPolicy, *corev1.PodDNSConfig, error) {
 	// DNSNone indicates that the pod should use empty DNS settings. DNS
 	// parameters such as nameservers and search paths should be defined via
 	// DNSConfig.
@@ -365,15 +365,15 @@ func UserClusterDNSPolicyAndConfig(d *TemplateData) (corev1.DNSPolicy, *corev1.P
 	if err != nil {
 		return corev1.DNSNone, nil, err
 	}
-	if len(d.Cluster.Spec.ClusterNetwork.DNSDomain) == 0 {
-		return corev1.DNSNone, nil, fmt.Errorf("invalid (empty) DNSDomain in ClusterNetwork spec for cluster %s", d.Cluster.Name)
+	if len(d.Cluster().Spec.ClusterNetwork.DNSDomain) == 0 {
+		return corev1.DNSNone, nil, fmt.Errorf("invalid (empty) DNSDomain in ClusterNetwork spec for cluster %s", d.Cluster().Name)
 	}
 	return corev1.DNSNone, &corev1.PodDNSConfig{
 		Nameservers: []string{dnsConfigResolverIP},
 		Searches: []string{
-			fmt.Sprintf("kube-system.svc.%s", d.Cluster.Spec.ClusterNetwork.DNSDomain),
-			fmt.Sprintf("svc.%s", d.Cluster.Spec.ClusterNetwork.DNSDomain),
-			d.Cluster.Spec.ClusterNetwork.DNSDomain,
+			fmt.Sprintf("kube-system.svc.%s", d.Cluster().Spec.ClusterNetwork.DNSDomain),
+			fmt.Sprintf("svc.%s", d.Cluster().Spec.ClusterNetwork.DNSDomain),
+			d.Cluster().Spec.ClusterNetwork.DNSDomain,
 		},
 		Options: []corev1.PodDNSConfigOption{
 			{

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -273,7 +273,7 @@ type StatefulSetCreator = func(data *TemplateData, existing *appsv1.StatefulSet)
 type ServiceCreator = func(data *TemplateData, existing *corev1.Service) (*corev1.Service, error)
 
 // RoleCreator defines an interface to create/update RBAC Roles
-type RoleCreator = func(data *TemplateData, existing *rbacv1.Role) (*rbacv1.Role, error)
+type RoleCreator = func(data RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error)
 
 // RoleBindingCreator defines an interface to create/update RBAC RoleBinding's
 type RoleBindingCreator = func(data *TemplateData, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error)

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.6-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.1-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.12.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.8.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.9.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-aws-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.9.10-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.6-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.1-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.12.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.8.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.9.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-azure-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.9.10-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.8.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.9.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.9.10-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.8.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.9.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.9.10-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.6-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.1-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.12.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.8.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.9.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-openstack-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.9.10-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.8.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.9.0-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.9.10-dns-resolver.yaml
@@ -1,6 +1,13 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
 spec:
   ports:
   - name: dns

--- a/api/pkg/resources/vpnsidecar/dnatController.go
+++ b/api/pkg/resources/vpnsidecar/dnatController.go
@@ -21,7 +21,7 @@ var (
 )
 
 // DnatControllerContainer returns a sidecar container for running the dnat controller.
-func DnatControllerContainer(data *resources.TemplateData, name string) (*corev1.Container, error) {
+func DnatControllerContainer(data resources.DeploymentDataProvider, name string) (*corev1.Container, error) {
 	return &corev1.Container{
 		Name:            name,
 		Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/vpnsidecar-dnat-controller:v0.2.0",
@@ -29,7 +29,7 @@ func DnatControllerContainer(data *resources.TemplateData, name string) (*corev1
 		Command:         []string{"/usr/local/bin/kubeletdnat-controller"},
 		Args: []string{
 			"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-			"--node-access-network", data.NodeAccessNetwork,
+			"--node-access-network", data.NodeAccessNetwork(),
 			"-v", "4",
 			"-logtostderr",
 		},

--- a/api/pkg/resources/vpnsidecar/dnatControllerClusterRole.go
+++ b/api/pkg/resources/vpnsidecar/dnatControllerClusterRole.go
@@ -4,19 +4,18 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DnatControllerClusterRole returns a cluster role for the kubeletdnat controller
-func DnatControllerClusterRole(data *resources.TemplateData, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-	var r *rbacv1.ClusterRole
-	if existing != nil {
-		r = existing
-	} else {
+func DnatControllerClusterRole(data resources.ClusterRoleDataProvider, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	r := existing
+	if r == nil {
 		r = &rbacv1.ClusterRole{}
 	}
 
 	r.Name = resources.KubeletDnatControllerClusterRoleName
-
+	r.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	r.Rules = []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},

--- a/api/pkg/resources/vpnsidecar/dnatControllerClusterRoleBinding.go
+++ b/api/pkg/resources/vpnsidecar/dnatControllerClusterRoleBinding.go
@@ -8,9 +8,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-// DnatControllerClusterRoleBinding returns a ClusterRoleBinding for the kubeletdnat-controller.
+// DnatControllerClusterRoleBinding returns a ClusterRoleBinding for the vpnsidecar-dnat-controller.
 // It has to be put into the user-cluster.
-func DnatControllerClusterRoleBinding(data *resources.TemplateData, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+func DnatControllerClusterRoleBinding(_ resources.ClusterRoleBindingDataProvider, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 	return createClusterRoleBinding(existing, "controller",
 		resources.KubeletDnatControllerClusterRoleName, rbacv1.Subject{
 			Kind:     "User",
@@ -20,10 +20,8 @@ func DnatControllerClusterRoleBinding(data *resources.TemplateData, existing *rb
 }
 
 func createClusterRoleBinding(existing *rbacv1.ClusterRoleBinding, crbSuffix, cRoleRef string, subj rbacv1.Subject) (*rbacv1.ClusterRoleBinding, error) {
-	var crb *rbacv1.ClusterRoleBinding
-	if existing != nil {
-		crb = existing
-	} else {
+	crb := existing
+	if crb == nil {
 		crb = &rbacv1.ClusterRoleBinding{}
 	}
 

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -21,7 +21,7 @@ var (
 // to user cluster networks.
 // Also required but not provided by this func:
 // * volumes: resources.OpenVPNClientCertificatesSecretName, resources.CACertSecretName
-func OpenVPNSidecarContainer(data *resources.TemplateData, name string) (*corev1.Container, error) {
+func OpenVPNSidecarContainer(data resources.DeploymentDataProvider, name string) (*corev1.Container, error) {
 	return &corev1.Container{
 		Name:            name,
 		Image:           data.ImageRegistry("docker.io") + "/kubermatic/openvpn:v0.4",
@@ -32,7 +32,7 @@ func OpenVPNSidecarContainer(data *resources.TemplateData, name string) (*corev1
 			"--proto", "tcp",
 			"--dev", "tun",
 			"--auth-nocache",
-			"--remote", fmt.Sprintf("%s.%s.svc.cluster.local", resources.OpenVPNServerServiceName, data.Cluster.Status.NamespaceName), "1194",
+			"--remote", fmt.Sprintf("%s.%s.svc.cluster.local", resources.OpenVPNServerServiceName, data.Cluster().Status.NamespaceName), "1194",
 			"--nobind",
 			"--connect-timeout", "5",
 			"--connect-retry", "1",


### PR DESCRIPTION
**What this PR does / why we need it**:

EnsureRole (et al) shall be used in seed and user-cluster side. TemplateData struct is specific to seed side.
For that reason Ensure functions should use interfaces instead of TemplateData struct which can be used from both sides.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
