### PR TITLE
e2e test: print health status if the cluster fails to come up

### DIFF
--- a/api/cmd/kubermatic-e2e/e2e_test_runner.go
+++ b/api/cmd/kubermatic-e2e/e2e_test_runner.go
@@ -89,6 +89,7 @@ func (ctl *e2eTestRunner) run(ctx context.Context) error {
 		ctl.runOpts.ClusterTimeout,
 		ctl.healthyClusterCond(ctx, cluster.Name))
 	if err != nil {
+		log.Infof("Cluster failed to come up. Health status: %+v", cluster.Status.Health.ClusterHealthStatus)
 		return err
 	}
 	log.Info("cluster control plane is up")


### PR DESCRIPTION

**Release note**:
```release-note
NONE
```
