### PR TITLE
consumes cloud providers APIs without presenting secrets. (cherry-pick)

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -70,6 +70,341 @@
         }
       }
     },
+    "/api/v1/dc/{dc}/cluster/{cluster}/azure/sizes": {
+      "get": {
+        "description": "Lists available VM sizes in an Azure region",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "azure"
+        ],
+        "operationId": "listLegacyAzureSizes",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AzureSizeList",
+            "schema": {
+              "$ref": "#/definitions/AzureSizeList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/digitalocean/sizes": {
+      "get": {
+        "description": "Lists sizes from digitalocean",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "digitalocean"
+        ],
+        "operationId": "listLegacyDigitaloceanSizes",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DigitaloceanSizeList",
+            "schema": {
+              "$ref": "#/definitions/DigitaloceanSizeList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/networks": {
+      "get": {
+        "description": "Lists networks from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackNetworks",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackNetwork",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackNetwork"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/securitygroups": {
+      "get": {
+        "description": "Lists security groups from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackSecurityGroups",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackSecurityGroup",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackSecurityGroup"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/sizes": {
+      "get": {
+        "description": "Lists sizes from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackSizes",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackSize",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackSize"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/subnets": {
+      "get": {
+        "description": "Lists subnets from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackSubnets",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "NetworkID",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackSubnet",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackSubnet"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/openstack/tenants": {
+      "get": {
+        "description": "Lists tenants from openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listLegacyOpenstackTenants",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenstackTenant",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OpenstackTenant"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/dc/{dc}/cluster/{cluster}/vsphere/networks": {
+      "get": {
+        "description": "Lists networks from vsphere datacenter",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "vsphere"
+        ],
+        "operationId": "listLegacyVSphereNetworks",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterName",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "VSphereNetwork",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/VSphereNetwork"
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/healthz": {
       "get": {
         "description": "Health endpoint",

--- a/api/pkg/handler/azure.go
+++ b/api/pkg/handler/azure.go
@@ -3,47 +3,85 @@ package handler
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/go-kit/kit/endpoint"
+
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
+
+func legacyAzureSizeEndpoint(dcs map[string]provider.DatacenterMeta) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyAzureSizeReq)
+		user := ctx.Value(apiUserContextKey).(apiv1.User)
+		clusterProvider := ctx.Value(clusterProviderContextKey).(provider.ClusterProvider)
+		cluster, err := clusterProvider.Cluster(user, req.ClusterName)
+		if err != nil {
+			if err == provider.ErrNotFound {
+				return nil, errors.NewNotFound("cluster", req.ClusterName)
+			}
+			return nil, err
+		}
+		if cluster.Spec.Cloud.Azure == nil {
+			return nil, errors.NewNotFound("cloud spec for ", req.ClusterName)
+		}
+
+		dc, err := listDatacenter(dcs, cluster.Spec.Cloud.DatacenterName)
+		if err != nil {
+			return nil, errors.New(http.StatusInternalServerError, err.Error())
+		}
+
+		if dc.Spec.Azure == nil {
+			return nil, errors.NewNotFound("cloud spec (dc) for ", req.ClusterName)
+		}
+
+		azureSpec := cluster.Spec.Cloud.Azure
+		azureLocation := dc.Spec.Azure.Location
+		return azureSize(ctx, azureSpec.SubscriptionID, azureSpec.ClientID, azureSpec.ClientSecret, azureSpec.TenantID, azureLocation)
+	}
+}
 
 func azureSizeEndpoint() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AzureSizeReq)
-
-		var err error
-		sizesClient := compute.NewVirtualMachineSizesClient(req.SubscriptionID)
-		sizesClient.Authorizer, err = auth.NewClientCredentialsConfig(req.ClientID, req.ClientSecret, req.TenantID).Authorizer()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create authorizer: %v", err)
-		}
-
-		sizesResult, err := sizesClient.List(ctx, req.Location)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list sizes: %v", err)
-		}
-
-		if sizesResult.Value == nil {
-			return nil, fmt.Errorf("failed to list sizes: Azure return a nil result")
-		}
-
-		var sizeList apiv1.AzureSizeList
-		for _, v := range *sizesResult.Value {
-			s := apiv1.AzureSize{
-				Name:                 v.Name,
-				NumberOfCores:        v.NumberOfCores,
-				OsDiskSizeInMB:       v.OsDiskSizeInMB,
-				ResourceDiskSizeInMB: v.ResourceDiskSizeInMB,
-				MemoryInMB:           v.MemoryInMB,
-				MaxDataDiskCount:     v.MaxDataDiskCount,
-			}
-
-			sizeList = append(sizeList, s)
-		}
-
-		return sizeList, nil
+		return azureSize(ctx, req.SubscriptionID, req.ClientID, req.ClientSecret, req.TenantID, req.Location)
 	}
+}
+
+func azureSize(ctx context.Context, subscriptionID, clientID, clientSecret, tenantID, location string) (apiv1.AzureSizeList, error) {
+	var err error
+	sizesClient := compute.NewVirtualMachineSizesClient(subscriptionID)
+	sizesClient.Authorizer, err = auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID).Authorizer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authorizer: %v", err)
+	}
+
+	sizesResult, err := sizesClient.List(ctx, location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sizes: %v", err)
+	}
+
+	if sizesResult.Value == nil {
+		return nil, fmt.Errorf("failed to list sizes: Azure return a nil result")
+	}
+
+	var sizeList apiv1.AzureSizeList
+	for _, v := range *sizesResult.Value {
+		s := apiv1.AzureSize{
+			Name:                 v.Name,
+			NumberOfCores:        v.NumberOfCores,
+			OsDiskSizeInMB:       v.OsDiskSizeInMB,
+			ResourceDiskSizeInMB: v.ResourceDiskSizeInMB,
+			MemoryInMB:           v.MemoryInMB,
+			MaxDataDiskCount:     v.MaxDataDiskCount,
+		}
+
+		sizeList = append(sizeList, s)
+	}
+
+	return sizeList, nil
 }

--- a/api/pkg/handler/digitalocean.go
+++ b/api/pkg/handler/digitalocean.go
@@ -7,53 +7,81 @@ import (
 
 	"github.com/digitalocean/godo"
 	"github.com/go-kit/kit/endpoint"
-	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"golang.org/x/oauth2"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
-func digitaloceanSizeEndpoint() endpoint.Endpoint {
-	reStandard := regexp.MustCompile("(^s|S)")
-	reOptimized := regexp.MustCompile("(^c|C)")
+var reStandard = regexp.MustCompile("(^s|S)")
+var reOptimized = regexp.MustCompile("(^c|C)")
 
+func legacyDigitaloceanSizeEndpoint() endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyDoSizesReq)
+		user := ctx.Value(apiUserContextKey).(apiv1.User)
+		clusterProvider := ctx.Value(clusterProviderContextKey).(provider.ClusterProvider)
+		cluster, err := clusterProvider.Cluster(user, req.ClusterName)
+		if err != nil {
+			if err == provider.ErrNotFound {
+				return nil, errors.NewNotFound("cluster", req.ClusterName)
+			}
+			return nil, err
+		}
+		if cluster.Spec.Cloud.Digitalocean == nil {
+			return nil, errors.NewNotFound("cloud spec for ", req.ClusterName)
+		}
+
+		doToken := cluster.Spec.Cloud.Digitalocean.Token
+		return digitaloceanSize(ctx, doToken)
+	}
+}
+
+func digitaloceanSizeEndpoint() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(DoSizesReq)
-		static := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: req.DoToken})
-		client := godo.NewClient(oauth2.NewClient(context.Background(), static))
-
-		listOptions := &godo.ListOptions{
-			Page:    1,
-			PerPage: 1000,
-		}
-
-		sizes, _, err := client.Sizes.List(ctx, listOptions)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list sizes: %v", err)
-		}
-
-		sizeList := apiv1.DigitaloceanSizeList{}
-		// currently there are 3 types of sizes: 1) starting with s, 2) starting with c and 3) the old ones
-		// type 3 isn't listed in the pricing anymore and only will be available for legacy issues until July 1st, 2018
-		// therefor we might not want to log all cases that aren't starting with s or c
-		for k := range sizes {
-			s := apiv1.DigitaloceanSize{
-				Slug:         sizes[k].Slug,
-				Available:    sizes[k].Available,
-				Transfer:     sizes[k].Transfer,
-				PriceMonthly: sizes[k].PriceMonthly,
-				PriceHourly:  sizes[k].PriceHourly,
-				Memory:       sizes[k].Memory,
-				VCPUs:        sizes[k].Vcpus,
-				Disk:         sizes[k].Disk,
-				Regions:      sizes[k].Regions,
-			}
-			switch {
-			case reStandard.MatchString(sizes[k].Slug):
-				sizeList.Standard = append(sizeList.Standard, s)
-			case reOptimized.MatchString(sizes[k].Slug):
-				sizeList.Optimized = append(sizeList.Optimized, s)
-			}
-		}
-
-		return sizeList, nil
+		return digitaloceanSize(ctx, req.DoToken)
 	}
