### PR TITLE
Update etcd to v3.3.9

### DIFF
--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -47,7 +47,7 @@ const (
 	// will write the backup to
 	SharedVolumeName = "etcd-backup"
 	// DefaultBackupContainerImage holds the default Image used for creating the etcd backups
-	DefaultBackupContainerImage = "quay.io/coreos/etcd:v3.3"
+	DefaultBackupContainerImage = "gcr.io/etcd-development/etcd:" + etcd.ImageTag
 	// DefaultBackupInterval defines the default interval used to create backups
 	DefaultBackupInterval = "20m"
 	// cronJobPrefix defines the prefix used for all backup cronjob names

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -106,12 +106,12 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 		{
 			Name:            "etcd-running",
-			Image:           data.ImageRegistry(resources.RegistryQuay) + "/coreos/etcd:" + etcd.ImageTag,
+			Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{
 				"/bin/sh",
 				"-ec",
-				fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints=[%s] get foo; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
+				fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' endpoint health; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
 			},
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
@@ -150,7 +150,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		*dnatControllerSidecar,
 		{
 			Name:                     name,
-			Image:                    data.ImageRegistry(resources.RegistryKubernetesGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
+			Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
 			ImagePullPolicy:          corev1.PullIfNotPresent,
 			Command:                  []string{"/hyperkube", "apiserver"},
 			Env:                      getEnvVars(data),

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -141,7 +141,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		*openvpnSidecar,
 		{
 			Name:                     name,
-			Image:                    data.ImageRegistry(resources.RegistryKubernetesGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
+			Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
 			ImagePullPolicy:          corev1.PullIfNotPresent,
 			Command:                  []string{"/hyperkube", "controller-manager"},
 			Args:                     getFlags(data),

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -91,7 +91,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		*openvpnSidecar,
 		{
 			Name:            resources.DNSResolverDeploymentName,
-			Image:           data.ImageRegistry(resources.RegistryKubernetesGCR) + "/google_containers/coredns:1.1.3",
+			Image:           data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.1.3",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Args:            []string{"-conf", "/etc/coredns/Corefile"},
 			Resources: corev1.ResourceRequirements{

--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -35,7 +35,7 @@ func CronJob(data *resources.TemplateData, existing *batchv1beta1.CronJob) (*bat
 	job.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
 		{
 			Name:                     "defragger",
-			Image:                    data.ImageRegistry(resources.RegistryQuay) + "/coreos/etcd:" + ImageTag,
+			Image:                    data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag,
 			ImagePullPolicy:          corev1.PullIfNotPresent,
 			Command:                  command,
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -32,7 +32,7 @@ const (
 	name    = "etcd"
 	dataDir = "/var/run/etcd/pod_${POD_NAME}/"
 	// ImageTag defines the image tag to use for the etcd image
-	ImageTag = "v3.2.24"
+	ImageTag = "v3.3.9"
 )
 
 // StatefulSet returns the etcd StatefulSet
@@ -90,7 +90,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 	set.Spec.Template.Spec.Containers = []corev1.Container{
 		{
 			Name:                     name,
-			Image:                    data.ImageRegistry(resources.RegistryQuay) + "/coreos/etcd:" + ImageTag,
+			Image:                    data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag,
 			ImagePullPolicy:          corev1.PullIfNotPresent,
 			Command:                  etcdStartCmd,
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
@@ -144,7 +144,7 @@ func StatefulSet(data *resources.TemplateData, existing *appsv1.StatefulSet) (*a
 							"--cacert", "/etc/etcd/pki/ca/ca.crt",
 							"--cert", "/etc/etcd/pki/client/apiserver-etcd-client.crt",
 							"--key", "/etc/etcd/pki/client/apiserver-etcd-client.key",
-							"--endpoints", "https://localhost:2379", "endpoint", "health",
+							"--endpoints", "https://127.0.0.1:2379", "endpoint", "health",
 						},
 					},
 				},

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -194,8 +194,8 @@ const (
 	// EtcdClusterSize defines the size of the etcd to use
 	EtcdClusterSize = 3
 
-	// RegistryKubernetesGCR defines the kubernetes docker registry at google
-	RegistryKubernetesGCR = "gcr.io"
+	// RegistryGCR defines the kubernetes docker registry at google
+	RegistryGCR = "gcr.io"
 	// RegistryDocker defines the default docker.io registry
 	RegistryDocker = "docker.io"
 	// RegistryQuay defines the image registry from coreos/redhat - quay

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -108,7 +108,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 		*openvpnSidecar,
 		{
 			Name:            name,
-			Image:           data.ImageRegistry(resources.RegistryKubernetesGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
+			Image:           data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"/hyperkube", "scheduler"},
 			Args: []string{

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.8.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.9.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.9.10-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.8.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.9.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.9.10-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.8.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.10-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.8.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.10-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.8.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.10-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.8.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.0-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.10-etcd-defragger.yaml
@@ -43,7 +43,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: quay.io/coreos/etcd:v3.2.24
+            image: gcr.io/etcd-development/etcd:v3.3.9
             imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -314,9 +314,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -318,9 +318,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -301,9 +301,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -301,9 +301,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -305,9 +305,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -309,9 +309,9 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints=[https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379]
-          get foo; do echo waiting for etcd; sleep 2; done;
-        image: quay.io/coreos/etcd:v3.2.24
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          endpoint health; do echo waiting for etcd; sleep 2; done;
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: quay.io/coreos/etcd:v3.2.24
+        image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd
         ports:
@@ -101,7 +101,7 @@ spec:
             - --key
             - /etc/etcd/pki/client/apiserver-etcd-client.key
             - --endpoints
-            - https://localhost:2379
+            - https://127.0.0.1:2379
             - endpoint
             - health
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Update etcd to v3.3.9 for general performance improvements & to fix the issue with the health check: https://github.com/etcd-io/etcd/pull/8342

According to https://github.com/kubernetes/kubernetes/issues/61326 its safe to run v3.3 & it will be promoted as default with Kubernetes v1.12.

**Release note**:
```release-note
Update etcd to v3.3.9
```
