### PR TITLE
use exponential backoff queue without max-retries/token-bucket

### DIFF
--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -121,7 +121,7 @@ func NewController(
 		kubeClient:              kubeClient,
 		userClusterConnProvider: userClusterConnProvider,
 
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cluster"),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute), "cluster"),
 
 		overwriteRegistry:                      overwriteRegistry,
 		nodePortRange:                          nodePortRange,


### PR DESCRIPTION
**What this PR does / why we need it**:
This replaces the current exponential-backoff+token-bucket queue with a simple exponential-backoff queue.
The former aproach deleted keys from the queue when they failed to get process successful after a given amount of retries. Those keys would not get re-processed until an event for that cluster gets triggered or the informer-resync kicks in. This does lead to really long processing times for clusters in special cases (For example: cloud-provider API is down/throws errors).

This aproach already gets used in the machine-controller.

**Release note**:
```release-note
NONE
```