+}
+
+func digitaloceanSize(ctx context.Context, token string) (apiv1.DigitaloceanSizeList, error) {
+	static := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	client := godo.NewClient(oauth2.NewClient(context.Background(), static))
+
+	listOptions := &godo.ListOptions{
+		Page:    1,
+		PerPage: 1000,
+	}
+
+	sizes, _, err := client.Sizes.List(ctx, listOptions)
+	if err != nil {
+		return apiv1.DigitaloceanSizeList{}, fmt.Errorf("failed to list sizes: %v", err)
+	}
+
+	sizeList := apiv1.DigitaloceanSizeList{}
+	// currently there are 3 types of sizes: 1) starting with s, 2) starting with c and 3) the old ones
+	// type 3 isn't listed in the pricing anymore and only will be available for legacy issues until July 1st, 2018
+	// therefor we might not want to log all cases that aren't starting with s or c
+	for k := range sizes {
+		s := apiv1.DigitaloceanSize{
+			Slug:         sizes[k].Slug,
+			Available:    sizes[k].Available,
+			Transfer:     sizes[k].Transfer,
+			PriceMonthly: sizes[k].PriceMonthly,
+			PriceHourly:  sizes[k].PriceHourly,
+			Memory:       sizes[k].Memory,
+			VCPUs:        sizes[k].Vcpus,
+			Disk:         sizes[k].Disk,
+			Regions:      sizes[k].Regions,
+		}
+		switch {
+		case reStandard.MatchString(sizes[k].Slug):
+			sizeList.Standard = append(sizeList.Standard, s)
+		case reOptimized.MatchString(sizes[k].Slug):
+			sizeList.Optimized = append(sizeList.Optimized, s)
+		}
+	}
+
+	return sizeList, nil
 }

