### PR TITLE
return function to avoid handling data variable in ensure functions

### DIFF
--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -305,25 +305,24 @@ func (cc *Controller) ensureSecrets(c *kubermaticv1.Cluster) error {
 }
 
 // GetConfigMapCreators returns all ConfigMapCreators that are currently in use
-func GetConfigMapCreators() []resources.ConfigMapCreator {
+func GetConfigMapCreators(data *resources.TemplateData) []resources.ConfigMapCreator {
 	return []resources.ConfigMapCreator{
-		cloudconfig.ConfigMap,
-		openvpn.ServerClientConfigsConfigMap,
-		prometheus.ConfigMap,
-		dns.ConfigMap,
+		cloudconfig.ConfigMapCreator(data),
+		openvpn.ServerClientConfigsConfigMapCreator(data),
+		prometheus.ConfigMapCreator(data),
+		dns.ConfigMapCreator(data),
 	}
 }
 
 func (cc *Controller) ensureConfigMaps(c *kubermaticv1.Cluster) error {
-	creators := GetConfigMapCreators()
-
 	data, err := cc.getClusterTemplateData(c)
 	if err != nil {
 		return err
 	}
+	creators := GetConfigMapCreators(data)
 
 	for _, create := range creators {
-		if err := resources.EnsureConfigMap(data, create, cc.configMapLister.ConfigMaps(c.Status.NamespaceName), cc.kubeClient.CoreV1().ConfigMaps(c.Status.NamespaceName)); err != nil {
+		if err := resources.EnsureConfigMap(create, cc.configMapLister.ConfigMaps(c.Status.NamespaceName), cc.kubeClient.CoreV1().ConfigMaps(c.Status.NamespaceName)); err != nil {
 			return fmt.Errorf("failed to ensure that the ConfigMap exists: %v", err)
 		}
 	}

--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -87,11 +87,11 @@ func TestConfigMapCreatorsKeepAdditionalData(t *testing.T) {
 	dc := &provider.DatacenterMeta{}
 	templateData := resources.NewTemplateData(cluster, dc, "", nil, nil, nil, "", "", "10.12.0.0/8", resource.Quantity{}, "", false, false, "", nil)
 
-	for _, create := range GetConfigMapCreators() {
+	for _, create := range GetConfigMapCreators(templateData) {
 		existing := &corev1.ConfigMap{
 			Data: map[string]string{"Test": "Data"},
 		}
-		new, err := create(templateData, existing)
+		new, err := create(existing)
 		if err != nil {
 			t.Fatalf("Error executing configmap creator: %v", err)
 		}

--- a/api/pkg/controller/cluster/userclusterresources.go
+++ b/api/pkg/controller/cluster/userclusterresources.go
@@ -317,18 +317,18 @@ func (cc *Controller) userClusterEnsureConfigMaps(c *kubermaticv1.Cluster) error
 		return err
 	}
 
-	creators := []resources.ConfigMapCreator{
-		openvpn.ClientConfigConfigMap,
-	}
-
 	data, err := cc.getClusterTemplateData(c)
 	if err != nil {
 		return err
 	}
 
+	creators := []resources.ConfigMapCreator{
+		openvpn.ClientConfigConfigMapCreator(data),
+	}
+
 	for _, create := range creators {
 		var existing *corev1.ConfigMap
-		cm, err := create(data, nil)
+		cm, err := create(nil)
 		if err != nil {
 			return fmt.Errorf("failed to build ConfigMap: %v", err)
 		}
@@ -345,7 +345,7 @@ func (cc *Controller) userClusterEnsureConfigMaps(c *kubermaticv1.Cluster) error
 			continue
 		}
 
-		cm, err = create(data, existing.DeepCopy())
+		cm, err = create(existing.DeepCopy())
 		if err != nil {
 			return fmt.Errorf("failed to build ConfigMap: %v", err)
 		}

--- a/api/pkg/resources/ensure.go
+++ b/api/pkg/resources/ensure.go
@@ -426,9 +426,9 @@ func EnsureSecret(name string, data SecretDataProvider, create SecretCreator, li
 
 // EnsureConfigMap will create the ConfigMap with the passed create function & create or update it if necessary.
 // To check if it's necessary it will do a lookup of the resource at the lister & compare the existing ConfigMap with the created one
-func EnsureConfigMap(data ConfigMapDataProvider, create ConfigMapCreator, lister corev1lister.ConfigMapNamespaceLister, client corev1client.ConfigMapInterface) error {
+func EnsureConfigMap(create ConfigMapCreator, lister corev1lister.ConfigMapNamespaceLister, client corev1client.ConfigMapInterface) error {
 	var existing *corev1.ConfigMap
-	cm, err := create(data, nil)
+	cm, err := create(nil)
 	if err != nil {
 		return fmt.Errorf("failed to build ConfigMap: %v", err)
 	}
@@ -449,7 +449,7 @@ func EnsureConfigMap(data ConfigMapDataProvider, create ConfigMapCreator, lister
 	}
 	existing = existing.DeepCopy()
 
-	cm, err = create(data, existing.DeepCopy())
+	cm, err = create(existing.DeepCopy())
 	if err != nil {
 		return fmt.Errorf("failed to build ConfigMap: %v", err)
 	}

--- a/api/pkg/resources/openvpn/configmap.go
+++ b/api/pkg/resources/openvpn/configmap.go
@@ -11,81 +11,84 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ServerClientConfigsConfigMap returns a ConfigMap containing the ClientConfig for the OpenVPN server. It lives inside the seed-cluster
-func ServerClientConfigsConfigMap(data resources.ConfigMapDataProvider, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	cm := existing
-	if cm == nil {
-		cm = &corev1.ConfigMap{}
-	}
-	if cm.Data == nil {
-		cm.Data = map[string]string{}
-	}
+// ServerClientConfigsConfigMapCreator returns a ConfigMap containing the ClientConfig for the OpenVPN server. It lives inside the seed-cluster
+func ServerClientConfigsConfigMapCreator(data resources.ConfigMapDataProvider) resources.ConfigMapCreator {
+	return func(existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+		cm := existing
+		if cm == nil {
+			cm = &corev1.ConfigMap{}
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
 
-	cm.Name = resources.OpenVPNClientConfigsConfigMapName
-	cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-	cm.Labels = resources.BaseAppLabel(name, nil)
+		cm.Name = resources.OpenVPNClientConfigsConfigMapName
+		cm.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
+		cm.Labels = resources.BaseAppLabel(name, nil)
 
-	var iroutes []string
+		var iroutes []string
 
-	// iroute for pod network
-	if len(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks) < 1 {
-		return nil, fmt.Errorf("cluster.Spec.ClusterNetwork.Pods.CIDRBlocks must contain at least one entry")
+		// iroute for pod network
+		if len(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks) < 1 {
+			return nil, fmt.Errorf("cluster.Spec.ClusterNetwork.Pods.CIDRBlocks must contain at least one entry")
+		}
+		_, podNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+		if err != nil {
+			return nil, err
+		}
+		iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
+			podNet.IP.String(),
+			net.IP(podNet.Mask).String()))
+
+		// iroute for service network
+		if len(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks) < 1 {
+			return nil, fmt.Errorf("cluster.Spec.ClusterNetwork.Services.CIDRBlocks must contain at least one entry")
+		}
+		_, serviceNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks[0])
+		if err != nil {
+			return nil, err
+		}
+		iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
+			serviceNet.IP.String(),
+			net.IP(serviceNet.Mask).String()))
+
+		_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork(), err)
+		}
+		iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
+			nodeAccessNetwork.IP.String(),
+			net.IP(nodeAccessNetwork.Mask).String()))
+
+		// trailing newline
+		iroutes = append(iroutes, "")
+		cm.Data["user-cluster-client"] = strings.Join(iroutes, "\n")
+
+		return cm, nil
 	}
-	_, podNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks[0])
-	if err != nil {
-		return nil, err
-	}
-	iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
-		podNet.IP.String(),
-		net.IP(podNet.Mask).String()))
-
-	// iroute for service network
-	if len(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks) < 1 {
-		return nil, fmt.Errorf("cluster.Spec.ClusterNetwork.Services.CIDRBlocks must contain at least one entry")
-	}
-	_, serviceNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks[0])
-	if err != nil {
-		return nil, err
-	}
-	iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
-		serviceNet.IP.String(),
-		net.IP(serviceNet.Mask).String()))
-
-	_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork())
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork(), err)
-	}
-	iroutes = append(iroutes, fmt.Sprintf("iroute %s %s",
-		nodeAccessNetwork.IP.String(),
-		net.IP(nodeAccessNetwork.Mask).String()))
-
-	// trailing newline
-	iroutes = append(iroutes, "")
-	cm.Data["user-cluster-client"] = strings.Join(iroutes, "\n")
-
-	return cm, nil
 }
 
