### PR TITLE
Use absolute dns names

### DIFF
--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -286,7 +286,7 @@ func (d *TemplateData) InClusterApiserverURL() (*url.URL, error) {
 		return nil, errors.New("apiserver service does not have exactly one port")
 	}
 
-	return url.Parse(fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", ApiserverExternalServiceName, d.Cluster().Status.NamespaceName, service.Spec.Ports[0].NodePort))
+	return url.Parse(fmt.Sprintf("https://%s.%s.svc.cluster.local.:%d", ApiserverExternalServiceName, d.Cluster().Status.NamespaceName, service.Spec.Ports[0].NodePort))
 }
 
 // ImageRegistry returns the image registry to use or the passed in default if no override is specified

--- a/api/pkg/resources/etcd/etcdservices.go
+++ b/api/pkg/resources/etcd/etcdservices.go
@@ -50,7 +50,7 @@ func GetClientEndpoints(namespace string) []string {
 	var endpoints []string
 	for i := 0; i < 3; i++ {
 		// Pod DNS name
-		absolutePodDNSName := fmt.Sprintf("https://etcd-%d.%s.%s.svc.cluster.local:2379", i, resources.EtcdServiceName, namespace)
+		absolutePodDNSName := fmt.Sprintf("https://etcd-%d.%s.%s.svc.cluster.local.:2379", i, resources.EtcdServiceName, namespace)
 		endpoints = append(endpoints, absolutePodDNSName)
 	}
 	return endpoints

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,7 +201,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,7 +201,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,7 +201,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,7 +201,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,7 +201,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -314,7 +314,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,7 +201,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,7 +201,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -201,7 +201,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -301,7 +301,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -301,7 +301,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -188,7 +188,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -192,7 +192,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,7 +196,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,7 +196,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,7 +196,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,7 +196,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,7 +196,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,7 +196,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,7 +196,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -196,7 +196,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -69,7 +69,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -161,7 +161,7 @@ spec:
       - command:
         - /bin/sh
         - -ec
-        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+        - until wget -T 1 https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz;
           do echo waiting for apiserver; sleep 2; done;
         image: docker.io/busybox
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -32,7 +32,7 @@ func OpenVPNSidecarContainer(data resources.DeploymentDataProvider, name string)
 			"--proto", "tcp",
 			"--dev", "tun",
 			"--auth-nocache",
-			"--remote", fmt.Sprintf("%s.%s.svc.cluster.local", resources.OpenVPNServerServiceName, data.Cluster().Status.NamespaceName), "1194",
+			"--remote", fmt.Sprintf("%s.%s.svc.cluster.local.", resources.OpenVPNServerServiceName, data.Cluster().Status.NamespaceName), "1194",
 			"--nobind",
 			"--connect-timeout", "5",
 			"--connect-retry", "1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Use absolute dns names for dns names used inside the seed-cluster.

**Release note**:
```release-note
NONE
```
