### PR TITLE
removes updating users resources

### DIFF
--- a/api/pkg/handler/user.go
+++ b/api/pkg/handler/user.go
@@ -293,19 +293,6 @@ func (r Routing) userSaverMiddleware() endpoint.Middleware {
 				}
 			}
 
-			// if for some reason ID and Name of the authenticated user
-			// are different than the ones we have in our database update the record.
-			if user.Spec.ID != apiUser.ID {
-				user.Spec.ID = apiUser.ID
-				if user.Spec.Name != apiUser.Name {
-					user.Spec.Name = apiUser.Name
-				}
-				user, err = r.userProvider.Update(user)
-				if err != nil {
-					return nil, kubernetesErrorToHTTPError(err)
-				}
-			}
-
 			return next(context.WithValue(ctx, userCRContextKey, user), request)
 		}
 	}

--- a/api/pkg/provider/kubernetes/user.go
+++ b/api/pkg/provider/kubernetes/user.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"strings"
-
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -62,7 +60,6 @@ func (p *UserProvider) UserByEmail(email string) (*kubermaticv1.User, error) {
 		return nil, err
 	}
 
-	email = normalizeText(email)
 	for _, user := range users {
 		if user.Spec.Email == email {
 			return user.DeepCopy(), nil
@@ -97,24 +94,6 @@ func (p *UserProvider) CreateUser(id, name, email string) (*kubermaticv1.User, e
 	user.Spec.Name = name
 	user.Spec.ID = id
 	user.Spec.Projects = []kubermaticv1.ProjectGroup{}
-	normalizedUser := normalizeUser(user)
 
-	return p.client.KubermaticV1().Users().Create(&normalizedUser)
-}
-
-// Update updates the given user
-func (p *UserProvider) Update(user *kubermaticv1.User) (*kubermaticv1.User, error) {
-	normalizedUser := normalizeUser(*user)
-	return p.client.KubermaticV1().Users().Update(&normalizedUser)
-}
-
-func normalizeText(text string) string {
-	return strings.TrimSpace(text)
-}
-
-func normalizeUser(user kubermaticv1.User) kubermaticv1.User {
-	user.Spec.Email = normalizeText(user.Spec.Email)
-	user.Spec.Name = normalizeText(user.Spec.Name)
-	user.Spec.ID = normalizeText(user.Spec.ID)
-	return user
+	return p.client.KubermaticV1().Users().Create(&user)
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -181,7 +181,6 @@ type NewSSHKeyProvider interface {
 type UserProvider interface {
 	UserByEmail(email string) (*kubermaticv1.User, error)
 	CreateUser(id, name, email string) (*kubermaticv1.User, error)
-	Update(*kubermaticv1.User) (*kubermaticv1.User, error)
 	ListByProject(projectName string) ([]*kubermaticv1.User, error)
 	UserByID(id string) (*kubermaticv1.User, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**: it turns out that the ID taken from the "sub" field of the token is not unique and changes depending of issuer. For example it will be different when a user logs in via Google or GitHub even if they map to the same email address. In the new model (UserMgmt) we don't rely on that value so there is no need to update it every time.

**Special notes for your reviewer**:
See also: https://app.zenhub.com/workspace/o/kubermatic/kubermatic/issues/2022#issuecomment-424270614

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
