### PR TITLE
prevents owner of the project deletion

### DIFF
--- a/api/pkg/handler/user.go
+++ b/api/pkg/handler/user.go
@@ -47,7 +47,12 @@ func deleteMemberFromProject(projectProvider provider.ProjectProvider, userProvi
 			return nil, k8cerrors.New(http.StatusInternalServerError, fmt.Sprintf("cannot delete the user user %s from the project, inconsistent state in database", user.Spec.Email))
 		}
 
-		err = memberProvider.Delete(userInfo, memberList[0].Name)
+		bindingForRequestedMember := memberList[0]
+		if bindingForRequestedMember.Spec.UserEmail == userInfo.Email {
+			return nil, k8cerrors.New(http.StatusForbidden, "you cannot delete yourself from the project")
+		}
+
+		err = memberProvider.Delete(userInfo, bindingForRequestedMember.Name)
 		if err != nil {
 			return nil, kubernetesErrorToHTTPError(err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: prevents owner of the project deletion, owner of the project cannot remove himself from the project.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
