### PR TITLE
fix e2e testing

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -125,13 +125,23 @@ local drone = import 'drone/drone.libsonnet';
     } + whenEventTag,
 
     // e2e
-    '6-kubermatic-e2e-docker-push': drone.step.docker.new('quay.io/kubermatic/e2e') + {
+    '6-kubermatic-e2e-docker-push-on-master': drone.step.docker.new('quay.io/kubermatic/e2e') + {
       secrets: [
         { source: 'docker_quay_username', target: 'docker_username' },
         { source: 'docker_quay_password', target: 'docker_password' },
       ],
       dockerfile: 'api/Dockerfile.e2e',
-      tags: ['${DRONE_TAG}', 'latest'],
+      tags: ['latest'],
+      context: 'api',
+    } + whenBranchMaster,
+
+    '6-kubermatic-e2e-docker-push-on-tag': drone.step.docker.new('quay.io/kubermatic/e2e') + {
+      secrets: [
+        { source: 'docker_quay_username', target: 'docker_username' },
+        { source: 'docker_quay_password', target: 'docker_password' },
+      ],
+      dockerfile: 'api/Dockerfile.e2e',
+      tags: ['${DRONE_TAG}'],
       context: 'api',
     } + whenEventTag,
 

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -228,7 +228,8 @@ local drone = import 'drone/drone.libsonnet';
 
     // run e2e tests
     '10-e2e-on-master': drone.step.new('quay.io/kubermatic/e2e:latest') + e2eStep + whenBranchMaster,
-    '10-e2e-on-tag': drone.step.new('quay.io/kubermatic/e2e:${DRONE_TAG}') + e2eStep + whenEventTag,
+    // the default value 'no_such_tag' will prevent YAML parsing error on non-tag builds
+    '10-e2e-on-tag': drone.step.new('quay.io/kubermatic/e2e:${DRONE_TAG=no_such_tag}') + e2eStep + whenEventTag,
 
     // Slack
     '11-slack': drone.step.new('kubermaticbot/drone-slack', group='slack') + {

--- a/.drone.yml
+++ b/.drone.yml
@@ -102,7 +102,22 @@ pipeline:
     when:
       event:
       - tag
-  6-kubermatic-e2e-docker-push:
+  6-kubermatic-e2e-docker-push-on-master:
+    context: api
+    dockerfile: api/Dockerfile.e2e
+    image: plugins/docker
+    pull: true
+    repo: quay.io/kubermatic/e2e
+    secrets:
+    - source: docker_quay_username
+      target: docker_username
+    - source: docker_quay_password
+      target: docker_password
+    tags:
+    - latest
+    when:
+      branch: master
+  6-kubermatic-e2e-docker-push-on-tag:
     context: api
     dockerfile: api/Dockerfile.e2e
     image: plugins/docker
@@ -115,7 +130,6 @@ pipeline:
       target: docker_password
     tags:
     - ${DRONE_TAG}
-    - latest
     when:
       event:
       - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -395,7 +395,7 @@ pipeline:
     - echo "$NODE_YAML" > /tmp/node.yaml
     - /kubermatic-e2e -kubeconfig=/tmp/kubeconfig -kubermatic-cluster=/tmp/cluster.yaml
       -kubermatic-node=/tmp/node.yaml
-    image: "quay.io/kubermatic/e2e:${DRONE_TAG}"
+    image: quay.io/kubermatic/e2e:${DRONE_TAG=no_such_tag}
     pull: true
     secrets:
     - source: kubeconfig_dev

--- a/.drone.yml
+++ b/.drone.yml
@@ -325,6 +325,9 @@ pipeline:
     - name: certs
       namespace: default
       path: config/certs/
+    - name: iap
+      namespace: iap
+      path: config/iap/
     - name: node-exporter
       namespace: monitoring
       path: config/monitoring/node-exporter/

--- a/.drone.yml
+++ b/.drone.yml
@@ -395,7 +395,7 @@ pipeline:
     - echo "$NODE_YAML" > /tmp/node.yaml
     - /kubermatic-e2e -kubeconfig=/tmp/kubeconfig -kubermatic-cluster=/tmp/cluster.yaml
       -kubermatic-node=/tmp/node.yaml
-    image: quay.io/kubermatic/e2e:${DRONE_TAG}
+    image: "quay.io/kubermatic/e2e:${DRONE_TAG}"
     pull: true
     secrets:
     - source: kubeconfig_dev

--- a/.drone.yml
+++ b/.drone.yml
@@ -370,14 +370,14 @@ pipeline:
     - values
     when:
       branch: release/v2.7.*
-  10-e2e:
+  10-e2e-on-master:
     commands:
     - echo "$KUBECONFIG" | base64 -d > /tmp/kubeconfig
     - echo "$CLUSTER_YAML" > /tmp/cluster.yaml
     - echo "$NODE_YAML" > /tmp/node.yaml
     - /kubermatic-e2e -kubeconfig=/tmp/kubeconfig -kubermatic-cluster=/tmp/cluster.yaml
       -kubermatic-node=/tmp/node.yaml
-    image: quay.io/kubermatic/e2e
+    image: quay.io/kubermatic/e2e:latest
     pull: true
     secrets:
     - source: kubeconfig_dev
@@ -388,6 +388,25 @@ pipeline:
       target: node_yaml
     when:
       branch: master
+  10-e2e-on-tag:
+    commands:
+    - echo "$KUBECONFIG" | base64 -d > /tmp/kubeconfig
+    - echo "$CLUSTER_YAML" > /tmp/cluster.yaml
+    - echo "$NODE_YAML" > /tmp/node.yaml
+    - /kubermatic-e2e -kubeconfig=/tmp/kubeconfig -kubermatic-cluster=/tmp/cluster.yaml
+      -kubermatic-node=/tmp/node.yaml
+    image: quay.io/kubermatic/e2e:${DRONE_TAG}
+    pull: true
+    secrets:
+    - source: kubeconfig_dev
+      target: kubeconfig
+    - source: aws_1.10.5_cluster_yaml
+      target: cluster_yaml
+    - source: aws_1.10.5_node_yaml
+      target: node_yaml
+    when:
+      event:
+      - tag
   11-slack:
     channel: dev
     group: slack

--- a/api/Dockerfile.e2e
+++ b/api/Dockerfile.e2e
@@ -2,7 +2,7 @@ FROM alpine:3.7 AS builder
 
 LABEL maintainer "artiom@loodse.com"
 
-ENV KUBE_VERSION=v1.10.5
+ENV KUBE_VERSION=v1.10.7
 ENV KUBE_TEST_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes-test.tar.gz
 ENV KUBE_TEST_CHECKSUM=7b2d0d8bf474c35ed30d89b00f601f2ccfa49ad3
 ENV KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl


### PR DESCRIPTION
**What this PR does / why we need it**:
* First of all, the way CI pipeline was configured so far, we built the e2e image on every release, but we used it on master. This made it difficult to control the testing for master branch. Now, master and tags will all build their own images and use them themselves.
* Second of all, bumped kubernetes e2e runner version to `v1.10.7`, since we're experiencing problems with retrieving logs which fails the tests, and I think kubernetes/kubernetes#64931 might fix it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
