### PR TITLE
Add dedicated e2e tester cmd for parallel conformance testing of kubermatic clusters

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -837,6 +837,19 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:947d49e87af88a8fe52844d3394b94f25eeb98d8008c3bf53569b74fc8d696a1"
+  name = "github.com/onsi/ginkgo"
+  packages = [
+    "config",
+    "reporters",
+    "reporters/stenographer",
+    "types",
+  ]
+  pruneopts = "NUT"
+  revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
+  version = "v1.6.0"
+
+[[projects]]
   digest = "1:cce3a18fb0b96b5015cd8ca03a57d20a662679de03c4dc4b6ff5f17ea2050fa6"
   name = "github.com/pborman/uuid"
   packages = ["."]
@@ -1778,6 +1791,7 @@
     "github.com/kubermatic/machine-controller/pkg/userdata/ubuntu",
     "github.com/minio/minio-go",
     "github.com/oklog/run",
+    "github.com/onsi/ginkgo/reporters",
     "github.com/pmezard/go-difflib/difflib",
     "github.com/prometheus/client_golang/api",
     "github.com/prometheus/client_golang/api/prometheus/v1",

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -145,6 +145,15 @@ required = [
   name = "github.com/stretchr/testify"
   version = "v1.2.*"
 
+[[constraint]]
+  name = "github.com/onsi/ginkgo"
+  version = "v1.6.0"
+
+# Otherwise dep panics: https://github.com/golang/dep/issues/1799
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "gopkg.in/fsnotify/fsnotify.v1"
+
 [[override]]
   name = "k8s.io/apiserver"
   branch = "release-1.10"

--- a/api/cmd/conformance-tests/README.md
+++ b/api/cmd/conformance-tests/README.md
@@ -1,0 +1,34 @@
+# E2E conformance tester
+
+Runs static test scenarios against a kubermatic cluster.
+
+### Running
+
+#### Docker
+
+TODO: Define
+
+#### Locally
+
+Requires the `containers/conformance-tests/install.sh` to be run before.
+```bash
+go build github.com/kubermatic/kubermatic/api/cmd/conformance-tests
+./conformance-tests \
+-kubeconfig=$(go env GOPATH)/src/github.com/kubermatic/secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
+-datacenters=$(go env GOPATH)/src/github.com/kubermatic/secrets/seed-clusters/dev.kubermatic.io/datacenters.yaml \
+-kubermatic-nodes=5 \
+-kubermatic-parallel-clusters=10 \
+-kubermatic-delete-cluster=true \
+-name-prefix=e2e \
+-reports-root=$(go env GOPATH)/src/github.com/kubermatic/kubermatic/reports \
+-v=4 \
+-cleanup-on-start=true \
+-aws-access-key-id=<<AWS_ACCESS_KEY_ID>> \
+-aws-secret-access-key=<<AWS_SECRET_ACCESS_KEY_ID>> \
+-digitalocean-token=<<DIGITALOCEAN_TOKEN>> \
+-hetzner-token=<<HETZNER_TOKEN>> \
+-openstack-domain=<<OPENSTACK_DOMAIN>> \
+-openstack-tenant=<<OPENSTACK_TENANT>> \
+-openstack-username=<<OPENSTACK_USERNAME>> \
+-openstack-password=<<OPENSTACK_PASSWORD>>
+```

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -30,6 +30,7 @@ var supportedVersions = []*semver.Version{
 	semver.MustParse("v1.9.10"),
 	semver.MustParse("v1.10.8"),
 	semver.MustParse("v1.11.3"),
+	semver.MustParse("v1.12.0"),
 }
 
 // Opts represent combination of flags and ENV options
@@ -182,13 +183,8 @@ func main() {
 	scenarios = append(scenarios, getOpenStackScenarios()...)
 
 	runner := newRunner(scenarios, &opts)
-	hadFailure, err := runner.Run()
-	if err != nil {
-		glog.Fatalf("failed to execute the scenarios: %v", err)
-	}
 
-	if hadFailure {
-		glog.Infof("Some tests failed.")
-		os.Exit(1)
+	if err := runner.Run(); err != nil {
+		glog.Fatal(err)
 	}
 }

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/golang/glog"
+
+	clusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	kubermaticsignals "github.com/kubermatic/kubermatic/api/pkg/signals"
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var supportedVersions = []*semver.Version{
+	semver.MustParse("v1.9.10"),
+	semver.MustParse("v1.10.8"),
+	semver.MustParse("v1.11.3"),
+}
+
+// Opts represent combination of flags and ENV options
+type Opts struct {
+	namePrefix                   string
+	controlPlaneReadyWaitTimeout time.Duration
+	deleteClusterAfterTests      bool
+	kubeconfigPath               string
+	nodeCount                    int
+	nodeReadyWaitTimeout         time.Duration
+	reportsRoot                  string
+	clusterLister                kubermaticv1lister.ClusterLister
+	kubermaticClient             kubermaticclientset.Interface
+	clusterClientProvider        *clusterclient.Provider
+	dcFile                       string
+	testBinPath                  string
+	dcs                          map[string]provider.DatacenterMeta
+	cleanupOnStart               bool
+	clusterParallelCount         int
+
+	secrets secrets
+}
+
+type secrets struct {
+	AWS struct {
+		AccessKeyID     string
+		SecretAccessKey string
+	}
+	Digitalocean struct {
+		Token string
+	}
+	Hetzner struct {
+		Token string
+	}
+	OpenStack struct {
+		Domain   string
+		Tenant   string
+		Username string
+		Password string
+	}
+}
+
+const (
+	defaultTimeout = 30 * time.Minute
+
+	controlPlaneReadyPollPeriod = 5 * time.Second
+	nodesReadyPollPeriod        = 5 * time.Second
+)
+
+func main() {
+	opts := Opts{}
+
+	flag.StringVar(&opts.kubeconfigPath, "kubeconfig", "/config/kubeconfig", "path to kubeconfig file")
+	flag.StringVar(&opts.namePrefix, "name-prefix", "", "prefix used for all cluster names")
+	flag.StringVar(&opts.testBinPath, "test-bin-path", "/opt/kube-test/", "Rootpath for the test binaries")
+	flag.IntVar(&opts.nodeCount, "kubermatic-nodes", 3, "number of worker nodes")
+	flag.IntVar(&opts.clusterParallelCount, "kubermatic-parallel-clusters", 5, "number of clusters to test in parallel")
+	flag.StringVar(&opts.dcFile, "datacenters", "datacenters.yaml", "The datacenters.yaml file path")
+	flag.StringVar(&opts.reportsRoot, "reports-root", "/opt/reports", "Root for reports")
+	flag.BoolVar(&opts.cleanupOnStart, "cleanup-on-start", false, "Cleans up all clusters on start and exit afterwards - must be used with name-prefix.")
+	flag.DurationVar(&opts.controlPlaneReadyWaitTimeout, "kubermatic-cluster-timeout", defaultTimeout, "cluster creation timeout")
+	flag.DurationVar(&opts.nodeReadyWaitTimeout, "kubermatic-nodes-timeout", defaultTimeout, "nodes creation timeout")
+	flag.BoolVar(&opts.deleteClusterAfterTests, "kubermatic-delete-cluster", true, "delete test cluster at the exit")
+
+	flag.StringVar(&opts.secrets.AWS.AccessKeyID, "aws-access-key-id", "", "AWS: AccessKeyID")
+	flag.StringVar(&opts.secrets.AWS.SecretAccessKey, "aws-secret-access-key", "", "AWS: SecretAccessKey")
+	flag.StringVar(&opts.secrets.Digitalocean.Token, "digitalocean-token", "", "Digitalocean: API Token")
+	flag.StringVar(&opts.secrets.Hetzner.Token, "hetzner-token", "", "Hetzner: API Token")
+	flag.StringVar(&opts.secrets.OpenStack.Domain, "openstack-domain", "", "OpenStack: Domain")
+	flag.StringVar(&opts.secrets.OpenStack.Tenant, "openstack-tenant", "", "OpenStack: Tenant")
+	flag.StringVar(&opts.secrets.OpenStack.Username, "openstack-username", "", "OpenStack: Username")
+	flag.StringVar(&opts.secrets.OpenStack.Password, "openstack-password", "", "OpenStack: Password")
+
+	if err := flag.CommandLine.Set("logtostderr", "1"); err != nil {
+		fmt.Printf("failed to set logtostderr flag: %v\n", err)
+		os.Exit(1)
+	}
+	flag.Parse()
+
+	stopCh := kubermaticsignals.SetupSignalHandler()
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+
+	go func() {
+		select {
+		case <-stopCh:
+			rootCancel()
+			glog.Info("user requested to stop the application")
+		case <-rootCtx.Done():
+			glog.Info("context has been closed")
+		}
+	}()
+
+	dcs, err := provider.LoadDatacentersMeta(opts.dcFile)
+	if err != nil {
+		glog.Fatalf("failed to load datacenter yaml %q: %v", opts.dcFile, err)
+	}
+	opts.dcs = dcs
+
+	config, err := clientcmd.BuildConfigFromFlags("", opts.kubeconfigPath)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	kubermaticClient := kubermaticclientset.NewForConfigOrDie(config)
+
+	if opts.cleanupOnStart {
+		if opts.namePrefix == "" {
+			log.Fatalf("cleanup-on-start was specified but name-prefix is empty")
+		}
+
+		clusterList, err := kubermaticClient.KubermaticV1().Clusters().List(metav1.ListOptions{})
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, cluster := range clusterList.Items {
+			if strings.HasPrefix(cluster.Name, opts.namePrefix) {
+				p := metav1.DeletePropagationBackground
+				opts := metav1.DeleteOptions{PropagationPolicy: &p}
+				fmt.Println("Deleting cluster " + cluster.Name + "...")
+				if err = kubermaticClient.KubermaticV1().Clusters().Delete(cluster.Name, &opts); err != nil {
+					log.Fatalf("failed to delete cluster %s: %v", cluster.Name, err)
+				}
+			}
+		}
+
+		fmt.Println("Cleaned up all old clusters")
+		os.Exit(0)
+	}
+
+	kubeClient := kubernetes.NewForConfigOrDie(config)
+	kubermaticInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticClient, informer.DefaultInformerResyncPeriod)
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, informer.DefaultInformerResyncPeriod)
+
+	opts.kubermaticClient = kubermaticClient
+	opts.clusterLister = kubermaticInformerFactory.Kubermatic().V1().Clusters().Lister()
+
+	opts.clusterClientProvider = clusterclient.New(kubeInformerFactory.Core().V1().Secrets().Lister())
+
+	kubermaticInformerFactory.Start(rootCtx.Done())
+	kubeInformerFactory.Start(rootCtx.Done())
+	kubermaticInformerFactory.WaitForCacheSync(rootCtx.Done())
+	kubeInformerFactory.WaitForCacheSync(rootCtx.Done())
+
+	glog.Info("Starting E2E tests...")
+
+	var scenarios []testScenario
+	scenarios = append(scenarios, getAWSScenarios()...)
+	scenarios = append(scenarios, getDigitaloceanScenarios()...)
+	scenarios = append(scenarios, getHetznerScenarios()...)
+	scenarios = append(scenarios, getOpenStackScenarios()...)
+
+	runner := newRunner(scenarios, &opts)
+	hadFailure, err := runner.Run()
+	if err != nil {
+		glog.Fatalf("failed to execute the scenarios: %v", err)
+	}
+
+	if hadFailure {
+		glog.Infof("Some tests failed.")
+		os.Exit(1)
+	}
+}

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -138,25 +137,25 @@ func main() {
 
 	if opts.cleanupOnStart {
 		if opts.namePrefix == "" {
-			log.Fatalf("cleanup-on-start was specified but name-prefix is empty")
+			glog.Fatalf("cleanup-on-start was specified but name-prefix is empty")
 		}
 
 		clusterList, err := kubermaticClient.KubermaticV1().Clusters().List(metav1.ListOptions{})
 		if err != nil {
-			log.Fatal(err)
+			glog.Fatal(err)
 		}
 		for _, cluster := range clusterList.Items {
 			if strings.HasPrefix(cluster.Name, opts.namePrefix) {
 				p := metav1.DeletePropagationBackground
 				opts := metav1.DeleteOptions{PropagationPolicy: &p}
-				fmt.Println("Deleting cluster " + cluster.Name + "...")
+				glog.Infof("Deleting cluster %s...", cluster.Name)
 				if err = kubermaticClient.KubermaticV1().Clusters().Delete(cluster.Name, &opts); err != nil {
-					log.Fatalf("failed to delete cluster %s: %v", cluster.Name, err)
+					glog.Fatalf("failed to delete cluster %s: %v", cluster.Name, err)
 				}
 			}
 		}
 
-		fmt.Println("Cleaned up all old clusters")
+		glog.Info("Cleaned up all old clusters")
 		os.Exit(0)
 	}
 

--- a/api/cmd/conformance-tests/os.go
+++ b/api/cmd/conformance-tests/os.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	kubermaticapiv2 "github.com/kubermatic/kubermatic/api/pkg/api/v2"
+)
+
+func getOSNameFromSpec(spec kubermaticapiv2.OperatingSystemSpec) string {
+	if spec.CentOS != nil {
+		return "centos"
+	}
+	if spec.ContainerLinux != nil {
+		return "coreos"
+	}
+	if spec.Ubuntu != nil {
+		return "ubuntu"
+	}
+
+	return ""
+}

