### PR TITLE
Add monitoring controller

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -13,6 +13,7 @@ import (
 
 	backupcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/backup"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/cluster"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/monitoring"
 	clusterv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
@@ -157,7 +158,11 @@ func getImagesForVersion(versions []*version.MasterVersion, requestedVersion str
 
 func getImagesFromCreators(templateData *resources.TemplateData) (images []string, err error) {
 	statefulsetCreators := cluster.GetStatefulSetCreators()
+	statefulsetCreators = append(statefulsetCreators, monitoring.GetStatefulSetCreators()...)
+
 	deploymentCreators := cluster.GetDeploymentCreators(nil)
+	deploymentCreators = append(deploymentCreators, monitoring.GetDeploymentCreators(nil)...)
+
 	cronjobCreators := cluster.GetCronJobCreators()
 
 	for _, createFunc := range statefulsetCreators {

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/addoninstaller"
 	backupcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/backup"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/cluster"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/monitoring"
 	updatecontroller "github.com/kubermatic/kubermatic/api/pkg/controller/update"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud"
@@ -33,6 +34,7 @@ var allControllers = map[string]controllerCreator{
 	"Addon":          createAddonController,
 	"AddonInstaller": createAddonInstallerController,
 	"Backup":         createBackupController,
+	"Monitoring":     createMonitoringController,
 }
 
 type controllerCreator func(*controllerContext) (runner, error)
@@ -154,6 +156,46 @@ func createBackupController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		ctrlCtx.kubeInformerFactory.Batch().V1beta1().CronJobs(),
 		ctrlCtx.kubeInformerFactory.Batch().V1().Jobs(),
+		ctrlCtx.kubeInformerFactory.Core().V1().Secrets(),
+	)
+}
+
+func createMonitoringController(ctrlCtx *controllerContext) (runner, error) {
+	dcs, err := provider.LoadDatacentersMeta(ctrlCtx.runOptions.dcFile)
+	if err != nil {
+		return nil, err
+	}
+
+	dockerPullConfigJSON, err := ioutil.ReadFile(ctrlCtx.runOptions.dockerPullConfigJSONFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load ImagePullSecret from %s: %v", ctrlCtx.runOptions.dockerPullConfigJSONFile, err)
+	}
+
+	return monitoring.New(
+		ctrlCtx.kubeClient,
+		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
+
+		ctrlCtx.runOptions.dc,
+		dcs,
+		ctrlCtx.runOptions.overwriteRegistry,
+		ctrlCtx.runOptions.nodePortRange,
+		ctrlCtx.runOptions.nodeAccessNetwork,
+		ctrlCtx.runOptions.etcdDiskSize,
+		ctrlCtx.runOptions.inClusterPrometheusRulesFile,
+		ctrlCtx.runOptions.inClusterPrometheusDisableDefaultRules,
+		ctrlCtx.runOptions.inClusterPrometheusDisableDefaultScrapingConfigs,
+		ctrlCtx.runOptions.inClusterPrometheusScrapingConfigsFile,
+		dockerPullConfigJSON,
+
+		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
+		ctrlCtx.kubeInformerFactory.Core().V1().ServiceAccounts(),
+		ctrlCtx.kubeInformerFactory.Core().V1().ConfigMaps(),
+		ctrlCtx.kubeInformerFactory.Rbac().V1().Roles(),
+		ctrlCtx.kubeInformerFactory.Rbac().V1().RoleBindings(),
+		ctrlCtx.kubeInformerFactory.Core().V1().Services(),
+		ctrlCtx.kubeInformerFactory.Apps().V1().StatefulSets(),
+		ctrlCtx.kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
+		ctrlCtx.kubeInformerFactory.Apps().V1().Deployments(),
 		ctrlCtx.kubeInformerFactory.Core().V1().Secrets(),
 	)
 }

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -38,8 +38,8 @@ import (
 	clusterv1alpha1clientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
-// UserClusterConnectionProvider offers functions to retrieve clients for the given user clusters
-type UserClusterConnectionProvider interface {
+// userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
+type userClusterConnectionProvider interface {
 	GetClient(*kubermaticv1.Cluster) (kubernetes.Interface, error)
 	GetMachineClient(*kubermaticv1.Cluster) (clusterv1alpha1clientset.Interface, error)
 	GetApiextensionsClient(*kubermaticv1.Cluster) (apiextensionsclientset.Interface, error)
@@ -49,7 +49,7 @@ type UserClusterConnectionProvider interface {
 type Controller struct {
 	kubermaticClient        kubermaticclientset.Interface
 	kubeClient              kubernetes.Interface
-	userClusterConnProvider UserClusterConnectionProvider
+	userClusterConnProvider userClusterConnectionProvider
 
 	externalURL string
 	dcs         map[string]provider.DatacenterMeta
@@ -93,7 +93,7 @@ func NewController(
 	dc string,
 	dcs map[string]provider.DatacenterMeta,
 	cps map[string]provider.CloudProvider,
-	userClusterConnProvider UserClusterConnectionProvider,
+	userClusterConnProvider userClusterConnectionProvider,
 	overwriteRegistry string,
 	nodePortRange string,
 	nodeAccessNetwork string,

--- a/api/pkg/controller/cluster/userclusterresources.go
+++ b/api/pkg/controller/cluster/userclusterresources.go
@@ -10,7 +10,6 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/ipamcontroller"
-	"github.com/kubermatic/kubermatic/api/pkg/resources/kubestatemetrics"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroller"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
@@ -169,7 +168,6 @@ func (cc *Controller) userClusterEnsureRoleBindings(c *kubermaticv1.Cluster, cli
 func GetUserClusterRoleCreators(c *kubermaticv1.Cluster) []resources.ClusterRoleCreator {
 	creators := []resources.ClusterRoleCreator{
 		machinecontroller.ClusterRole,
-		kubestatemetrics.ClusterRole,
 		vpnsidecar.DnatControllerClusterRole,
 	}
 
@@ -231,7 +229,6 @@ func GetUserClusterRoleBindingCreators(c *kubermaticv1.Cluster) []resources.Clus
 		machinecontroller.ClusterRoleBinding,
 		machinecontroller.NodeBootstrapperClusterRoleBinding,
 		machinecontroller.NodeSignerClusterRoleBinding,
-		kubestatemetrics.ClusterRoleBinding,
 		vpnsidecar.DnatControllerClusterRoleBinding,
 	}
 

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -1,0 +1,367 @@
+package monitoring
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	kubermaticv1informers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions/kubermatic/v1"
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	appsv1informer "k8s.io/client-go/informers/apps/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	rbacv1informer "k8s.io/client-go/informers/rbac/v1"
+	"k8s.io/client-go/kubernetes"
+	appsv1lister "k8s.io/client-go/listers/apps/v1"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+	rbacb1lister "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	// The monitoring controller waits for the cluster to become healthy,
+	// before adding the monitoring components to the clusters
+	healthCheckPeriod = 5 * time.Second
+)
+
+// userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
+type userClusterConnectionProvider interface {
+	GetClient(*kubermaticv1.Cluster) (kubernetes.Interface, error)
+}
+
+// Controller stores all components required for monitoring
+type Controller struct {
+	kubeClient              kubernetes.Interface
+	userClusterConnProvider userClusterConnectionProvider
+
+	dcs                                              map[string]provider.DatacenterMeta
+	dc                                               string
+	overwriteRegistry                                string
+	nodePortRange                                    string
+	nodeAccessNetwork                                string
+	etcdDiskSize                                     resource.Quantity
+	inClusterPrometheusRulesFile                     string
+	inClusterPrometheusDisableDefaultRules           bool
+	inClusterPrometheusDisableDefaultScrapingConfigs bool
+	inClusterPrometheusScrapingConfigsFile           string
+	dockerPullConfigJSON                             []byte
+
+	queue workqueue.RateLimitingInterface
+
+	clusterLister            kubermaticv1lister.ClusterLister
+	serviceAccountLister     corev1lister.ServiceAccountLister
+	configMapLister          corev1lister.ConfigMapLister
+	roleLister               rbacb1lister.RoleLister
+	roleBindingLister        rbacb1lister.RoleBindingLister
+	serviceLister            corev1lister.ServiceLister
+	statefulSetLister        appsv1lister.StatefulSetLister
+	clusterRoleBindingLister rbacb1lister.ClusterRoleBindingLister
+	deploymentLister         appsv1lister.DeploymentLister
+	secretLister             corev1lister.SecretLister
+}
+
+// New creates a new Monitoring controller that is responsible for
+// operating the monitoring components for all managed user clusters
+func New(
+	kubeClient kubernetes.Interface,
+	userClusterConnProvider userClusterConnectionProvider,
+
+	dc string,
+	dcs map[string]provider.DatacenterMeta,
+	overwriteRegistry string,
+	nodePortRange string,
+	nodeAccessNetwork string,
+	etcdDiskSize string,
+	inClusterPrometheusRulesFile string,
+	inClusterPrometheusDisableDefaultRules bool,
+	inClusterPrometheusDisableDefaultScrapingConfigs bool,
+	inClusterPrometheusScrapingConfigsFile string,
+	dockerPullConfigJSON []byte,
+
+	clusterInformer kubermaticv1informers.ClusterInformer,
+	serviceAccountInformer corev1informers.ServiceAccountInformer,
+	configMapInformer corev1informers.ConfigMapInformer,
+	roleInformer rbacv1informer.RoleInformer,
+	roleBindingInformer rbacv1informer.RoleBindingInformer,
+	serviceInformer corev1informers.ServiceInformer,
+	statefulSetInformer appsv1informer.StatefulSetInformer,
+	clusterRoleBindingInformer rbacv1informer.ClusterRoleBindingInformer,
+	deploymentInformer appsv1informer.DeploymentInformer,
+	secretInformer corev1informers.SecretInformer,
+) (*Controller, error) {
+	c := &Controller{
+		kubeClient:              kubeClient,
+		userClusterConnProvider: userClusterConnProvider,
+
+		queue: workqueue.NewNamedRateLimitingQueue(
+			workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 5*time.Minute),
+			"monitoring_cluster",
+		),
+
+		overwriteRegistry:                      overwriteRegistry,
+		nodePortRange:                          nodePortRange,
+		nodeAccessNetwork:                      nodeAccessNetwork,
+		etcdDiskSize:                           resource.MustParse(etcdDiskSize),
+		inClusterPrometheusRulesFile:           inClusterPrometheusRulesFile,
+		inClusterPrometheusDisableDefaultRules: inClusterPrometheusDisableDefaultRules,
+		inClusterPrometheusDisableDefaultScrapingConfigs: inClusterPrometheusDisableDefaultScrapingConfigs,
+		inClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
+		dockerPullConfigJSON:                             dockerPullConfigJSON,
+
+		dc:  dc,
+		dcs: dcs,
+	}
+
+	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueue(obj.(*kubermaticv1.Cluster))
+		},
+		UpdateFunc: func(_, new interface{}) {
+			c.enqueue(new.(*kubermaticv1.Cluster))
+		},
+		DeleteFunc: func(obj interface{}) {
+			cluster, ok := obj.(*kubermaticv1.Cluster)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					runtime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+					return
+				}
+				cluster, ok = tombstone.Obj.(*kubermaticv1.Cluster)
+				if !ok {
+					runtime.HandleError(fmt.Errorf("tombstone contained object that is not a Cluster %#v", obj))
+					return
+				}
+			}
+			c.enqueue(cluster)
+		},
+	})
+	deploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { c.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { c.handleChildObject(obj) },
+	})
+	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { c.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { c.handleChildObject(obj) },
+	})
+	configMapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { c.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { c.handleChildObject(obj) },
+	})
+	serviceAccountInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { c.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { c.handleChildObject(obj) },
+	})
+	roleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { c.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { c.handleChildObject(obj) },
+	})
+	roleBindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { c.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { c.handleChildObject(obj) },
+	})
+	clusterRoleBindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.handleChildObject(obj) },
+		UpdateFunc: func(old, cur interface{}) { c.handleChildObject(cur) },
+		DeleteFunc: func(obj interface{}) { c.handleChildObject(obj) },
+	})
+
+	c.clusterLister = clusterInformer.Lister()
+	c.serviceLister = serviceInformer.Lister()
+	c.configMapLister = configMapInformer.Lister()
+	c.serviceAccountLister = serviceAccountInformer.Lister()
+	c.deploymentLister = deploymentInformer.Lister()
+	c.statefulSetLister = statefulSetInformer.Lister()
+	c.roleLister = roleInformer.Lister()
+	c.roleBindingLister = roleBindingInformer.Lister()
+	c.clusterRoleBindingLister = clusterRoleBindingInformer.Lister()
+	c.secretLister = secretInformer.Lister()
+
+	return c, nil
+}
+
+// Run starts the controller's worker routines. This method is blocking and ends when stopCh gets closed
+func (c *Controller) Run(workerCount int, stopCh <-chan struct{}) {
+	defer runtime.HandleCrash()
+
+	for i := 0; i < workerCount; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextItem() {
+	}
+}
+
+func (c *Controller) processNextItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.sync(key.(string))
+	c.handleErr(err, key)
+
+	return true
+}
+
+// handleErr checks if an error happened and makes sure we will retry later.
+func (c *Controller) handleErr(err error, key interface{}) {
+	if err == nil {
+		// Forget about the #AddRateLimited history of the key on every successful synchronization.
+		// This ensures that future processing of updates for this key is not delayed because of
+		// an outdated error history.
+		c.queue.Forget(key)
+		return
+	}
+
+	// This controller retries 5 times if something goes wrong. After that, it stops trying.
+	if c.queue.NumRequeues(key) < 5 {
+		glog.V(0).Infof("Error syncing %v: %v", key, err)
+
+		// Re-enqueue the key rate limited. Based on the rate limiter on the
+		// queue and the re-enqueue history, the key will be processed later again.
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	c.queue.Forget(key)
+	// Report to an external entity that, even after several retries, we could not successfully process this key
+	runtime.HandleError(err)
+	glog.V(0).Infof("Dropping %q out of the monitoring controller queue after exceeding max retries: %v", key, err)
+}
+
+func (c *Controller) enqueueAfter(cluster *kubermaticv1.Cluster, duration time.Duration) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(cluster)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", cluster, err))
+		return
+	}
+
+	c.queue.AddAfter(key, duration)
+}
+
+func (c *Controller) enqueue(cluster *kubermaticv1.Cluster) {
+	c.enqueueAfter(cluster, 0)
+}
+
+func (c *Controller) handleChildObject(obj interface{}) {
+	object, ok := obj.(metav1.Object)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("error decoding object, invalid type"))
+		return
+	}
+
+	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil && ownerRef.Kind == kubermaticv1.ClusterKindName {
+		cluster, err := c.clusterLister.Get(ownerRef.Name)
+		if err != nil {
+			glog.V(4).Infof("Ignoring orphaned object '%s' from cluster '%s'", object.GetSelfLink(), ownerRef.Name)
+			return
+		}
+		c.enqueue(cluster)
+		return
+	}
+}
+
+func (c *Controller) sync(key string) error {
+	clusterFromCache, err := c.clusterLister.Get(key)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			glog.V(2).Infof("cluster '%s' in work queue no longer exists", key)
+			return nil
+		}
+		return err
+	}
+
+	if clusterFromCache.Spec.Pause {
+		glog.V(6).Infof("skipping cluster %s due to it was set to paused", key)
+		return nil
+	}
+
+	glog.V(4).Infof("syncing cluster %s", key)
+	cluster := clusterFromCache.DeepCopy()
+
+	if !clusterFromCache.Status.Health.AllHealthy() {
+		glog.V(6).Infof("waiting for cluster %s to become healthy", key)
+		c.enqueueAfter(cluster, healthCheckPeriod)
+		return nil
+	}
+
+	if cluster.DeletionTimestamp != nil {
+		// Cluster got deleted - all monitoring components will die soon
+		return nil
+	}
+
+	data, err := c.getClusterTemplateData(cluster)
+	if err != nil {
+		return err
+	}
+
+	client, err := c.userClusterConnProvider.GetClient(cluster)
+	if err != nil {
+		return err
+	}
+
+	// check that all cluster roles in the user cluster are created
+	if err = c.userClusterEnsureClusterRoles(cluster, data, client); err != nil {
+		return err
+	}
+
+	// check that all cluster role bindings in the user cluster are created
+	if err = c.userClusterEnsureClusterRoleBindings(cluster, data, client); err != nil {
+		return err
+	}
+
+	// check that all service accounts are created
+	if err := c.ensureServiceAccounts(cluster, data); err != nil {
+		return err
+	}
+
+	// check that all roles are created
+	if err := c.ensureRoles(cluster, data); err != nil {
+		return err
+	}
+
+	// check that all role bindings are created
+	if err := c.ensureRoleBindings(cluster, data); err != nil {
+		return err
+	}
+
+	// check that all services are available
+	if err := c.ensureServices(cluster, data); err != nil {
+		return err
+	}
+
+	// check that all ConfigMaps are available
+	if err := c.ensureConfigMaps(cluster, data); err != nil {
+		return err
+	}
+
+	// check that all Deployments are available
+	if err := c.ensureDeployments(cluster, data); err != nil {
+		return err
+	}
+
+	// check that all StatefulSets are created
+	return c.ensureStatefulSets(cluster, data)
+}

