### PR TITLE
update cert-manager certs to fix validation

### DIFF
--- a/config/certs/templates/certificates.yaml
+++ b/config/certs/templates/certificates.yaml
@@ -10,6 +10,7 @@ spec:
   # The Issuer to use for this certificate
   issuerRef:
     name: letsencrypt-prod
+    kind: Issuer
   # A list of domains to include on the TLS certificate
   dnsNames:
   {{- range $key, $val := .Values.certificates.domains }}

--- a/config/certs/templates/issuer.yaml
+++ b/config/certs/templates/issuer.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   acme:
     # The ACME server URL
-    server: https://acme-v01.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     # Email address used for ACME registration
     email: "dev@loodse.com"
     # Name of a secret used to store the ACME account private key


### PR DESCRIPTION
**What this PR does / why we need it**:
Update cert-manager certs to fix validation:
- issuerRef requires Kind
- Letsencrypt api version has changed

**Release note**:
```release-note
NONE
```
