### PR TITLE
Fix etcd defrag cmd

### DIFF
--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -103,9 +103,9 @@ const (
 	defraggerCommandTpl = `etcdctl() {
 ETCDCTL_API=3 /usr/local/bin/etcdctl \
   --endpoints https://$1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local.:2379 \
-  --cacert /etc/etcd/client/{{ .CACertFile }} \
-  --cert /etc/etcd/client/{{ .CertFile }} \
-  --key /etc/etcd/client/{{ .KeyFile }} \
+  --cacert /etc/etcd/pki/client/{{ .CACertFile }} \
+  --cert /etc/etcd/pki/client/{{ .CertFile }} \
+  --key /etc/etcd/pki/client/{{ .KeyFile }} \
   $2
 }
 

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.8.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.9.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.9.10-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.8.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.9.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.9.10-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.8.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.10-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.8.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.10-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.8.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.10-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.8.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.0-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.10-etcd-defragger.yaml
@@ -26,9 +26,9 @@ spec:
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
-                --cacert /etc/etcd/client/ca.crt \
-                --cert /etc/etcd/client/apiserver-etcd-client.crt \
-                --key /etc/etcd/client/apiserver-etcd-client.key \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
                 $2
               }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix wrong path's to certs in etcd defrag cronjob.

**Release note**:
```release-note
NONE
```
