### PR TITLE
increase informer resync period

### DIFF
--- a/api/cmd/ipam-controller/main.go
+++ b/api/cmd/ipam-controller/main.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
+
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 
 	"github.com/golang/glog"
 
@@ -60,7 +61,7 @@ func (nf *networkFlags) Set(value string) error {
 	splitted := strings.Split(value, ",")
 
 	if len(splitted) < 3 {
-		return fmt.Errorf("Expected cidr,gateway,dns1,dns2,... but got: %s", value)
+		return fmt.Errorf("expected cidr,gateway,dns1,dns2,... but got: %s", value)
 	}
 
 	cidrStr := splitted[0]
@@ -119,10 +120,10 @@ func main() {
 			options.IncludeUninitialized = true
 		}
 
-		factory := machineinformers.NewFilteredSharedInformerFactory(client, 20*time.Second, metav1.NamespaceAll, tweakFunc)
-		informer := factory.Machine().V1alpha1().Machines()
+		factory := machineinformers.NewFilteredSharedInformerFactory(client, informer.DefaultInformerResyncPeriod, metav1.NamespaceAll, tweakFunc)
+		machineInformer := factory.Machine().V1alpha1().Machines()
 
-		controller := ipam.NewController(client, informer, networks)
+		controller := ipam.NewController(client, machineInformer, networks)
 
 		factory.Start(stopCh)
 		factory.WaitForCacheSync(stopCh)

--- a/api/cmd/kubeletdnat-controller/main.go
+++ b/api/cmd/kubeletdnat-controller/main.go
@@ -7,7 +7,8 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
+
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 
 	"github.com/golang/glog"
 	"github.com/oklog/run"
@@ -42,7 +43,7 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	kubeInformerFactory := coreinformers.NewSharedInformerFactory(client, time.Minute*5)
+	kubeInformerFactory := coreinformers.NewSharedInformerFactory(client, informer.DefaultInformerResyncPeriod)
 
 	ctrl := kubeletdnat.NewController(
 		client,

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -26,7 +26,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
+
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/handlers"
@@ -65,10 +66,6 @@ var (
 	tokenIssuerSkipTLSVerify bool
 )
 
-const (
-	informerResyncPeriod = 5 * time.Minute
-)
-
 func main() {
 	flag.StringVar(&listenAddress, "address", ":8080", "The address to listen on")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig.")
@@ -96,7 +93,7 @@ func main() {
 	}
 
 	kubermaticMasterClient := kubermaticclientset.NewForConfigOrDie(config)
-	kubermaticMasterInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticMasterClient, informerResyncPeriod)
+	kubermaticMasterInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticMasterClient, informer.DefaultInformerResyncPeriod)
 
 	defaultImpersonationClient := kubernetesprovider.NewKubermaticImpersonationClient(config)
 
@@ -132,10 +129,10 @@ func main() {
 		glog.V(2).Infof("adding %s as seed", ctx)
 
 		kubeClient := kubernetes.NewForConfigOrDie(cfg)
-		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, informerResyncPeriod)
+		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, informer.DefaultInformerResyncPeriod)
 
 		kubermaticSeedClient := kubermaticclientset.NewForConfigOrDie(cfg)
-		kubermaticSeedInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticSeedClient, informerResyncPeriod)
+		kubermaticSeedInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticSeedClient, informer.DefaultInformerResyncPeriod)
 
 		defaultImpersonationClientForSeed := kubernetesprovider.NewKubermaticImpersonationClient(cfg)
 

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
+
 	"github.com/golang/glog"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
@@ -300,8 +302,8 @@ func newControllerContext(runOp controllerRunOptions, done <-chan struct{}, kube
 		return nil, err
 	}
 
-	ctrlCtx.kubermaticInformerFactory = kubermaticinformers.NewFilteredSharedInformerFactory(ctrlCtx.kubermaticClient, time.Minute*5, metav1.NamespaceAll, selector)
-	ctrlCtx.kubeInformerFactory = kubeinformers.NewSharedInformerFactory(ctrlCtx.kubeClient, time.Minute*5)
+	ctrlCtx.kubermaticInformerFactory = kubermaticinformers.NewFilteredSharedInformerFactory(ctrlCtx.kubermaticClient, informer.DefaultInformerResyncPeriod, metav1.NamespaceAll, selector)
+	ctrlCtx.kubeInformerFactory = kubeinformers.NewSharedInformerFactory(ctrlCtx.kubeClient, informer.DefaultInformerResyncPeriod)
 
 	return ctrlCtx, nil
 }

--- a/api/cmd/rbac-generator/main.go
+++ b/api/cmd/rbac-generator/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
+
 	"github.com/golang/glog"
 	rbaccontroller "github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
@@ -57,8 +59,8 @@ func main() {
 	ctrlCtx.stopCh = signals.SetupSignalHandler()
 	ctrlCtx.kubeMasterClient = kubernetes.NewForConfigOrDie(config)
 	ctrlCtx.kubermaticMasterClient = kubermaticclientset.NewForConfigOrDie(config)
-	ctrlCtx.kubermaticMasterInformerFactory = externalversions.NewFilteredSharedInformerFactory(ctrlCtx.kubermaticMasterClient, time.Minute*5, metav1.NamespaceAll, selector)
-	ctrlCtx.kubeMasterInformerFactory = kuberinformers.NewSharedInformerFactory(ctrlCtx.kubeMasterClient, time.Minute*5)
+	ctrlCtx.kubermaticMasterInformerFactory = externalversions.NewFilteredSharedInformerFactory(ctrlCtx.kubermaticMasterClient, informer.DefaultInformerResyncPeriod, metav1.NamespaceAll, selector)
+	ctrlCtx.kubeMasterInformerFactory = kuberinformers.NewSharedInformerFactory(ctrlCtx.kubeMasterClient, informer.DefaultInformerResyncPeriod)
 	ctrlCtx.seedClusterProviders = []*rbaccontroller.ClusterProvider{}
 	{
 		clientcmdConfig, err := clientcmd.LoadFromFile(ctrlCtx.runOptions.kubeconfig)

--- a/api/pkg/util/informer/resync.go
+++ b/api/pkg/util/informer/resync.go
@@ -1,0 +1,8 @@
+package informer
+
+import "time"
+
+const (
+	// DefaultInformerResyncPeriod defines the default resync period for all informers
+	DefaultInformerResyncPeriod = 30 * time.Minute
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase informer resync period, to avoid unnecessary processing.
As mentioned during last KubeCon, events are being delivered reliable - Though they might get grouped & deduplicated on the Apiserver.

**Release note**:
```release-note
NONE
```