--- a/api/cmd/conformance-tests/reports.go
+++ b/api/cmd/conformance-tests/reports.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func collectReports(name, reportsDir string, time time.Duration) (*reporters.JUnitTestSuite, error) {
+	files, err := ioutil.ReadDir(reportsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files in reportsDir '%s': %v", reportsDir, err)
+	}
+
+	resultSuite := reporters.JUnitTestSuite{
+		Time: time.Seconds(),
+	}
+	resultSuite.Name = name
+
+	var individualReportFiles []string
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+
+		if !strings.HasPrefix(f.Name(), "junit_") || !strings.HasSuffix(f.Name(), ".xml") {
+			continue
+		}
+
+		absName := path.Join(reportsDir, f.Name())
+		individualReportFiles = append(individualReportFiles, absName)
+
+		b, err := ioutil.ReadFile(absName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file '%s': %v", absName, err)
+		}
+
+		suite := &reporters.JUnitTestSuite{}
+		if err := xml.Unmarshal(b, suite); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal report file '%s': %v", absName, err)
+		}
+
+		resultSuite.Tests += suite.Tests
+		resultSuite.Errors += suite.Errors
+		resultSuite.Failures += suite.Failures
+		resultSuite.TestCases = append(resultSuite.TestCases, suite.TestCases...)
+	}
+	sort.Slice(resultSuite.TestCases, func(i, j int) bool { return resultSuite.TestCases[i].Name < resultSuite.TestCases[j].Name })
+
+	b, err := xml.Marshal(resultSuite)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal combined report file: %v", err)
+	}
+
+	if err := ioutil.WriteFile(path.Join(reportsDir, "junit.xml"), b, 0644); err != nil {
+		return nil, fmt.Errorf("failed to wrte combined report file: %v", err)
+	}
+
+	for _, f := range individualReportFiles {
+		if err := os.Remove(f); err != nil {
+			return nil, fmt.Errorf("failed to remove report file: %v", err)
+		}
+	}
+
+	return &resultSuite, nil
+}
+
+func printDetailedReport(report *reporters.JUnitTestSuite) {
+	testBuf := &bytes.Buffer{}
+	for _, t := range report.TestCases {
+		status := "PASS"
+		if t.FailureMessage != nil {
+			status = "FAIL"
+		}
+
+		if t.FailureMessage == nil {
+			continue
+		}
+
+		fmt.Fprintln(testBuf, fmt.Sprintf("[%s] - %s", status, t.Name))
+		if t.FailureMessage != nil {
+			fmt.Fprintln(testBuf, fmt.Sprintf("      %s", t.FailureMessage.Message))
+		}
+	}
+
+	buf := &bytes.Buffer{}
+	const separator = "============================================================="
+	fmt.Fprintln(buf, separator)
+	fmt.Fprintln(buf, fmt.Sprintf("Test results for: %s", report.Name))
+
+	fmt.Fprint(buf, testBuf.String())
+
+	fmt.Fprintln(buf, "----------------------------")
+	fmt.Fprintln(buf, fmt.Sprintf("Passed: %d", report.Tests-report.Failures))
+	fmt.Fprintln(buf, fmt.Sprintf("Failed: %d", report.Failures))
+	fmt.Fprintln(buf, separator)
+
+	fmt.Println(buf.String())
+}

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -118,15 +118,17 @@ func (r *testRunner) Run() (bool, error) {
 	scenariosCh := make(chan testScenario, len(r.scenarios))
 	resultsCh := make(chan testResult, len(r.scenarios))
 
-	for i := 1; i <= r.clusterParallelCount; i++ {
-		go r.worker(i, scenariosCh, resultsCh)
-	}
-
 	glog.V(2).Infoln("Test suite:")
 	for _, scenario := range r.scenarios {
 		glog.V(2).Infoln(scenario.Name())
 		scenariosCh <- scenario
 	}
+	glog.V(2).Infoln(fmt.Sprintf("Total: %d tests", len(r.scenarios)))
+
+	for i := 1; i <= r.clusterParallelCount; i++ {
+		go r.worker(i, scenariosCh, resultsCh)
+	}
+
 	close(scenariosCh)
 
 	var results []testResult

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -114,7 +114,7 @@ func (r *testRunner) worker(id int, scenarios <-chan testScenario, results chan<
 	}
 }
 
