### PR TITLE
uses UpdateCloudSpec funtion when updating a cluster

### DIFF
--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -194,9 +194,10 @@ func newUpdateCluster(cloudProviders map[string]provider.CloudProvider, projectP
 			return nil, kubernetesErrorToHTTPError(err)
 		}
 
-		existingCluster.Spec.Cloud = req.Body.Spec.Cloud
+		newCluster := req.Body
 		existingCluster.Spec.Version = req.Body.Spec.Version
-		existingCluster.Spec.MachineNetworks = req.Body.Spec.MachineNetworks
+		existingCluster.Spec.MachineNetworks = newCluster.Spec.MachineNetworks
+		newCluster.Spec.Cloud = kubermaticapiv1.UpdateCloudSpec(newCluster.Spec.Cloud, existingCluster.Spec.Cloud)
 
 		if err = validation.ValidateUpdateCluster(existingCluster, existingCluster, cloudProviders); err != nil {
 			return nil, errors.NewBadRequest("invalid cluster: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**: The UpdateCloudSpec is a helper for updating the cloud spec, it rewrites cloud specific credentials if were not updated. Note that cloud credentials are removed from responses and they are empty on requests, for example when a client wants to upgrade a cluster it sends the full cluster spec without the credentials.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
