### PR TITLE
consumes cloud providers APIs without presenting secrets.

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -93,6 +93,341 @@
         }
       }
     },
+    "/api/v1/dc/{dc}/cluster/{cluster}/azure/sizes": {
+      "get": {
+        "description": "Lists available VM sizes in an Azure region",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "azure"
+        ],
+        "operationId": "listLegacyAzureSizes",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AzureSizeList",
+            "schema": {
+              "$ref": "#/definitions/AzureSizeList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/digitalocean/sizes": {
+      "get": {
+        "description": "Lists sizes from digitalocean",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "digitalocean"
+        ],
+        "operationId": "listLegacyDigitaloceanSizes",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DigitaloceanSizeList",
+            "schema": {
+              "$ref": "#/definitions/DigitaloceanSizeList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/networks": {
+      "get": {
+        "description": "Lists networks from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackNetworks",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackNetwork",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackNetwork"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/securitygroups": {
+      "get": {
+        "description": "Lists security groups from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackSecurityGroups",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackSecurityGroup",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackSecurityGroup"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/sizes": {
+      "get": {
+        "description": "Lists sizes from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackSizes",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackSize",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackSize"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/subnets": {
+      "get": {
+        "description": "Lists subnets from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackSubnets",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "NetworkID",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackSubnet",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackSubnet"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/tenants": {
+      "get": {
+        "description": "Lists tenants from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackTenants",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackTenant",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackTenant"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/vsphere/networks": {
+      "get": {
+        "description": "Lists networks from vsphere datacenter",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "vsphere"
+        ],
+        "operationId": "listLegacyVSphereNetworks",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "VSphereNetwork",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/VSphereNetwork"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/digitalocean/sizes": {
       "get": {
         "description": "Lists sizes from digitalocean",

--- a/api/pkg/handler/azure.go
+++ b/api/pkg/handler/azure.go
@@ -30,7 +30,7 @@ func legacyAzureSizeEndpoint(dcs map[string]provider.DatacenterMeta) endpoint.En
 			return nil, errors.NewNotFound("cloud spec for ", req.ClusterName)
 		}
 
-		dc, err := listDatacenter(dcs, req.DC)
+		dc, err := listDatacenter(dcs, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, err.Error())
 		}

--- a/api/pkg/handler/digitalocean.go
+++ b/api/pkg/handler/digitalocean.go
@@ -7,53 +7,81 @@ import (
 
 	"github.com/digitalocean/godo"
 	"github.com/go-kit/kit/endpoint"
-	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"golang.org/x/oauth2"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
-func digitaloceanSizeEndpoint() endpoint.Endpoint {
-	reStandard := regexp.MustCompile("(^s|S)")
-	reOptimized := regexp.MustCompile("(^c|C)")
+var reStandard = regexp.MustCompile("(^s|S)")
+var reOptimized = regexp.MustCompile("(^c|C)")
 
+func legacyDigitaloceanSizeEndpoint() endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyDoSizesReq)
+		user := ctx.Value(apiUserContextKey).(apiv1.User)
+		clusterProvider := ctx.Value(clusterProviderContextKey).(provider.ClusterProvider)
+		cluster, err := clusterProvider.Cluster(user, req.ClusterName)
+		if err != nil {
+			if err == provider.ErrNotFound {
+				return nil, errors.NewNotFound("cluster", req.ClusterName)
+			}
+			return nil, err
+		}
+		if cluster.Spec.Cloud.Digitalocean == nil {
+			return nil, errors.NewNotFound("cloud spec for ", req.ClusterName)
+		}
+
+		doToken := cluster.Spec.Cloud.Digitalocean.Token
+		return digitaloceanSize(ctx, doToken)
+	}
+}
+
+func digitaloceanSizeEndpoint() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(DoSizesReq)
-		static := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: req.DoToken})
-		client := godo.NewClient(oauth2.NewClient(context.Background(), static))
-
-		listOptions := &godo.ListOptions{
-			Page:    1,
-			PerPage: 1000,
-		}
-
-		sizes, _, err := client.Sizes.List(ctx, listOptions)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list sizes: %v", err)
-		}
-
-		sizeList := apiv1.DigitaloceanSizeList{}
-		// currently there are 3 types of sizes: 1) starting with s, 2) starting with c and 3) the old ones
-		// type 3 isn't listed in the pricing anymore and only will be available for legacy issues until July 1st, 2018
-		// therefor we might not want to log all cases that aren't starting with s or c
-		for k := range sizes {
-			s := apiv1.DigitaloceanSize{
-				Slug:         sizes[k].Slug,
-				Available:    sizes[k].Available,
-				Transfer:     sizes[k].Transfer,
-				PriceMonthly: sizes[k].PriceMonthly,
-				PriceHourly:  sizes[k].PriceHourly,
-				Memory:       sizes[k].Memory,
-				VCPUs:        sizes[k].Vcpus,
-				Disk:         sizes[k].Disk,
-				Regions:      sizes[k].Regions,
-			}
-			switch {
-			case reStandard.MatchString(sizes[k].Slug):
-				sizeList.Standard = append(sizeList.Standard, s)
-			case reOptimized.MatchString(sizes[k].Slug):
-				sizeList.Optimized = append(sizeList.Optimized, s)
-			}
-		}
-
-		return sizeList, nil
+		return digitaloceanSize(ctx, req.DoToken)
 	}
+}
+
+func digitaloceanSize(ctx context.Context, token string) (apiv1.DigitaloceanSizeList, error) {
+	static := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	client := godo.NewClient(oauth2.NewClient(context.Background(), static))
+
+	listOptions := &godo.ListOptions{
+		Page:    1,
+		PerPage: 1000,
+	}
+
+	sizes, _, err := client.Sizes.List(ctx, listOptions)
+	if err != nil {
+		return apiv1.DigitaloceanSizeList{}, fmt.Errorf("failed to list sizes: %v", err)
+	}
+
+	sizeList := apiv1.DigitaloceanSizeList{}
+	// currently there are 3 types of sizes: 1) starting with s, 2) starting with c and 3) the old ones
+	// type 3 isn't listed in the pricing anymore and only will be available for legacy issues until July 1st, 2018
+	// therefor we might not want to log all cases that aren't starting with s or c
+	for k := range sizes {
+		s := apiv1.DigitaloceanSize{
+			Slug:         sizes[k].Slug,
+			Available:    sizes[k].Available,
+			Transfer:     sizes[k].Transfer,
+			PriceMonthly: sizes[k].PriceMonthly,
+			PriceHourly:  sizes[k].PriceHourly,
+			Memory:       sizes[k].Memory,
+			VCPUs:        sizes[k].Vcpus,
+			Disk:         sizes[k].Disk,
+			Regions:      sizes[k].Regions,
+		}
+		switch {
+		case reStandard.MatchString(sizes[k].Slug):
+			sizeList.Standard = append(sizeList.Standard, s)
+		case reOptimized.MatchString(sizes[k].Slug):
+			sizeList.Optimized = append(sizeList.Optimized, s)
+		}
+	}
+
+	return sizeList, nil
 }

--- a/api/pkg/handler/openstack.go
+++ b/api/pkg/handler/openstack.go
@@ -33,7 +33,7 @@ func legacyOpenstackSizeEndpoint(providers provider.CloudRegistry) endpoint.Endp
 		}
 
 		openstackSpec := cluster.Spec.Cloud.Openstack
-		datacenterName := "TODO: HOW DO I GET DC NAME"
+		datacenterName := cluster.Spec.Cloud.DatacenterName
 		return getOpenstackSizes(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Tenant, openstackSpec.Domain, datacenterName)
 	}
 }
@@ -99,7 +99,7 @@ func legacyOpenstackTenantEndpoint(providers provider.CloudRegistry) endpoint.En
 		}
 
 		openstackSpec := cluster.Spec.Cloud.Openstack
