### PR TITLE
check for running apiserver with curl

### DIFF
--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -34,7 +34,7 @@ func IsRunningInitContainer(data resources.DeploymentDataProvider) (*corev1.Cont
 					exit 1
 				fi
 				sleep 2
-				echo "Retry $timeout/3"
+				echo "Retry $timeout/100"
 				ip=$(getent hosts $name | cut -d" " -f1)
 			done`, url.Hostname(), url.Port(), url),
 		},

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -20,14 +20,13 @@ func IsRunningInitContainer(data resources.DeploymentDataProvider) (*corev1.Cont
 		Name:            "apiserver-running",
 		Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/curl:v0.1",
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"/usr/bin/curl"},
+		Command:         []string{"/bin/sh"},
 		Args: []string{
-			"--retry", "100",
-			"--retry-delay", "2",
-			"--insecure",
-			"--silent",
-			"--show-error",
-			fmt.Sprintf("%s/healthz", url),
+			"-c",
+			fmt.Sprintf(`while ! curl --insecure --show-error --max-time 3 %s/healthz; do
+				[ $(( timeout++ )) -gt 100 ] && exit 1
+				sleep 2
+			done`, url),
 		},
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -29,8 +29,12 @@ func IsRunningInitContainer(data resources.DeploymentDataProvider) (*corev1.Cont
 			# manual re-resolving enables use of trailing dot with curl
 			ip=$(getent hosts $name | cut -d" " -f1)
 			while ! curl --resolve $name:$port:$ip --insecure --silent --show-error --max-time 3 %s/healthz; do
-				[ $(( timeout++ )) -gt 100 ] && exit 1
+				if [ $(( timeout++ )) -gt 100 ]; then
+					echo "Giving up after 100 tries."
+					exit 1
+				fi
 				sleep 2
+				echo "Retry $timeout/3"
 				ip=$(getent hosts $name | cut -d" " -f1)
 			done`, url.Hostname(), url.Port(), url),
 		},

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -199,16 +199,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -204,8 +204,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -199,16 +199,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -204,8 +204,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -199,16 +199,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -204,8 +204,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -199,16 +199,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -204,8 +204,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -199,16 +199,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -204,8 +204,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -199,16 +199,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -204,8 +204,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -199,16 +199,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -204,8 +204,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -199,16 +199,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -204,8 +204,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -74,16 +74,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -79,8 +79,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -77,16 +77,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -82,8 +82,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -77,16 +77,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -82,8 +82,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -77,16 +77,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -82,8 +82,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -77,16 +77,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -82,8 +82,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -77,16 +77,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -82,8 +82,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -77,16 +77,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -82,8 +82,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -77,16 +77,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -82,8 +82,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -191,8 +191,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -186,16 +186,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -77,16 +77,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -82,8 +82,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -90,8 +90,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -85,16 +85,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -90,8 +90,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -85,16 +85,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -90,8 +90,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -85,16 +85,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -90,8 +90,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -85,16 +85,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -90,8 +90,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -85,16 +85,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -90,8 +90,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -85,16 +85,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -90,8 +90,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -85,16 +85,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -190,16 +190,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -195,8 +195,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -90,8 +90,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -85,16 +85,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -194,16 +194,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -199,8 +199,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -194,16 +194,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -199,8 +199,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -194,16 +194,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -199,8 +199,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -194,16 +194,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -199,8 +199,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -194,16 +194,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -199,8 +199,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -194,16 +194,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -199,8 +199,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -194,16 +194,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -199,8 +199,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -194,16 +194,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -199,8 +199,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -74,7 +74,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -72,8 +72,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -67,16 +67,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -79,16 +79,15 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -84,8 +84,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -166,7 +166,7 @@ spec:
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
           do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
           up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
-          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          \"Retry $timeout/100\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -159,16 +159,15 @@ spec:
       dnsPolicy: None
       initContainers:
       - args:
-        - --retry
-        - "100"
-        - --retry-delay
-        - "2"
-        - --insecure
-        - --silent
-        - --show-error
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - -c
+        - "\n\t\t\tname=apiserver-external.cluster-de-test-01.svc.cluster.local\n\t\t\tport=30000\n\t\t\t#
+          manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
+          --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
+          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
+          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
-        - /usr/bin/curl
+        - /bin/sh
         image: quay.io/kubermatic/curl:v0.1
         imagePullPolicy: IfNotPresent
         name: apiserver-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -164,8 +164,9 @@ spec:
           manual re-resolving enables use of trailing dot with curl\n\t\t\tip=$(getent
           hosts $name | cut -d\" \" -f1)\n\t\t\twhile ! curl --resolve $name:$port:$ip
           --insecure --silent --show-error --max-time 3 https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz;
-          do\n\t\t\t\t[ $(( timeout++ )) -gt 100 ] && exit 1\n\t\t\t\tsleep 2\n\t\t\t\tip=$(getent
-          hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
+          do\n\t\t\t\tif [ $(( timeout++ )) -gt 100 ]; then\n\t\t\t\t\techo \"Giving
+          up after 100 tries.\"\n\t\t\t\t\texit 1\n\t\t\t\tfi\n\t\t\t\tsleep 2\n\t\t\t\techo
+          \"Retry $timeout/3\"\n\t\t\t\tip=$(getent hosts $name | cut -d\" \" -f1)\n\t\t\tdone"
         command:
         - /bin/sh
         image: quay.io/kubermatic/curl:v0.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an enhanced check for running apiserver with curl in a loop.
This allows a trailing dot in service names.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Improve detection of user-cluster apiserver health on startup.
```