--- a/api/pkg/controller/monitoring/monitoring_controller_test.go
+++ b/api/pkg/controller/monitoring/monitoring_controller_test.go
@@ -1,0 +1,127 @@
+package monitoring
+
+import (
+	"log"
+	"time"
+
+	"github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	kubermaticfakeclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
+	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	TestClusterName = "fqpcvnc6v"
+	TestDC          = "regular-do1"
+)
+
+func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime.Object) *Controller {
+	dcs := buildDatacenterMeta()
+
+	kubeClient := kubefake.NewSimpleClientset(kubeObjects...)
+	kubermaticClient := kubermaticfakeclientset.NewSimpleClientset(kubermaticObjects...)
+
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, time.Minute*5)
+	kubermaticInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticClient, time.Minute*5)
+
+	controller, err := New(
+		kubeClient,
+		client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
+		TestDC,
+		dcs,
+		"",
+		"",
+		"192.0.2.0/24",
+		"5Gi",
+		"",
+		false,
+		false,
+		"",
+		[]byte{},
+
+		kubermaticInformerFactory.Kubermatic().V1().Clusters(),
+		kubeInformerFactory.Core().V1().ServiceAccounts(),
+		kubeInformerFactory.Core().V1().ConfigMaps(),
+		kubeInformerFactory.Rbac().V1().Roles(),
+		kubeInformerFactory.Rbac().V1().RoleBindings(),
+		kubeInformerFactory.Core().V1().Services(),
+		kubeInformerFactory.Apps().V1().StatefulSets(),
+		kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
+		kubeInformerFactory.Apps().V1().Deployments(),
+		kubeInformerFactory.Core().V1().Secrets(),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	kubeInformerFactory.Start(wait.NeverStop)
+	kubermaticInformerFactory.Start(wait.NeverStop)
+
+	kubeInformerFactory.WaitForCacheSync(wait.NeverStop)
+	kubermaticInformerFactory.WaitForCacheSync(wait.NeverStop)
+
+	return controller
+}
+
+func buildDatacenterMeta() map[string]provider.DatacenterMeta {
+	seedAlias := "alias-europe-west3-c"
+	return map[string]provider.DatacenterMeta{
+		"us-central1": {
+			Location: "us-central",
+			Country:  "US",
+			Private:  false,
+			IsSeed:   true,
+			Spec: provider.DatacenterSpec{
+				Digitalocean: &provider.DigitaloceanSpec{
+					Region: "ams2",
+				},
+			},
+		},
+		"us-central1-byo": {
+			Location: "us-central",
+			Country:  "US",
+			Private:  false,
+			Seed:     "us-central1",
+			Spec: provider.DatacenterSpec{
+				BringYourOwn: &provider.BringYourOwnSpec{},
+			},
+		},
+		"private-do1": {
+			Location: "US ",
+			Seed:     "us-central1",
+			Country:  "NL",
+			Private:  true,
+			Spec: provider.DatacenterSpec{
+				Digitalocean: &provider.DigitaloceanSpec{
+					Region: "ams2",
+				},
+			},
+		},
+		"regular-do1": {
+			Location: "Amsterdam",
+			Seed:     "us-central1",
+			Country:  "NL",
+			Spec: provider.DatacenterSpec{
+				Digitalocean: &provider.DigitaloceanSpec{
+					Region: "ams2",
+				},
+			},
+		},
+		"dns-override-do2": {
+			Location:         "Amsterdam",
+			Seed:             "us-central1",
+			Country:          "NL",
+			SeedDNSOverwrite: &seedAlias,
+			Spec: provider.DatacenterSpec{
+				Digitalocean: &provider.DigitaloceanSpec{
+					Region: "ams3",
+				},
+			},
+		},
+	}
+}