--- a/api/pkg/handler/openstack.go
+++ b/api/pkg/handler/openstack.go
@@ -5,59 +5,78 @@ import (
 	"fmt"
 
 	"github.com/go-kit/kit/endpoint"
+
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/openstack"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
 func openstackSizeEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-
 		req, ok := request.(OpenstackReq)
 		if !ok {
 			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got = %T", request)
 		}
 
-		osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
-		if !ok {
-			return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
-		}
+		return getOpenstackSizes(providers, req.Username, req.Password, req.Tenant, req.Domain, req.DatacenterName)
+	}
+}
 
-		osProvider, ok := osProviderInterface.(*openstack.Provider)
-		if !ok {
-			return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
-		}
-
-		flavors, dc, err := osProvider.GetFlavors(kubermaticv1.CloudSpec{
-			DatacenterName: req.DatacenterName,
-			Openstack: &kubermaticv1.OpenstackCloudSpec{
-				Username: req.Username,
-				Password: req.Password,
-				Tenant:   req.Tenant,
-				Domain:   req.Domain,
-			},
-		})
+func legacyOpenstackSizeEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyOpenstackReq)
+		cluster, err := getClusterForOpenstack(ctx, req.ClusterName)
 		if err != nil {
 			return nil, err
 		}
 
-		apiSizes := []apiv1.OpenstackSize{}
-		for _, flavor := range flavors {
-			apiSize := apiv1.OpenstackSize{
-				Slug:     flavor.Name,
-				Memory:   flavor.RAM,
-				VCPUs:    flavor.VCPUs,
-				Disk:     flavor.Disk,
-				Swap:     flavor.Swap,
-				Region:   dc.Spec.Openstack.Region,
-				IsPublic: flavor.IsPublic,
-			}
-			apiSizes = append(apiSizes, apiSize)
-		}
-
-		return apiSizes, nil
+		openstackSpec := cluster.Spec.Cloud.Openstack
+		datacenterName := cluster.Spec.Cloud.DatacenterName
+		return getOpenstackSizes(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Tenant, openstackSpec.Domain, datacenterName)
 	}
