### PR TITLE
Always set a higher timeout for nodeport proxy lb on aws

### DIFF
--- a/config/nodeport-proxy/templates/lb.yaml
+++ b/config/nodeport-proxy/templates/lb.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nodeport-lb
   annotations:
     "helm.sh/resource-policy": keep
+    "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "600"
 spec:
   selector:
     app: nodeport-proxy

--- a/config/nodeport-proxy/templates/lb.yaml
+++ b/config/nodeport-proxy/templates/lb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nodeport-lb
   annotations:
     "helm.sh/resource-policy": keep
-    "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "600"
+    "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600"  # On AWS default timeout is 60s, which means: kubectl logs -f will recieve EOF after 60s.
 spec:
   selector:
     app: nodeport-proxy


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases the nodeport proxy lb timeout so users can execute kubectl logs on aws nodes without running into timeouts every 60s

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Increased kubectl timeouts on aws 
```