-// ClientConfigConfigMap returns a ConfigMap containing the config for the OpenVPN client. It lives inside the user-cluster
-func ClientConfigConfigMap(data resources.ConfigMapDataProvider, existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	cm := existing
-	if cm == nil {
-		cm = &corev1.ConfigMap{}
-	}
-	if cm.Data == nil {
-		cm.Data = map[string]string{}
-	}
+// ClientConfigConfigMapCreator returns a ConfigMap containing the config for the OpenVPN client. It lives inside the user-cluster
+func ClientConfigConfigMapCreator(data resources.ConfigMapDataProvider) resources.ConfigMapCreator {
+	return func(existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+		cm := existing
+		if cm == nil {
+			cm = &corev1.ConfigMap{}
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
 
-	cm.Name = resources.OpenVPNClientConfigConfigMapName
-	cm.Namespace = metav1.NamespaceSystem
-	cm.Labels = resources.BaseAppLabel(name, nil)
+		cm.Name = resources.OpenVPNClientConfigConfigMapName
+		cm.Namespace = metav1.NamespaceSystem
+		cm.Labels = resources.BaseAppLabel(name, nil)
 
-	openvpnSvc, err := data.ServiceLister().Services(data.Cluster().Status.NamespaceName).Get(resources.OpenVPNServerServiceName)
-	if err != nil {
-		return nil, err
-	}
+		openvpnSvc, err := data.ServiceLister().Services(data.Cluster().Status.NamespaceName).Get(resources.OpenVPNServerServiceName)
+		if err != nil {
+			return nil, err
+		}
 
-	config := fmt.Sprintf(`client
+		config := fmt.Sprintf(`client
 proto tcp
 dev kube
 dev-type tun
@@ -106,7 +109,8 @@ up '/bin/sh -c "/sbin/iptables -t nat -I POSTROUTING -s 10.20.0.0/24 -j MASQUERA
 log /dev/stdout
 `, data.Cluster().Address.ExternalName, openvpnSvc.Spec.Ports[0].NodePort)
 
-	cm.Data["config"] = config
+		cm.Data["config"] = config
 
-	return cm, nil
+		return cm, nil
+	}
 }

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -269,7 +269,7 @@ const (
 )
 
 // ConfigMapCreator defines an interface to create/update ConfigMap's
-type ConfigMapCreator = func(data ConfigMapDataProvider, existing *corev1.ConfigMap) (*corev1.ConfigMap, error)
+type ConfigMapCreator = func(*corev1.ConfigMap) (*corev1.ConfigMap, error)
 
 // SecretCreator defines an interface to create/update Secret's
 type SecretCreator = func(data SecretDataProvider, existing *corev1.Secret) (*corev1.Secret, error)

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -487,8 +487,8 @@ func TestLoadFiles(t *testing.T) {
 					checkTestResult(t, fixturePath, res)
 				}
 
-				for _, create := range clustercontroller.GetConfigMapCreators() {
-					res, err := create(data, nil)
+				for _, create := range clustercontroller.GetConfigMapCreators(data) {
+					res, err := create(nil)
 					if err != nil {
 						t.Fatalf("failed to create ConfigMap: %v", err)
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:
Return function to avoid handling data variable in ensure functions - makes ensure functions more portable.

**Release note**:
```release-note
NONE
```
