### PR TITLE
make prometheus backups not copy the same files over and over again

### DIFF
--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
         backup.ark.heptio.com/backup-volumes: prometheus-backup
         pre.hook.backup.ark.heptio.com/container: backup
         pre.hook.backup.ark.heptio.com/timeout: 30m
-        pre.hook.backup.ark.heptio.com/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -XPOST http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot && rsync -r --owner --delete /prometheus/snapshots/*/ /backup"]'
+        pre.hook.backup.ark.heptio.com/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot && rsync --archive /prometheus/snapshots/*/ /backup"]'
         {{- end }}
     spec:
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Without `-t` (`--times`), the modification times will not be preserved. This causes rsync to see old files as modified even though they are not. ``--archive`` includes the flag and makes the purpose easier to understand.

**Release note**:
```release-note
NONE
```
