### PR TITLE
fix JSON typo in Minio backup command

### DIFF
--- a/config/minio/templates/deployment.yaml
+++ b/config/minio/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         backup.ark.heptio.com/backup-volumes: minio-backup
         pre.hook.backup.ark.heptio.com/container: backup
         pre.hook.backup.ark.heptio.com/timeout: 60m
-        pre.hook.backup.ark.heptio.com/command: '["/mc", "mirror", "--remove", "--quiet", src", "/backup"]'
+        pre.hook.backup.ark.heptio.com/command: '["/mc", "mirror", "--remove", "--quiet", "src", "/backup"]'
       {{- end }}
     spec:
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a typo I made when defining the backup command that Ark executes to create a minio mirror.

**Release note**:
```release-note
NONE
```
