### PR TITLE
add missing 1.10 1.11 update path

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -21,6 +21,9 @@ updates:
   #We need to skip 1.10.0 as it broke OpenStack.
   to: ^1.10.1
   automatic: false
+- from: 1.10.*
+  to: 1.11.0
+  automatic: false
 
 # ======= 1.11 =======
 # Allow to change to any patch version


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing 1.10 1.11 update path

**Release note**:
```release-note bugfix
Missing upgrade paths for K8S 1.10 and 1.11 have been addded.
```
