### PR TITLE
requeue cluster in case its not completely healthy yet

### DIFF
--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -106,6 +106,7 @@ func (cc *Controller) reconcileCluster(cluster *kubermaticv1.Cluster) (*kubermat
 
 	if !cluster.Status.Health.AllHealthy() {
 		glog.V(5).Infof("Cluster %q not yet healthy: %+v", cluster.Name, cluster.Status.Health)
+		cc.enqueueAfter(cluster, reachableCheckPeriod)
 		return cluster, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Requeue cluster in case its not completely healthy yet

**Release note**:
```release-note
NONE
```