+}
+
+func getOpenstackSizes(providers provider.CloudRegistry, username, passowrd, tenant, domain, datacenterName string) ([]apiv1.OpenstackSize, error) {
+	osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
+	if !ok {
+		return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
+	}
+
+	osProvider, ok := osProviderInterface.(*openstack.Provider)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
+	}
+
+	flavors, dc, err := osProvider.GetFlavors(kubermaticv1.CloudSpec{
+		DatacenterName: datacenterName,
+		Openstack: &kubermaticv1.OpenstackCloudSpec{
+			Username: username,
+			Password: passowrd,
+			Tenant:   tenant,
+			Domain:   domain,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	apiSizes := []apiv1.OpenstackSize{}
+	for _, flavor := range flavors {
+		apiSize := apiv1.OpenstackSize{
+			Slug:     flavor.Name,
+			Memory:   flavor.RAM,
+			VCPUs:    flavor.VCPUs,
+			Disk:     flavor.Disk,
+			Swap:     flavor.Swap,
+			Region:   dc.Spec.Openstack.Region,
+			IsPublic: flavor.IsPublic,
+		}
+		apiSizes = append(apiSizes, apiSize)
+	}
+
+	return apiSizes, nil
 }
 
 func openstackTenantEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
@@ -67,131 +86,181 @@ func openstackTenantEndpoint(providers provider.CloudRegistry) endpoint.Endpoint
 			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackTenantReq, got = %T", request)
 		}
 
-		osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
-		if !ok {
-			return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
-		}
-
-		osProvider, ok := osProviderInterface.(*openstack.Provider)
-		if !ok {
-			return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
-		}
-
-		tenants, err := osProvider.GetTenants(kubermaticv1.CloudSpec{
-			DatacenterName: req.DatacenterName,
-			Openstack: &kubermaticv1.OpenstackCloudSpec{
-				Username: req.Username,
-				Password: req.Password,
-				Domain:   req.Domain,
-			},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("couldn't get tenants: %v", err)
-		}
-
-		apiTenants := []apiv1.OpenstackTenant{}
-		for _, tenant := range tenants {
-			apiTenant := apiv1.OpenstackTenant{
-				Name: tenant.Name,
-				ID:   tenant.ID,
-			}
-
-			apiTenants = append(apiTenants, apiTenant)
-		}
-
-		return apiTenants, nil
+		return getOpenstackTenants(providers, req.Username, req.Password, req.Domain, req.DatacenterName)
 	}
+}
+
+func legacyOpenstackTenantEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyOpenstackReq)
+		cluster, err := getClusterForOpenstack(ctx, req.ClusterName)
+		if err != nil {
+			return nil, err
+		}
+
+		openstackSpec := cluster.Spec.Cloud.Openstack
+		datacenterName := cluster.Spec.Cloud.DatacenterName
+		return getOpenstackTenants(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Domain, datacenterName)
+	}
+}
+
+func getOpenstackTenants(providers provider.CloudRegistry, username, password, domain, datacenterName string) ([]apiv1.OpenstackTenant, error) {
+	osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
+	if !ok {
+		return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
+	}
+
+	osProvider, ok := osProviderInterface.(*openstack.Provider)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
+	}
+
+	tenants, err := osProvider.GetTenants(kubermaticv1.CloudSpec{
+		DatacenterName: datacenterName,
+		Openstack: &kubermaticv1.OpenstackCloudSpec{
+			Username: username,
+			Password: password,
+			Domain:   domain,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get tenants: %v", err)
+	}
+
+	apiTenants := []apiv1.OpenstackTenant{}
+	for _, tenant := range tenants {
+		apiTenant := apiv1.OpenstackTenant{
+			Name: tenant.Name,
+			ID:   tenant.ID,
+		}
+
+		apiTenants = append(apiTenants, apiTenant)
+	}
+
+	return apiTenants, nil
 }
 
 func openstackNetworkEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-
 		req, ok := request.(OpenstackReq)
 		if !ok {
 			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got = %T", request)
 		}
+		return getOpenstackNetworks(providers, req.Username, req.Password, req.Tenant, req.Domain, req.DatacenterName)
+	}
+}
 
