### PR TITLE
Use absolute dns names

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1478,7 +1478,6 @@
     "github.com/aws/aws-sdk-go/service/ec2",
     "github.com/aws/aws-sdk-go/service/iam",
     "github.com/coreos/go-oidc",
-    "github.com/davecgh/go-spew/spew",
     "github.com/digitalocean/godo",
     "github.com/ghodss/yaml",
     "github.com/go-kit/kit/endpoint",

--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1478,6 +1478,7 @@
     "github.com/aws/aws-sdk-go/service/ec2",
     "github.com/aws/aws-sdk-go/service/iam",
     "github.com/coreos/go-oidc",
+    "github.com/davecgh/go-spew/spew",
     "github.com/digitalocean/godo",
     "github.com/ghodss/yaml",
     "github.com/go-kit/kit/endpoint",

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -286,7 +286,8 @@ func (d *TemplateData) InClusterApiserverURL() (*url.URL, error) {
 		return nil, errors.New("apiserver service does not have exactly one port")
 	}
 
-	return url.Parse(fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", ApiserverExternalServiceName, d.Cluster().Status.NamespaceName, service.Spec.Ports[0].NodePort))
+	dnsName := GetAbsoluteServiceDNSName(ApiserverExternalServiceName, d.Cluster().Status.NamespaceName)
+	return url.Parse(fmt.Sprintf("https://%s:%d", dnsName, service.Spec.Ports[0].NodePort))
 }
 
 // ImageRegistry returns the image registry to use or the passed in default if no override is specified

--- a/api/pkg/resources/etcd/etcdservices.go
+++ b/api/pkg/resources/etcd/etcdservices.go
@@ -50,7 +50,8 @@ func GetClientEndpoints(namespace string) []string {
 	var endpoints []string
 	for i := 0; i < 3; i++ {
 		// Pod DNS name
-		absolutePodDNSName := fmt.Sprintf("https://etcd-%d.%s.%s.svc.cluster.local:2379", i, resources.EtcdServiceName, namespace)
+		serviceDNSName := resources.GetAbsoluteServiceDNSName(resources.EtcdServiceName, namespace)
+		absolutePodDNSName := fmt.Sprintf("https://etcd-%d.%s:2379", i, serviceDNSName)
 		endpoints = append(endpoints, absolutePodDNSName)
 	}
 	return endpoints

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -524,3 +524,8 @@ func DeepEqual(a, b metav1.Object) bool {
 	glog.V(8).Infof("Object %T %s/%s differs from the one, generated: %v", a, a.GetNamespace(), a.GetName(), diff)
 	return false
 }
+
+// GetAbsoluteServiceDNSName returns the absolute DNS name for the given service and the given cluster. Absolute means a trailing dot will be appended to the DNS name
+func GetAbsoluteServiceDNSName(service, namespace string) string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local.", service, namespace)
+}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -314,7 +314,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -318,7 +318,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -301,7 +301,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -301,7 +301,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -305,7 +305,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -61,7 +61,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -155,7 +155,7 @@ spec:
         - --insecure-port
         - "8080"
         - --etcd-servers
-        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
         - /etc/etcd/pki/client/ca.crt
         - --etcd-certfile
@@ -309,7 +309,7 @@ spec:
         - -ec
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
-          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           endpoint health; do echo waiting for etcd; sleep 2; done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -55,7 +55,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
@@ -49,7 +49,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -53,7 +53,7 @@ spec:
         - tun
         - --auth-nocache
         - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
         - "1194"
         - --nobind
         - --connect-timeout
@@ -160,7 +160,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local:30000/healthz
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -1,8 +1,6 @@
 package vpnsidecar
 
 import (
-	"fmt"
-
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +30,7 @@ func OpenVPNSidecarContainer(data resources.DeploymentDataProvider, name string)
 			"--proto", "tcp",
 			"--dev", "tun",
 			"--auth-nocache",
-			"--remote", fmt.Sprintf("%s.%s.svc.cluster.local", resources.OpenVPNServerServiceName, data.Cluster().Status.NamespaceName), "1194",
+			"--remote", resources.GetAbsoluteServiceDNSName(resources.OpenVPNServerServiceName, data.Cluster().Status.NamespaceName), "1194",
 			"--nobind",
 			"--connect-timeout", "5",
 			"--connect-retry", "1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Use absolute DNS names for services inside the cluster namespace.

**Release note**:
```release-note
NONE
```