--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -1,0 +1,155 @@
+package monitoring
+
+import (
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/kubestatemetrics"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/prometheus"
+)
+
+func (c *Controller) getClusterTemplateData(cluster *kubermaticv1.Cluster) (*resources.TemplateData, error) {
+	dc, found := c.dcs[cluster.Spec.Cloud.DatacenterName]
+	if !found {
+		return nil, fmt.Errorf("failed to get datacenter %s", cluster.Spec.Cloud.DatacenterName)
+	}
+
+	return resources.NewTemplateData(
+		cluster,
+		&dc,
+		c.dc,
+		c.secretLister,
+		c.configMapLister,
+		c.serviceLister,
+		c.overwriteRegistry,
+		c.nodePortRange,
+		c.nodeAccessNetwork,
+		c.etcdDiskSize,
+		c.inClusterPrometheusRulesFile,
+		c.inClusterPrometheusDisableDefaultRules,
+		c.inClusterPrometheusDisableDefaultScrapingConfigs,
+		c.inClusterPrometheusScrapingConfigsFile,
+		c.dockerPullConfigJSON,
+	), nil
+}
+
+func (c *Controller) ensureServiceAccounts(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
+	creators := []resources.ServiceAccountCreator{
+		prometheus.ServiceAccount,
+	}
+
+	for _, create := range creators {
+		if err := resources.EnsureServiceAccount(data, create, c.serviceAccountLister.ServiceAccounts(cluster.Status.NamespaceName), c.kubeClient.CoreV1().ServiceAccounts(cluster.Status.NamespaceName)); err != nil {
+			return fmt.Errorf("failed to ensure that the ServiceAccount exists: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) ensureRoles(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
+	creators := []resources.RoleCreator{
+		prometheus.Role,
+	}
+
+	for _, create := range creators {
+		if err := resources.EnsureRole(data, create, c.roleLister.Roles(cluster.Status.NamespaceName), c.kubeClient.RbacV1().Roles(cluster.Status.NamespaceName)); err != nil {
+			return fmt.Errorf("failed to ensure that the Role exists: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) ensureRoleBindings(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
+	creators := []resources.RoleBindingCreator{
+		prometheus.RoleBinding,
+	}
+
+	for _, create := range creators {
+		if err := resources.EnsureRoleBinding(data, create, c.roleBindingLister.RoleBindings(cluster.Status.NamespaceName), c.kubeClient.RbacV1().RoleBindings(cluster.Status.NamespaceName)); err != nil {
+			return fmt.Errorf("failed to ensure that the RoleBinding exists: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// GetDeploymentCreators returns all DeploymentCreators that are currently in use
+func GetDeploymentCreators(c *kubermaticv1.Cluster) []resources.DeploymentCreator {
+	creators := []resources.DeploymentCreator{
+		kubestatemetrics.Deployment,
+	}
+
+	return creators
+}
+
+func (c *Controller) ensureDeployments(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
+	creators := GetDeploymentCreators(cluster)
+
+	for _, create := range creators {
+		if err := resources.EnsureDeployment(data, create, c.deploymentLister.Deployments(cluster.Status.NamespaceName), c.kubeClient.AppsV1().Deployments(cluster.Status.NamespaceName)); err != nil {
+			return fmt.Errorf("failed to ensure that the Deployment exists: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// GetConfigMapCreators returns all ConfigMapCreators that are currently in use
+func GetConfigMapCreators(data *resources.TemplateData) []resources.ConfigMapCreator {
+	return []resources.ConfigMapCreator{
+		prometheus.ConfigMapCreator(data),
+	}
+}
+
+func (c *Controller) ensureConfigMaps(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
+	creators := GetConfigMapCreators(data)
+
+	for _, create := range creators {
+		if err := resources.EnsureConfigMap(create, c.configMapLister.ConfigMaps(cluster.Status.NamespaceName), c.kubeClient.CoreV1().ConfigMaps(cluster.Status.NamespaceName)); err != nil {
+			return fmt.Errorf("failed to ensure that the ConfigMap exists: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// GetStatefulSetCreators returns all StatefulSetCreators that are currently in use
+func GetStatefulSetCreators() []resources.StatefulSetCreator {
+	return []resources.StatefulSetCreator{
+		prometheus.StatefulSet,
+	}
+}
+
+func (c *Controller) ensureStatefulSets(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
+	creators := GetStatefulSetCreators()
+
+	for _, create := range creators {
+		if err := resources.EnsureStatefulSet(data, create, c.statefulSetLister.StatefulSets(cluster.Status.NamespaceName), c.kubeClient.AppsV1().StatefulSets(cluster.Status.NamespaceName)); err != nil {
+			return fmt.Errorf("failed to ensure that the StatefulSet exists: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// GetServiceCreators returns all service creators that are currently in use
+func GetServiceCreators() []resources.ServiceCreator {
+	return []resources.ServiceCreator{
+		prometheus.Service,
+	}
+}
+
+func (c *Controller) ensureServices(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
+	creators := GetServiceCreators()
+
+	for _, create := range creators {
+		if err := resources.EnsureService(data, create, c.serviceLister.Services(cluster.Status.NamespaceName), c.kubeClient.CoreV1().Services(cluster.Status.NamespaceName)); err != nil {
+			return fmt.Errorf("failed to ensure that the service exists: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/api/pkg/controller/monitoring/resources_test.go
+++ b/api/pkg/controller/monitoring/resources_test.go
@@ -1,0 +1,91 @@
+package monitoring
+
+import (
+	"testing"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateConfigMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *kubermaticv1.Cluster
+		err     error
+		cfgm    *corev1.ConfigMap
+	}{
+		{
+			name: "successfully created",
+			err:  nil,
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nico1",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						DatacenterName: TestDC,
+					},
+				},
+				Address: kubermaticv1.ClusterAddress{},
+				Status: kubermaticv1.ClusterStatus{
+					NamespaceName: "cluster-nico1",
+				},
+			},
+		},
+		{
+			name: "needs update",
+			err:  nil,
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nico1",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						DatacenterName: TestDC,
+					},
+				},
+				Address: kubermaticv1.ClusterAddress{},
+				Status: kubermaticv1.ClusterStatus{
+					NamespaceName: "cluster-nico1",
+				},
+			},
+			cfgm: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "prometheus", Namespace: "cluster-nico1"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var objects []runtime.Object
+			if test.cfgm != nil {
+				objects = append(objects, test.cfgm)
+			}
+			controller := newTestController(objects, []runtime.Object{test.cluster})
+			beforeActionCount := len(controller.kubeClient.(*fake.Clientset).Actions())
+
+			data, err := controller.getClusterTemplateData(test.cluster)
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+
+			if err := controller.ensureConfigMaps(test.cluster, data); err != nil {
+				t.Errorf("failed to ensure ConfigMap: %v", err)
+			}
+			if test.cfgm != nil {
+				if len(controller.kubeClient.(*fake.Clientset).Actions()) != beforeActionCount+1 ||
+					controller.kubeClient.(*fake.Clientset).Actions()[beforeActionCount].GetVerb() != "update" {
+					t.Error("client made a unknown call/calls when updating a ConfigMap", controller.kubeClient.(*fake.Clientset).Actions()[beforeActionCount:])
+				}
+			} else {
+				if len(controller.kubeClient.(*fake.Clientset).Actions()) != beforeActionCount+1 {
+					t.Error("client made more or less than 1 call to create a ConfigMap", controller.kubeClient.(*fake.Clientset).Actions()[beforeActionCount:])
+				}
+			}
+
+		})
+	}
+}

--- a/api/pkg/controller/monitoring/userclusterresources.go
+++ b/api/pkg/controller/monitoring/userclusterresources.go
@@ -1,0 +1,124 @@
+package monitoring
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/ipamcontroller"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/kubestatemetrics"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetUserClusterRoleCreators returns a list of GetUserClusterRoleCreators
+func GetUserClusterRoleCreators(c *kubermaticv1.Cluster) []resources.ClusterRoleCreator {
+	creators := []resources.ClusterRoleCreator{
+		kubestatemetrics.ClusterRole,
+	}
+
+	if len(c.Spec.MachineNetworks) > 0 {
+		creators = append(creators, ipamcontroller.ClusterRole)
+	}
+
+	return creators
+}
+
+func (cc *Controller) userClusterEnsureClusterRoles(c *kubermaticv1.Cluster, data *resources.TemplateData, client kubernetes.Interface) error {
+	creators := GetUserClusterRoleCreators(c)
+
+	for _, create := range creators {
+		var existing *rbacv1.ClusterRole
+		cRole, err := create(data, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build ClusterRole: %v", err)
+		}
+
+		if existing, err = client.RbacV1().ClusterRoles().Get(cRole.Name, metav1.GetOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+
+			if _, err = client.RbacV1().ClusterRoles().Create(cRole); err != nil {
+				return fmt.Errorf("failed to create ClusterRole %s: %v", cRole.Name, err)
+			}
+			glog.V(4).Infof("Created ClusterRole %s inside user-cluster %s", cRole.Name, c.Name)
+			continue
+		}
+
+		cRole, err = create(data, existing.DeepCopy())
+		if err != nil {
+			return fmt.Errorf("failed to build ClusterRole: %v", err)
+		}
+
+		if equality.Semantic.DeepEqual(cRole, existing) {
+			continue
+		}
+
+		if _, err = client.RbacV1().ClusterRoles().Update(cRole); err != nil {
+			return fmt.Errorf("failed to update ClusterRole %s: %v", cRole.Name, err)
+		}
+		glog.V(4).Infof("Updated ClusterRole %s inside user-cluster %s", cRole.Name, c.Name)
+	}
+
+	return nil
+}
+
+// GetUserClusterRoleBindingCreators returns a list of ClusterRoleBindingCreators which should be used to - guess what - create user cluster role bindings.
+func GetUserClusterRoleBindingCreators(c *kubermaticv1.Cluster) []resources.ClusterRoleBindingCreator {
+	creators := []resources.ClusterRoleBindingCreator{
+		kubestatemetrics.ClusterRoleBinding,
+	}
+
+	if len(c.Spec.MachineNetworks) > 0 {
+		creators = append(creators, ipamcontroller.ClusterRoleBinding)
+	}
+
+	return creators
+}
+
+func (cc *Controller) userClusterEnsureClusterRoleBindings(c *kubermaticv1.Cluster, data *resources.TemplateData, client kubernetes.Interface) error {
+	creators := GetUserClusterRoleBindingCreators(c)
+
+	for _, create := range creators {
+		var existing *rbacv1.ClusterRoleBinding
+		crb, err := create(data, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build ClusterRoleBinding: %v", err)
+		}
+
+		if existing, err = client.RbacV1().ClusterRoleBindings().Get(crb.Name, metav1.GetOptions{}); err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+
+			if _, err = client.RbacV1().ClusterRoleBindings().Create(crb); err != nil {
+				return fmt.Errorf("failed to create ClusterRoleBinding %s: %v", crb.Name, err)
+			}
+			glog.V(4).Infof("Created ClusterRoleBinding %s inside user-cluster %s", crb.Name, c.Name)
+			continue
+		}
+
+		crb, err = create(data, existing.DeepCopy())
+		if err != nil {
+			return fmt.Errorf("failed to build ClusterRoleBinding: %v", err)
+		}
+
+		if equality.Semantic.DeepEqual(crb, existing) {
+			continue
+		}
+
+		if _, err = client.RbacV1().ClusterRoleBindings().Update(crb); err != nil {
+			return fmt.Errorf("failed to update ClusterRoleBinding %s: %v", crb.Name, err)
+		}
+		glog.V(4).Infof("Updated ClusterRoleBinding %s inside user-cluster %s", crb.Name, c.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
See #2124 
**tl;dr**: Move monitoring stuff into its own controller. The cluster controller should only need to handle cluster live-cycle relevant components.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2124 

**Special notes for your reviewer**:
I duplicated quite a lot of code, but I did not want to waste time on abstractions, before discussing it with someone in person.
I did not yet test if this is actually working, apart from a very basic unittest, because I did not get my hands on a test system yet. 

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
*internal refactoring*
```release-note
NONE
```