### PR TITLE
enable K8S 1.12.0-rc.1 for testing

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -27,6 +27,10 @@ updates:
 - from: 1.11.*
   to: 1.11.*
   automatic: false
+# Allow to next minor release
+- from: 1.11.*
+  to: 1.12.*
+  automatic: false
 
 # ======= 1.12 =======
 # Allow to change to any patch version

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -27,3 +27,9 @@ updates:
 - from: 1.11.*
   to: 1.11.*
   automatic: false
+
+# ======= 1.12 =======
+# Allow to change to any patch version
+- from: 1.12.*
+  to: 1.12.*
+  automatic: false

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -21,3 +21,9 @@ updates:
   #We need to skip 1.10.0 as it broke OpenStack.
   to: ^1.10.1
   automatic: false
+
+# ======= 1.11 =======
+# Allow to change to any patch version
+- from: 1.11.*
+  to: 1.11.*
+  automatic: false

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -3,6 +3,7 @@ allowed-node-versions: &node-versions
 - "1.9.*"
 - "1.10.*"
 - "1.11.*"
+- "1.12.*"
 
 versions:
 - version: "1.9.0"
@@ -77,5 +78,9 @@ versions:
   default: false
   allowedNodeVersions: *node-versions
 - version: "1.11.3"
+  default: false
+  allowedNodeVersions: *node-versions
+# Kubernetes 1.12
+- version: "1.12.0-rc.1"
   default: false
   allowedNodeVersions: *node-versions


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows us to try out the RC on dev

```release-note
NONE
```