-		osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
-		if !ok {
-			return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
-		}
-
-		osProvider, ok := osProviderInterface.(*openstack.Provider)
-		if !ok {
-			return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
-		}
-
-		networks, err := osProvider.GetNetworks(kubermaticv1.CloudSpec{
-			DatacenterName: req.DatacenterName,
-			Openstack: &kubermaticv1.OpenstackCloudSpec{
-				Username: req.Username,
-				Password: req.Password,
-				Tenant:   req.Tenant,
-				Domain:   req.Domain,
-			},
-		})
+func legacyOpenstackNetworkEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyOpenstackReq)
+		cluster, err := getClusterForOpenstack(ctx, req.ClusterName)
 		if err != nil {
 			return nil, err
 		}
 
-		apiNetworks := []apiv1.OpenstackNetwork{}
-		for _, network := range networks {
-			apiNetwork := apiv1.OpenstackNetwork{
-				Name:     network.Name,
-				ID:       network.ID,
-				External: network.External,
-			}
+		openstackSpec := cluster.Spec.Cloud.Openstack
+		datacenterName := cluster.Spec.Cloud.DatacenterName
+		return getOpenstackNetworks(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Tenant, openstackSpec.Domain, datacenterName)
+	}
+}
 
-			apiNetworks = append(apiNetworks, apiNetwork)
+func getOpenstackNetworks(providers provider.CloudRegistry, username, password, tenant, domain, datacenterName string) ([]apiv1.OpenstackNetwork, error) {
+	osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
+	if !ok {
+		return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
+	}
+
+	osProvider, ok := osProviderInterface.(*openstack.Provider)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
+	}
+
+	networks, err := osProvider.GetNetworks(kubermaticv1.CloudSpec{
+		DatacenterName: datacenterName,
+		Openstack: &kubermaticv1.OpenstackCloudSpec{
+			Username: username,
+			Password: password,
+			Tenant:   tenant,
+			Domain:   domain,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	apiNetworks := []apiv1.OpenstackNetwork{}
+	for _, network := range networks {
+		apiNetwork := apiv1.OpenstackNetwork{
+			Name:     network.Name,
+			ID:       network.ID,
+			External: network.External,
 		}
 
-		return apiNetworks, nil
+		apiNetworks = append(apiNetworks, apiNetwork)
 	}
+
+	return apiNetworks, nil
 }
 
 func openstackSecurityGroupEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-
 		req, ok := request.(OpenstackReq)
 		if !ok {
 			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackReq, got = %T", request)
 		}
+		return getOpenstackSecurityGroups(providers, req.Username, req.Password, req.Tenant, req.Domain, req.DatacenterName)
+	}
+}
 
-		osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
-		if !ok {
-			return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
-		}
-
-		osProvider, ok := osProviderInterface.(*openstack.Provider)
-		if !ok {
-			return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
-		}
-
-		securityGroups, err := osProvider.GetSecurityGroups(kubermaticv1.CloudSpec{
-			DatacenterName: req.DatacenterName,
-			Openstack: &kubermaticv1.OpenstackCloudSpec{
-				Username: req.Username,
-				Password: req.Password,
-				Tenant:   req.Tenant,
-				Domain:   req.Domain,
-			},
-		})
+func legacyOpenstackSecurityGroupEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyOpenstackReq)
+		cluster, err := getClusterForOpenstack(ctx, req.ClusterName)
 		if err != nil {
 			return nil, err
 		}
 
-		apiSecurityGroups := []apiv1.OpenstackSecurityGroup{}
-		for _, securityGroup := range securityGroups {
-			apiSecurityGroup := apiv1.OpenstackSecurityGroup{
-				Name: securityGroup.Name,
-				ID:   securityGroup.ID,
-			}
+		openstackSpec := cluster.Spec.Cloud.Openstack
+		datacenterName := cluster.Spec.Cloud.DatacenterName
+		return getOpenstackSecurityGroups(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Tenant, openstackSpec.Domain, datacenterName)
+	}
+}
 
