### PR TITLE
increase kubermatic controller manager cpu request & limit

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -104,10 +104,10 @@ spec:
           resources:
             requests:
               memory: "64Mi"
-              cpu: "100m"
+              cpu: "200m"
             limits:
               memory: "256Mi"
-              cpu: "200m"
+              cpu: "500m"
       imagePullSecrets:
         - name: dockercfg
       tolerations:


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase kubermatic controller manager cpu request & limit.
The controller manager generates quite a few certificates and runs into the cpu limit too often.

**Release note**:
```release-note
Increase CPU&Memory limit for the Kubermatic controller manager deployment
```
