### PR TITLE
disables flaky TestGetUsersForProject

### DIFF
--- a/api/pkg/handler/user_test.go
+++ b/api/pkg/handler/user_test.go
@@ -36,6 +36,7 @@ var plan9 = &kubermaticapiv1.Project{
 }
 
 func TestGetUsersForProject(t *testing.T) {
+	t.SkipNow()
 	testcases := []struct {
 		Name                        string
 		ExpectedResponse            string


### PR DESCRIPTION
**What this PR does / why we need it**: temporary disables a flaky test. 

**Special notes for your reviewer**:
Will be fixed in https://github.com/kubermatic/kubermatic/pull/1968

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
