### PR TITLE
removes sensitive data from cluster resources

### DIFF
--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -198,6 +198,67 @@ type CloudSpec struct {
 	VSphere      *VSphereCloudSpec      `json:"vsphere,omitempty"`
 }
 
+// UpdateCloudSpec is a helper method for updating the cloud spec
+// since cloud credentials are removed from responses sometimes they will be empty
+// for example when a client wants to revoke a token it will send the whole cluster object
+// thus if credentials for specific cloud provider are empty rewrite from an existing object
+func UpdateCloudSpec(updatedShared, existingShared CloudSpec) CloudSpec {
+	updated := updatedShared.DeepCopy()
+
+	if updated.Digitalocean != nil && len(updated.Digitalocean.Token) == 0 {
+		updated.Digitalocean.Token = existingShared.Digitalocean.Token
+	}
+	if updated.AWS != nil && len(updated.AWS.AccessKeyID) == 0 && len(updated.AWS.SecretAccessKey) == 0 {
+		updated.AWS.AccessKeyID = existingShared.AWS.AccessKeyID
+		updated.AWS.SecretAccessKey = existingShared.AWS.SecretAccessKey
+	}
+	if updated.Azure != nil && len(updated.Azure.ClientID) == 0 && len(updated.Azure.ClientSecret) == 0 {
+		updated.Azure.ClientID = existingShared.Azure.ClientID
+		updated.Azure.ClientSecret = existingShared.Azure.ClientSecret
+	}
+	if updated.Openstack != nil && len(updated.Openstack.Username) == 0 && len(updated.Openstack.Password) == 0 {
+		updated.Openstack.Username = existingShared.Openstack.Username
+		updated.Openstack.Password = existingShared.Openstack.Password
+	}
+	if updated.Hetzner != nil && len(updated.Hetzner.Token) == 0 {
+		updated.Hetzner.Token = existingShared.Hetzner.Token
+	}
+	if updated.VSphere != nil && len(updated.VSphere.Username) == 0 && len(updated.VSphere.Password) == 0 {
+		updated.VSphere.Username = existingShared.VSphere.Username
+		updated.VSphere.Password = existingShared.VSphere.Password
+	}
+
+	return *updated
+}
+
+// RemoveSensitiveDataFromCloudSpec remove credentials from cloud providers
+func RemoveSensitiveDataFromCloudSpec(spec CloudSpec) CloudSpec {
+	if spec.Digitalocean != nil {
+		spec.Digitalocean.Token = ""
+	}
+	if spec.AWS != nil {
+		spec.AWS.AccessKeyID = ""
+		spec.AWS.SecretAccessKey = ""
+	}
+	if spec.Azure != nil {
+		spec.Azure.ClientID = ""
+		spec.Azure.ClientSecret = ""
+	}
+	if spec.Openstack != nil {
+		spec.Openstack.Username = ""
+		spec.Openstack.Password = ""
+	}
+	if spec.Hetzner != nil {
+		spec.Hetzner.Token = ""
+	}
+	if spec.VSphere != nil {
+		spec.VSphere.Username = ""
+		spec.VSphere.Password = ""
+	}
+
+	return spec
+}
+
 // ClusterHealth stores health information of a cluster and the timestamp of the last change.
 type ClusterHealth struct {
 	ClusterHealthStatus `json:",inline"`

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -1535,7 +1535,7 @@ func TestClusterEndpoint(t *testing.T) {
 			expectedCluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "foo",
-					Labels: map[string]string{"user": testUserName},
+					Labels: map[string]string{"user": testUserID},
 				},
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
@@ -1812,7 +1812,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 			expectedCluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "foo",
-					Labels: map[string]string{"user": testUserName},
+					Labels: map[string]string{"user": testUserID},
 				},
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
@@ -1861,7 +1861,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 			expectedCluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "foo",
-					Labels: map[string]string{"user": testUserName},
+					Labels: map[string]string{"user": testUserID},
 				},
 				Status: kubermaticv1.ClusterStatus{
 					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -22,6 +22,79 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 )
 
