### PR TITLE
getting uninitialised projects doesn't produce errors

### DIFF
--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -70,7 +70,7 @@ func newClusterEndpoint(sshKeysProvider provider.SSHKeyProvider, cloudProviders 
 	}
 }
 
-func newCreateClusterEndpoint(sshKeyProvider provider.NewSSHKeyProvider, cloudProviders map[string]provider.CloudProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
+func newCreateClusterEndpoint(cloudProviders map[string]provider.CloudProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(NewCreateClusterReq)
 		clusterProvider := ctx.Value(newClusterProviderContextKey).(provider.NewClusterProvider)

--- a/api/pkg/handler/project.go
+++ b/api/pkg/handler/project.go
@@ -52,7 +52,7 @@ func listProjectsEndpoint(projectProvider provider.ProjectProvider, memberMapper
 		projects := []*apiv1.Project{}
 		for _, pg := range user.Spec.Projects {
 			userInfo := &provider.UserInfo{Email: user.Spec.Email, Group: pg.Group}
-			projectInternal, err := projectProvider.Get(userInfo, pg.Name, &provider.ProjectGetOptions{IncludeUninitialized:true})
+			projectInternal, err := projectProvider.Get(userInfo, pg.Name, &provider.ProjectGetOptions{IncludeUninitialized: true})
 			if err != nil {
 				return nil, kubernetesErrorToHTTPError(err)
 			}

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -776,7 +776,7 @@ func (r Routing) newCreateCluster() http.Handler {
 			r.userSaverMiddleware(),
 			r.newDatacenterMiddleware(),
 			r.userInfoMiddleware(),
-		)(newCreateClusterEndpoint(r.newSSHKeyProvider, r.cloudProviders, r.projectProvider)),
+		)(newCreateClusterEndpoint(r.cloudProviders, r.projectProvider)),
 		newDecodeCreateClusterReq,
 		setStatusCreatedHeader(encodeJSON),
 		r.defaultServerOptions()...,


### PR DESCRIPTION
**What this PR does / why we need it**: before the API explicitly checked the status field and responded with 503 HTTP error. It seems like we could relax the validation when a caller just wants to read projects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2078

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
