### PR TITLE
user cluster prometheus proxy api

### DIFF
--- a/api/pkg/handler/request.go
+++ b/api/pkg/handler/request.go
@@ -96,6 +96,33 @@ func decodeClusterReq(c context.Context, r *http.Request) (interface{}, error) {
 	return req, nil
 }
 
+// LegacyGetPrometheusProxyReq represents a request to the Prometheus proxy route
+type LegacyGetPrometheusProxyReq struct {
+	LegacyGetClusterReq
+	PrometheusQueryPath string `json:"prometheus_query_path"`
+	PrometheusRawQuery  string `json:"prometheus_raw_query"`
+	RequestHeaders      http.Header
+}
+
+func decodeLegacyPrometheusProxyReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyGetPrometheusProxyReq
+
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
+	req.PrometheusQueryPath = mux.Vars(r)["query_path"]
+	if req.PrometheusQueryPath != "query" && req.PrometheusQueryPath != "query_range" {
+		return nil, errors.New(http.StatusBadRequest, "invalid Prometheus query path")
+	}
+
+	req.PrometheusRawQuery = r.URL.RawQuery
+	req.RequestHeaders = r.Header
+
+	return req, nil
+}
+
 // CreateClusterReqBody represents the request body for a create cluster request
 type CreateClusterReqBody struct {
 	Cluster *kubermaticv1.Cluster `json:"cluster"`

--- a/api/pkg/handler/routes_v3.go
+++ b/api/pkg/handler/routes_v3.go
@@ -57,6 +57,10 @@ func (r Routing) RegisterV3(mux *mux.Router) {
 	mux.Methods(http.MethodGet).
 		Path("/dc/{dc}/cluster/{cluster}/metrics").
 		Handler(r.legacyClusterMetricsHandlerV3())
+
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/prometheus/{query_path}").
+		Handler(r.prometheusProxyHandlerV3())
 }
 
 // Creates a cluster
@@ -316,6 +320,19 @@ func (r Routing) legacyClusterMetricsHandlerV3() http.Handler {
 		)(legacyGetClusterMetricsEndpoint(r.prometheusClient)),
 		decodeLegacyClusterReq,
 		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+func (r Routing) prometheusProxyHandlerV3() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(getPrometheusProxyEndpoint()),
+		decodeLegacyPrometheusProxyReq,
+		encodeRawResponse,
 		r.defaultServerOptions()...,
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds an authenticated reverse proxy API for the user cluster Prometheus instances, reachable via `/api/v3/dc/<dc>/cluster/<cluster>/prometheus/query[_range]?<params>`. We want to use this to display dashboards in the UI.

Is this of interest to you guys? We could add a boolean "enable this" flag to the CLI if needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
User cluster Prometheus reverse proxy API
```
