### PR TITLE
make vsphere credentials public

### DIFF
--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -37,9 +37,9 @@ type OpenstackSpec struct {
 	AuthURL          string `yaml:"auth_url"`
 	AvailabilityZone string `yaml:"availability_zone"`
 	Region           string `yaml:"region"`
-	IgnoreVolumeAZ   bool   `yaml:"ignore_volume_az,omitempty"`
+	IgnoreVolumeAZ   bool   `yaml:"ignore_volume_az"`
 	// Used for automatic network creation
-	DNSServers []string  `yaml:"dns_servers,omitempty"`
+	DNSServers []string  `yaml:"dns_servers"`
 	Images     ImageList `yaml:"images"`
 }
 
@@ -58,7 +58,7 @@ type VSphereCredentials struct {
 // VSphereSpec describes a vsphere datacenter
 type VSphereSpec struct {
 	Endpoint      string `yaml:"endpoint"`
-	AllowInsecure bool   `yaml:"allow_insecure,omitempty"`
+	AllowInsecure bool   `yaml:"allow_insecure"`
 
 	Datastore  string    `yaml:"datastore"`
 	Datacenter string    `yaml:"datacenter"`
@@ -96,12 +96,12 @@ type DatacenterSpec struct {
 
 // DatacenterMeta describes a Kubermatic datacenter.
 type DatacenterMeta struct {
-	Location         string         `yaml:"location,omitempty"`
-	Seed             string         `yaml:"seed,omitempty"`
-	Country          string         `yaml:"country,omitempty"`
+	Location         string         `yaml:"location"`
+	Seed             string         `yaml:"seed"`
+	Country          string         `yaml:"country"`
 	Spec             DatacenterSpec `yaml:"spec"`
-	Private          bool           `yaml:"private,omitempty"`
-	IsSeed           bool           `yaml:"is_seed,omitempty"`
+	Private          bool           `yaml:"private"`
+	IsSeed           bool           `yaml:"is_seed"`
 	SeedDNSOverwrite *string        `yaml:"seed_dns_overwrite,omitempty"`
 }
 

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -37,9 +37,9 @@ type OpenstackSpec struct {
 	AuthURL          string `yaml:"auth_url"`
 	AvailabilityZone string `yaml:"availability_zone"`
 	Region           string `yaml:"region"`
-	IgnoreVolumeAZ   bool   `yaml:"ignore_volume_az"`
+	IgnoreVolumeAZ   bool   `yaml:"ignore_volume_az,omitempty"`
 	// Used for automatic network creation
-	DNSServers []string  `yaml:"dns_servers"`
+	DNSServers []string  `yaml:"dns_servers,omitempty"`
 	Images     ImageList `yaml:"images"`
 }
 
@@ -58,7 +58,7 @@ type VSphereCredentials struct {
 // VSphereSpec describes a vsphere datacenter
 type VSphereSpec struct {
 	Endpoint      string `yaml:"endpoint"`
-	AllowInsecure bool   `yaml:"allow_insecure"`
+	AllowInsecure bool   `yaml:"allow_insecure,omitempty"`
 
 	Datastore  string    `yaml:"datastore"`
 	Datacenter string    `yaml:"datacenter"`
@@ -85,23 +85,23 @@ type BringYourOwnSpec struct {
 
 // DatacenterSpec describes mutually points to provider datacenter spec
 type DatacenterSpec struct {
-	Digitalocean *DigitaloceanSpec `yaml:"digitalocean"`
-	BringYourOwn *BringYourOwnSpec `yaml:"bringyourown"`
-	AWS          *AWSSpec          `yaml:"aws"`
-	Azure        *AzureSpec        `yaml:"azure"`
-	Openstack    *OpenstackSpec    `yaml:"openstack"`
-	Hetzner      *HetznerSpec      `yaml:"hetzner"`
-	VSphere      *VSphereSpec      `yaml:"vsphere"`
+	Digitalocean *DigitaloceanSpec `yaml:"digitalocean,omitempty"`
+	BringYourOwn *BringYourOwnSpec `yaml:"bringyourown,omitempty"`
+	AWS          *AWSSpec          `yaml:"aws,omitempty"`
+	Azure        *AzureSpec        `yaml:"azure,omitempty"`
+	Openstack    *OpenstackSpec    `yaml:"openstack,omitempty"`
+	Hetzner      *HetznerSpec      `yaml:"hetzner,omitempty"`
+	VSphere      *VSphereSpec      `yaml:"vsphere,omitempty"`
 }
 
 // DatacenterMeta describes a Kubermatic datacenter.
 type DatacenterMeta struct {
-	Location         string         `yaml:"location"`
-	Seed             string         `yaml:"seed"`
-	Country          string         `yaml:"country"`
+	Location         string         `yaml:"location,omitempty"`
+	Seed             string         `yaml:"seed,omitempty"`
+	Country          string         `yaml:"country,omitempty"`
 	Spec             DatacenterSpec `yaml:"spec"`
-	Private          bool           `yaml:"private"`
-	IsSeed           bool           `yaml:"is_seed"`
+	Private          bool           `yaml:"private,omitempty"`
+	IsSeed           bool           `yaml:"is_seed,omitempty"`
 	SeedDNSOverwrite *string        `yaml:"seed_dns_overwrite,omitempty"`
 }
 

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -48,7 +48,7 @@ type AzureSpec struct {
 	Location string `yaml:"location"`
 }
 
-type vsphereCredentials struct {
+type VSphereCredentials struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
 }
@@ -67,7 +67,7 @@ type VSphereSpec struct {
 	// Infra management user is an optional user that will be used only
 	// for everything except the cloud provider functionality which will
 	// still use the credentials passed in via the frontend/api
-	InfraManagementUser *vsphereCredentials `yaml:"infra_management_user,omitempty"`
+	InfraManagementUser *VSphereCredentials `yaml:"infra_management_user,omitempty"`
 }
 
 // AWSSpec describes a aws datacenter

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -48,6 +48,8 @@ type AzureSpec struct {
 	Location string `yaml:"location"`
 }
 
+// VSphereCredentials describes the credentials used
+// as the infra management user
 type VSphereCredentials struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`


### PR DESCRIPTION
**What this PR does / why we need it**:
The installer is planned to use this package to create the datacenters.yaml and therefore needs access to this struct as well.

To make the output somewhat prettier, I also set the optional/rarely-used fields to `omitempty`.

**Release note**:
```release-note
NONE
```