-		datacenterName := "TODO: HOW DO I GET DC NAME"
+		datacenterName := cluster.Spec.Cloud.DatacenterName
 		return getOpenstackTenants(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Domain, datacenterName)
 	}
 }
@@ -159,7 +159,7 @@ func legacyOpenstackNetworkEndpoint(providers provider.CloudRegistry) endpoint.E
 		}
 
 		openstackSpec := cluster.Spec.Cloud.Openstack
-		datacenterName := "TODO: HOW DO I GET DC NAME"
+		datacenterName := cluster.Spec.Cloud.DatacenterName
 		return getOpenstackNetworks(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Tenant, openstackSpec.Domain, datacenterName)
 	}
 }
@@ -221,7 +221,7 @@ func legacyOpenstackSecurityGroupEndpoint(providers provider.CloudRegistry) endp
 		}
 
 		openstackSpec := cluster.Spec.Cloud.Openstack
-		datacenterName := "TODO: HOW DO I GET DC NAME"
+		datacenterName := cluster.Spec.Cloud.DatacenterName
 		return getOpenstackSecurityGroups(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Tenant, openstackSpec.Domain, datacenterName)
 	}
 }
@@ -282,7 +282,7 @@ func legacyOpenstackSubnetsEndpoint(providers provider.CloudRegistry) endpoint.E
 		}
 
 		openstackSpec := cluster.Spec.Cloud.Openstack
