### PR TITLE
Update dex to 2.11.0

### DIFF
--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -1,8 +1,8 @@
 ##### Kubermatic oauth
 dex:
   image:
-    repository: "quay.io/coreos/dex"
-    tag: "v2.10.0"
+    repository: "quay.io/dexidp/dex"
+    tag: "v2.11.0"
   replicas: 1
   ingress:
     host: ""


### PR DESCRIPTION
**What this PR does / why we need it**: 
Update dex to 2.11.0

Release notes https://github.com/dexidp/dex/releases/tag/v2.11.0

Also for 2.11.0 the organization changed from coreos to dexip, so the repository needed to be adapted.

2.11.0 is tested and works well in our setups.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update dex to 2.11.0
```