-func (r *testRunner) Run() (bool, error) {
+func (r *testRunner) Run() error {
 	scenariosCh := make(chan testScenario, len(r.scenarios))
 	resultsCh := make(chan testResult, len(r.scenarios))
 
@@ -159,7 +159,10 @@ func (r *testRunner) Run() (bool, error) {
 	fmt.Println("========================== RESULT ===========================")
 	fmt.Println(overallResultBuf.String())
 
-	return hadFailure, nil
+	if hadFailure {
+		return errors.New("some tests failed")
+	}
+	return nil
 }
 
 func (r *testRunner) testScenario(scenario testScenario) (*reporters.JUnitTestSuite, error) {

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -1,0 +1,434 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path"
+	"text/template"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/golang/glog"
+	"github.com/onsi/ginkgo/reporters"
+
+	kubermaticapiv2 "github.com/kubermatic/kubermatic/api/pkg/api/v2"
+	clusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/machine"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+type testScenario interface {
+	Name() string
+	Cluster(secrets secrets) *kubermaticv1.Cluster
+	Nodes(num int) []*kubermaticapiv2.Node
+}
+
+func newRunner(scenarios []testScenario, opts *Opts) *testRunner {
+	return &testRunner{
+		scenarios:                    scenarios,
+		clusterLister:                opts.clusterLister,
+		controlPlaneReadyWaitTimeout: opts.controlPlaneReadyWaitTimeout,
+		deleteClusterAfterTests:      opts.deleteClusterAfterTests,
+		kubermaticClient:             opts.kubermaticClient,
+		secrets:                      opts.secrets,
+		namePrefix:                   opts.namePrefix,
+		clusterClientProvider:        opts.clusterClientProvider,
+		nodesReadyWaitTimeout:        opts.nodeReadyWaitTimeout,
+		dcs:                          opts.dcs,
+		nodeCount:                    opts.nodeCount,
+		testBinPath:                  opts.testBinPath,
+		reportsRoot:                  opts.reportsRoot,
+		clusterParallelCount:         opts.clusterParallelCount,
+	}
+}
+
+type testRunner struct {
+	scenarios   []testScenario
+	secrets     secrets
+	namePrefix  string
+	testBinPath string
+	reportsRoot string
+
+	controlPlaneReadyWaitTimeout time.Duration
+	deleteClusterAfterTests      bool
+	nodesReadyWaitTimeout        time.Duration
+	nodeCount                    int
+	clusterParallelCount         int
+
+	kubermaticClient      kubermaticclientset.Interface
+	clusterLister         kubermaticv1lister.ClusterLister
+	clusterClientProvider *clusterclient.Provider
+	dcs                   map[string]provider.DatacenterMeta
+}
+
+type testResult struct {
+	report   *reporters.JUnitTestSuite
+	err      error
+	scenario testScenario
+}
+
+func (t *testResult) Passed() bool {
+	if t.err != nil {
+		return false
+	}
+
+	if t.report == nil {
+		return false
+	}
+
+	if len(t.report.TestCases) == 0 {
+		return false
+	}
+
+	if t.report.Errors > 0 || t.report.Failures > 0 {
+		return false
+	}
+
+	return true
+}
+
+func (r *testRunner) worker(id int, scenarios <-chan testScenario, results chan<- testResult) {
+	for s := range scenarios {
+		r.logInfo(s, "Starting...")
+		report, err := r.testScenario(s)
+		res := testResult{
+			report:   report,
+			scenario: s,
+			err:      err,
+		}
+		r.logInfo(s, "Finished")
+		results <- res
+	}
+}
+
+func (r *testRunner) Run() (bool, error) {
+	scenariosCh := make(chan testScenario, len(r.scenarios))
+	resultsCh := make(chan testResult, len(r.scenarios))
+
+	for i := 1; i <= r.clusterParallelCount; i++ {
+		go r.worker(i, scenariosCh, resultsCh)
+	}
+
+	glog.V(2).Infoln("Test suite:")
+	for _, scenario := range r.scenarios {
+		glog.V(2).Infoln(scenario.Name())
+		scenariosCh <- scenario
+	}
+	close(scenariosCh)
+
+	var results []testResult
+	for range r.scenarios {
+		results = append(results, <-resultsCh)
+		glog.V(2).Infof("Finished %d/%d test cases", len(results), len(r.scenarios))
+	}
+
+	overallResultBuf := &bytes.Buffer{}
+	hadFailure := false
+	for _, result := range results {
+		prefix := "PASS"
+		if !result.Passed() {
+			prefix = "FAIL"
+			hadFailure = true
+		}
+		scenarioResultMsg := fmt.Sprintf("[%s] - %s", prefix, result.scenario.Name())
+		if result.err != nil {
+			scenarioResultMsg = fmt.Sprintf("%s : %v", scenarioResultMsg, result.err)
+		}
+
+		fmt.Fprintln(overallResultBuf, scenarioResultMsg)
+		if result.report != nil {
+			printDetailedReport(result.report)
+		}
+	}
+
+	fmt.Println("========================== RESULT ===========================")
+	fmt.Println(overallResultBuf.String())
+
+	return hadFailure, nil
+}
+
+func (r *testRunner) testScenario(scenario testScenario) (*reporters.JUnitTestSuite, error) {
+	// Always generate a random name
+	cluster := scenario.Cluster(r.secrets)
+	cluster.Name = rand.String(8)
+	if r.namePrefix != "" {
+		cluster.Name = fmt.Sprintf("%s-%s", r.namePrefix, cluster.Name)
+	}
+
+	dc, found := r.dcs[cluster.Spec.Cloud.DatacenterName]
+	if !found {
+		return nil, fmt.Errorf("invalid cloud datacenter specified '%s'. Not found in datacenters list", cluster.Spec.Cloud.DatacenterName)
+	}
+
+	r.logInfo(scenario, "Creating cluster: %s...", cluster.Name)
+	cluster, err := r.kubermaticClient.KubermaticV1().Clusters().Create(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the cluster: %v", err)
+	}
+	if r.deleteClusterAfterTests {
+		defer r.tryToDeleteCluster(cluster.Name, scenario)
+	}
+	r.logInfo(scenario, "Successfully created cluster!")
+
+	r.logInfo(scenario, "Waiting for control plane to become ready...")
+	cluster, err = r.waitForControlPlane(scenario, cluster.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed waiting for control plane to become ready: %v", err)
+	}
+	r.logInfo(scenario, "Control plane became ready!")
+
+	r.logInfo(scenario, "Getting kubeconfig...")
+	kubeconfig, err := r.clusterClientProvider.GetAdminKubeconfig(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig for cluster: %v", err)
+	}
+	filename := fmt.Sprintf("/tmp/%s-kubeconfig", cluster.Name)
+	if err := ioutil.WriteFile(filename, kubeconfig, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write kubeconfig to %s: %v", filename, err)
+	}
+	r.logInfo(scenario, "Wrote kubeconfig to %s", filename)
+
+	r.logInfo(scenario, "Creating machines...")
+	kubeMachineClient, err := r.clusterClientProvider.GetMachineClient(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the machine client for the cluster: %v", err)
+	}
+
+	apiNodes := scenario.Nodes(r.nodeCount)
+	for _, node := range apiNodes {
+		m, err := machine.Machine(cluster, node, dc, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Machine from scenario node '%s': %v", node.Metadata.Name, err)
+		}
+
+		if _, err := kubeMachineClient.ClusterV1alpha1().Machines(metav1.NamespaceSystem).Create(m); err != nil {
+			return nil, fmt.Errorf("failed to create machine %s: %v", m.Name, err)
+		}
+	}
+	r.logInfo(scenario, "Successfully created %d machine(s)!", len(apiNodes))
+
+	clusterKubeClient, err := r.clusterClientProvider.GetClient(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the client for the cluster: %v", err)
+	}
+
+	r.logInfo(scenario, "Waiting for nodes to become ready...")
+	if err := r.waitForReadyNodes(scenario, clusterKubeClient, len(apiNodes)); err != nil {
+		return nil, fmt.Errorf("failed waiting for nodes to become ready: %v", err)
+	}
+	r.logInfo(scenario, "All nodes became ready!")
+
+	var report *reporters.JUnitTestSuite
+	for attempt := 1; attempt <= 3; attempt++ {
+		startedE2E := time.Now()
+		reportsDir := path.Join(r.reportsRoot, scenario.Name(), fmt.Sprintf("attempt-%d", attempt))
+
+		r.logInfo(scenario, "[Attempt: %d] Starting E2E tests...", attempt)
+		if err := r.runE2E(scenario, cluster, filename, reportsDir); err != nil {
+			r.logInfo(scenario, "[Attempt: %d] failed to run E2E tests: %v", attempt, err)
+			continue
+		}
+		r.logInfo(scenario, "[Attempt: %d] E2E tests finished after %.2f seconds", attempt, time.Since(startedE2E).Seconds())
+
+		report, err = collectReports(scenario.Name(), reportsDir, time.Since(startedE2E))
+		if err != nil {
+			r.logInfo(scenario, "[Attempt: %d] failed to combine reports: %v. Restarting...", attempt, err)
+			continue
+		}
+
+		if report.Errors > 0 || report.Failures > 0 {
+			r.logInfo(scenario, "[Attempt: %d] e2e tests had some failures (See %s for details). Restarting...", attempt, reportsDir)
+			continue
+		}
+		return report, nil
+	}
+
+	if report == nil {
+		return nil, errors.New("no report generated")
+	}
+	return report, nil
+}
+
+func (r *testRunner) logInfo(scenario testScenario, msg string, args ...interface{}) {
+	scenarioName := scenario.Name()
+	if len(args) > 0 {
+		msg = fmt.Sprintf(msg, args...)
+	}
+
+	glog.Infof("[%s] %s", scenarioName, msg)
+}
+
+func (r *testRunner) tryToDeleteCluster(clusterName string, scenario testScenario) {
+	if err := r.kubermaticClient.KubermaticV1().Clusters().Delete(clusterName, &metav1.DeleteOptions{}); err != nil {
+		r.logInfo(scenario, "Failed to delete cluster %s: %v. Make sure to delete it manually afterwards", clusterName, err)
+	}
+}
+
+func (r *testRunner) waitForReadyNodes(scenario testScenario, client kubernetes.Interface, num int) error {
+	started := time.Now()
+
+	nodeIsReady := func(n corev1.Node) bool {
+		for _, condition := range n.Status.Conditions {
+			if condition.Type == corev1.NodeReady {
+				if condition.Status == corev1.ConditionTrue {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	err := wait.Poll(nodesReadyPollPeriod, r.nodesReadyWaitTimeout, func() (done bool, err error) {
+		nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to list nodes: %v", err)
+		}
+
+		if len(nodeList.Items) != num {
+			return false, nil
+		}
+
+		for _, node := range nodeList.Items {
+			if !nodeIsReady(node) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	r.logInfo(scenario, "Nodes got ready after %.2f seconds", time.Since(started).Seconds())
+	return nil
+}
+
+func (r *testRunner) waitForControlPlane(scenario testScenario, clusterName string) (*kubermaticv1.Cluster, error) {
+	started := time.Now()
+
+	err := wait.Poll(controlPlaneReadyPollPeriod, r.controlPlaneReadyWaitTimeout, func() (done bool, err error) {
+		cluster, err := r.clusterLister.Get(clusterName)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get the cluster %s from the lister: %v", clusterName, err)
+		}
+
+		return cluster.Status.Health.AllHealthy() && cluster.Status.Health.OpenVPN, nil
+	})
+	// Timeout or other error
+	if err != nil {
+		return nil, err
+	}
+
+	// Get copy of latest version
+	cluster, err := r.clusterLister.Get(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	r.logInfo(scenario, "Control plane got ready after %.2f seconds", time.Since(started).Seconds())
+	return cluster.DeepCopy(), nil
+}
+
+func (r *testRunner) runE2E(scenario testScenario, cluster *kubermaticv1.Cluster, kubeconfigFilename, reportsDir string) error {
+	kubeconfigFilename = path.Clean(kubeconfigFilename)
+	testBinDir := path.Clean(r.testBinPath)
+
+	version, err := semver.NewVersion(cluster.Spec.Version)
+	if err != nil {
+		return fmt.Errorf("invalid cluster version '%s': %v", cluster.Spec.Version, err)
+	}
+
+	data := struct {
+		// Only main + minor
+		Version            string
+		TestBinDir         string
+		KubeconfigFilename string
+		ReportsDir         string
+	}{
+		Version:            fmt.Sprintf("%d.%d", version.Major(), version.Minor()),
+		TestBinDir:         testBinDir,
+		KubeconfigFilename: kubeconfigFilename,
+		ReportsDir:         reportsDir,
+	}
+
+	tpl, err := template.New("script").Parse(testScriptTpl)
+	if err != nil {
+		return fmt.Errorf("failed to parse test script template: %v", err)
+	}
+
+	scriptBuffer := &bytes.Buffer{}
+	err = tpl.Execute(scriptBuffer, data)
+	if err != nil {
+		return fmt.Errorf("failed to execute test script template: %v", err)
+	}
+
+	script := scriptBuffer.String()
+	cmd := exec.Command("bash", "-c", script)
+
+	logFile := path.Join(reportsDir, "e2e.log")
+	out, err := cmd.CombinedOutput()
+	defer func() {
+		if err := ioutil.WriteFile(logFile, out, 0644); err != nil {
+			r.logInfo(scenario, "failed to write e2e logs: %v", err)
+		}
+	}()
+	if err != nil {
+		r.logInfo(scenario, script)
+		return fmt.Errorf("failed to run ginkgo script (logs: %s): %v", logFile, err)
+	}
+
+	return nil
+}
+
+const (
+	testScriptTpl = `#!/usr/bin/env bash
+{{ .TestBinDir }}/{{ .Version }}/ginkgo \
+    -progress \
+    -nodes=10 \
+    -noColor=true \
+    -flakeAttempts=10 \
+    -focus="\[Conformance\]" \
+    -skip="\[Serial\]" \
+    {{ .TestBinDir }}/{{ .Version }}/e2e.test -- \
+    --disable-log-dump \
+    --repo-root={{ .TestBinDir }}/{{ .Version }}/ \
+    --provider="local" \
+    --report-dir="{{ .ReportsDir }}" \
+    --report-prefix="parallel" \
+    --kubectl-path={{ .TestBinDir }}/{{ .Version }}/kubectl \
+    --kubeconfig="{{ .KubeconfigFilename }}"
+
+{{ .TestBinDir }}/{{ .Version }}/ginkgo \
+    -progress \
+    -nodes=1 \
+    -noColor=true \
+    -flakeAttempts=10 \
+    -focus="\[Serial\].*\[Conformance\]" \
+    {{ .TestBinDir }}/{{ .Version }}/e2e.test -- \
+    --disable-log-dump \
+    --repo-root={{ .TestBinDir }}/{{ .Version }}/ \
+    --provider="local" \
+    --report-dir="{{ .ReportsDir }}" \
+    --report-prefix="serial" \
+    --kubectl-path={{ .TestBinDir }}/{{ .Version }}/kubectl \
+    --kubeconfig="{{ .KubeconfigFilename }}"
+`
+)

--- a/api/cmd/conformance-tests/scenarios_aws.go
+++ b/api/cmd/conformance-tests/scenarios_aws.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Masterminds/semver"
+
+	kubermaticapiv2 "github.com/kubermatic/kubermatic/api/pkg/api/v2"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getAWSScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &awsScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv2.UbuntuSpec{},
+			},
+		})
+		// CoreOS
+		scenarios = append(scenarios, &awsScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+				ContainerLinux: &kubermaticapiv2.ContainerLinuxSpec{
+					// Otherwise the nodes restart directly after creation - bad for tests
+					DisableAutoUpdate: true,
+				},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &awsScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv2.CentOSSpec{},
+		//	},
+		//})
+	}
+	return scenarios
+}
+
+type awsScenario struct {
+	version    *semver.Version
+	nodeOsSpec kubermaticapiv2.OperatingSystemSpec
+}
+
+func (s *awsScenario) Name() string {
+	return fmt.Sprintf("aws-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *awsScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           s.version.String(),
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "aws-eu-central-1a",
+				AWS: &v1.AWSCloudSpec{
+					SecretAccessKey: secrets.AWS.SecretAccessKey,
+					AccessKeyID:     secrets.AWS.AccessKeyID,
+				},
+			},
+		},
+	}
+}
+
+func (s *awsScenario) Nodes(num int) []*kubermaticapiv2.Node {
+	var nodes []*kubermaticapiv2.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv2.Node{
+			Metadata: kubermaticapiv2.ObjectMeta{
+				Name: "node" + strconv.Itoa(i),
+			},
+			Spec: kubermaticapiv2.NodeSpec{
+				Cloud: kubermaticapiv2.NodeCloudSpec{
+					AWS: &kubermaticapiv2.AWSNodeSpec{
+						InstanceType: "t2.medium",
+						VolumeType:   "gp2",
+						VolumeSize:   50,
+					},
+				},
+				Versions: kubermaticapiv2.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_digitalocean.go
+++ b/api/cmd/conformance-tests/scenarios_digitalocean.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Masterminds/semver"
+
+	kubermaticapiv2 "github.com/kubermatic/kubermatic/api/pkg/api/v2"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getDigitaloceanScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &digitaloceanScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv2.UbuntuSpec{},
+			},
+		})
+		// CoreOS
+		scenarios = append(scenarios, &digitaloceanScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+				ContainerLinux: &kubermaticapiv2.ContainerLinuxSpec{
+					// Otherwise the nodes restart directly after creation - bad for tests
+					DisableAutoUpdate: true,
+				},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &digitaloceanScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv2.CentOSSpec{},
+		//	},
+		//})
+	}
+
+	return scenarios
+}
+
+type digitaloceanScenario struct {
+	version    *semver.Version
+	nodeOsSpec kubermaticapiv2.OperatingSystemSpec
+}
+
+func (s *digitaloceanScenario) Name() string {
+	return fmt.Sprintf("digitalocean-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *digitaloceanScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           s.version.String(),
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "do-fra1",
+				Digitalocean: &v1.DigitaloceanCloudSpec{
+					Token: secrets.Digitalocean.Token,
+				},
+			},
+		},
+	}
+}
+
+func (s *digitaloceanScenario) Nodes(num int) []*kubermaticapiv2.Node {
+	var nodes []*kubermaticapiv2.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv2.Node{
+			Metadata: kubermaticapiv2.ObjectMeta{
+				Name: "node" + strconv.Itoa(i),
+			},
+			Spec: kubermaticapiv2.NodeSpec{
+				Cloud: kubermaticapiv2.NodeCloudSpec{
+					Digitalocean: &kubermaticapiv2.DigitaloceanNodeSpec{
+						Size: "4gb",
+					},
+				},
+				Versions: kubermaticapiv2.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_hetzner.go
+++ b/api/cmd/conformance-tests/scenarios_hetzner.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Masterminds/semver"
+
+	kubermaticapiv2 "github.com/kubermatic/kubermatic/api/pkg/api/v2"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getHetznerScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &hetznerScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv2.UbuntuSpec{},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &hetznerScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv2.CentOSSpec{},
+		//	},
+		//})
+	}
+
+	return scenarios
+}
+
+type hetznerScenario struct {
+	version    *semver.Version
+	nodeOsSpec kubermaticapiv2.OperatingSystemSpec
+}
+
+func (s *hetznerScenario) Name() string {
+	return fmt.Sprintf("hetzner-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *hetznerScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           s.version.String(),
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "hetzner-fsn1",
+				Hetzner: &v1.HetznerCloudSpec{
+					Token: secrets.Hetzner.Token,
+				},
+			},
+		},
+	}
+}
+
+func (s *hetznerScenario) Nodes(num int) []*kubermaticapiv2.Node {
+	var nodes []*kubermaticapiv2.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv2.Node{
+			Metadata: kubermaticapiv2.ObjectMeta{
+				Name: "node" + strconv.Itoa(i),
+			},
+			Spec: kubermaticapiv2.NodeSpec{
+				Cloud: kubermaticapiv2.NodeCloudSpec{
+					Hetzner: &kubermaticapiv2.HetznerNodeSpec{
+						Type: "cx31",
+					},
+				},
+				Versions: kubermaticapiv2.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_openstack.go
+++ b/api/cmd/conformance-tests/scenarios_openstack.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Masterminds/semver"
+
+	kubermaticapiv2 "github.com/kubermatic/kubermatic/api/pkg/api/v2"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getOpenStackScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &openStackScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv2.UbuntuSpec{},
+			},
+		})
+		// CoreOS
+		scenarios = append(scenarios, &openStackScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+				ContainerLinux: &kubermaticapiv2.ContainerLinuxSpec{
+					// Otherwise the nodes restart directly after creation - bad for tests
+					DisableAutoUpdate: true,
+				},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &openStackScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv2.CentOSSpec{},
+		//	},
+		//})
+	}
+
+	return scenarios
+}
+
+type openStackScenario struct {
+	version    *semver.Version
+	nodeOsSpec kubermaticapiv2.OperatingSystemSpec
+}
+
+func (s *openStackScenario) Name() string {
+	return fmt.Sprintf("openstack-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *openStackScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           s.version.String(),
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "syseleven-dbl1",
+				Openstack: &v1.OpenstackCloudSpec{
+					Domain:   secrets.OpenStack.Domain,
+					Tenant:   secrets.OpenStack.Tenant,
+					Username: secrets.OpenStack.Username,
+					Password: secrets.OpenStack.Password,
+				},
+			},
+		},
+	}
+}
+
+func (s *openStackScenario) Nodes(num int) []*kubermaticapiv2.Node {
+	osName := getOSNameFromSpec(s.nodeOsSpec)
+	var nodes []*kubermaticapiv2.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv2.Node{
+			Metadata: kubermaticapiv2.ObjectMeta{
+				Name: "node" + strconv.Itoa(i),
+			},
+			Spec: kubermaticapiv2.NodeSpec{
+				Cloud: kubermaticapiv2.NodeCloudSpec{
+					Openstack: &kubermaticapiv2.OpenstackNodeSpec{
+						Flavor: "m1.small",
+						Image:  "kubermatic-e2e-" + osName,
+					},
+				},
+				Versions: kubermaticapiv2.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -101,10 +101,10 @@ func main() {
 	newSSHKeyProvider := kubernetesprovider.NewRBACCompliantSSHKeyProvider(defaultImpersonationClient.CreateImpersonatedClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserSSHKeies().Lister())
 	userProvider := kubernetesprovider.NewUserProvider(kubermaticMasterClient, kubermaticMasterInformerFactory.Kubermatic().V1().Users().Lister())
 	projectProvider, err := kubernetesprovider.NewProjectProvider(defaultImpersonationClient.CreateImpersonatedClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().Projects().Lister())
-	projectMemberProvider := kubernetesprovider.NewProjectMemberProvider(defaultImpersonationClient.CreateImpersonatedClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserProjectBindings().Lister())
 	if err != nil {
 		glog.Fatalf("failed to create project provider due to %v", err)
 	}
+	projectMemberProvider := kubernetesprovider.NewProjectMemberProvider(defaultImpersonationClient.CreateImpersonatedClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserProjectBindings().Lister())
 
 	// create a cluster provider for each context
 	clientcmdConfig, err := clientcmd.LoadFromFile(kubeconfig)

--- a/api/errcheck_excludes.txt
+++ b/api/errcheck_excludes.txt
@@ -1,3 +1,4 @@
 strconv.ParseBool
 os.RemoveAll
 fmt.Fprint
+fmt.Fprintln

--- a/api/vendor/github.com/onsi/ginkgo/LICENSE
+++ b/api/vendor/github.com/onsi/ginkgo/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2013-2014 Onsi Fakhouri
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/api/vendor/github.com/onsi/ginkgo/config/config.go
+++ b/api/vendor/github.com/onsi/ginkgo/config/config.go
@@ -1,0 +1,200 @@
+/*
+Ginkgo accepts a number of configuration options.
+
+These are documented [here](http://onsi.github.io/ginkgo/#the_ginkgo_cli)
+
+You can also learn more via
+
+	ginkgo help
+
+or (I kid you not):
+
+	go test -asdf
+*/
+package config
+
+import (
+	"flag"
+	"time"
+
+	"fmt"
+)
+
+const VERSION = "1.6.0"
+
+type GinkgoConfigType struct {
+	RandomSeed         int64
+	RandomizeAllSpecs  bool
+	RegexScansFilePath bool
+	FocusString        string
+	SkipString         string
+	SkipMeasurements   bool
+	FailOnPending      bool
+	FailFast           bool
+	FlakeAttempts      int
+	EmitSpecProgress   bool
+	DryRun             bool
+	DebugParallel      bool
+
+	ParallelNode  int
+	ParallelTotal int
+	SyncHost      string
+	StreamHost    string
+}
+
+var GinkgoConfig = GinkgoConfigType{}
+
+type DefaultReporterConfigType struct {
+	NoColor           bool
+	SlowSpecThreshold float64
+	NoisyPendings     bool
+	NoisySkippings    bool
+	Succinct          bool
+	Verbose           bool
+	FullTrace         bool
+}
+
+var DefaultReporterConfig = DefaultReporterConfigType{}
+
+func processPrefix(prefix string) string {
+	if prefix != "" {
+		prefix = prefix + "."
+	}
+	return prefix
+}
+
+func Flags(flagSet *flag.FlagSet, prefix string, includeParallelFlags bool) {
+	prefix = processPrefix(prefix)
+	flagSet.Int64Var(&(GinkgoConfig.RandomSeed), prefix+"seed", time.Now().Unix(), "The seed used to randomize the spec suite.")
+	flagSet.BoolVar(&(GinkgoConfig.RandomizeAllSpecs), prefix+"randomizeAllSpecs", false, "If set, ginkgo will randomize all specs together.  By default, ginkgo only randomizes the top level Describe, Context and When groups.")
+	flagSet.BoolVar(&(GinkgoConfig.SkipMeasurements), prefix+"skipMeasurements", false, "If set, ginkgo will skip any measurement specs.")
+	flagSet.BoolVar(&(GinkgoConfig.FailOnPending), prefix+"failOnPending", false, "If set, ginkgo will mark the test suite as failed if any specs are pending.")
+	flagSet.BoolVar(&(GinkgoConfig.FailFast), prefix+"failFast", false, "If set, ginkgo will stop running a test suite after a failure occurs.")
+
+	flagSet.BoolVar(&(GinkgoConfig.DryRun), prefix+"dryRun", false, "If set, ginkgo will walk the test hierarchy without actually running anything.  Best paired with -v.")
+
+	flagSet.StringVar(&(GinkgoConfig.FocusString), prefix+"focus", "", "If set, ginkgo will only run specs that match this regular expression.")
+	flagSet.StringVar(&(GinkgoConfig.SkipString), prefix+"skip", "", "If set, ginkgo will only run specs that do not match this regular expression.")
+
+	flagSet.BoolVar(&(GinkgoConfig.RegexScansFilePath), prefix+"regexScansFilePath", false, "If set, ginkgo regex matching also will look at the file path (code location).")
+
+	flagSet.IntVar(&(GinkgoConfig.FlakeAttempts), prefix+"flakeAttempts", 1, "Make up to this many attempts to run each spec. Please note that if any of the attempts succeed, the suite will not be failed. But any failures will still be recorded.")
+
+	flagSet.BoolVar(&(GinkgoConfig.EmitSpecProgress), prefix+"progress", false, "If set, ginkgo will emit progress information as each spec runs to the GinkgoWriter.")
+
+	flagSet.BoolVar(&(GinkgoConfig.DebugParallel), prefix+"debug", false, "If set, ginkgo will emit node output to files when running in parallel.")
+
+	if includeParallelFlags {
+		flagSet.IntVar(&(GinkgoConfig.ParallelNode), prefix+"parallel.node", 1, "This worker node's (one-indexed) node number.  For running specs in parallel.")
+		flagSet.IntVar(&(GinkgoConfig.ParallelTotal), prefix+"parallel.total", 1, "The total number of worker nodes.  For running specs in parallel.")
+		flagSet.StringVar(&(GinkgoConfig.SyncHost), prefix+"parallel.synchost", "", "The address for the server that will synchronize the running nodes.")
+		flagSet.StringVar(&(GinkgoConfig.StreamHost), prefix+"parallel.streamhost", "", "The address for the server that the running nodes should stream data to.")
+	}
+
+	flagSet.BoolVar(&(DefaultReporterConfig.NoColor), prefix+"noColor", false, "If set, suppress color output in default reporter.")
+	flagSet.Float64Var(&(DefaultReporterConfig.SlowSpecThreshold), prefix+"slowSpecThreshold", 5.0, "(in seconds) Specs that take longer to run than this threshold are flagged as slow by the default reporter.")
+	flagSet.BoolVar(&(DefaultReporterConfig.NoisyPendings), prefix+"noisyPendings", true, "If set, default reporter will shout about pending tests.")
+	flagSet.BoolVar(&(DefaultReporterConfig.NoisySkippings), prefix+"noisySkippings", true, "If set, default reporter will shout about skipping tests.")
+	flagSet.BoolVar(&(DefaultReporterConfig.Verbose), prefix+"v", false, "If set, default reporter print out all specs as they begin.")
+	flagSet.BoolVar(&(DefaultReporterConfig.Succinct), prefix+"succinct", false, "If set, default reporter prints out a very succinct report")
+	flagSet.BoolVar(&(DefaultReporterConfig.FullTrace), prefix+"trace", false, "If set, default reporter prints out the full stack trace when a failure occurs")
+}
+
+func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultReporterConfigType) []string {
+	prefix = processPrefix(prefix)
+	result := make([]string, 0)
+
+	if ginkgo.RandomSeed > 0 {
+		result = append(result, fmt.Sprintf("--%sseed=%d", prefix, ginkgo.RandomSeed))
+	}
+
+	if ginkgo.RandomizeAllSpecs {
+		result = append(result, fmt.Sprintf("--%srandomizeAllSpecs", prefix))
+	}
+
+	if ginkgo.SkipMeasurements {
+		result = append(result, fmt.Sprintf("--%sskipMeasurements", prefix))
+	}
+
+	if ginkgo.FailOnPending {
+		result = append(result, fmt.Sprintf("--%sfailOnPending", prefix))
+	}
+
+	if ginkgo.FailFast {
+		result = append(result, fmt.Sprintf("--%sfailFast", prefix))
+	}
+
+	if ginkgo.DryRun {
+		result = append(result, fmt.Sprintf("--%sdryRun", prefix))
+	}
+
+	if ginkgo.FocusString != "" {
+		result = append(result, fmt.Sprintf("--%sfocus=%s", prefix, ginkgo.FocusString))
+	}
+
+	if ginkgo.SkipString != "" {
+		result = append(result, fmt.Sprintf("--%sskip=%s", prefix, ginkgo.SkipString))
+	}
+
+	if ginkgo.FlakeAttempts > 1 {
+		result = append(result, fmt.Sprintf("--%sflakeAttempts=%d", prefix, ginkgo.FlakeAttempts))
+	}
+
+	if ginkgo.EmitSpecProgress {
+		result = append(result, fmt.Sprintf("--%sprogress", prefix))
+	}
+
+	if ginkgo.DebugParallel {
+		result = append(result, fmt.Sprintf("--%sdebug", prefix))
+	}
+
+	if ginkgo.ParallelNode != 0 {
+		result = append(result, fmt.Sprintf("--%sparallel.node=%d", prefix, ginkgo.ParallelNode))
+	}
+
+	if ginkgo.ParallelTotal != 0 {
+		result = append(result, fmt.Sprintf("--%sparallel.total=%d", prefix, ginkgo.ParallelTotal))
+	}
+
+	if ginkgo.StreamHost != "" {
+		result = append(result, fmt.Sprintf("--%sparallel.streamhost=%s", prefix, ginkgo.StreamHost))
+	}
+
+	if ginkgo.SyncHost != "" {
+		result = append(result, fmt.Sprintf("--%sparallel.synchost=%s", prefix, ginkgo.SyncHost))
+	}
+
+	if ginkgo.RegexScansFilePath {
+		result = append(result, fmt.Sprintf("--%sregexScansFilePath", prefix))
+	}
+
+	if reporter.NoColor {
+		result = append(result, fmt.Sprintf("--%snoColor", prefix))
+	}
+
+	if reporter.SlowSpecThreshold > 0 {
+		result = append(result, fmt.Sprintf("--%sslowSpecThreshold=%.5f", prefix, reporter.SlowSpecThreshold))
+	}
+
+	if !reporter.NoisyPendings {
+		result = append(result, fmt.Sprintf("--%snoisyPendings=false", prefix))
+	}
+
+	if !reporter.NoisySkippings {
+		result = append(result, fmt.Sprintf("--%snoisySkippings=false", prefix))
+	}
+
+	if reporter.Verbose {
+		result = append(result, fmt.Sprintf("--%sv", prefix))
+	}
+
+	if reporter.Succinct {
+		result = append(result, fmt.Sprintf("--%ssuccinct", prefix))
+	}
+
+	if reporter.FullTrace {
+		result = append(result, fmt.Sprintf("--%strace", prefix))
+	}
+
+	return result
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
@@ -1,0 +1,84 @@
+/*
+Ginkgo's Default Reporter
+
+A number of command line flags are available to tweak Ginkgo's default output.
+
+These are documented [here](http://onsi.github.io/ginkgo/#running_tests)
+*/
+package reporters
+
+import (
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/onsi/ginkgo/types"
+)
+
+type DefaultReporter struct {
+	config        config.DefaultReporterConfigType
+	stenographer  stenographer.Stenographer
+	specSummaries []*types.SpecSummary
+}
+
+func NewDefaultReporter(config config.DefaultReporterConfigType, stenographer stenographer.Stenographer) *DefaultReporter {
+	return &DefaultReporter{
+		config:       config,
+		stenographer: stenographer,
+	}
+}
+
+func (reporter *DefaultReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	reporter.stenographer.AnnounceSuite(summary.SuiteDescription, config.RandomSeed, config.RandomizeAllSpecs, reporter.config.Succinct)
+	if config.ParallelTotal > 1 {
+		reporter.stenographer.AnnounceParallelRun(config.ParallelNode, config.ParallelTotal, reporter.config.Succinct)
+	} else {
+		reporter.stenographer.AnnounceNumberOfSpecs(summary.NumberOfSpecsThatWillBeRun, summary.NumberOfTotalSpecs, reporter.config.Succinct)
+	}
+}
+
+func (reporter *DefaultReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		reporter.stenographer.AnnounceBeforeSuiteFailure(setupSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	}
+}
+
+func (reporter *DefaultReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		reporter.stenographer.AnnounceAfterSuiteFailure(setupSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	}
+}
+
+func (reporter *DefaultReporter) SpecWillRun(specSummary *types.SpecSummary) {
+	if reporter.config.Verbose && !reporter.config.Succinct && specSummary.State != types.SpecStatePending && specSummary.State != types.SpecStateSkipped {
+		reporter.stenographer.AnnounceSpecWillRun(specSummary)
+	}
+}
+
+func (reporter *DefaultReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	switch specSummary.State {
+	case types.SpecStatePassed:
+		if specSummary.IsMeasurement {
+			reporter.stenographer.AnnounceSuccesfulMeasurement(specSummary, reporter.config.Succinct)
+		} else if specSummary.RunTime.Seconds() >= reporter.config.SlowSpecThreshold {
+			reporter.stenographer.AnnounceSuccesfulSlowSpec(specSummary, reporter.config.Succinct)
+		} else {
+			reporter.stenographer.AnnounceSuccesfulSpec(specSummary)
+		}
+	case types.SpecStatePending:
+		reporter.stenographer.AnnouncePendingSpec(specSummary, reporter.config.NoisyPendings && !reporter.config.Succinct)
+	case types.SpecStateSkipped:
+		reporter.stenographer.AnnounceSkippedSpec(specSummary, reporter.config.Succinct || !reporter.config.NoisySkippings, reporter.config.FullTrace)
+	case types.SpecStateTimedOut:
+		reporter.stenographer.AnnounceSpecTimedOut(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	case types.SpecStatePanicked:
+		reporter.stenographer.AnnounceSpecPanicked(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	case types.SpecStateFailed:
+		reporter.stenographer.AnnounceSpecFailed(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	}
+
+	reporter.specSummaries = append(reporter.specSummaries, specSummary)
+}
+
+func (reporter *DefaultReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	reporter.stenographer.SummarizeFailures(reporter.specSummaries)
+	reporter.stenographer.AnnounceSpecRunCompletion(summary, reporter.config.Succinct)
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/fake_reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/fake_reporter.go
@@ -1,0 +1,59 @@
+package reporters
+
+import (
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+//FakeReporter is useful for testing purposes
+type FakeReporter struct {
+	Config config.GinkgoConfigType
+
+	BeginSummary         *types.SuiteSummary
+	BeforeSuiteSummary   *types.SetupSummary
+	SpecWillRunSummaries []*types.SpecSummary
+	SpecSummaries        []*types.SpecSummary
+	AfterSuiteSummary    *types.SetupSummary
+	EndSummary           *types.SuiteSummary
+
+	SpecWillRunStub     func(specSummary *types.SpecSummary)
+	SpecDidCompleteStub func(specSummary *types.SpecSummary)
+}
+
+func NewFakeReporter() *FakeReporter {
+	return &FakeReporter{
+		SpecWillRunSummaries: make([]*types.SpecSummary, 0),
+		SpecSummaries:        make([]*types.SpecSummary, 0),
+	}
+}
+
+func (fakeR *FakeReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	fakeR.Config = config
+	fakeR.BeginSummary = summary
+}
+
+func (fakeR *FakeReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	fakeR.BeforeSuiteSummary = setupSummary
+}
+
+func (fakeR *FakeReporter) SpecWillRun(specSummary *types.SpecSummary) {
+	if fakeR.SpecWillRunStub != nil {
+		fakeR.SpecWillRunStub(specSummary)
+	}
+	fakeR.SpecWillRunSummaries = append(fakeR.SpecWillRunSummaries, specSummary)
+}
+
+func (fakeR *FakeReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	if fakeR.SpecDidCompleteStub != nil {
+		fakeR.SpecDidCompleteStub(specSummary)
+	}
+	fakeR.SpecSummaries = append(fakeR.SpecSummaries, specSummary)
+}
+
+func (fakeR *FakeReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	fakeR.AfterSuiteSummary = setupSummary
+}
+
+func (fakeR *FakeReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	fakeR.EndSummary = summary
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
@@ -1,0 +1,152 @@
+/*
+
+JUnit XML Reporter for Ginkgo
+
+For usage instructions: http://onsi.github.io/ginkgo/#generating_junit_xml_output
+
+*/
+
+package reporters
+
+import (
+	"encoding/xml"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+type JUnitTestSuite struct {
+	XMLName   xml.Name        `xml:"testsuite"`
+	TestCases []JUnitTestCase `xml:"testcase"`
+	Name      string          `xml:"name,attr"`
+	Tests     int             `xml:"tests,attr"`
+	Failures  int             `xml:"failures,attr"`
+	Errors    int             `xml:"errors,attr"`
+	Time      float64         `xml:"time,attr"`
+}
+
+type JUnitTestCase struct {
+	Name           string               `xml:"name,attr"`
+	ClassName      string               `xml:"classname,attr"`
+	FailureMessage *JUnitFailureMessage `xml:"failure,omitempty"`
+	Skipped        *JUnitSkipped        `xml:"skipped,omitempty"`
+	Time           float64              `xml:"time,attr"`
+	SystemOut      string               `xml:"system-out,omitempty"`
+}
+
+type JUnitFailureMessage struct {
+	Type    string `xml:"type,attr"`
+	Message string `xml:",chardata"`
+}
+
+type JUnitSkipped struct {
+	XMLName xml.Name `xml:"skipped"`
+}
+
+type JUnitReporter struct {
+	suite         JUnitTestSuite
+	filename      string
+	testSuiteName string
+}
+
+//NewJUnitReporter creates a new JUnit XML reporter.  The XML will be stored in the passed in filename.
+func NewJUnitReporter(filename string) *JUnitReporter {
+	return &JUnitReporter{
+		filename: filename,
+	}
+}
+
+func (reporter *JUnitReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	reporter.suite = JUnitTestSuite{
+		Name:      summary.SuiteDescription,
+		TestCases: []JUnitTestCase{},
+	}
+	reporter.testSuiteName = summary.SuiteDescription
+}
+
+func (reporter *JUnitReporter) SpecWillRun(specSummary *types.SpecSummary) {
+}
+
+func (reporter *JUnitReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("BeforeSuite", setupSummary)
+}
+
+func (reporter *JUnitReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("AfterSuite", setupSummary)
+}
+
+func failureMessage(failure types.SpecFailure) string {
+	return fmt.Sprintf("%s\n%s\n%s", failure.ComponentCodeLocation.String(), failure.Message, failure.Location.String())
+}
+
+func (reporter *JUnitReporter) handleSetupSummary(name string, setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		testCase := JUnitTestCase{
+			Name:      name,
+			ClassName: reporter.testSuiteName,
+		}
+
+		testCase.FailureMessage = &JUnitFailureMessage{
+			Type:    reporter.failureTypeForState(setupSummary.State),
+			Message: failureMessage(setupSummary.Failure),
+		}
+		testCase.SystemOut = setupSummary.CapturedOutput
+		testCase.Time = setupSummary.RunTime.Seconds()
+		reporter.suite.TestCases = append(reporter.suite.TestCases, testCase)
+	}
+}
+
+func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	testCase := JUnitTestCase{
+		Name:      strings.Join(specSummary.ComponentTexts[1:], " "),
+		ClassName: reporter.testSuiteName,
+	}
+	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
+		testCase.FailureMessage = &JUnitFailureMessage{
+			Type:    reporter.failureTypeForState(specSummary.State),
+			Message: failureMessage(specSummary.Failure),
+		}
+		testCase.SystemOut = specSummary.CapturedOutput
+	}
+	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {
+		testCase.Skipped = &JUnitSkipped{}
+	}
+	testCase.Time = specSummary.RunTime.Seconds()
+	reporter.suite.TestCases = append(reporter.suite.TestCases, testCase)
+}
+
+func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	reporter.suite.Tests = summary.NumberOfSpecsThatWillBeRun
+	reporter.suite.Time = math.Trunc(summary.RunTime.Seconds() * 1000 / 1000)
+	reporter.suite.Failures = summary.NumberOfFailedSpecs
+	reporter.suite.Errors = 0
+	file, err := os.Create(reporter.filename)
+	if err != nil {
+		fmt.Printf("Failed to create JUnit report file: %s\n\t%s", reporter.filename, err.Error())
+	}
+	defer file.Close()
+	file.WriteString(xml.Header)
+	encoder := xml.NewEncoder(file)
+	encoder.Indent("  ", "    ")
+	err = encoder.Encode(reporter.suite)
+	if err != nil {
+		fmt.Printf("Failed to generate JUnit report\n\t%s", err.Error())
+	}
+}
+
+func (reporter *JUnitReporter) failureTypeForState(state types.SpecState) string {
+	switch state {
+	case types.SpecStateFailed:
+		return "Failure"
+	case types.SpecStateTimedOut:
+		return "Timeout"
+	case types.SpecStatePanicked:
+		return "Panic"
+	default:
+		return ""
+	}
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/reporter.go
@@ -1,0 +1,15 @@
+package reporters
+
+import (
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+type Reporter interface {
+	SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary)
+	BeforeSuiteDidRun(setupSummary *types.SetupSummary)
+	SpecWillRun(specSummary *types.SpecSummary)
+	SpecDidComplete(specSummary *types.SpecSummary)
+	AfterSuiteDidRun(setupSummary *types.SetupSummary)
+	SpecSuiteDidEnd(summary *types.SuiteSummary)
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/console_logging.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/console_logging.go
@@ -1,0 +1,64 @@
+package stenographer
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (s *consoleStenographer) colorize(colorCode string, format string, args ...interface{}) string {
+	var out string
+
+	if len(args) > 0 {
+		out = fmt.Sprintf(format, args...)
+	} else {
+		out = format
+	}
+
+	if s.color {
+		return fmt.Sprintf("%s%s%s", colorCode, out, defaultStyle)
+	} else {
+		return out
+	}
+}
+
+func (s *consoleStenographer) printBanner(text string, bannerCharacter string) {
+	fmt.Fprintln(s.w, text)
+	fmt.Fprintln(s.w, strings.Repeat(bannerCharacter, len(text)))
+}
+
+func (s *consoleStenographer) printNewLine() {
+	fmt.Fprintln(s.w, "")
+}
+
+func (s *consoleStenographer) printDelimiter() {
+	fmt.Fprintln(s.w, s.colorize(grayColor, "%s", strings.Repeat("-", 30)))
+}
+
+func (s *consoleStenographer) print(indentation int, format string, args ...interface{}) {
+	fmt.Fprint(s.w, s.indent(indentation, format, args...))
+}
+
+func (s *consoleStenographer) println(indentation int, format string, args ...interface{}) {
+	fmt.Fprintln(s.w, s.indent(indentation, format, args...))
+}
+
+func (s *consoleStenographer) indent(indentation int, format string, args ...interface{}) string {
+	var text string
+
+	if len(args) > 0 {
+		text = fmt.Sprintf(format, args...)
+	} else {
+		text = format
+	}
+
+	stringArray := strings.Split(text, "\n")
+	padding := ""
+	if indentation >= 0 {
+		padding = strings.Repeat("  ", indentation)
+	}
+	for i, s := range stringArray {
+		stringArray[i] = fmt.Sprintf("%s%s", padding, s)
+	}
+
+	return strings.Join(stringArray, "\n")
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/fake_stenographer.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/fake_stenographer.go
@@ -1,0 +1,142 @@
+package stenographer
+
+import (
+	"sync"
+
+	"github.com/onsi/ginkgo/types"
+)
+
+func NewFakeStenographerCall(method string, args ...interface{}) FakeStenographerCall {
+	return FakeStenographerCall{
+		Method: method,
+		Args:   args,
+	}
+}
+
+type FakeStenographer struct {
+	calls []FakeStenographerCall
+	lock  *sync.Mutex
+}
+
+type FakeStenographerCall struct {
+	Method string
+	Args   []interface{}
+}
+
+func NewFakeStenographer() *FakeStenographer {
+	stenographer := &FakeStenographer{
+		lock: &sync.Mutex{},
+	}
+	stenographer.Reset()
+	return stenographer
+}
+
+func (stenographer *FakeStenographer) Calls() []FakeStenographerCall {
+	stenographer.lock.Lock()
+	defer stenographer.lock.Unlock()
+
+	return stenographer.calls
+}
+
+func (stenographer *FakeStenographer) Reset() {
+	stenographer.lock.Lock()
+	defer stenographer.lock.Unlock()
+
+	stenographer.calls = make([]FakeStenographerCall, 0)
+}
+
+func (stenographer *FakeStenographer) CallsTo(method string) []FakeStenographerCall {
+	stenographer.lock.Lock()
+	defer stenographer.lock.Unlock()
+
+	results := make([]FakeStenographerCall, 0)
+	for _, call := range stenographer.calls {
+		if call.Method == method {
+			results = append(results, call)
+		}
+	}
+
+	return results
+}
+
+func (stenographer *FakeStenographer) registerCall(method string, args ...interface{}) {
+	stenographer.lock.Lock()
+	defer stenographer.lock.Unlock()
+
+	stenographer.calls = append(stenographer.calls, NewFakeStenographerCall(method, args...))
+}
+
+func (stenographer *FakeStenographer) AnnounceSuite(description string, randomSeed int64, randomizingAll bool, succinct bool) {
+	stenographer.registerCall("AnnounceSuite", description, randomSeed, randomizingAll, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceAggregatedParallelRun(nodes int, succinct bool) {
+	stenographer.registerCall("AnnounceAggregatedParallelRun", nodes, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceParallelRun(node int, nodes int, succinct bool) {
+	stenographer.registerCall("AnnounceParallelRun", node, nodes, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceNumberOfSpecs(specsToRun int, total int, succinct bool) {
+	stenographer.registerCall("AnnounceNumberOfSpecs", specsToRun, total, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceTotalNumberOfSpecs(total int, succinct bool) {
+	stenographer.registerCall("AnnounceTotalNumberOfSpecs", total, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecRunCompletion(summary *types.SuiteSummary, succinct bool) {
+	stenographer.registerCall("AnnounceSpecRunCompletion", summary, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecWillRun(spec *types.SpecSummary) {
+	stenographer.registerCall("AnnounceSpecWillRun", spec)
+}
+
+func (stenographer *FakeStenographer) AnnounceBeforeSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceBeforeSuiteFailure", summary, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) AnnounceAfterSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceAfterSuiteFailure", summary, succinct, fullTrace)
+}
+func (stenographer *FakeStenographer) AnnounceCapturedOutput(output string) {
+	stenographer.registerCall("AnnounceCapturedOutput", output)
+}
+
+func (stenographer *FakeStenographer) AnnounceSuccesfulSpec(spec *types.SpecSummary) {
+	stenographer.registerCall("AnnounceSuccesfulSpec", spec)
+}
+
+func (stenographer *FakeStenographer) AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool) {
+	stenographer.registerCall("AnnounceSuccesfulSlowSpec", spec, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool) {
+	stenographer.registerCall("AnnounceSuccesfulMeasurement", spec, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnouncePendingSpec(spec *types.SpecSummary, noisy bool) {
+	stenographer.registerCall("AnnouncePendingSpec", spec, noisy)
+}
+
+func (stenographer *FakeStenographer) AnnounceSkippedSpec(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSkippedSpec", spec, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecTimedOut(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSpecTimedOut", spec, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecPanicked(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSpecPanicked", spec, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecFailed(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSpecFailed", spec, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) SummarizeFailures(summaries []*types.SpecSummary) {
+	stenographer.registerCall("SummarizeFailures", summaries)
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/stenographer.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/stenographer.go
@@ -1,0 +1,572 @@
+/*
+The stenographer is used by Ginkgo's reporters to generate output.
+
+Move along, nothing to see here.
+*/
+
+package stenographer
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+
+	"github.com/onsi/ginkgo/types"
+)
+
+const defaultStyle = "\x1b[0m"
+const boldStyle = "\x1b[1m"
+const redColor = "\x1b[91m"
+const greenColor = "\x1b[32m"
+const yellowColor = "\x1b[33m"
+const cyanColor = "\x1b[36m"
+const grayColor = "\x1b[90m"
+const lightGrayColor = "\x1b[37m"
+
+type cursorStateType int
+
+const (
+	cursorStateTop cursorStateType = iota
+	cursorStateStreaming
+	cursorStateMidBlock
+	cursorStateEndBlock
+)
+
+type Stenographer interface {
+	AnnounceSuite(description string, randomSeed int64, randomizingAll bool, succinct bool)
+	AnnounceAggregatedParallelRun(nodes int, succinct bool)
+	AnnounceParallelRun(node int, nodes int, succinct bool)
+	AnnounceTotalNumberOfSpecs(total int, succinct bool)
+	AnnounceNumberOfSpecs(specsToRun int, total int, succinct bool)
+	AnnounceSpecRunCompletion(summary *types.SuiteSummary, succinct bool)
+
+	AnnounceSpecWillRun(spec *types.SpecSummary)
+	AnnounceBeforeSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool)
+	AnnounceAfterSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool)
+
+	AnnounceCapturedOutput(output string)
+
+	AnnounceSuccesfulSpec(spec *types.SpecSummary)
+	AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool)
+	AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool)
+
+	AnnouncePendingSpec(spec *types.SpecSummary, noisy bool)
+	AnnounceSkippedSpec(spec *types.SpecSummary, succinct bool, fullTrace bool)
+
+	AnnounceSpecTimedOut(spec *types.SpecSummary, succinct bool, fullTrace bool)
+	AnnounceSpecPanicked(spec *types.SpecSummary, succinct bool, fullTrace bool)
+	AnnounceSpecFailed(spec *types.SpecSummary, succinct bool, fullTrace bool)
+
+	SummarizeFailures(summaries []*types.SpecSummary)
+}
+
+func New(color bool, enableFlakes bool, writer io.Writer) Stenographer {
+	denoter := "•"
+	if runtime.GOOS == "windows" {
+		denoter = "+"
+	}
+	return &consoleStenographer{
+		color:        color,
+		denoter:      denoter,
+		cursorState:  cursorStateTop,
+		enableFlakes: enableFlakes,
+		w:            writer,
+	}
+}
+
+type consoleStenographer struct {
+	color        bool
+	denoter      string
+	cursorState  cursorStateType
+	enableFlakes bool
+	w            io.Writer
+}
+
+var alternatingColors = []string{defaultStyle, grayColor}
+
+func (s *consoleStenographer) AnnounceSuite(description string, randomSeed int64, randomizingAll bool, succinct bool) {
+	if succinct {
+		s.print(0, "[%d] %s ", randomSeed, s.colorize(boldStyle, description))
+		return
+	}
+	s.printBanner(fmt.Sprintf("Running Suite: %s", description), "=")
+	s.print(0, "Random Seed: %s", s.colorize(boldStyle, "%d", randomSeed))
+	if randomizingAll {
+		s.print(0, " - Will randomize all specs")
+	}
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceParallelRun(node int, nodes int, succinct bool) {
+	if succinct {
+		s.print(0, "- node #%d ", node)
+		return
+	}
+	s.println(0,
+		"Parallel test node %s/%s.",
+		s.colorize(boldStyle, "%d", node),
+		s.colorize(boldStyle, "%d", nodes),
+	)
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceAggregatedParallelRun(nodes int, succinct bool) {
+	if succinct {
+		s.print(0, "- %d nodes ", nodes)
+		return
+	}
+	s.println(0,
+		"Running in parallel across %s nodes",
+		s.colorize(boldStyle, "%d", nodes),
+	)
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceNumberOfSpecs(specsToRun int, total int, succinct bool) {
+	if succinct {
+		s.print(0, "- %d/%d specs ", specsToRun, total)
+		s.stream()
+		return
+	}
+	s.println(0,
+		"Will run %s of %s specs",
+		s.colorize(boldStyle, "%d", specsToRun),
+		s.colorize(boldStyle, "%d", total),
+	)
+
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceTotalNumberOfSpecs(total int, succinct bool) {
+	if succinct {
+		s.print(0, "- %d specs ", total)
+		s.stream()
+		return
+	}
+	s.println(0,
+		"Will run %s specs",
+		s.colorize(boldStyle, "%d", total),
+	)
+
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceSpecRunCompletion(summary *types.SuiteSummary, succinct bool) {
+	if succinct && summary.SuiteSucceeded {
+		s.print(0, " %s %s ", s.colorize(greenColor, "SUCCESS!"), summary.RunTime)
+		return
+	}
+	s.printNewLine()
+	color := greenColor
+	if !summary.SuiteSucceeded {
+		color = redColor
+	}
+	s.println(0, s.colorize(boldStyle+color, "Ran %d of %d Specs in %.3f seconds", summary.NumberOfSpecsThatWillBeRun, summary.NumberOfTotalSpecs, summary.RunTime.Seconds()))
+
+	status := ""
+	if summary.SuiteSucceeded {
+		status = s.colorize(boldStyle+greenColor, "SUCCESS!")
+	} else {
+		status = s.colorize(boldStyle+redColor, "FAIL!")
+	}
+
+	flakes := ""
+	if s.enableFlakes {
+		flakes = " | " + s.colorize(yellowColor+boldStyle, "%d Flaked", summary.NumberOfFlakedSpecs)
+	}
+
+	s.print(0,
+		"%s -- %s | %s | %s | %s\n",
+		status,
+		s.colorize(greenColor+boldStyle, "%d Passed", summary.NumberOfPassedSpecs),
+		s.colorize(redColor+boldStyle, "%d Failed", summary.NumberOfFailedSpecs)+flakes,
+		s.colorize(yellowColor+boldStyle, "%d Pending", summary.NumberOfPendingSpecs),
+		s.colorize(cyanColor+boldStyle, "%d Skipped", summary.NumberOfSkippedSpecs),
+	)
+}
+
+func (s *consoleStenographer) AnnounceSpecWillRun(spec *types.SpecSummary) {
+	s.startBlock()
+	for i, text := range spec.ComponentTexts[1 : len(spec.ComponentTexts)-1] {
+		s.print(0, s.colorize(alternatingColors[i%2], text)+" ")
+	}
+
+	indentation := 0
+	if len(spec.ComponentTexts) > 2 {
+		indentation = 1
+		s.printNewLine()
+	}
+	index := len(spec.ComponentTexts) - 1
+	s.print(indentation, s.colorize(boldStyle, spec.ComponentTexts[index]))
+	s.printNewLine()
+	s.print(indentation, s.colorize(lightGrayColor, spec.ComponentCodeLocations[index].String()))
+	s.printNewLine()
+	s.midBlock()
+}
+
+func (s *consoleStenographer) AnnounceBeforeSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	s.announceSetupFailure("BeforeSuite", summary, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) AnnounceAfterSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	s.announceSetupFailure("AfterSuite", summary, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) announceSetupFailure(name string, summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	s.startBlock()
+	var message string
+	switch summary.State {
+	case types.SpecStateFailed:
+		message = "Failure"
+	case types.SpecStatePanicked:
+		message = "Panic"
+	case types.SpecStateTimedOut:
+		message = "Timeout"
+	}
+
+	s.println(0, s.colorize(redColor+boldStyle, "%s [%.3f seconds]", message, summary.RunTime.Seconds()))
+
+	indentation := s.printCodeLocationBlock([]string{name}, []types.CodeLocation{summary.CodeLocation}, summary.ComponentType, 0, summary.State, true)
+
+	s.printNewLine()
+	s.printFailure(indentation, summary.State, summary.Failure, fullTrace)
+
+	s.endBlock()
+}
+
+func (s *consoleStenographer) AnnounceCapturedOutput(output string) {
+	if output == "" {
+		return
+	}
+
+	s.startBlock()
+	s.println(0, output)
+	s.midBlock()
+}
+
+func (s *consoleStenographer) AnnounceSuccesfulSpec(spec *types.SpecSummary) {
+	s.print(0, s.colorize(greenColor, s.denoter))
+	s.stream()
+}
+
+func (s *consoleStenographer) AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool) {
+	s.printBlockWithMessage(
+		s.colorize(greenColor, "%s [SLOW TEST:%.3f seconds]", s.denoter, spec.RunTime.Seconds()),
+		"",
+		spec,
+		succinct,
+	)
+}
+
+func (s *consoleStenographer) AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool) {
+	s.printBlockWithMessage(
+		s.colorize(greenColor, "%s [MEASUREMENT]", s.denoter),
+		s.measurementReport(spec, succinct),
+		spec,
+		succinct,
+	)
+}
+
+func (s *consoleStenographer) AnnouncePendingSpec(spec *types.SpecSummary, noisy bool) {
+	if noisy {
+		s.printBlockWithMessage(
+			s.colorize(yellowColor, "P [PENDING]"),
+			"",
+			spec,
+			false,
+		)
+	} else {
+		s.print(0, s.colorize(yellowColor, "P"))
+		s.stream()
+	}
+}
+
+func (s *consoleStenographer) AnnounceSkippedSpec(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	// Skips at runtime will have a non-empty spec.Failure. All others should be succinct.
+	if succinct || spec.Failure == (types.SpecFailure{}) {
+		s.print(0, s.colorize(cyanColor, "S"))
+		s.stream()
+	} else {
+		s.startBlock()
+		s.println(0, s.colorize(cyanColor+boldStyle, "S [SKIPPING]%s [%.3f seconds]", s.failureContext(spec.Failure.ComponentType), spec.RunTime.Seconds()))
+
+		indentation := s.printCodeLocationBlock(spec.ComponentTexts, spec.ComponentCodeLocations, spec.Failure.ComponentType, spec.Failure.ComponentIndex, spec.State, succinct)
+
+		s.printNewLine()
+		s.printSkip(indentation, spec.Failure)
+		s.endBlock()
+	}
+}
+
+func (s *consoleStenographer) AnnounceSpecTimedOut(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	s.printSpecFailure(fmt.Sprintf("%s... Timeout", s.denoter), spec, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) AnnounceSpecPanicked(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	s.printSpecFailure(fmt.Sprintf("%s! Panic", s.denoter), spec, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) AnnounceSpecFailed(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	s.printSpecFailure(fmt.Sprintf("%s Failure", s.denoter), spec, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) SummarizeFailures(summaries []*types.SpecSummary) {
+	failingSpecs := []*types.SpecSummary{}
+
+	for _, summary := range summaries {
+		if summary.HasFailureState() {
+			failingSpecs = append(failingSpecs, summary)
+		}
+	}
+
+	if len(failingSpecs) == 0 {
+		return
+	}
+
+	s.printNewLine()
+	s.printNewLine()
+	plural := "s"
+	if len(failingSpecs) == 1 {
+		plural = ""
+	}
+	s.println(0, s.colorize(redColor+boldStyle, "Summarizing %d Failure%s:", len(failingSpecs), plural))
+	for _, summary := range failingSpecs {
+		s.printNewLine()
+		if summary.HasFailureState() {
+			if summary.TimedOut() {
+				s.print(0, s.colorize(redColor+boldStyle, "[Timeout...] "))
+			} else if summary.Panicked() {
+				s.print(0, s.colorize(redColor+boldStyle, "[Panic!] "))
+			} else if summary.Failed() {
+				s.print(0, s.colorize(redColor+boldStyle, "[Fail] "))
+			}
+			s.printSpecContext(summary.ComponentTexts, summary.ComponentCodeLocations, summary.Failure.ComponentType, summary.Failure.ComponentIndex, summary.State, true)
+			s.printNewLine()
+			s.println(0, s.colorize(lightGrayColor, summary.Failure.Location.String()))
+		}
+	}
+}
+
+func (s *consoleStenographer) startBlock() {
+	if s.cursorState == cursorStateStreaming {
+		s.printNewLine()
+		s.printDelimiter()
+	} else if s.cursorState == cursorStateMidBlock {
+		s.printNewLine()
+	}
+}
+
+func (s *consoleStenographer) midBlock() {
+	s.cursorState = cursorStateMidBlock
+}
+
+func (s *consoleStenographer) endBlock() {
+	s.printDelimiter()
+	s.cursorState = cursorStateEndBlock
+}
+
+func (s *consoleStenographer) stream() {
+	s.cursorState = cursorStateStreaming
+}
+
+func (s *consoleStenographer) printBlockWithMessage(header string, message string, spec *types.SpecSummary, succinct bool) {
+	s.startBlock()
+	s.println(0, header)
+
+	indentation := s.printCodeLocationBlock(spec.ComponentTexts, spec.ComponentCodeLocations, types.SpecComponentTypeInvalid, 0, spec.State, succinct)
+
+	if message != "" {
+		s.printNewLine()
+		s.println(indentation, message)
+	}
+
+	s.endBlock()
+}
+
+func (s *consoleStenographer) printSpecFailure(message string, spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	s.startBlock()
+	s.println(0, s.colorize(redColor+boldStyle, "%s%s [%.3f seconds]", message, s.failureContext(spec.Failure.ComponentType), spec.RunTime.Seconds()))
+
+	indentation := s.printCodeLocationBlock(spec.ComponentTexts, spec.ComponentCodeLocations, spec.Failure.ComponentType, spec.Failure.ComponentIndex, spec.State, succinct)
+
+	s.printNewLine()
+	s.printFailure(indentation, spec.State, spec.Failure, fullTrace)
+	s.endBlock()
+}
+
+func (s *consoleStenographer) failureContext(failedComponentType types.SpecComponentType) string {
+	switch failedComponentType {
+	case types.SpecComponentTypeBeforeSuite:
+		return " in Suite Setup (BeforeSuite)"
+	case types.SpecComponentTypeAfterSuite:
+		return " in Suite Teardown (AfterSuite)"
+	case types.SpecComponentTypeBeforeEach:
+		return " in Spec Setup (BeforeEach)"
+	case types.SpecComponentTypeJustBeforeEach:
+		return " in Spec Setup (JustBeforeEach)"
+	case types.SpecComponentTypeAfterEach:
+		return " in Spec Teardown (AfterEach)"
+	}
+
+	return ""
+}
+
+func (s *consoleStenographer) printSkip(indentation int, spec types.SpecFailure) {
+	s.println(indentation, s.colorize(cyanColor, spec.Message))
+	s.printNewLine()
+	s.println(indentation, spec.Location.String())
+}
+
+func (s *consoleStenographer) printFailure(indentation int, state types.SpecState, failure types.SpecFailure, fullTrace bool) {
+	if state == types.SpecStatePanicked {
+		s.println(indentation, s.colorize(redColor+boldStyle, failure.Message))
+		s.println(indentation, s.colorize(redColor, failure.ForwardedPanic))
+		s.println(indentation, failure.Location.String())
+		s.printNewLine()
+		s.println(indentation, s.colorize(redColor, "Full Stack Trace"))
+		s.println(indentation, failure.Location.FullStackTrace)
+	} else {
+		s.println(indentation, s.colorize(redColor, failure.Message))
+		s.printNewLine()
+		s.println(indentation, failure.Location.String())
+		if fullTrace {
+			s.printNewLine()
+			s.println(indentation, s.colorize(redColor, "Full Stack Trace"))
+			s.println(indentation, failure.Location.FullStackTrace)
+		}
+	}
+}
+
+func (s *consoleStenographer) printSpecContext(componentTexts []string, componentCodeLocations []types.CodeLocation, failedComponentType types.SpecComponentType, failedComponentIndex int, state types.SpecState, succinct bool) int {
+	startIndex := 1
+	indentation := 0
+
+	if len(componentTexts) == 1 {
+		startIndex = 0
+	}
+
+	for i := startIndex; i < len(componentTexts); i++ {
+		if (state.IsFailure() || state == types.SpecStateSkipped) && i == failedComponentIndex {
+			color := redColor
+			if state == types.SpecStateSkipped {
+				color = cyanColor
+			}
+			blockType := ""
+			switch failedComponentType {
+			case types.SpecComponentTypeBeforeSuite:
+				blockType = "BeforeSuite"
+			case types.SpecComponentTypeAfterSuite:
+				blockType = "AfterSuite"
+			case types.SpecComponentTypeBeforeEach:
+				blockType = "BeforeEach"
+			case types.SpecComponentTypeJustBeforeEach:
+				blockType = "JustBeforeEach"
+			case types.SpecComponentTypeAfterEach:
+				blockType = "AfterEach"
+			case types.SpecComponentTypeIt:
+				blockType = "It"
+			case types.SpecComponentTypeMeasure:
+				blockType = "Measurement"
+			}
+			if succinct {
+				s.print(0, s.colorize(color+boldStyle, "[%s] %s ", blockType, componentTexts[i]))
+			} else {
+				s.println(indentation, s.colorize(color+boldStyle, "%s [%s]", componentTexts[i], blockType))
+				s.println(indentation, s.colorize(grayColor, "%s", componentCodeLocations[i]))
+			}
+		} else {
+			if succinct {
+				s.print(0, s.colorize(alternatingColors[i%2], "%s ", componentTexts[i]))
+			} else {
+				s.println(indentation, componentTexts[i])
+				s.println(indentation, s.colorize(grayColor, "%s", componentCodeLocations[i]))
+			}
+		}
+		indentation++
+	}
+
+	return indentation
+}
+
+func (s *consoleStenographer) printCodeLocationBlock(componentTexts []string, componentCodeLocations []types.CodeLocation, failedComponentType types.SpecComponentType, failedComponentIndex int, state types.SpecState, succinct bool) int {
+	indentation := s.printSpecContext(componentTexts, componentCodeLocations, failedComponentType, failedComponentIndex, state, succinct)
+
+	if succinct {
+		if len(componentTexts) > 0 {
+			s.printNewLine()
+			s.print(0, s.colorize(lightGrayColor, "%s", componentCodeLocations[len(componentCodeLocations)-1]))
+		}
+		s.printNewLine()
+		indentation = 1
+	} else {
+		indentation--
+	}
+
+	return indentation
+}
+
+func (s *consoleStenographer) orderedMeasurementKeys(measurements map[string]*types.SpecMeasurement) []string {
+	orderedKeys := make([]string, len(measurements))
+	for key, measurement := range measurements {
+		orderedKeys[measurement.Order] = key
+	}
+	return orderedKeys
+}
+
+func (s *consoleStenographer) measurementReport(spec *types.SpecSummary, succinct bool) string {
+	if len(spec.Measurements) == 0 {
+		return "Found no measurements"
+	}
+
+	message := []string{}
+	orderedKeys := s.orderedMeasurementKeys(spec.Measurements)
+
+	if succinct {
+		message = append(message, fmt.Sprintf("%s samples:", s.colorize(boldStyle, "%d", spec.NumberOfSamples)))
+		for _, key := range orderedKeys {
+			measurement := spec.Measurements[key]
+			message = append(message, fmt.Sprintf("  %s - %s: %s%s, %s: %s%s ± %s%s, %s: %s%s",
+				s.colorize(boldStyle, "%s", measurement.Name),
+				measurement.SmallestLabel,
+				s.colorize(greenColor, measurement.PrecisionFmt(), measurement.Smallest),
+				measurement.Units,
+				measurement.AverageLabel,
+				s.colorize(cyanColor, measurement.PrecisionFmt(), measurement.Average),
+				measurement.Units,
+				s.colorize(cyanColor, measurement.PrecisionFmt(), measurement.StdDeviation),
+				measurement.Units,
+				measurement.LargestLabel,
+				s.colorize(redColor, measurement.PrecisionFmt(), measurement.Largest),
+				measurement.Units,
+			))
+		}
+	} else {
+		message = append(message, fmt.Sprintf("Ran %s samples:", s.colorize(boldStyle, "%d", spec.NumberOfSamples)))
+		for _, key := range orderedKeys {
+			measurement := spec.Measurements[key]
+			info := ""
+			if measurement.Info != nil {
+				message = append(message, fmt.Sprintf("%v", measurement.Info))
+			}
+
+			message = append(message, fmt.Sprintf("%s:\n%s  %s: %s%s\n  %s: %s%s\n  %s: %s%s ± %s%s",
+				s.colorize(boldStyle, "%s", measurement.Name),
+				info,
+				measurement.SmallestLabel,
+				s.colorize(greenColor, measurement.PrecisionFmt(), measurement.Smallest),
+				measurement.Units,
+				measurement.LargestLabel,
+				s.colorize(redColor, measurement.PrecisionFmt(), measurement.Largest),
+				measurement.Units,
+				measurement.AverageLabel,
+				s.colorize(cyanColor, measurement.PrecisionFmt(), measurement.Average),
+				measurement.Units,
+				s.colorize(cyanColor, measurement.PrecisionFmt(), measurement.StdDeviation),
+				measurement.Units,
+			))
+		}
+	}
+
+	return strings.Join(message, "\n")
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable/LICENSE
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty/LICENSE
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/api/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
@@ -1,0 +1,93 @@
+/*
+
+TeamCity Reporter for Ginkgo
+
+Makes use of TeamCity's support for Service Messages
+http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
+*/
+
+package reporters
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+const (
+	messageId = "##teamcity"
+)
+
+type TeamCityReporter struct {
+	writer        io.Writer
+	testSuiteName string
+}
+
+func NewTeamCityReporter(writer io.Writer) *TeamCityReporter {
+	return &TeamCityReporter{
+		writer: writer,
+	}
+}
+
+func (reporter *TeamCityReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	reporter.testSuiteName = escape(summary.SuiteDescription)
+	fmt.Fprintf(reporter.writer, "%s[testSuiteStarted name='%s']", messageId, reporter.testSuiteName)
+}
+
+func (reporter *TeamCityReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("BeforeSuite", setupSummary)
+}
+
+func (reporter *TeamCityReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("AfterSuite", setupSummary)
+}
+
+func (reporter *TeamCityReporter) handleSetupSummary(name string, setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		testName := escape(name)
+		fmt.Fprintf(reporter.writer, "%s[testStarted name='%s']", messageId, testName)
+		message := escape(setupSummary.Failure.ComponentCodeLocation.String())
+		details := escape(setupSummary.Failure.Message)
+		fmt.Fprintf(reporter.writer, "%s[testFailed name='%s' message='%s' details='%s']", messageId, testName, message, details)
+		durationInMilliseconds := setupSummary.RunTime.Seconds() * 1000
+		fmt.Fprintf(reporter.writer, "%s[testFinished name='%s' duration='%v']", messageId, testName, durationInMilliseconds)
+	}
+}
+
+func (reporter *TeamCityReporter) SpecWillRun(specSummary *types.SpecSummary) {
+	testName := escape(strings.Join(specSummary.ComponentTexts[1:], " "))
+	fmt.Fprintf(reporter.writer, "%s[testStarted name='%s']", messageId, testName)
+}
+
+func (reporter *TeamCityReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	testName := escape(strings.Join(specSummary.ComponentTexts[1:], " "))
+
+	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
+		message := escape(specSummary.Failure.ComponentCodeLocation.String())
+		details := escape(specSummary.Failure.Message)
+		fmt.Fprintf(reporter.writer, "%s[testFailed name='%s' message='%s' details='%s']", messageId, testName, message, details)
+	}
+	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {
+		fmt.Fprintf(reporter.writer, "%s[testIgnored name='%s']", messageId, testName)
+	}
+
+	durationInMilliseconds := specSummary.RunTime.Seconds() * 1000
+	fmt.Fprintf(reporter.writer, "%s[testFinished name='%s' duration='%v']", messageId, testName, durationInMilliseconds)
+}
+
+func (reporter *TeamCityReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	fmt.Fprintf(reporter.writer, "%s[testSuiteFinished name='%s']", messageId, reporter.testSuiteName)
+}
+
+func escape(output string) string {
+	output = strings.Replace(output, "|", "||", -1)
+	output = strings.Replace(output, "'", "|'", -1)
+	output = strings.Replace(output, "\n", "|n", -1)
+	output = strings.Replace(output, "\r", "|r", -1)
+	output = strings.Replace(output, "[", "|[", -1)
+	output = strings.Replace(output, "]", "|]", -1)
+	return output
+}

--- a/api/vendor/github.com/onsi/ginkgo/types/code_location.go
+++ b/api/vendor/github.com/onsi/ginkgo/types/code_location.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"fmt"
+)
+
+type CodeLocation struct {
+	FileName       string
+	LineNumber     int
+	FullStackTrace string
+}
+
+func (codeLocation CodeLocation) String() string {
+	return fmt.Sprintf("%s:%d", codeLocation.FileName, codeLocation.LineNumber)
+}

--- a/api/vendor/github.com/onsi/ginkgo/types/synchronization.go
+++ b/api/vendor/github.com/onsi/ginkgo/types/synchronization.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"encoding/json"
+)
+
+type RemoteBeforeSuiteState int
+
+const (
+	RemoteBeforeSuiteStateInvalid RemoteBeforeSuiteState = iota
+
+	RemoteBeforeSuiteStatePending
+	RemoteBeforeSuiteStatePassed
+	RemoteBeforeSuiteStateFailed
+	RemoteBeforeSuiteStateDisappeared
+)
+
+type RemoteBeforeSuiteData struct {
+	Data  []byte
+	State RemoteBeforeSuiteState
+}
+
+func (r RemoteBeforeSuiteData) ToJSON() []byte {
+	data, _ := json.Marshal(r)
+	return data
+}
+
+type RemoteAfterSuiteData struct {
+	CanRun bool
+}

--- a/api/vendor/github.com/onsi/ginkgo/types/types.go
+++ b/api/vendor/github.com/onsi/ginkgo/types/types.go
@@ -1,0 +1,173 @@
+package types
+
+import (
+	"strconv"
+	"time"
+)
+
+const GINKGO_FOCUS_EXIT_CODE = 197
+
+/*
+SuiteSummary represents the a summary of the test suite and is passed to both
+Reporter.SpecSuiteWillBegin
+Reporter.SpecSuiteDidEnd
+
+this is unfortunate as these two methods should receive different objects.  When running in parallel
+each node does not deterministically know how many specs it will end up running.
+
+Unfortunately making such a change would break backward compatibility.
+
+Until Ginkgo 2.0 comes out we will continue to reuse this struct but populate unkown fields
+with -1.
+*/
+type SuiteSummary struct {
+	SuiteDescription string
+	SuiteSucceeded   bool
+	SuiteID          string
+
+	NumberOfSpecsBeforeParallelization int
+	NumberOfTotalSpecs                 int
+	NumberOfSpecsThatWillBeRun         int
+	NumberOfPendingSpecs               int
+	NumberOfSkippedSpecs               int
+	NumberOfPassedSpecs                int
+	NumberOfFailedSpecs                int
+	// Flaked specs are those that failed initially, but then passed on a
+	// subsequent try.
+	NumberOfFlakedSpecs int
+	RunTime             time.Duration
+}
+
+type SpecSummary struct {
+	ComponentTexts         []string
+	ComponentCodeLocations []CodeLocation
+
+	State           SpecState
+	RunTime         time.Duration
+	Failure         SpecFailure
+	IsMeasurement   bool
+	NumberOfSamples int
+	Measurements    map[string]*SpecMeasurement
+
+	CapturedOutput string
+	SuiteID        string
+}
+
+func (s SpecSummary) HasFailureState() bool {
+	return s.State.IsFailure()
+}
+
+func (s SpecSummary) TimedOut() bool {
+	return s.State == SpecStateTimedOut
+}
+
+func (s SpecSummary) Panicked() bool {
+	return s.State == SpecStatePanicked
+}
+
+func (s SpecSummary) Failed() bool {
+	return s.State == SpecStateFailed
+}
+
+func (s SpecSummary) Passed() bool {
+	return s.State == SpecStatePassed
+}
+
+func (s SpecSummary) Skipped() bool {
+	return s.State == SpecStateSkipped
+}
+
+func (s SpecSummary) Pending() bool {
+	return s.State == SpecStatePending
+}
+
+type SetupSummary struct {
+	ComponentType SpecComponentType
+	CodeLocation  CodeLocation
+
+	State   SpecState
+	RunTime time.Duration
+	Failure SpecFailure
+
+	CapturedOutput string
+	SuiteID        string
+}
+
+type SpecFailure struct {
+	Message        string
+	Location       CodeLocation
+	ForwardedPanic string
+
+	ComponentIndex        int
+	ComponentType         SpecComponentType
+	ComponentCodeLocation CodeLocation
+}
+
+type SpecMeasurement struct {
+	Name  string
+	Info  interface{}
+	Order int
+
+	Results []float64
+
+	Smallest     float64
+	Largest      float64
+	Average      float64
+	StdDeviation float64
+
+	SmallestLabel string
+	LargestLabel  string
+	AverageLabel  string
+	Units         string
+	Precision     int
+}
+
+func (s SpecMeasurement) PrecisionFmt() string {
+	if s.Precision == 0 {
+		return "%f"
+	}
+
+	str := strconv.Itoa(s.Precision)
+
+	return "%." + str + "f"
+}
+
+type SpecState uint
+
+const (
+	SpecStateInvalid SpecState = iota
+
+	SpecStatePending
+	SpecStateSkipped
+	SpecStatePassed
+	SpecStateFailed
+	SpecStatePanicked
+	SpecStateTimedOut
+)
+
+func (state SpecState) IsFailure() bool {
+	return state == SpecStateTimedOut || state == SpecStatePanicked || state == SpecStateFailed
+}
+
+type SpecComponentType uint
+
+const (
+	SpecComponentTypeInvalid SpecComponentType = iota
+
+	SpecComponentTypeContainer
+	SpecComponentTypeBeforeSuite
+	SpecComponentTypeAfterSuite
+	SpecComponentTypeBeforeEach
+	SpecComponentTypeJustBeforeEach
+	SpecComponentTypeAfterEach
+	SpecComponentTypeIt
+	SpecComponentTypeMeasure
+)
+
+type FlagType uint
+
+const (
+	FlagTypeNone FlagType = iota
+	FlagTypeFocused
+	FlagTypePending
+)

--- a/containers/conformance-tests/Dockerfile
+++ b/containers/conformance-tests/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stretch
+
+LABEL maintainer "henrik@loodse.com"
+
+RUN apt-get update && apt-get install -y curl
+
+COPY ./conformance-tests /usr/local/bin/
+COPY ./install.sh /opt/install.sh
+
+RUN chmod +x /opt/install.sh
+RUN /opt/install.sh

--- a/containers/conformance-tests/install.sh
+++ b/containers/conformance-tests/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="/opt/kube-test"
+
+set -euox pipefail
+
+for VERSION in 1.9 1.10 1.11; do
+    DIRECTORY="${ROOT_DIR}/${VERSION}"
+    if [ ! -d "${DIRECTORY}" ]; then
+
+        FULL_VERSION=$(curl -Ss https://storage.googleapis.com/kubernetes-release/release/stable-${VERSION}.txt)
+        echo "kube-test for ${VERSION} not found. Downloading to ${DIRECTORY} ..."
+
+        TMP_DIR="./.install-tmp/${VERSION}"
+        mkdir -p ${TMP_DIR}
+        mkdir -p ${DIRECTORY}
+
+        curl -L http://gcsweb.k8s.io/gcs/kubernetes-release/release/${FULL_VERSION}/kubernetes.tar.gz -o ${TMP_DIR}/kubernetes.tar.gz
+        tar -zxvf ${TMP_DIR}/kubernetes.tar.gz -C ${TMP_DIR}
+
+        cd ${TMP_DIR} && KUBE_VERSION="${FULL_VERSION}" KUBERNETES_DOWNLOAD_TESTS=true KUBERNETES_SKIP_CONFIRM=true ./kubernetes/cluster/get-kube-binaries.sh
+        cd -
+
+        mv ${TMP_DIR}/kubernetes/cluster ${DIRECTORY}/
+        mv ${TMP_DIR}/kubernetes/platforms/linux/amd64/e2e.test ${DIRECTORY}/
+        mv ${TMP_DIR}/kubernetes/platforms/linux/amd64/ginkgo ${DIRECTORY}/
+        mv ${TMP_DIR}/kubernetes/platforms/linux/amd64/kubectl ${DIRECTORY}/
+
+        rm -rf ${TMP_DIR}
+    fi
+done

--- a/containers/conformance-tests/install.sh
+++ b/containers/conformance-tests/install.sh
@@ -4,7 +4,7 @@ ROOT_DIR="/opt/kube-test"
 
 set -euox pipefail
 
-for VERSION in 1.9 1.10 1.11; do
+for VERSION in 1.9 1.10 1.11 1.12; do
     DIRECTORY="${ROOT_DIR}/${VERSION}"
     if [ ! -d "${DIRECTORY}" ]; then
 

--- a/containers/conformance-tests/release.sh
+++ b/containers/conformance-tests/release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+ver=v0.1-dev1
+
+set -euox pipefail
+
+GOOS=linux GOARCH=amd64 go build github.com/kubermatic/kubermatic/api/cmd/conformance-tests
+
+docker build --no-cache --pull -t quay.io/kubermatic/conformance-tests:${ver} .
+docker push quay.io/kubermatic/conformance-tests:${ver}
+
+rm conformance-tests

--- a/containers/conformance-tests/release.sh
+++ b/containers/conformance-tests/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.1-dev1
+ver=v0.1
 
 set -euox pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a dedicated command to run multiple e2e tests in parallel.
It also adds retries in case a particular test fails.
There are 2 kinds of retries:
- Single test during conformance test suite fails -> retries are being done by Ginkgo
- Single test fails even after Ginkgo retries: command will restart the whole suite

Test results are being stored into a dedicated directory. Test result include:
- junit.xml
- logs of conformance tests

**Release note**:
```release-note
NONE
```
