### PR TITLE
Update machine controller to v0.7.22

### DIFF
--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -14,7 +14,7 @@ import (
 const (
 	name = "machine-controller"
 
-	tag = "v0.7.21"
+	tag = "v0.7.22"
 )
 
 // Deployment returns the machine-controller Deployment
@@ -101,7 +101,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 				"-cluster-dns", clusterDNSIP,
 				"-internal-listen-address", "0.0.0.0:8085",
 			},
-			Env: getEnvVars(data),
+			Env:                      getEnvVars(data),
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 			ReadinessProbe: &corev1.Probe{

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -101,7 +101,7 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 				"-cluster-dns", clusterDNSIP,
 				"-internal-listen-address", "0.0.0.0:8085",
 			},
-			Env:                      getEnvVars(data),
+			Env: getEnvVars(data),
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 			ReadinessProbe: &corev1.Probe{

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -44,7 +44,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -47,7 +47,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.7.21
+        image: docker.io/kubermatic/machine-controller:v0.7.22
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8


### PR DESCRIPTION
**What this PR does / why we need it**:
Update machine controller to v0.7.22.
Includes a improvement for OpenStack FloatingIP assignment.

**Release note**:
```release-note
Updated machine-controller to `v0.7.22`
```