-			apiSecurityGroups = append(apiSecurityGroups, apiSecurityGroup)
+func getOpenstackSecurityGroups(providers provider.CloudRegistry, username, password, tenant, domain, datacenterName string) ([]apiv1.OpenstackSecurityGroup, error) {
+	osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
+	if !ok {
+		return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
+	}
+
+	osProvider, ok := osProviderInterface.(*openstack.Provider)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
+	}
+
+	securityGroups, err := osProvider.GetSecurityGroups(kubermaticv1.CloudSpec{
+		DatacenterName: datacenterName,
+		Openstack: &kubermaticv1.OpenstackCloudSpec{
+			Username: username,
+			Password: password,
+			Tenant:   tenant,
+			Domain:   domain,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	apiSecurityGroups := []apiv1.OpenstackSecurityGroup{}
+	for _, securityGroup := range securityGroups {
+		apiSecurityGroup := apiv1.OpenstackSecurityGroup{
+			Name: securityGroup.Name,
+			ID:   securityGroup.ID,
 		}
 
-		return apiSecurityGroups, nil
+		apiSecurityGroups = append(apiSecurityGroups, apiSecurityGroup)
 	}
+
+	return apiSecurityGroups, nil
 }
 
 func openstackSubnetsEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
@@ -200,38 +269,71 @@ func openstackSubnetsEndpoint(providers provider.CloudRegistry) endpoint.Endpoin
 		if !ok {
 			return nil, fmt.Errorf("incorrect type of request, expected = OpenstackSubnetReq, got = %T", request)
 		}
+		return getOpenstackSubnets(providers, req.Username, req.Password, req.Domain, req.Tenant, req.NetworkID, req.DatacenterName)
+	}
+}
 
-		osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
-		if !ok {
-			return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
-		}
-
-		osProvider, ok := osProviderInterface.(*openstack.Provider)
-		if !ok {
-			return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
-		}
-
-		subnets, err := osProvider.GetSubnets(kubermaticv1.CloudSpec{
-			DatacenterName: req.DatacenterName,
-			Openstack: &kubermaticv1.OpenstackCloudSpec{
-				Username: req.Username,
-				Password: req.Password,
-				Domain:   req.Domain,
-				Tenant:   req.Tenant,
-			},
-		}, req.NetworkID)
+func legacyOpenstackSubnetsEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyOpenstackSubnetReq)
+		cluster, err := getClusterForOpenstack(ctx, req.ClusterName)
 		if err != nil {
 			return nil, err
 		}
 
-		apiSubnetIDs := []apiv1.OpenstackSubnet{}
-		for _, subnet := range subnets {
-			apiSubnetIDs = append(apiSubnetIDs, apiv1.OpenstackSubnet{
-				ID:   subnet.ID,
-				Name: subnet.Name,
-			})
-		}
-
-		return apiSubnetIDs, nil
+		openstackSpec := cluster.Spec.Cloud.Openstack
+		datacenterName := cluster.Spec.Cloud.DatacenterName
+		return getOpenstackSubnets(providers, openstackSpec.Username, openstackSpec.Password, openstackSpec.Domain, openstackSpec.Tenant, req.NetworkID, datacenterName)
 	}
+}
+
+func getOpenstackSubnets(providers provider.CloudRegistry, username, password, domain, tenant, networkID, datacenterName string) ([]apiv1.OpenstackSubnet, error) {
+	osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
+	if !ok {
+		return nil, fmt.Errorf("unable to get %s provider", provider.OpenstackCloudProvider)
+	}
+
+	osProvider, ok := osProviderInterface.(*openstack.Provider)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast osProviderInterface to *openstack.Provider")
+	}
+
+	subnets, err := osProvider.GetSubnets(kubermaticv1.CloudSpec{
+		DatacenterName: datacenterName,
+		Openstack: &kubermaticv1.OpenstackCloudSpec{
+			Username: username,
+			Password: password,
+			Domain:   domain,
+			Tenant:   tenant,
+		},
+	}, networkID)
+	if err != nil {
+		return nil, err
+	}
+
+	apiSubnetIDs := []apiv1.OpenstackSubnet{}
+	for _, subnet := range subnets {
+		apiSubnetIDs = append(apiSubnetIDs, apiv1.OpenstackSubnet{
+			ID:   subnet.ID,
+			Name: subnet.Name,
+		})
+	}
+
+	return apiSubnetIDs, nil
+}
+
+func getClusterForOpenstack(ctx context.Context, clusterName string) (*kubermaticv1.Cluster, error) {
+	user := ctx.Value(apiUserContextKey).(apiv1.User)
+	clusterProvider := ctx.Value(clusterProviderContextKey).(provider.ClusterProvider)
+	cluster, err := clusterProvider.Cluster(user, clusterName)
+	if err != nil {
+		if err == provider.ErrNotFound {
+			return nil, errors.NewNotFound("cluster", clusterName)
+		}
+		return nil, err
+	}
+	if cluster.Spec.Cloud.Openstack == nil {
+		return nil, errors.NewNotFound("cloud spec for ", clusterName)
+	}
+	return cluster, nil
 }

