### PR TITLE
generates a unique name for user resources

### DIFF
--- a/api/cmd/projects-migrator/main.go
+++ b/api/cmd/projects-migrator/main.go
@@ -465,7 +465,7 @@ func removeOrDetectDuplicatedUsers(ctx migrationContext, phase string, stopOnDup
 						if seenUserWithProjects {
 							return errors.New("there is more that one user that belongs to some projects fot the given key, please manually remove one of them and rerun the app")
 						}
-						glog.Warningf("cannot remove the user = %s because it already belongs to some projects = %v", user.Name, user.Spec.Projects)
+						glog.Warningf("cannot remove the user = %s because it already belongs to some projects = %v", user.Name, projectName)
 						seenUserWithProjects = true
 						continue
 					}

--- a/api/pkg/controller/rbac/sync_project.go
+++ b/api/pkg/controller/rbac/sync_project.go
@@ -73,15 +73,15 @@ func (c *Controller) ensureProjectInitialized(project *kubermaticv1.Project) err
 }
 
 func (c *Controller) ensureProjectIsInActivePhase(project *kubermaticv1.Project) error {
-	var err error
-	if project.Status.Phase != kubermaticv1.ProjectActive {
+	if project.Status.Phase == kubermaticv1.ProjectInactive {
+		var err error
 		project.Status.Phase = kubermaticv1.ProjectActive
 		project, err = c.masterClusterProvider.kubermaticClient.KubermaticV1().Projects().Update(project)
 		if err != nil {
 			return err
 		}
 	}
-	return err
+	return nil
 }
 
 // ensureProjectOwner makes sure that the owner of the project is assign to "owners" group

--- a/api/pkg/controller/rbac/sync_project_test.go
+++ b/api/pkg/controller/rbac/sync_project_test.go
@@ -2128,6 +2128,9 @@ func createProject(name string, owner *kubermaticv1.User) *kubermaticv1.Project 
 		Spec: kubermaticv1.ProjectSpec{
 			Name: name,
 		},
+		Status: kubermaticv1.ProjectStatus{
+			Phase: kubermaticv1.ProjectInactive,
+		},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:  previously the name was generated automatically and given the nature of our system that lead to generating multiple object for the same user (email).
To fix the issue we could acquire a distributed lock or generate a unique name. Decided to implement the latter.

The name of the newly created resource will be unique and it is derived from the user's email address (sha256(email)
in the beginning I was considering to hex-encode the email address as it will produce a unique output because the email address in unique.
the only issue I have found with this approach is that the length can get quite long quite fast.
thus decided to use sha256 as it produces fixed output and the hash collisions are very, very, very, very rare.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2126 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
