### PR TITLE
Allow cluster namespace DNS

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -265,16 +265,6 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 			ClusterIP: "192.0.2.11",
 		},
 	}
-	etcdclientService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.EtcdClientServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{NodePort: 97}},
-			ClusterIP: "192.0.2.1",
-		},
-	}
 	openvpnserverService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resources.OpenVPNServerServiceName,
@@ -299,7 +289,6 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 		Items: []corev1.Service{
 			apiServerExternalService,
 			apiserverService,
-			etcdclientService,
 			openvpnserverService,
 			dnsService,
 		},

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -158,8 +158,7 @@ func GetServiceCreators() []resources.ServiceCreator {
 		apiserver.ExternalService,
 		prometheus.Service,
 		openvpn.Service,
-		etcd.DiscoveryService,
-		etcd.ClientService,
+		etcd.Service,
 		dns.Service,
 	}
 }

--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -132,11 +132,6 @@ func TestSecretV2CreatorsKeepAdditionalData(t *testing.T) {
 		resources.CAKeySecretKey:  certutil.EncodePrivateKeyPEM(keyPair.Key),
 	}
 
-	etcdClientService := &corev1.Service{}
-	etcdClientService.Name = resources.EtcdClientServiceName
-	etcdClientService.Namespace = "test-ns"
-	etcdClientService.Spec.ClusterIP = "1.2.3.4"
-
 	apiserverExternalService := &corev1.Service{}
 	apiserverExternalService.Name = resources.ApiserverExternalServiceName
 	apiserverExternalService.Namespace = "test-ns"
@@ -163,9 +158,6 @@ func TestSecretV2CreatorsKeepAdditionalData(t *testing.T) {
 	secretLister := listerscorev1.NewSecretLister(secretIndexer)
 
 	serviceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	if err := serviceIndexer.Add(etcdClientService); err != nil {
-		t.Fatalf("Error adding service to indexer: %v", err)
-	}
 	if err := serviceIndexer.Add(apiserverExternalService); err != nil {
 		t.Fatalf("Error adding service to indexer: %v", err)
 	}

--- a/api/pkg/resources/apiserver/tls-serving-certificate.go
+++ b/api/pkg/resources/apiserver/tls-serving-certificate.go
@@ -33,14 +33,6 @@ func TLSServingCertificate(data *resources.TemplateData, existing *corev1.Secret
 		return nil, fmt.Errorf("failed to get cluster ca: %v", err)
 	}
 
-	apiserverExternalIP, err := data.ServiceClusterIP(resources.ApiserverExternalServiceName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ClusterIP of service %s: %v", resources.ApiserverExternalServiceName, err)
-	}
-	apiserverInternalIP, err := data.ServiceClusterIP(resources.ApiserverInternalServiceName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ClusterIP of service %s: %v", resources.ApiserverInternalServiceName, err)
-	}
 	externalIP, err := data.ExternalIP()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get external IP for cluster: %v", err)
@@ -72,8 +64,6 @@ func TLSServingCertificate(data *resources.TemplateData, existing *corev1.Secret
 			fmt.Sprintf("%s.%s.svc.cluster.local", resources.ApiserverInternalServiceName, data.Cluster.Status.NamespaceName),
 		},
 		IPs: []net.IP{
-			*apiserverExternalIP,
-			*apiserverInternalIP,
 			*externalIP,
 			*inClusterIP,
 		},

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -129,19 +129,12 @@ func (d *TemplateData) InClusterApiserverURL() (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get service %s from lister for cluster %s: %v", ApiserverExternalServiceName, d.Cluster.Name, err)
 	}
-	if net.ParseIP(service.Spec.ClusterIP) == nil {
-		return nil, fmt.Errorf("service %s in cluster %s has no valid cluster ip (\"%s\"): %v", ApiserverExternalServiceName, d.Cluster.Name, service.Spec.ClusterIP, err)
-	}
 
 	if len(service.Spec.Ports) != 1 {
 		return nil, errors.New("apiserver service does not have exactly one port")
 	}
 
-	if service.Spec.ClusterIP == "" {
-		return nil, errors.New("apiserver service has no ClusterIP")
-	}
-
-	return url.Parse(fmt.Sprintf("https://%s:%d", service.Spec.ClusterIP, service.Spec.Ports[0].NodePort))
+	return url.Parse(fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", ApiserverExternalServiceName, d.Cluster.Status.NamespaceName, service.Spec.Ports[0].NodePort))
 }
 
 // ImageRegistry returns the image registry to use or the passed in default if no override is specified
@@ -160,14 +153,6 @@ func (d *TemplateData) GetRootCA() (*triple.KeyPair, error) {
 // GetFrontProxyCA returns the root CA of the cluster
 func (d *TemplateData) GetFrontProxyCA() (*triple.KeyPair, error) {
 	return GetClusterFrontProxyCA(d.Cluster, d.SecretLister)
-}
-
-// ServiceClusterIP returns the ClusterIP as string for the
-// Service specified by `name`. Service lookup happens within
-// `Cluster.Status.NamespaceName`. When ClusterIP fails to parse
-// as valid IP address, an error is returned.
-func (d *TemplateData) ServiceClusterIP(name string) (*net.IP, error) {
-	return ClusterIPForService(name, d.Cluster.Status.NamespaceName, d.ServiceLister)
 }
 
 // SecretRevision returns the resource version of the secret specified by name. A empty string will be returned in case of an error

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -131,6 +131,8 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 
 	dep.Spec.Template.Spec.Volumes = volumes
 
+	dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(resources.DNSResolverDeploymentName, data.Cluster.Name, nil))
+
 	return dep, nil
 }
 