--- a/api/pkg/handler/request.go
+++ b/api/pkg/handler/request.go
@@ -216,6 +216,23 @@ func decodeDcReq(c context.Context, r *http.Request) (interface{}, error) {
 	}, nil
 }
 
+// LegacyDoSizesReq represent a request for legacy digitalocean sizes EP
+// swagger:parameters listLegacyDigitaloceanSizes
+type LegacyDoSizesReq struct {
+	LegacyGetClusterReq
+}
+
+func decodeLegacyDoSizesReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyDoSizesReq
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
+	return req, nil
+}
+
 // DoSizesReq represent a request for digitalocean sizes
 type DoSizesReq struct {
 	DoToken string
@@ -225,6 +242,23 @@ func decodeDoSizesReq(c context.Context, r *http.Request) (interface{}, error) {
 	var req DoSizesReq
 
 	req.DoToken = r.Header.Get("DoToken")
+	return req, nil
+}
+
+// LegacyAzureSizeReq represent a request for legacy Azure VM sizes
+// swagger:parameters listLegacyAzureSizes
+type LegacyAzureSizeReq struct {
+	LegacyGetClusterReq
+}
+
+func decodeLegacyAzureSizesReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyAzureSizeReq
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
 	return req, nil
 }
 
@@ -269,6 +303,23 @@ func decodeOpenstackReq(c context.Context, r *http.Request) (interface{}, error)
 	return req, nil
 }
 
+// LegacyOpenstackReq represent a request for openstack
+// swagger:parameters listLegacyOpenstackSizes listLegacyOpenstackTenants listLegacyOpenstackNetworks listLegacyOpenstackSecurityGroups
+type LegacyOpenstackReq struct {
+	LegacyGetClusterReq
+}
+
+func decodeLegacyOpenstackReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyOpenstackReq
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
+	return req, nil
+}
+
 // OpenstackSubnetReq represent a request for openstack subnets
 // swagger:parameters listOpenstackSubnets
 type OpenstackSubnetReq struct {
@@ -289,6 +340,30 @@ func decodeOpenstackSubnetReq(c context.Context, r *http.Request) (interface{}, 
 	if req.NetworkID == "" {
 		return nil, fmt.Errorf("get openstack subnets needs a parameter 'network_id'")
 	}
+	return req, nil
+}
+
+// LegacyOpenstackSubnetReq represent a request for openstack subnets
+// swagger:parameters listLegacyOpenstackSubnets
+type LegacyOpenstackSubnetReq struct {
+	LegacyOpenstackReq
+	// in: query
+	NetworkID string
+}
+
+func decodeLegacyOpenstackSubnetReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyOpenstackSubnetReq
+	lr, err := decodeLegacyOpenstackReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+	req.LegacyOpenstackReq = lr.(LegacyOpenstackReq)
+
+	req.NetworkID = r.URL.Query().Get("network_id")
+	if req.NetworkID == "" {
+		return nil, fmt.Errorf("get openstack subnets needs a parameter 'network_id'")
+	}
+
 	return req, nil
 }
 
@@ -404,5 +479,22 @@ func decodeVSphereNetworksReq(c context.Context, r *http.Request) (interface{}, 
 	req.Password = r.Header.Get("Password")
 	req.DatacenterName = r.Header.Get("DatacenterName")
 
+	return req, nil
+}
+
+// LegacyVSphereNetworksReq represent a request for vsphere networks
+// swagger:parameters listLegacyVSphereNetworks
+type LegacyVSphereNetworksReq struct {
+	LegacyGetClusterReq
+}
+
+func decodeLegacyVSphereNetworksReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req LegacyVSphereNetworksReq
+	cr, err := decodeLegacyClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.LegacyGetClusterReq = cr.(LegacyGetClusterReq)
 	return req, nil
 }

