### PR TITLE
add openvpn health to cluster status

### DIFF
--- a/api/pkg/controller/cluster/health.go
+++ b/api/pkg/controller/cluster/health.go
@@ -25,6 +25,7 @@ func (cc *Controller) clusterHealth(c *kubermaticv1.Cluster) (*kubermaticv1.Clus
 		resources.ControllerManagerDeploymentName: {healthy: &health.Controller},
 		resources.SchedulerDeploymentName:         {healthy: &health.Scheduler},
 		resources.MachineControllerDeploymentName: {healthy: &health.MachineController},
+		resources.OpenVPNServerDeploymentName:     {healthy: &health.OpenVPN},
 	}
 
 	for name := range healthMapping {

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -301,6 +301,7 @@ type ClusterHealthStatus struct {
 	Controller        bool `json:"controller"`
 	MachineController bool `json:"machineController"`
 	Etcd              bool `json:"etcd"`
+	OpenVPN           bool `json:"openvpn"`
 }
 
 // AllHealthy returns if all components are healthy


### PR DESCRIPTION
**What this PR does / why we need it**:
Add openvpn health to cluster status. It reduces the flakeyness in the e2e tests, as they must wait until the openvpn-server is running. Otherwise, the apiserver->pod, apiserver->service, apiserver->kubelet communication won't work.

**Release note**:
```release-note
OpenVPN status is now a part of cluster health 
```
