### PR TITLE
use own wwhrd container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,13 +5,11 @@ pipeline:
     - dep ensure -v
     - git diff --exit-code
     image: quay.io/kubermatic/dep:0.5.0-1
-    pull: true
   gofmt:
     commands:
     - cd api
     - make gofmt
     image: golang:1.11.0
-    pull: true
   verify-codegen:
     commands:
     - cd api
@@ -23,8 +21,7 @@ pipeline:
     - cd api
     - wwhrd check -f ../allowed_licensed.yaml
     group: lint
-    image: metalmatze/wwhrd:1.9
-    pull: true
+    image: quay.io/kubermatic/wwhrd:0.2.1-dev-1
   lint:
     commands:
     - cd api

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ pipeline:
     - cd api
     - wwhrd check -f ../allowed_licensed.yaml
     group: lint
-    image: quay.io/kubermatic/wwhrd:0.2.1-dev-1
+    image: quay.io/kubermatic/wwhrd:0.2.1-1
   lint:
     commands:
     - cd api

--- a/containers/wwhrd/Dockerfile
+++ b/containers/wwhrd/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.11.1
+
+RUN mkdir tmp
+RUN cd tmp && curl -L --fail https://github.com/frapposelli/wwhrd/releases/download/v0.2.1/wwhrd_0.2.1_linux_amd64.tar.gz | tar -xvz
+RUN mv tmp/wwhrd /usr/local/bin/wwhrd
+RUN rm -rf tmp

--- a/containers/wwhrd/release.sh
+++ b/containers/wwhrd/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-NUMBER=dev-1
+NUMBER=1
 VERSION=0.2.1
 
 set -euox pipefail

--- a/containers/wwhrd/release.sh
+++ b/containers/wwhrd/release.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+NUMBER=dev-1
+VERSION=0.2.1
+
+set -euox pipefail
+
+docker build --no-cache --pull -t quay.io/kubermatic/wwhrd:${VERSION}-${NUMBER} .
+docker push quay.io/kubermatic/wwhrd:${VERSION}-${NUMBER}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use own wwhrd container to get rid of the external dependency and update wwhrd.

**Release note**:
```release-note
NONE
```