-		datacenterName := "TODO: HOW DO I GET DC NAME"
+		datacenterName := cluster.Spec.Cloud.DatacenterName
 		return getOpenstackSubnets(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Domain, openstackSpec.Tenant, req.NetworkID, datacenterName)
 	}
 }

--- a/api/pkg/handler/request.go
+++ b/api/pkg/handler/request.go
@@ -206,6 +206,23 @@ func decodeDcReq(c context.Context, r *http.Request) (interface{}, error) {
 	}, nil
 }
 
+// LegacyDoSizesReq represent a request for legacy digitalocean sizes EP
+// swagger:parameters listLegacyDigitaloceanSizes
+type LegacyDoSizesReq struct {
+	LegacyGetClusterReq
+}
+
+func decodeLegacyDoSizesReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyDoSizesReq
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
+	return req, nil
+}
+
 // DoSizesReq represent a request for digitalocean sizes
 type DoSizesReq struct {
 	DoToken string
@@ -215,6 +232,23 @@ func decodeDoSizesReq(c context.Context, r *http.Request) (interface{}, error) {
 	var req DoSizesReq
 
 	req.DoToken = r.Header.Get("DoToken")
+	return req, nil
+}
+
+// LegacyAzureSizeReq represent a request for legacy Azure VM sizes
+// swagger:parameters listLegacyAzureSizes
+type LegacyAzureSizeReq struct {
+	LegacyGetClusterReq
+}
+
+func decodeLegacyAzureSizesReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyAzureSizeReq
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
 	return req, nil
 }
 
@@ -259,6 +293,23 @@ func decodeOpenstackReq(c context.Context, r *http.Request) (interface{}, error)
 	return req, nil
 }
 
+// LegacyOpenstackReq represent a request for openstack
+// swagger:parameters listLegacyOpenstackSizes listLegacyOpenstackTenants listLegacyOpenstackNetworks listLegacyOpenstackSecurityGroups
+type LegacyOpenstackReq struct {
+	LegacyGetClusterReq
+}
+
+func decodeLegacyOpenstackReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyOpenstackReq
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
+	return req, nil
+}
+
 // OpenstackSubnetReq represent a request for openstack subnets
 // swagger:parameters listOpenstackSubnets
 type OpenstackSubnetReq struct {
@@ -279,6 +330,30 @@ func decodeOpenstackSubnetReq(c context.Context, r *http.Request) (interface{}, 
 	if req.NetworkID == "" {
 		return nil, fmt.Errorf("get openstack subnets needs a parameter 'network_id'")
 	}
+	return req, nil
+}
+
+// LegacyOpenstackSubnetReq represent a request for openstack subnets
+// swagger:parameters listLegacyOpenstackSubnets
+type LegacyOpenstackSubnetReq struct {
+	LegacyOpenstackReq
+	// in: query
+	NetworkID string
+}
+
+func decodeLegacyOpenstackSubnetReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyOpenstackSubnetReq
+	lr, err := decodeLegacyOpenstackReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+	req.LegacyOpenstackReq = lr.(LegacyOpenstackReq)
+
+	req.NetworkID = r.URL.Query().Get("network_id")
+	if req.NetworkID == "" {
+		return nil, fmt.Errorf("get openstack subnets needs a parameter 'network_id'")
+	}
+
 	return req, nil
 }
 
@@ -394,5 +469,22 @@ func decodeVSphereNetworksReq(c context.Context, r *http.Request) (interface{}, 
 	req.Password = r.Header.Get("Password")
 	req.DatacenterName = r.Header.Get("DatacenterName")
 
+	return req, nil
+}
+
+// LegacyVSphereNetworksReq represent a request for vsphere networks
+// swagger:parameters listLegacyVSphereNetworks
+type LegacyVSphereNetworksReq struct {
+	LegacyGetClusterReq
+}
+
+func decodeLegacyVSphereNetworksReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyVSphereNetworksReq
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
 	return req, nil
 }

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -79,6 +79,41 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 		Handler(r.listVSphereNetworks())
 
 	//