@@ -191,7 +193,12 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
 	}
 	cm.Name = resources.DNSResolverConfigMapName
 	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
+	seedClusterNamespaceDNS := fmt.Sprintf("%s.svc.cluster.local.", data.Cluster.Status.NamespaceName)
 	cm.Data["Corefile"] = fmt.Sprintf(`
+%s {
+    forward . /etc/resolv.conf
+    errors
+}
 %s {
     forward . %s
     errors
@@ -201,7 +208,7 @@ func ConfigMap(data *resources.TemplateData, existing *corev1.ConfigMap) (*corev
   errors
   health
 }
-`, data.Cluster.Spec.ClusterNetwork.DNSDomain, dnsIP)
+`, seedClusterNamespaceDNS, data.Cluster.Spec.ClusterNetwork.DNSDomain, dnsIP)
 
 	return cm, nil
 }

--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -35,7 +35,7 @@ func CronJob(data *resources.TemplateData, existing *batchv1beta1.CronJob) (*bat
 	job.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
 		{
 			Name:                     "defragger",
-			Image:                    data.ImageRegistry(resources.RegistryQuay) + "/coreos/etcd:" + tag,
+			Image:                    data.ImageRegistry(resources.RegistryQuay) + "/coreos/etcd:" + ImageTag,
 			ImagePullPolicy:          corev1.PullIfNotPresent,
 			Command:                  command,
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,

--- a/api/pkg/resources/etcd/etcdservices.go
+++ b/api/pkg/resources/etcd/etcdservices.go
@@ -1,6 +1,8 @@
 package etcd
 
 import (
+	"fmt"
+
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -8,8 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DiscoveryService returns a service for the etcd peers to find each other?
-func DiscoveryService(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
+// Service returns a service for the etcd StatefulSet
+func Service(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
 	var se *corev1.Service
 	if existing != nil {
 		se = existing
@@ -45,29 +47,13 @@ func DiscoveryService(data *resources.TemplateData, existing *corev1.Service) (*
 	return se, nil
 }
 
-// ClientService returns a service for access by clients (ClusterIP)
-func ClientService(data *resources.TemplateData, existing *corev1.Service) (*corev1.Service, error) {
-	var se *corev1.Service
-	if existing != nil {
-		se = existing
-	} else {
-		se = &corev1.Service{}
+// GetClientEndpoints returns the slice with the etcd endpoints for client communication
+func GetClientEndpoints(namespace string) []string {
+	var endpoints []string
+	for i := 0; i < 3; i++ {
+		// Pod DNS name
+		absolutePodDNSName := fmt.Sprintf("https://etcd-%d.%s.%s.svc.cluster.local:2379", i, resources.EtcdServiceName, namespace)
+		endpoints = append(endpoints, absolutePodDNSName)
 	}
-
-	se.Name = resources.EtcdClientServiceName
-	se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	se.Spec.Selector = map[string]string{
-		resources.AppLabelKey: name,
-		"cluster":             data.Cluster.Name,
-	}
-	se.Spec.Ports = []corev1.ServicePort{
-		{
-			Name:       "client",
-			Port:       2379,
-			TargetPort: intstr.FromInt(2379),
-			Protocol:   corev1.ProtocolTCP,
-		},
-	}
-
-	return se, nil
+	return endpoints
 }

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -31,7 +31,8 @@ var (
 const (
 	name    = "etcd"
 	dataDir = "/var/run/etcd/pod_${POD_NAME}/"
-	tag     = "v3.2.24"
+	// ImageTag defines the image tag to use for the etcd image
+	ImageTag = "v3.2.24"
 )
 
 // StatefulSet returns the etcd StatefulSet
@@ -89,7 +90,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	set.Spec.Template.Spec.Containers = []corev1.Container{
 		{
 			Name:                     name,
-			Image:                    data.ImageRegistry(resources.RegistryQuay) + "/coreos/etcd:" + tag,
+			Image:                    data.ImageRegistry(resources.RegistryQuay) + "/coreos/etcd:" + ImageTag,
 			ImagePullPolicy:          corev1.PullIfNotPresent,
 			Command:                  etcdStartCmd,
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,

--- a/api/pkg/resources/etcd/tls-serving-certificate.go
+++ b/api/pkg/resources/etcd/tls-serving-certificate.go
@@ -31,10 +31,11 @@ func TLSCertificate(data *resources.TemplateData, existing *corev1.Secret) (*cor
 
 	altNames := certutil.AltNames{
 		DNSNames: []string{
-			"127.0.0.1",
 			"localhost",
 		},
-		IPs: []net.IP{},
+		IPs: []net.IP{
+			net.ParseIP("127.0.0.1"),
+		},
 	}
 
 	for i := 0; i < 3; i++ {

--- a/api/pkg/resources/etcd/tls-serving-certificate.go
+++ b/api/pkg/resources/etcd/tls-serving-certificate.go
@@ -29,24 +29,12 @@ func TLSCertificate(data *resources.TemplateData, existing *corev1.Secret) (*cor
 		return nil, fmt.Errorf("failed to get cluster ca: %v", err)
 	}
 
-	clientIP, err := data.ServiceClusterIP(resources.EtcdClientServiceName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ClientIP of etcd client service '%s': %v", resources.EtcdClientServiceName, err)
-	}
-
 	altNames := certutil.AltNames{
 		DNSNames: []string{
 			"127.0.0.1",
 			"localhost",
-
-			resources.EtcdClientServiceName,
-			fmt.Sprintf("%s.%s", resources.EtcdClientServiceName, data.Cluster.Status.NamespaceName),
-			fmt.Sprintf("%s.%s.svc", resources.EtcdClientServiceName, data.Cluster.Status.NamespaceName),
-			fmt.Sprintf("%s.%s.svc.cluster.local", resources.EtcdClientServiceName, data.Cluster.Status.NamespaceName),
 		},
-		IPs: []net.IP{
-			*clientIP,
-		},
+		IPs: []net.IP{},
 	}
 
 	for i := 0; i < 3; i++ {

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -64,8 +64,6 @@ const (
 	PrometheusServiceName = "prometheus"
 	//EtcdServiceName is the name for the etcd service
 	EtcdServiceName = "etcd"
-	//EtcdClientServiceName is the name for the etcd service for clients (ClusterIP)
-	EtcdClientServiceName = "etcd-client"
 	//EtcdDefragCronJobName is the name for the defrag cronjob deployment
 	EtcdDefragCronJobName = "etcd-defragger"
 	//OpenVPNServerServiceName is the name for the openvpn server service

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.8.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.9.10-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.8.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.9.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.9.10-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.8.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.9.10-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.8.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.9.10-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.8.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.9.10-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.8.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.0-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.9.10-dns-resolver.yaml
@@ -1,6 +1,10 @@
 data:
   Corefile: |2
 
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,8 +201,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,8 +201,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,8 +201,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,8 +201,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,8 +201,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -314,9 +314,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,8 +201,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,8 +201,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,8 +201,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -301,9 +301,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -76,8 +76,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -79,8 +79,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -79,8 +79,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -79,8 +79,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -79,8 +79,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -79,8 +79,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -301,9 +301,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -79,8 +79,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -79,8 +79,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,8 +188,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -79,8 +79,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -87,8 +87,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -87,8 +87,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -87,8 +87,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -87,8 +87,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -87,8 +87,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -87,8 +87,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -87,8 +87,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,8 +192,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -87,8 +87,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,8 +196,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,8 +196,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,8 +196,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,8 +196,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,8 +196,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,8 +196,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,8 +196,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://192.0.2.12:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://192.0.2.12:2379] get foo; do echo
-          waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.7
+          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
+          get foo; do echo waiting for etcd; sleep 2; done;
+        image: quay.io/coreos/etcd:v3.2.24
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,8 +196,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
@@ -30,6 +30,16 @@ spec:
         dns-resolver-configmap-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --client
@@ -39,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -69,8 +69,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -81,8 +81,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - 192.0.2.13
+        - openvpn-server.cluster-de-test-01.svc.cluster.local
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,8 +161,8 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://192.0.2.10:30000/healthz; do echo waiting for apiserver;
-          sleep 2; done;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -394,20 +394,6 @@ func TestLoadFiles(t *testing.T) {
 					},
 					&v1.Service{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      resources.EtcdClientServiceName,
-							Namespace: cluster.Status.NamespaceName,
-						},
-						Spec: v1.ServiceSpec{
-							Ports: []v1.ServicePort{
-								{
-									NodePort: 30002,
-								},
-							},
-							ClusterIP: "192.0.2.12",
-						},
-					},
-					&v1.Service{
-						ObjectMeta: metav1.ObjectMeta{
 							Name:      resources.OpenVPNServerServiceName,
 							Namespace: cluster.Status.NamespaceName,
 						},

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -1,6 +1,8 @@
 package vpnsidecar
 
 import (
+	"fmt"
+
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,10 +22,6 @@ var (
 // Also required but not provided by this func:
 // * volumes: resources.OpenVPNClientCertificatesSecretName, resources.CACertSecretName
 func OpenVPNSidecarContainer(data *resources.TemplateData, name string) (*corev1.Container, error) {
-	openvpnServiceIP, err := data.ClusterIPByServiceName(resources.OpenVPNServerServiceName)
-	if err != nil {
-		return nil, err
-	}
 	return &corev1.Container{
 		Name:            name,
 		Image:           data.ImageRegistry("docker.io") + "/kubermatic/openvpn:v0.4",
@@ -34,7 +32,7 @@ func OpenVPNSidecarContainer(data *resources.TemplateData, name string) (*corev1
 			"--proto", "tcp",
 			"--dev", "tun",
 			"--auth-nocache",
-			"--remote", openvpnServiceIP, "1194",
+			"--remote", fmt.Sprintf("%s.%s.svc.cluster.local", resources.OpenVPNServerServiceName, data.Cluster.Status.NamespaceName), "1194",
 			"--nobind",
 			"--connect-timeout", "5",
 			"--connect-retry", "1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow the usage of the seed cluster DNS inside the cluster-namespaces.

**Release note**:
```release-note
Use DNS names inside the cluster namespaces. Scoped to the cluster namespace
```
