### PR TITLE
Prevent kubeconfig recreation with orgs

### DIFF
--- a/api/pkg/resources/kubeconfig.go
+++ b/api/pkg/resources/kubeconfig.go
@@ -80,7 +80,7 @@ func GetInternalKubeconfigCreator(name, commonName string, organizations []strin
 		}
 
 		b := se.Data[KubeconfigSecretKey]
-		valid, err := isValidKubeconfig(b, ca.Cert, url.String(), commonName, data.Cluster().Name)
+		valid, err := isValidKubeconfig(b, ca.Cert, url.String(), commonName, organizations, data.Cluster().Name)
 		if err != nil || !valid {
 			if err != nil {
 				glog.V(2).Infof("failed to validate existing kubeconfig from %s/%s %v. Regenerating it...", se.Namespace, se.Name, err)
@@ -146,7 +146,7 @@ func getBaseKubeconfig(caCert *x509.Certificate, server, clusterName string) *cl
 	}
 }
 
-func isValidKubeconfig(kubeconfigBytes []byte, caCert *x509.Certificate, server, commonName, clusterName string) (bool, error) {
+func isValidKubeconfig(kubeconfigBytes []byte, caCert *x509.Certificate, server, commonName string, organizations []string, clusterName string) (bool, error) {
 	if len(kubeconfigBytes) == 0 {
 		return false, nil
 	}
@@ -176,7 +176,7 @@ func isValidKubeconfig(kubeconfigBytes []byte, caCert *x509.Certificate, server,
 		return false, err
 	}
 
-	if !IsClientCertificateValidForAllOf(certs[0], commonName, nil) {
+	if !IsClientCertificateValidForAllOf(certs[0], commonName, organizations) {
 		return false, nil
 	}
 

--- a/api/pkg/resources/kubeconfig_test.go
+++ b/api/pkg/resources/kubeconfig_test.go
@@ -74,17 +74,17 @@ func TestGetInternalKubeconfigCreatorWithOrgs(t *testing.T) {
 	checkKubeConfigRegeneration(t, []string{"org1", "org2"})
 }
 
-// FakeDataProvider provides just enough for testing kubeconfig creation.
-type FakeDataProvider struct {
+// fakeDataProvider provides just enough for testing kubeconfig creation.
+type fakeDataProvider struct {
 	caPair *triple.KeyPair
 }
 
-func (fake *FakeDataProvider) Cluster() *kubermaticv1.Cluster            { return &kubermaticv1.Cluster{} }
-func (fake *FakeDataProvider) ExternalIP() (*net.IP, error)              { return nil, nil }
-func (fake *FakeDataProvider) GetClusterRef() metav1.OwnerReference      { return metav1.OwnerReference{} }
-func (fake *FakeDataProvider) GetFrontProxyCA() (*triple.KeyPair, error) { return nil, nil }
-func (fake *FakeDataProvider) GetRootCA() (*triple.KeyPair, error)       { return fake.caPair, nil }
-func (fake *FakeDataProvider) InClusterApiserverURL() (*url.URL, error)  { return &url.URL{}, nil }
+func (fake *fakeDataProvider) Cluster() *kubermaticv1.Cluster            { return &kubermaticv1.Cluster{} }
+func (fake *fakeDataProvider) ExternalIP() (*net.IP, error)              { return nil, nil }
+func (fake *fakeDataProvider) GetClusterRef() metav1.OwnerReference      { return metav1.OwnerReference{} }
+func (fake *fakeDataProvider) GetFrontProxyCA() (*triple.KeyPair, error) { return nil, nil }
+func (fake *fakeDataProvider) GetRootCA() (*triple.KeyPair, error)       { return fake.caPair, nil }
+func (fake *fakeDataProvider) InClusterApiserverURL() (*url.URL, error)  { return &url.URL{}, nil }
 
 func checkKubeConfigRegeneration(t *testing.T, orgs []string) {
 	// get a ca for testing and setup fake data
@@ -92,7 +92,7 @@ func checkKubeConfigRegeneration(t *testing.T, orgs []string) {
 	if err != nil {
 		t.Fatalf("Failed to generate test root ca: %v", err)
 	}
-	data := &FakeDataProvider{caPair: ca}
+	data := &fakeDataProvider{caPair: ca}
 	assert.NotNil(t, data)
 
 	create := GetInternalKubeconfigCreator("test-creator", "test-creator-cn", orgs)

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -439,7 +439,8 @@ func IsServerCertificateValidForAllOf(cert *x509.Certificate, commonName string,
 	return wantDNSNames.Equal(certDNSNames)
 }
 
-// IsClientCertificateValidForAllOf validates if the given data is present in the given client certificate
+// IsClientCertificateValidForAllOf validates if the given data matches exactly the given client certificate
+// (It also returns true if all given data is in the cert, but the cert has more organizations)
 func IsClientCertificateValidForAllOf(cert *x509.Certificate, commonName string, organizations []string) bool {
 	if CertWillExpireSoon(cert) {
 		return false


### PR DESCRIPTION
**What this PR does / why we need it**:

GetInternalKubeconfigCreator always regenerates a kubeconfig when organizations are used. This PR adds a test which checks that no regeneration happens when not necessary.
This PR also fixes the actual issue with GetInternalKubeconfigCreator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