+	// legacy cloud providers endpoints that don't accept credentials on requests
+	// instead they read them from the associated cluster resource
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/digitalocean/sizes").
+		Handler(r.listLegacyDigitaloceanSizes())
+
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/azure/sizes").
+		Handler(r.listLegacyAzureSizes())
+
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/openstack/sizes").
+		Handler(r.listLegacyOpenstackSizes())
+
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/openstack/tenants").
+		Handler(r.listLegacyOpenstackTenants())
+
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/openstack/networks").
+		Handler(r.listLegacyOpenstackNetworks())
+
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/openstack/securitygroups").
+		Handler(r.listLegacyOpenstackSecurityGroups())
+
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/openstack/subnets").
+		Handler(r.listLegacyOpenstackSubnets())
+
+	mux.Methods(http.MethodGet).
+		Path("/dc/{dc}/cluster/{cluster}/vsphere/networks").
+		Handler(r.listLegacyVSphereNetworks())
+
+	//
 	// Defines a set of HTTP endpoints for project resource
 	mux.Methods(http.MethodGet).
 		Path("/projects").
@@ -1232,6 +1267,190 @@ func (r Routing) getCurrentUser() http.Handler {
 			r.userSaverMiddleware(),
 		)(getCurrentUserEndpoint(r.userProvider)),
 		decodeEmptyReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/dc/{dc}/cluster/{cluster}/digitalocean/sizes digitalocean listLegacyDigitaloceanSizes
+//
+// Lists sizes from digitalocean
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: DigitaloceanSizeList
+func (r Routing) listLegacyDigitaloceanSizes() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(legacyDigitaloceanSizeEndpoint()),
+		decodeLegacyDoSizesReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/dc/{dc}/cluster/{cluster}/azure/sizes azure listLegacyAzureSizes
+//
+// Lists available VM sizes in an Azure region
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: AzureSizeList
+func (r Routing) listLegacyAzureSizes() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(legacyAzureSizeEndpoint(r.datacenters)),
+		decodeLegacyAzureSizesReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/dc/{dc}/cluster/{cluster}/openstack/sizes openstack listLegacyOpenstackSizes
+//
+// Lists sizes from openstack
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: []OpenstackSize
+func (r Routing) listLegacyOpenstackSizes() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(legacyOpenstackSizeEndpoint(r.cloudProviders)),
+		decodeLegacyOpenstackReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/dc/{dc}/cluster/{cluster}/openstack/tenants openstack listLegacyOpenstackTenants
+//
+// Lists tenants from openstack
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: []OpenstackTenant
+func (r Routing) listLegacyOpenstackTenants() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(legacyOpenstackTenantEndpoint(r.cloudProviders)),
+		decodeLegacyOpenstackReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/dc/{dc}/cluster/{cluster}/openstack/networks openstack listLegacyOpenstackNetworks
+//
+// Lists networks from openstack
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: []OpenstackNetwork
+func (r Routing) listLegacyOpenstackNetworks() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(legacyOpenstackNetworkEndpoint(r.cloudProviders)),
+		decodeLegacyOpenstackReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/dc/{dc}/cluster/{cluster}/openstack/securitygroups openstack listLegacyOpenstackSecurityGroups
+//
+// Lists security groups from openstack
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: []OpenstackSecurityGroup
+func (r Routing) listLegacyOpenstackSecurityGroups() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(legacyOpenstackSecurityGroupEndpoint(r.cloudProviders)),
+		decodeLegacyOpenstackReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/dc/{dc}/cluster/{cluster}/openstack/subnets openstack listLegacyOpenstackSubnets
+//
+// Lists subnets from openstack
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: []OpenstackSubnet
+func (r Routing) listLegacyOpenstackSubnets() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(legacyOpenstackSubnetsEndpoint(r.cloudProviders)),
+		decodeLegacyOpenstackSubnetReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/dc/{dc}/cluster/{cluster}/vsphere/networks vsphere listLegacyVSphereNetworks
+//
+// Lists networks from vsphere datacenter
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: []VSphereNetwork
+func (r Routing) listLegacyVSphereNetworks() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.datacenterMiddleware(),
+		)(legacyVsphereNetworksEndpoint(r.cloudProviders)),
+		decodeLegacyVSphereNetworksReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/vsphere.go
+++ b/api/pkg/handler/vsphere.go
@@ -40,7 +40,7 @@ func legacyVsphereNetworksEndpoint(providers provider.CloudRegistry) endpoint.En
 			return nil, errors.NewNotFound("cloud spec for ", req.ClusterName)
 		}
 
