### PR TITLE
Add apiserver pdb

### DIFF
--- a/api/cmd/kubeletdnat-controller/main.go
+++ b/api/cmd/kubeletdnat-controller/main.go
@@ -8,12 +8,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
-
 	"github.com/golang/glog"
 	"github.com/oklog/run"
 
 	"github.com/kubermatic/kubermatic/api/pkg/controller/kubeletdnat"
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers"

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -360,6 +360,7 @@ func (cc *Controller) ensureStatefulSets(c *kubermaticv1.Cluster) error {
 func GetPodDisruptionBudgetCreators() []resources.PodDisruptionBudgetCreator {
 	return []resources.PodDisruptionBudgetCreator{
 		etcd.PodDisruptionBudget,
+		apiserver.PodDisruptionBudget,
 	}
 }
 

--- a/api/pkg/resources/apiserver/pdb.go
+++ b/api/pkg/resources/apiserver/pdb.go
@@ -1,0 +1,33 @@
+package apiserver
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodDisruptionBudget returns the apiserver PodDisruptionBudget
+func PodDisruptionBudget(data *resources.TemplateData, existing *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
+	var pdb *policyv1beta1.PodDisruptionBudget
+	if existing != nil {
+		pdb = existing
+	} else {
+		pdb = &policyv1beta1.PodDisruptionBudget{}
+	}
+
+	pdb.Name = resources.ApiserverPodDisruptionBudgetName
+	pdb.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
+
+	maxUnavailable := intstr.FromInt(1)
+	pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: resources.BaseAppLabel(name, nil),
+		},
+		// we can only specify maxUnavailable as minAvailable would block in case we have replicas=1. See https://github.com/kubernetes/kubernetes/issues/66811
+		MaxUnavailable: &maxUnavailable,
+	}
+
+	return pdb, nil
+}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -182,6 +182,8 @@ const (
 
 	// EtcdPodDisruptionBudgetName is the name of the PDB for the etcd statefulset
 	EtcdPodDisruptionBudgetName = "etcd"
+	// ApiserverPodDisruptionBudgetName is the name of the PDB for the apiserver deployment
+	ApiserverPodDisruptionBudgetName = "apiserver"
 
 	// DefaultOwnerReadOnlyMode represents file mode with read permission for owner only
 	DefaultOwnerReadOnlyMode = 0400

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.6-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.1-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.12.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.8.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.9.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.9.10-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.6-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.1-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.12.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.8.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.9.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.9.10-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.6-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.1-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.12.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.8.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.9.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.9.10-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.6-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.1-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.12.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.8.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.9.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.9.10-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.6-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.1-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.12.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.8.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.9.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.9.10-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.6-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.1-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.12.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.8.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.9.0-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.9.10-apiserver.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: apiserver
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds PodDisruptionBudget for the Apiserver deployment.
It uses `maxUnavailable=1` as `minAvailable` is not possible when using 1 replica - See https://github.com/kubernetes/kubernetes/issues/66811

The PodDisruptionBudget helps in scenarios with multiple Apiservers (Possible by overriding the replicas via `cluster.spec.componentOverride`)

**Release note**:
```release-note
PodDisruptionBudget is now configured for the API server deployment
```
