### PR TITLE
add own dep container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,8 +3,8 @@ pipeline:
     commands:
     - cd api
     - dep ensure -v
-    - '[[ -z "$(git diff)" ]]'
-    image: metalmatze/dep:0.5.0
+    - git diff --exit-code
+    image: quay.io/kubermatic/dep:0.5.0
     pull: true
   gofmt:
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ pipeline:
     - cd api
     - dep ensure -v
     - git diff --exit-code
-    image: quay.io/kubermatic/dep:0.5.0
+    image: quay.io/kubermatic/dep:0.5.0-1
     pull: true
   gofmt:
     commands:

--- a/containers/dep/Dockerfile
+++ b/containers/dep/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.11.1
+
+RUN apt-get update && apt-get install -y mercurial
+
+RUN wget --quiet -O /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
+RUN chmod +x /usr/local/bin/dep

--- a/containers/dep/release.sh
+++ b/containers/dep/release.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-ver=0.5.0
+NUMBER=1
+VERSION=0.5.0
+
 
 set -euox pipefail
 
-docker build --no-cache --pull -t quay.io/kubermatic/dep:$ver .
-docker push quay.io/kubermatic/dep:$ver
+docker build --no-cache --pull -t quay.io/kubermatic/dep:${VERSION}-${NUMBER} .
+docker push quay.io/kubermatic/dep:${VERSION}-${NUMBER}

--- a/containers/dep/release.sh
+++ b/containers/dep/release.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ver=0.5.0
+
+set -euox pipefail
+
+docker build --no-cache --pull -t quay.io/kubermatic/dep:$ver .
+docker push quay.io/kubermatic/dep:$ver


### PR DESCRIPTION
**What this PR does / why we need it**:
Add's a own dep container as the previous one was missing mercurial and it was not under our control.

**Release note**:
```release-note
NONE
```
