### PR TITLE
Update supported kubernetes versions

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -1,13 +1,9 @@
 updates:
 # ======= 1.8 =======
-# Allow to change to any patch version
-- from: 1.8.*
-  to: 1.8.*
-  automatic: false
 # Allow to next minor release
 - from: 1.8.*
   to: 1.9.0
-  automatic: false
+  automatic: true
 
 # ======= 1.9 =======
 # Allow to change to any patch version

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,66 +1,10 @@
-# We support 1.8,1.9,1.10 & kubernetes is able to handle the whole matrix of those versions
+# We support 1.9,1.10,1.11 & kubernetes is able to handle the whole matrix of those versions
 allowed-node-versions: &node-versions
-- "1.8.*"
-- "1.9.*"
-- "1.10.*"
-
-allowed-node-versions-1-11: &node-versions-1-11
 - "1.9.*"
 - "1.10.*"
 - "1.11.*"
 
 versions:
-# Kubernetes 1.8
-- version: "1.8.0"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.1"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.2"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.3"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.4"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.5"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.6"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.7"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.8"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.9"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.10"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.11"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.12"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.13"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.8.14"
-  default: false
-  allowedNodeVersions: *node-versions
-# Broken -> https://github.com/kubernetes/kubeadm/issues/1039
-#- version: "1.8.15"
-#  default: false
-#  allowedNodeVersions: *node-versions
-# Kubernetes 1.9
 - version: "1.9.0"
   default: false
   allowedNodeVersions: *node-versions
@@ -116,11 +60,22 @@ versions:
 - version: "1.10.6"
   default: true
   allowedNodeVersions: *node-versions
+- version: "1.10.7"
+  default: true
+  allowedNodeVersions: *node-versions
+- version: "1.10.8"
+  default: true
+  allowedNodeVersions: *node-versions
 # Kubernetes 1.11
 - version: "1.11.0"
   default: false
-  allowedNodeVersions: *node-versions-1-11
-# Kubernetes 1.11
+  allowedNodeVersions: *node-versions
 - version: "1.11.1"
   default: false
-  allowedNodeVersions: *node-versions-1-11
+  allowedNodeVersions: *node-versions
+- version: "1.11.2"
+  default: false
+  allowedNodeVersions: *node-versions
+- version: "1.11.3"
+  default: false
+  allowedNodeVersions: *node-versions


### PR DESCRIPTION
**What this PR does / why we need it**:
Update supported kubernetes versions & drop kubernetes v1.8.

**Release note**:
```release-note
Support for Kubernetes v1.8 has been dropped. The control planes of all clusters running 1.8 will be automatically updated
```
