### PR TITLE
fix wrong env var & specify boilerplate code flag

### DIFF
--- a/api/pkg/controller/ipam/testdata/gen-clusterapi-client.sh
+++ b/api/pkg/controller/ipam/testdata/gen-clusterapi-client.sh
@@ -6,17 +6,20 @@ cd $(dirname $0)/../../../..
 
 TEMPDIR=$(mktemp -d)
 
-type client-gen &>/dev/null || go build -o $GOPATH/bin/client-gen github.com/kubermatic/kubermatic/api/vendor/k8s.io/code-generator/cmd/client-gen
+type client-gen &>/dev/null || go build -o $(go env GOPATH)/bin/client-gen github.com/kubermatic/kubermatic/api/vendor/k8s.io/code-generator/cmd/client-gen
 
 ls $(go env GOPATH)/src/sigs.k8s.io/cluster-api &>/dev/null || git clone https://github.com/kubernetes-sigs/cluster-api.git $(go env GOPATH)/src/sigs.k8s.io/cluster-api
+
+touch ${TEMPDIR}/header.txt
 
 client-gen --clientset-name clientset \
   --input-base sigs.k8s.io/cluster-api/pkg/apis \
   --input cluster/v1alpha1 \
-  --output-base=$TEMPDIR \
+  --output-base=${TEMPDIR} \
+  --go-header-file=${TEMPDIR}/header.txt \
   --output-package="sigs.k8s.io/cluster-api/pkg/client/clientset_generated"
 
-mv $TEMPDIR/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake/* \
+mv ${TEMPDIR}/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake/* \
   vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake/
 
-rm -rf $TEMPDIR
+rm -rf ${TEMPDIR}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix wrong env var & specify boilerplate code flag.

Not specifying the boilerplate code flag resulted to:
```
ERROR: logging before flag.Parse: F0929 22:15:28.224015   15993 client_generator.go:321] Failed loading boilerplate: open github.com/kubermatic/kubermatic/api/vendor/k8s.io/code-generator/hack/boilerplate.go.txt: no such file or directory
```

**Release note**:
```release-note
NONE
```
