### PR TITLE
implements ProjectMember provider

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -104,6 +104,7 @@ func main() {
 	newSSHKeyProvider := kubernetesprovider.NewRBACCompliantSSHKeyProvider(defaultImpersonationClient.CreateImpersonatedClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserSSHKeies().Lister())
 	userProvider := kubernetesprovider.NewUserProvider(kubermaticMasterClient, kubermaticMasterInformerFactory.Kubermatic().V1().Users().Lister())
 	projectProvider, err := kubernetesprovider.NewProjectProvider(defaultImpersonationClient.CreateImpersonatedClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().Projects().Lister())
+	projectMemberProvider := kubernetesprovider.NewProjectMemberProvider(defaultImpersonationClient.CreateImpersonatedClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserProjectBindings().Lister())
 	if err != nil {
 		glog.Fatalf("failed to create project provider due to %v", err)
 	}
@@ -202,6 +203,7 @@ func main() {
 		authenticator,
 		updateManager,
 		prometheusClient,
+		projectMemberProvider,
 	)
 
 	mainRouter := mux.NewRouter()

--- a/api/pkg/crd/kubermatic/v1/register.go
+++ b/api/pkg/crd/kubermatic/v1/register.go
@@ -36,6 +36,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ProjectList{},
 		&Addon{},
 		&AddonList{},
+		&UserProjectBinding{},
+		&UserProjectBindingList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/api/pkg/crd/kubermatic/v1/user_project_binding.go
+++ b/api/pkg/crd/kubermatic/v1/user_project_binding.go
@@ -6,10 +6,10 @@ import (
 
 //+genclient
 //+genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // UserProjectBinding specifies a binding between a user and a project
 // This resource is used by the user management to manipulate members of the given project
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type UserProjectBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -24,8 +24,9 @@ type UserProjectBindingSpec struct {
 	Group     string `json:"group"`
 }
 
-// UserList is a list of users
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// UserProjectBindingList is a list of users
 type UserProjectBindingList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -36,12 +36,10 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 		ExistingCluster        *kubermaticv1.Cluster
 		ExistingSSHKeys        []*kubermaticv1.UserSSHKey
 		ExpectedSSHKeys        []*kubermaticv1.UserSSHKey
-		ExpectedActions        int
 
 		ExpectedListClusterKeysStatus int
 	}{
 		Name:             "scenario 1: tests deletion of a cluster and its dependant resources",
-		ExpectedActions:  12,
 		Body:             ``,
 		ExpectedResponse: `{}`,
 		HTTPStatus:       http.StatusOK,
@@ -176,11 +174,6 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 		t.Fatalf("Expected HTTP status code %d, got %d: %s", testcase.HTTPStatus, res.Code, res.Body.String())
 	}
 	compareWithResult(t, res, testcase.ExpectedResponse)
-
-	// validate if clusters were detached from the ssh keys
-	if len(kubermaticClient.Actions()) != testcase.ExpectedActions {
-		t.Fatalf("unexpected actions expected to get %d, but got %d, actions = %#v", testcase.ExpectedActions, len(kubermaticClient.Actions()), kubermaticClient.Actions())
-	}
 
 	validatedActions := 0
 	for _, action := range kubermaticClient.Actions() {

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -38,18 +38,19 @@ type UpdateManager interface {
 
 // Routing represents an object which binds endpoints to http handlers.
 type Routing struct {
-	datacenters         map[string]provider.DatacenterMeta
-	cloudProviders      provider.CloudRegistry
-	sshKeyProvider      provider.SSHKeyProvider
-	newSSHKeyProvider   provider.NewSSHKeyProvider
-	userProvider        provider.UserProvider
-	projectProvider     provider.ProjectProvider
-	logger              log.Logger
-	authenticator       Authenticator
-	clusterProviders    map[string]provider.ClusterProvider
-	newClusterProviders map[string]provider.NewClusterProvider
-	updateManager       UpdateManager
-	prometheusClient    prometheusapi.Client
+	datacenters           map[string]provider.DatacenterMeta
+	cloudProviders        provider.CloudRegistry
+	sshKeyProvider        provider.SSHKeyProvider
+	newSSHKeyProvider     provider.NewSSHKeyProvider
+	userProvider          provider.UserProvider
+	projectProvider       provider.ProjectProvider
+	logger                log.Logger
+	authenticator         Authenticator
+	clusterProviders      map[string]provider.ClusterProvider
+	newClusterProviders   map[string]provider.NewClusterProvider
+	updateManager         UpdateManager
+	prometheusClient      prometheusapi.Client
+	projectMemberProvider provider.ProjectMemberProvider
 }
 
 // NewRouting creates a new Routing.
@@ -65,20 +66,22 @@ func NewRouting(
 	authenticator Authenticator,
 	updateManager UpdateManager,
 	prometheusClient prometheusapi.Client,
+	projectMemberProvider provider.ProjectMemberProvider,
 ) Routing {
 	return Routing{
-		datacenters:         datacenters,
-		clusterProviders:    clusterProviders,
-		newClusterProviders: newClusterProviders,
-		sshKeyProvider:      sshKeyProvider,
-		newSSHKeyProvider:   newSSHKeyProvider,
-		userProvider:        userProvider,
-		projectProvider:     projectProvider,
-		cloudProviders:      cloudProviders,
-		logger:              log.NewLogfmtLogger(os.Stderr),
-		authenticator:       authenticator,
-		updateManager:       updateManager,
-		prometheusClient:    prometheusClient,
+		datacenters:           datacenters,
+		clusterProviders:      clusterProviders,
+		newClusterProviders:   newClusterProviders,
+		sshKeyProvider:        sshKeyProvider,
+		newSSHKeyProvider:     newSSHKeyProvider,
+		userProvider:          userProvider,
+		projectProvider:       projectProvider,
+		cloudProviders:        cloudProviders,
+		logger:                log.NewLogfmtLogger(os.Stderr),
+		authenticator:         authenticator,
+		updateManager:         updateManager,
+		prometheusClient:      prometheusClient,
+		projectMemberProvider: projectMemberProvider,
 	}
 }
 

--- a/api/pkg/handler/routing_test.go
+++ b/api/pkg/handler/routing_test.go
@@ -60,6 +60,7 @@ func createTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.Dat
 	sshKeyProvider := kubernetes.NewSSHKeyProvider(kubermaticClient, kubermaticInformerFactory.Kubermatic().V1().UserSSHKeies().Lister(), IsAdmin)
 	newSSHKeyProvider := kubernetes.NewRBACCompliantSSHKeyProvider(fakeImpersonationClient, kubermaticInformerFactory.Kubermatic().V1().UserSSHKeies().Lister())
 	userProvider := kubernetes.NewUserProvider(kubermaticClient, kubermaticInformerFactory.Kubermatic().V1().Users().Lister())
+	projectMemberProvider := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, kubermaticInformerFactory.Kubermatic().V1().UserProjectBindings().Lister())
 	projectProvider, err := kubernetes.NewProjectProvider(fakeImpersonationClient, kubermaticInformerFactory.Kubermatic().V1().Projects().Lister())
 	if err != nil {
 		return nil, nil, err
@@ -107,6 +108,7 @@ func createTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.Dat
 		authenticator,
 		updateManager,
 		prometheusClient,
+		projectMemberProvider,
 	)
 	mainRouter := mux.NewRouter()
 	v1Router := mainRouter.PathPrefix("/api/v1").Subrouter()

--- a/api/pkg/handler/user_test.go
+++ b/api/pkg/handler/user_test.go
@@ -209,7 +209,6 @@ func TestAddUserToProject(t *testing.T) {
 		Name                        string
 		Body                        string
 		ExpectedResponse            string
-		ExpectedActions             int
 		ExpectedUserAfterInvitation *kubermaticapiv1.User
 		ProjectToSync               string
 		HTTPStatus                  int
@@ -271,7 +270,6 @@ func TestAddUserToProject(t *testing.T) {
 				Email: testUserEmail,
 			},
 			ExpectedResponse: `{"id":"bob","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"placeX","group":"editors-placeX"},{"id":"plan9","group":"editors-plan9"}]}`,
-			ExpectedActions:  10,
 			ExpectedUserAfterInvitation: &kubermaticapiv1.User{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bob",
@@ -347,7 +345,6 @@ func TestAddUserToProject(t *testing.T) {
 				Email: testUserEmail,
 			},
 			ExpectedResponse: `{"error":{"code":403,"message":"only the owner of the project can invite the other users"}}`,
-			ExpectedActions:  9,
 		},
 
 		{
@@ -404,7 +401,6 @@ func TestAddUserToProject(t *testing.T) {
 				Email: testUserEmail,
 			},
 			ExpectedResponse: `{"error":{"code":403,"message":"you can only assign the user to plan9 project"}}`,
-			ExpectedActions:  8,
 		},
 
 		{
@@ -461,7 +457,6 @@ func TestAddUserToProject(t *testing.T) {
 				Email: testUserEmail,
 			},
 			ExpectedResponse: `{"error":{"code":403,"message":"you cannot assign yourself to a different group"}}`,
-			ExpectedActions:  8,
 		},
 
 		{
@@ -518,7 +513,6 @@ func TestAddUserToProject(t *testing.T) {
 				Email: testUserEmail,
 			},
 			ExpectedResponse: `{"error":{"code":403,"message":"the given user cannot be assigned to owners group"}}`,
-			ExpectedActions:  8,
 		},
 
 		{
@@ -579,7 +573,6 @@ func TestAddUserToProject(t *testing.T) {
 				Email: testUserEmail,
 			},
 			ExpectedResponse: `{"error":{"code":400,"message":"cannot add the user = bob@acme.com to the project plan9 because user is already in the project"}}`,
-			ExpectedActions:  9,
 		},
 	}
 
@@ -609,19 +602,24 @@ func TestAddUserToProject(t *testing.T) {
 
 			kubermaticFakeClient := clients.fakeKubermaticClient
 			{
-				actions := kubermaticFakeClient.Actions()
-				if len(actions) != tc.ExpectedActions {
-					t.Fatalf("expected to get %d actions but got %d from fake kubermatic client, actions = %v", tc.ExpectedActions, len(actions), actions)
-				}
-
 				if tc.ExpectedUserAfterInvitation != nil {
-					updateAction, ok := actions[len(actions)-1].(clienttesting.CreateAction)
-					if !ok {
-
+					actionWasValidated := false
+					for _, action := range kubermaticFakeClient.Actions() {
+						if action.Matches("update", "users") {
+							updateAction, ok := action.(clienttesting.CreateAction)
+							if !ok {
+								t.Fatalf("unexpected action %#v", action)
+							}
+							updatedUser := updateAction.GetObject().(*kubermaticapiv1.User)
+							if !equality.Semantic.DeepEqual(updatedUser, tc.ExpectedUserAfterInvitation) {
+								t.Fatalf("%v", diff.ObjectDiff(updatedUser, tc.ExpectedUserAfterInvitation))
+							}
+							actionWasValidated = true
+							break
+						}
 					}
-					updatedUser := updateAction.GetObject().(*kubermaticapiv1.User)
-					if !equality.Semantic.DeepEqual(updatedUser, tc.ExpectedUserAfterInvitation) {
-						t.Fatalf("%v", diff.ObjectDiff(updatedUser, tc.ExpectedUserAfterInvitation))
+					if !actionWasValidated {
+						t.Fatal("update action was not validated, user resource was not updated ?")
 					}
 				}
 			}
@@ -774,11 +772,11 @@ func TestNewUser(t *testing.T) {
 	compareWithResult(t, res, expectedResponse)
 
 	actions := clientSet.fakeKubermaticClient.Actions()
-	if len(actions) != 10 {
+	if len(actions) != 12 {
 		t.Fatalf("expected to get exactly 10 action but got %d, actions = %v", len(actions), actions)
 	}
 
-	action := actions[9]
+	action := actions[11]
 	if !action.Matches("create", "users") {
 		t.Fatalf("unexpected action %#v", action)
 	}

--- a/api/pkg/provider/kubernetes/member.go
+++ b/api/pkg/provider/kubernetes/member.go
@@ -19,7 +19,7 @@ func NewProjectMemberProvider(createMasterImpersonatedClient kubermaticImpersona
 
 var _ provider.ProjectMemberProvider = &ProjectMemberProvider{}
 
-// ProjectMembersProvider binds users with projects
+// ProjectMemberProvider binds users with projects
 type ProjectMemberProvider struct {
 	// createMasterImpersonatedClient is used as a ground for impersonation
 	createMasterImpersonatedClient kubermaticImpersonationClient

--- a/api/pkg/provider/kubernetes/member.go
+++ b/api/pkg/provider/kubernetes/member.go
@@ -1,0 +1,122 @@
+package kubernetes
+
+import (
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// NewProjectMemberProvider returns a project members provider
+func NewProjectMemberProvider(createMasterImpersonatedClient kubermaticImpersonationClient, membersLister kubermaticv1lister.UserProjectBindingLister) *ProjectMemberProvider {
+	return &ProjectMemberProvider{
+		createMasterImpersonatedClient: createMasterImpersonatedClient,
+		membersLister:                  membersLister,
+	}
+}
+
+var _ provider.ProjectMemberProvider = &ProjectMemberProvider{}
+
+// ProjectMembersProvider binds users with projects
+type ProjectMemberProvider struct {
+	// createMasterImpersonatedClient is used as a ground for impersonation
+	createMasterImpersonatedClient kubermaticImpersonationClient
+
+	// membersLister local cache that stores bindings for members and projects
+	membersLister kubermaticv1lister.UserProjectBindingLister
+}
+
+// Create creates a binding for the given member and the given project
+func (p *ProjectMemberProvider) Create(userInfo *provider.UserInfo, project *kubermaticapiv1.Project, memberEmail, group string) (*kubermaticapiv1.UserProjectBinding, error) {
+	binding := &kubermaticapiv1.UserProjectBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
+					Kind:       kubermaticapiv1.ProjectKindName,
+					UID:        project.GetUID(),
+					Name:       project.Name,
+				},
+			},
+		},
+		Spec: kubermaticapiv1.UserProjectBindingSpec{
+			ProjectID: project.Name,
+			UserEmail: memberEmail,
+			Group:     group,
+		},
+	}
+
+	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+	if err != nil {
+		return nil, err
+	}
+	return masterImpersonatedClient.UserProjectBindings().Create(binding)
+}
+
+// List gets all members of the given project
+func (p *ProjectMemberProvider) List(userInfo *provider.UserInfo, project *kubermaticapiv1.Project, options *provider.ProjectMemberListOptions) ([]*kubermaticapiv1.UserProjectBinding, error) {
+	allMembers, err := p.membersLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	projectMembers := []*kubermaticapiv1.UserProjectBinding{}
+	for _, member := range allMembers {
+		if member.Spec.ProjectID == project.Name {
+			projectMembers = append(projectMembers, member)
+		}
+	}
+
+	// Note:
+	// After we get the list of members we try to get at least one item using unprivileged account to see if the user have read access
+	if len(projectMembers) > 0 {
+		masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+		if err != nil {
+			return nil, err
+		}
+
+		memberToGet := projectMembers[0]
+		_, err = masterImpersonatedClient.UserProjectBindings().Get(memberToGet.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if options == nil {
+		return projectMembers, nil
+	}
+
+	filteredMembers := []*kubermaticapiv1.UserProjectBinding{}
+	if options != nil {
+		for _, member := range projectMembers {
+			if member.Spec.UserEmail == options.MemberEmail {
+				filteredMembers = append(filteredMembers, member)
+				break
+			}
+		}
+	}
+
+	return filteredMembers, nil
+}
+
+// Delete simply deletes the given binding
+// Note:
+// Use List to get binding for the specific member of the given project
+func (p *ProjectMemberProvider) Delete(userInfo *provider.UserInfo, bindinName string) error {
+	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+	if err != nil {
+		return err
+	}
+	return masterImpersonatedClient.UserProjectBindings().Delete(bindinName, &metav1.DeleteOptions{})
+}
+
+// Update simply updates the given binding
+func (p *ProjectMemberProvider) Update(userInfo *provider.UserInfo, binding *kubermaticapiv1.UserProjectBinding) (*kubermaticapiv1.UserProjectBinding, error) {
+	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+	if err != nil {
+		return nil, err
+	}
+	return masterImpersonatedClient.UserProjectBindings().Update(binding)
+}

--- a/api/pkg/provider/kubernetes/member_test.go
+++ b/api/pkg/provider/kubernetes/member_test.go
@@ -1,0 +1,221 @@
+package kubernetes_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-test/deep"
+
+	kubermaticfakeclentset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
+	kubermaticclientv1 "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/typed/kubermatic/v1"
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
+
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestCreateBinding(t *testing.T) {
+	// test data
+	kubermaticObjects := []runtime.Object{}
+	impersonationClient, _, bindingLister, err := createFakeClients(kubermaticObjects)
+	if err != nil {
+		t.Fatalf("unable to create fake clients, err = %v", err)
+	}
+	authenticatedUser := createAuthenitactedUser()
+	existingProject := createProject("abcd")
+	memberEmail := ""
+	groupName := fmt.Sprintf("owners-%s", existingProject.Name)
+
+	// act
+	target := kubernetes.NewProjectMemberProvider(impersonationClient.CreateFakeImpersonatedClientSet, bindingLister)
+	result, err := target.Create(&provider.UserInfo{Email: authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", existingProject.Name)}, existingProject, memberEmail, groupName)
+
+	// validate
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil {
+
+	}
+	if result.Spec.Group != groupName {
+		t.Fatalf("unexpected result returned, expected %s, got %s", groupName, result.Spec.Group)
+	}
+	if result.Spec.UserEmail != memberEmail {
+		t.Fatalf("unexpected result returned, expected %s, got %s", memberEmail, result.Spec.UserEmail)
+	}
+	if result.Spec.ProjectID != existingProject.Name {
+		t.Fatalf("unexpected result returned, expected %s, got %s", existingProject.Name, result.Spec.ProjectID)
+	}
+}
+
+func TestListBinding(t *testing.T) {
+	// test data
+	testcases := []struct {
+		name              string
+		authenticatedUser *kubermaticv1.User
+		projectToSync     *kubermaticv1.Project
+		existingBindings  []*kubermaticv1.UserProjectBinding
+		expectedBindings  []*kubermaticv1.UserProjectBinding
+	}{
+		{
+			name:              "scenario 1: list bindings for the given project",
+			authenticatedUser: createAuthenitactedUser(),
+			projectToSync:     createProject("1234"),
+			existingBindings: []*kubermaticv1.UserProjectBinding{
+				&kubermaticv1.UserProjectBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "abcdBinding",
+					},
+					Spec: kubermaticv1.UserProjectBindingSpec{
+						ProjectID: createProject("1234").Name,
+						UserEmail: "bob@acme.com",
+						Group:     fmt.Sprintf("owners-%s", createProject("123").Name),
+					},
+				},
+
+				&kubermaticv1.UserProjectBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cdBinding",
+					},
+					Spec: kubermaticv1.UserProjectBindingSpec{
+						ProjectID: createProject("1234").Name,
+						UserEmail: "bob@acme.com",
+						Group:     fmt.Sprintf("owners-%s", createProject("123").Name),
+					},
+				},
+
+				&kubermaticv1.UserProjectBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "differentProjectBinding",
+					},
+					Spec: kubermaticv1.UserProjectBindingSpec{
+						ProjectID: createProject("abcd").Name,
+						UserEmail: "bob@acme.com",
+						Group:     fmt.Sprintf("owners-%s", createProject("abcd").Name),
+					},
+				},
+			},
+			expectedBindings: []*kubermaticv1.UserProjectBinding{
+				&kubermaticv1.UserProjectBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "abcdBinding",
+					},
+					Spec: kubermaticv1.UserProjectBindingSpec{
+						ProjectID: createProject("1234").Name,
+						UserEmail: "bob@acme.com",
+						Group:     fmt.Sprintf("owners-%s", createProject("123").Name),
+					},
+				},
+				&kubermaticv1.UserProjectBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cdBinding",
+					},
+					Spec: kubermaticv1.UserProjectBindingSpec{
+						ProjectID: createProject("1234").Name,
+						UserEmail: "bob@acme.com",
+						Group:     fmt.Sprintf("owners-%s", createProject("123").Name),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			kubermaticObjects := []runtime.Object{}
+			for _, binding := range tc.existingBindings {
+				kubermaticObjects = append(kubermaticObjects, binding)
+			}
+
+			impersonationClient, _, bindingLister, err := createFakeClients(kubermaticObjects)
+			if err != nil {
+				t.Fatalf("unable to create fake clients, err = %v", err)
+			}
+
+			// act
+			target := kubernetes.NewProjectMemberProvider(impersonationClient.CreateFakeImpersonatedClientSet, bindingLister)
+			result, err := target.List(&provider.UserInfo{Email: tc.authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", tc.projectToSync.Name)}, tc.projectToSync, nil)
+
+			// validate
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tc.expectedBindings) != len(result) {
+				t.Fatalf("expected to get %d bindings, but got %d", len(tc.expectedBindings), len(result))
+			}
+			for _, returnedBinding := range result {
+				bindingFound := false
+				for _, expectedBinding := range tc.expectedBindings {
+					if diff := deep.Equal(returnedBinding, expectedBinding); diff == nil {
+						bindingFound = true
+						break
+					}
+				}
+				if !bindingFound {
+					t.Fatalf("returned binding was not found on the list of expected ones, binding = %#v", returnedBinding)
+				}
+			}
+		})
+	}
+}
+
+// fakeImpersonationClient gives kubermatic client set that uses user impersonation
+type FakeImpersonationClient struct {
+	kubermaticClent *kubermaticfakeclentset.Clientset
+}
+
+func (f *FakeImpersonationClient) CreateFakeImpersonatedClientSet(impCfg restclient.ImpersonationConfig) (kubermaticclientv1.KubermaticV1Interface, error) {
+	return f.kubermaticClent.KubermaticV1(), nil
+}
+
+func createFakeClients(kubermaticObjects []runtime.Object) (*FakeImpersonationClient, *kubermaticfakeclentset.Clientset, kubermaticv1lister.UserProjectBindingLister, error) {
+	kubermaticClient := kubermaticfakeclentset.NewSimpleClientset(kubermaticObjects...)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, obj := range kubermaticObjects {
+		err := indexer.Add(obj)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	lister := kubermaticv1lister.NewUserProjectBindingLister(indexer)
+
+	return &FakeImpersonationClient{kubermaticClient}, kubermaticClient, lister, nil
+}
+
+func createAuthenitactedUser() *kubermaticv1.User {
+	testUserID := "1233"
+	testUserName := "user1"
+	testUserEmail := "john@acme.com"
+	return &kubermaticv1.User{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: kubermaticv1.UserSpec{
+			Name:  testUserName,
+			ID:    testUserID,
+			Email: testUserEmail,
+		},
+	}
+
+}
+
+func createProject(name string) *kubermaticv1.Project {
+	return &kubermaticv1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "kubermatic.io/v1",
+					Kind:       "User",
+					UID:        "",
+					Name:       "my-first-project",
+				},
+			},
+		},
+		Spec: kubermaticv1.ProjectSpec{Name: "my-first-project"},
+	}
+}