--- a/api/pkg/handler/vsphere.go
+++ b/api/pkg/handler/vsphere.go
@@ -10,44 +10,70 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/vsphere"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
 func vsphereNetworksEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-
 		req, ok := request.(VSphereNetworksReq)
 		if !ok {
 			return nil, fmt.Errorf("incorrect type of request, expected = VSphereNetworksReq, got = %T", request)
 		}
 
-		vsProviderInterface, ok := providers[provider.VSphereCloudProvider]
-		if !ok {
-			return nil, fmt.Errorf("unable to get %s provider", provider.VSphereCloudProvider)
-		}
+		return getVsphereNetworks(providers, req.Username, req.Password, req.DatacenterName)
+	}
+}
 
-		vsProvider, ok := vsProviderInterface.(*vsphere.Provider)
-		if !ok {
-			return nil, fmt.Errorf("unable to cast vsProviderInterface to *vsphere.Provider")
-		}
-
-		networks, err := vsProvider.GetNetworks(kubermaticv1.CloudSpec{
-			DatacenterName: req.DatacenterName,
-			VSphere: &kubermaticv1.VSphereCloudSpec{
-				InfraManagementUser: kubermaticv1.VSphereCredentials{
-					Username: req.Username,
-					Password: req.Password,
-				},
-			},
-		})
+func legacyVsphereNetworksEndpoint(providers provider.CloudRegistry) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(LegacyVSphereNetworksReq)
+		user := ctx.Value(apiUserContextKey).(apiv1.User)
+		clusterProvider := ctx.Value(clusterProviderContextKey).(provider.ClusterProvider)
+		cluster, err := clusterProvider.Cluster(user, req.ClusterName)
 		if err != nil {
+			if err == provider.ErrNotFound {
+				return nil, errors.NewNotFound("cluster", req.ClusterName)
+			}
 			return nil, err
 		}
-
-		var apiNetworks []apiv1.VSphereNetwork
-		for _, net := range networks {
-			apiNetworks = append(apiNetworks, apiv1.VSphereNetwork{Name: net.Name})
+		if cluster.Spec.Cloud.VSphere == nil {
+			return nil, errors.NewNotFound("cloud spec for ", req.ClusterName)
 		}
 
-		return apiNetworks, nil
+		datacenterName := cluster.Spec.Cloud.DatacenterName
+		vSpec := cluster.Spec.Cloud.VSphere
+		return getVsphereNetworks(providers, vSpec.Username, vSpec.Password, datacenterName)
 	}
+}
+
+func getVsphereNetworks(providers provider.CloudRegistry, username, password, datacenterName string) ([]apiv1.VSphereNetwork, error) {
+	vsProviderInterface, ok := providers[provider.VSphereCloudProvider]
+	if !ok {
+		return nil, fmt.Errorf("unable to get %s provider", provider.VSphereCloudProvider)
+	}
+
+	vsProvider, ok := vsProviderInterface.(*vsphere.Provider)
+	if !ok {
+		return nil, fmt.Errorf("unable to cast vsProviderInterface to *vsphere.Provider")
+	}
+
+	networks, err := vsProvider.GetNetworks(kubermaticv1.CloudSpec{
+		DatacenterName: datacenterName,
+		VSphere: &kubermaticv1.VSphereCloudSpec{
+			InfraManagementUser: kubermaticv1.VSphereCredentials{
+				Username: username,
+				Password: password,
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var apiNetworks []apiv1.VSphereNetwork
+	for _, net := range networks {
+		apiNetworks = append(apiNetworks, apiv1.VSphereNetwork{Name: net.Name})
+	}
+
+	return apiNetworks, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: allows to consume cloud providers APIs without presenting the credentials. For example getting the list of flavours(sizes).
Those EPs are needed to maintain backward compatibility where the dashboard was sending request to providers after creating a cluster. This didn't work because we stopped sending the credentials from API.

**Special notes for your reviewer**: This is a cherry-pick of https://github.com/kubermatic/kubermatic/commit/32882924174c82b8fcff81b72d9888ba519bf457

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Communicating with cloud providers through the non-project APIs no longer requires providing additional credentials.
```
