### PR TITLE
Mitigate prometheus RAM flooding

### DIFF
--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -85,6 +85,7 @@ func TestConfigMapCreatorsKeepAdditionalData(t *testing.T) {
 	cluster := &kubermaticv1.Cluster{}
 	cluster.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"10.10.0.0/8"}
 	cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.11.0.0/8"}
+	cluster.Spec.Version = "v1.11.0"
 	dc := &provider.DatacenterMeta{}
 	templateData := resources.NewTemplateData(cluster, dc, "", nil, nil, nil, "", "", "10.12.0.0/8", resource.Quantity{}, "", false, false, "", nil)
 

--- a/api/pkg/controller/monitoring/resources_test.go
+++ b/api/pkg/controller/monitoring/resources_test.go
@@ -30,6 +30,7 @@ func TestCreateConfigMap(t *testing.T) {
 					Cloud: kubermaticv1.CloudSpec{
 						DatacenterName: TestDC,
 					},
+					Version: "v1.11.3",
 				},
 				Address: kubermaticv1.ClusterAddress{},
 				Status: kubermaticv1.ClusterStatus{
@@ -48,6 +49,7 @@ func TestCreateConfigMap(t *testing.T) {
 					Cloud: kubermaticv1.CloudSpec{
 						DatacenterName: TestDC,
 					},
+					Version: "v1.11.3",
 				},
 				Address: kubermaticv1.ClusterAddress{},
 				Status: kubermaticv1.ClusterStatus{

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -144,7 +144,7 @@ scrape_configs:
       names:
       - "{{ $.TemplateData.Cluster.Status.NamespaceName }}"
 
-{{- if semverCompare "~1.11.0" $.TemplateData.Cluster.Spec.Version }}
+{{- if semverCompare ">=1.11.0, <= 1.11.3" $.TemplateData.Cluster.Spec.Version }}
   metric_relabel_configs:
   - source_labels: [job, __name__]
     regex: 'controller-manager;rest_.*'

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -144,7 +144,7 @@ scrape_configs:
       names:
       - "{{ $.TemplateData.Cluster.Status.NamespaceName }}"
 
-{{- if semverCompare "~1.11" .TemplateData.Cluster.Spec.Version }}
+{{- if semverCompare "~1.11.0" $.TemplateData.Cluster.Spec.Version }}
   metric_relabel_configs:
   - source_labels: [job, __name__]
     regex: 'controller-manager;rest_.*'

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -149,8 +149,8 @@ scrape_configs:
   - source_labels: [job, __name__]
     regex: 'controller-manager;rest_.*'
     action: drop
-
 {{- end }}
+
   relabel_configs:
   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_{{ $i }}_scrape]
     action: keep

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -144,6 +144,13 @@ scrape_configs:
       names:
       - "{{ $.TemplateData.Cluster.Status.NamespaceName }}"
 
+{{- if semverCompare "~1.11" .TemplateData.Cluster.Spec.Version }}
+  metric_relabel_configs:
+  - source_labels: [job, __name__]
+    regex: 'controller-manager;rest_.*'
+    action: drop
+
+{{- end }}
   relabel_configs:
   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_{{ $i }}_scrape]
     action: keep

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubernetes/kubernetes/pull/68530 fixes a bug in kubernetes, which floods the metrics created by the controller-manager. As the fix seems not to be backported to v1.11 this change will drop all rest_* series from the controller-manager when any clusterversion v1.11.x is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note monitoring
Version v1.11.0 - 1.11.3 Clusters will no longer gather `rest_*` metrics from the controller-manager due to a [bug in kubernetes](https://github.com/kubernetes/kubernetes/pull/68530)
```