-		datacenterName := "TODO: HOW DO I GET DC NAME"
+		datacenterName := cluster.Spec.Cloud.DatacenterName
 		vSpec := cluster.Spec.Cloud.VSphere
 		return getVsphereNetworks(providers, vSpec.Username, vSpec.Password, datacenterName)
 	}

--- a/api/pkg/handler/vsphere.go
+++ b/api/pkg/handler/vsphere.go
@@ -10,44 +10,70 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/vsphere"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
 func vsphereNetworksEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-
 		req, ok := request.(VSphereNetworksReq)
 		if !ok {
 			return nil, fmt.Errorf("incorrect type of request, expected = VSphereNetworksReq, got = %T", request)
 		}
 
-		vsProviderInterface, ok := providers[provider.VSphereCloudProvider]
-		if !ok {
-			return nil, fmt.Errorf("unable to get %s provider", provider.VSphereCloudProvider)
-		}
+		return getVsphereNetworks(providers, req.Username, req.Password, req.DatacenterName)
+	}
+}
 
-		vsProvider, ok := vsProviderInterface.(*vsphere.Provider)
-		if !ok {
-			return nil, fmt.Errorf("unable to cast vsProviderInterface to *vsphere.Provider")
-		}
-
-		networks, err := vsProvider.GetNetworks(kubermaticv1.CloudSpec{
-			DatacenterName: req.DatacenterName,
-			VSphere: &kubermaticv1.VSphereCloudSpec{
-				InfraManagementUser: kubermaticv1.VSphereCredentials{
-					Username: req.Username,
-					Password: req.Password,
-				},
-			},
-		})
+func legacyVsphereNetworksEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyVSphereNetworksReq)
+		user := ctx.Value(apiUserContextKey).(apiv1.User)
+		clusterProvider := ctx.Value(clusterProviderContextKey).(provider.ClusterProvider)
+		cluster, err := clusterProvider.Cluster(user, req.ClusterName)
 		if err != nil {
+			if err == provider.ErrNotFound {
+				return nil, errors.NewNotFound("cluster", req.ClusterName)
+			}
 			return nil, err
 		}
-
-		var apiNetworks []apiv1.VSphereNetwork
-		for _, net := range networks {
-			apiNetworks = append(apiNetworks, apiv1.VSphereNetwork{Name: net.Name})
+		if cluster.Spec.Cloud.VSphere == nil {
+			return nil, errors.NewNotFound("cloud spec for ", req.ClusterName)
 		}
 
-		return apiNetworks, nil
+		datacenterName := "TODO: HOW DO I GET DC NAME"
+		vSpec := cluster.Spec.Cloud.VSphere
+		return getVsphereNetworks(providers, vSpec.Username, vSpec.Password, datacenterName)
 	}
+}
+
+func getVsphereNetworks(providers provider.CloudRegistry, username, password, datacenterName string) ([]apiv1.VSphereNetwork, error) {
+	vsProviderInterface, ok := providers[provider.VSphereCloudProvider]
+	if !ok {
+		return nil, fmt.Errorf("unable to get %s provider", provider.VSphereCloudProvider)
+	}
+
+	vsProvider, ok := vsProviderInterface.(*vsphere.Provider)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast vsProviderInterface to *vsphere.Provider")
+	}
+
+	networks, err := vsProvider.GetNetworks(kubermaticv1.CloudSpec{
+		DatacenterName: datacenterName,
+		VSphere: &kubermaticv1.VSphereCloudSpec{
+			InfraManagementUser: kubermaticv1.VSphereCredentials{
+				Username: username,
+				Password: password,
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var apiNetworks []apiv1.VSphereNetwork
+	for _, net := range networks {
+		apiNetworks = append(apiNetworks, apiv1.VSphereNetwork{Name: net.Name})
+	}
+
+	return apiNetworks, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: allows to consume cloud providers APIs without presenting the credentials. For example getting the list of flavours(sizes). Those EPs are needed to maintain backward compatibility where the dashboard was sending request to providers after creating a cluster. This didn't work because we stopped sending the credentials from API.

**Special notes for your reviewer**: we manually tested cluster creation, deletion and edition, we also tested "Add Node" functionality (after cluster creation) for DigitalOcean and Openstack providers.

Marcin is going to issue a separate pull that has necessary changes for the dashboard.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Communicating with cloud providers APIs no longer requires providing additional credentials.
```