--- a/api/pkg/provider/kubernetes/project.go
+++ b/api/pkg/provider/kubernetes/project.go
@@ -100,7 +100,7 @@ func (p *ProjectProvider) Delete(user *kubermaticapiv1.User, projectInternalName
 	if user == nil {
 		return errors.New("a user is missing but required")
 	}
-	masterImpersonatedClient, err := p.createMasterImpersonationClientWrapper(user, projectInternalName)
+	masterImpersonatedClient, err := createImpersonationClientWrapper(user, projectInternalName, p.createMasterImpersonatedClient)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func (p *ProjectProvider) Get(user *kubermaticapiv1.User, projectInternalName st
 	if user == nil {
 		return nil, errors.New("a user is missing but required")
 	}
-	masterImpersonatedClient, err := p.createMasterImpersonationClientWrapper(user, projectInternalName)
+	masterImpersonatedClient, err := createImpersonationClientWrapper(user, projectInternalName, p.createMasterImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
@@ -134,22 +134,6 @@ func (p *ProjectProvider) Get(user *kubermaticapiv1.User, projectInternalName st
 		return nil, kerrors.NewServiceUnavailable("Project is not initialized yet")
 	}
 	return project, nil
-}
-
-// createMasterImpersonationClientWrapper is a helper method that spits back kubermatic client that uses user impersonation
-func (p *ProjectProvider) createMasterImpersonationClientWrapper(user *kubermaticapiv1.User, projectInternalName string) (kubermaticclientv1.KubermaticV1Interface, error) {
-	if user == nil || len(projectInternalName) == 0 {
-		return nil, errors.New("a project and/or a user is missing but required")
-	}
-	groupName, err := user.GroupForProject(projectInternalName)
-	if err != nil {
-		return nil, kerrors.NewForbidden(schema.GroupResource{}, projectInternalName, err)
-	}
-	impersonationCfg := restclient.ImpersonationConfig{
-		UserName: user.Spec.Email,
-		Groups:   []string{groupName},
-	}
-	return p.createMasterImpersonatedClient(impersonationCfg)
 }
 
 // NewKubermaticImpersonationClient creates a new default impersonation client

--- a/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
+++ b/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 
-	kubermaticclientv1 "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/typed/kubermatic/v1"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -14,11 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -79,7 +76,7 @@ func (p *RBACCompliantClusterProvider) New(project *kubermaticapiv1.Project, use
 		Address: kubermaticapiv1.ClusterAddress{},
 	}
 
-	seedImpersonatedClient, err := p.createSeedImpersonationClientWrapper(user, project)
+	seedImpersonatedClient, err := createImpersonationClientWrapper(user, project.Name, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +136,7 @@ func (p *RBACCompliantClusterProvider) List(project *kubermaticapiv1.Project, op
 
 // Get returns the given cluster, it uses the projectInternalName to determine the group the user belongs to
 func (p *RBACCompliantClusterProvider) Get(user *kubermaticapiv1.User, project *kubermaticapiv1.Project, clusterName string, options *provider.ClusterGetOptions) (*kubermaticapiv1.Cluster, error) {
-	seedImpersonatedClient, err := p.createSeedImpersonationClientWrapper(user, project)
+	seedImpersonatedClient, err := createImpersonationClientWrapper(user, project.Name, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +160,7 @@ func (p *RBACCompliantClusterProvider) Get(user *kubermaticapiv1.User, project *
 
 // Delete deletes the given cluster
 func (p *RBACCompliantClusterProvider) Delete(user *kubermaticapiv1.User, project *kubermaticapiv1.Project, clusterName string) error {
-	seedImpersonatedClient, err := p.createSeedImpersonationClientWrapper(user, project)
+	seedImpersonatedClient, err := createImpersonationClientWrapper(user, project.Name, p.createSeedImpersonatedClient)
 	if err != nil {
 		return err
 	}
@@ -173,7 +170,7 @@ func (p *RBACCompliantClusterProvider) Delete(user *kubermaticapiv1.User, projec
 
 // Update updates a cluster
 func (p *RBACCompliantClusterProvider) Update(user *kubermaticapiv1.User, project *kubermaticapiv1.Project, newCluster *kubermaticapiv1.Cluster) (*kubermaticapiv1.Cluster, error) {
-	seedImpersonatedClient, err := p.createSeedImpersonationClientWrapper(user, project)
+	seedImpersonatedClient, err := createImpersonationClientWrapper(user, project.Name, p.createSeedImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
@@ -203,22 +200,6 @@ func (p *RBACCompliantClusterProvider) GetMachineClientForCustomerCluster(c *kub
 // Note that the client you will get has admin privileges
 func (p *RBACCompliantClusterProvider) GetKubernetesClientForCustomerCluster(c *kubermaticapiv1.Cluster) (kubernetes.Interface, error) {
 	return p.userClusterConnProvider.GetClient(c)
-}
-
-// createSeedImpersonationClientWrapper is a helper method that spits back kubermatic client that uses user impersonation
-func (p *RBACCompliantClusterProvider) createSeedImpersonationClientWrapper(user *kubermaticapiv1.User, project *kubermaticapiv1.Project) (kubermaticclientv1.KubermaticV1Interface, error) {
-	if user == nil || project == nil {
-		return nil, errors.New("user and/or project is missing but required")
-	}
-	groupName, err := user.GroupForProject(project.Name)
-	if err != nil {
-		return nil, kerrors.NewForbidden(schema.GroupResource{}, project.Name, err)
-	}
-	impersonationCfg := restclient.ImpersonationConfig{
-		UserName: user.Spec.Email,
-		Groups:   []string{groupName},
-	}
-	return p.createSeedImpersonatedClient(impersonationCfg)
 }
 
 // sortBy sort the given clusters by the specified field name (sortBy param)

--- a/api/pkg/provider/kubernetes/util.go
+++ b/api/pkg/provider/kubernetes/util.go
@@ -2,6 +2,14 @@ package kubernetes
 
 import (
 	"errors"
+
+	kubermaticclientv1 "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/typed/kubermatic/v1"
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	restclient "k8s.io/client-go/rest"
 )
 
 const (
@@ -17,4 +25,30 @@ var (
 // NamespaceName returns the namespace name for a cluster
 func NamespaceName(clusterName string) string {
 	return NamespacePrefix + clusterName
+}
+
+// createImpersonationClientWrapper is a helper method that spits back kubermatic client that uses user impersonation
+func createImpersonationClientWrapper(user *kubermaticapiv1.User, projectInternalName string, createImpersonationClient kubermaticImpersonationClient) (kubermaticclientv1.KubermaticV1Interface, error) {
+	if user == nil || len(projectInternalName) == 0 {
+		return nil, errors.New("a project and/or a user is missing but required")
+	}
+	groupName, err := user.GroupForProject(projectInternalName)
+	if err != nil {
+		return nil, kerrors.NewForbidden(schema.GroupResource{}, projectInternalName, err)
+	}
+	impersonationCfg := restclient.ImpersonationConfig{
+		UserName: user.Spec.Email,
+		Groups:   []string{groupName},
+	}
+	return createImpersonationClient(impersonationCfg)
+}
+
+// createImpersonationClientWrapperFromUserInfo is a helper method that spits back kubermatic client that uses user impersonation
+func createImpersonationClientWrapperFromUserInfo(userInfo *provider.UserInfo, createImpersonationClient kubermaticImpersonationClient) (kubermaticclientv1.KubermaticV1Interface, error) {
+	impersonationCfg := restclient.ImpersonationConfig{
+		UserName: userInfo.Email,
+		Groups:   []string{userInfo.Group},
+	}
+
+	return createImpersonationClient(impersonationCfg)
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -221,7 +221,7 @@ type ProjectMemberListOptions struct {
 	MemberEmail string
 }
 
-// ProjectMembersProvider binds users with projects
+// ProjectMemberProvider binds users with projects
 type ProjectMemberProvider interface {
 	// Create creates a binding for the given member and the given project
 	Create(userInfo *UserInfo, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error)

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -209,6 +209,35 @@ type ProjectProvider interface {
 	Get(user *kubermaticv1.User, projectInternalName string, options *ProjectGetOptions) (*kubermaticv1.Project, error)
 }
 
+// UserInfo represent authenticated user
+type UserInfo struct {
+	Email string
+	Group string
+}
+
+// ProjectMemberListOptions allows to set filters that will be applied to filter the result.
+type ProjectMemberListOptions struct {
+	// MemberEmail set the email address of a member for the given project
+	MemberEmail string
+}
+
+// ProjectMembersProvider binds users with projects
+type ProjectMemberProvider interface {
+	// Create creates a binding for the given member and the given project
+	Create(userInfo *UserInfo, project *kubermaticv1.Project, memberEmail, group string) (*kubermaticv1.UserProjectBinding, error)
+
+	// List gets all members of the given project
+	List(userInfo *UserInfo, project *kubermaticv1.Project, options *ProjectMemberListOptions) ([]*kubermaticv1.UserProjectBinding, error)
+
+	// Delete simply deletes the given binding
+	// Note:
+	// Use List to get binding for the specific member of the given project
+	Delete(userInfo *UserInfo, bindinName string) error
+
+	// Update simply updates the given binding
+	Update(userInfo *UserInfo, binding *kubermaticv1.UserProjectBinding) (*kubermaticv1.UserProjectBinding, error)
+}
+
 // ClusterCloudProviderName returns the provider name for the given CloudSpec.
 func ClusterCloudProviderName(spec kubermaticv1.CloudSpec) (string, error) {
 	var clouds []string


### PR DESCRIPTION
**What this PR does / why we need it**: adds a new provider. the provider will be used by HTTP endpoints and makes sure that connection to kube-API server is maintained as user bob that
belongs to owners group. The provider allow us to manage members of a given project.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
#1966

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
