### PR TITLE
update dashboard version to fix the update-credentials issues

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -54,7 +54,7 @@ kubermatic:
     replicas: 2
     image:
       repository: "kubermatic/ui-v2"
-      tag: "v0.37.1"
+      tag: "v0.38.0"
       pullPolicy: "IfNotPresent"
     config: |
       {


### PR DESCRIPTION
**What this PR does / why we need it**:
Update dashboard version to fix the update-cloud-provider credentials issue.

**Release note**:
```release-note
Update the kubermatic dashboard to v0.38.0
```
