### PR TITLE
remove wrong worker name label

### DIFF
--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -83,8 +83,7 @@ func (p *ClusterProvider) NewCluster(user apiv1.User, spec *kubermaticv1.Cluster
 	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				kubermaticv1.WorkerNameLabelKey: p.workerName,
-				UserLabelKey:                    user.ID,
+				UserLabelKey: user.ID,
 			},
 			Name: name,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove wrong worker name label as it got introduced due to bad cherry-pick .

**Release note**:
```release-note
NONE
```