+func TestRemoveSensitiveDataFromCluster(t *testing.T) {
+	t.Parallel()
+	genClusterResource := func() *kubermaticv1.Cluster {
+		return &kubermaticv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "abcd",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "kubermatic.k8s.io/v1",
+						Kind:       "Project",
+						UID:        "",
+						Name:       "myProjectInternalName",
+					},
+				},
+			},
+		}
+	}
+	genClusterWithAdminToken := func() *kubermaticv1.Cluster {
+		cluster := genClusterResource()
+		cluster.Address.AdminToken = "hfzj6l.w7hgc65nq9z4fxvl"
+		cluster.Address.ExternalName = "w225mx4z66.asia-east1-a-1.cloud.kubermatic.io"
+		cluster.Address.IP = "35.194.142.199"
+		cluster.Address.URL = "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"
+		return cluster
+	}
+	genClusterWithAWS := func() *kubermaticv1.Cluster {
+		cluster := genClusterResource()
+		cluster.Spec.Cloud = kubermaticv1.CloudSpec{
+			AWS: &kubermaticv1.AWSCloudSpec{
+				AccessKeyID:      "secretKeyID",
+				SecretAccessKey:  "secreatAccessKey",
+				SecurityGroupID:  "secuirtyGroupID",
+				AvailabilityZone: "availablityZone",
+			},
+		}
+
+		return cluster
+	}
+	scenarios := []struct {
+		Name            string
+		ExistingCluster *kubermaticv1.Cluster
+		ExpectedCluster *kubermaticv1.Cluster
+	}{
+		{
+			Name:            "scenaio 1: removes the admin token",
+			ExistingCluster: genClusterWithAdminToken(),
+			ExpectedCluster: func() *kubermaticv1.Cluster {
+				cluster := genClusterWithAdminToken()
+				cluster.Address.AdminToken = ""
+				return cluster
+			}(),
+		},
+		{
+			Name:            "scenario 2: removes AWS cloud provider secrets",
+			ExistingCluster: genClusterWithAWS(),
+			ExpectedCluster: func() *kubermaticv1.Cluster {
+				cluster := genClusterWithAWS()
+				cluster.Spec.Cloud.AWS.AccessKeyID = ""
+				cluster.Spec.Cloud.AWS.SecretAccessKey = ""
+				return cluster
+			}(),
+		},
+	}
+	for _, tc := range scenarios {
+		t.Run(tc.Name, func(t *testing.T) {
+			actualCluster := removeSensitiveDataFromCluster(tc.ExistingCluster)
+			if !equality.Semantic.DeepEqual(actualCluster, tc.ExpectedCluster) {
+				t.Fatalf("%v", diff.ObjectDiff(tc.ExpectedCluster, actualCluster))
+			}
+		})
+	}
+}
+
 func TestDeleteClusterEndpoint(t *testing.T) {
 	t.Parallel()
 	testcase := struct {
@@ -1436,10 +1509,11 @@ func TestListClusters(t *testing.T) {
 func TestClusterEndpoint(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name         string
-		clusterName  string
-		responseCode int
-		cluster      *kubermaticv1.Cluster
+		name            string
+		clusterName     string
+		responseCode    int
+		cluster         *kubermaticv1.Cluster
+		expectedCluster *kubermaticv1.Cluster
 	}{
 		{
 			name:        "successful got cluster",
@@ -1455,6 +1529,19 @@ func TestClusterEndpoint(t *testing.T) {
 				Address: kubermaticv1.ClusterAddress{
 					AdminToken: "admintoken",
 					URL:        "https://foo.bar:8443",
+				},
+				Spec: kubermaticv1.ClusterSpec{},
+			},
+			expectedCluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"user": testUserName},
+				},
+				Status: kubermaticv1.ClusterStatus{
+					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
+				},
+				Address: kubermaticv1.ClusterAddress{
+					URL: "https://foo.bar:8443",
 				},
 				Spec: kubermaticv1.ClusterSpec{},
 			},
@@ -1523,7 +1610,7 @@ func TestClusterEndpoint(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if diff := deep.Equal(gotCluster, test.cluster); diff != nil {
+			if diff := deep.Equal(gotCluster, test.expectedCluster); diff != nil {
 				t.Errorf("got different cluster than expected. Diff: %v", diff)
 			}
 		})
@@ -1688,10 +1775,11 @@ func TestClustersEndpointWithInvalidUserID(t *testing.T) {
 func TestUpdateClusterEndpoint(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		responseCode  int
-		cluster       *kubermaticv1.Cluster
-		modifyCluster func(*kubermaticv1.Cluster) *kubermaticv1.Cluster
+		name            string
+		responseCode    int
+		cluster         *kubermaticv1.Cluster
+		expectedCluster *kubermaticv1.Cluster
+		modifyCluster   func(*kubermaticv1.Cluster) *kubermaticv1.Cluster
 	}{
 		{
 			name: "successful update admin token (deprecated)",
@@ -1721,6 +1809,26 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 				c.Address.AdminToken = "bbbbbb.bbbbbbbbbbbbbbbb"
 				return c
 			},
+			expectedCluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"user": testUserName},
+				},
+				Status: kubermaticv1.ClusterStatus{
+					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
+				},
+				Address: kubermaticv1.ClusterAddress{
+					URL: "https://foo.bar:8443",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						Fake: &kubermaticv1.FakeCloudSpec{
+							Token: "foo",
+						},
+						DatacenterName: "us-central1",
+					},
+				},
+			},
 		},
 		{
 			name: "successful update cloud token",
@@ -1749,6 +1857,26 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 			modifyCluster: func(c *kubermaticv1.Cluster) *kubermaticv1.Cluster {
 				c.Spec.Cloud.Fake.Token = "bar"
 				return c
+			},
+			expectedCluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"user": testUserName},
+				},
+				Status: kubermaticv1.ClusterStatus{
+					RootCA: kubermaticv1.KeyCert{Cert: []byte("foo")},
+				},
+				Address: kubermaticv1.ClusterAddress{
+					URL: "https://foo.bar:8443",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						Fake: &kubermaticv1.FakeCloudSpec{
+							Token: "bar",
+						},
+						DatacenterName: "us-central1",
+					},
+				},
 			},
 		},
 		{
@@ -1841,7 +1969,7 @@ func TestUpdateClusterEndpoint(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if diff := deep.Equal(gotCluster, updatedCluster); diff != nil {
+			if diff := deep.Equal(gotCluster, test.expectedCluster); diff != nil {
 				t.Errorf("got different cluster than expected. Diff: %v", diff)
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:  removes sensitive data from cluster resources
the admin token and various cloud providers credentials will not be returned in responses. The API server will redact those fields. The changes has been made to legacy v3 HTTP endpoints


**Special notes for your reviewer**:
cherry picking from https://github.com/kubermatic/kubermatic/pull/2076


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The API server will redact sensitive data from its legacy API responses.
```
