### PR TITLE
use correct deletion policy to prevent race conditions

### DIFF
--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -162,7 +162,11 @@ func (p *ClusterProvider) DeleteCluster(user apiv1.User, name string) error {
 		return err
 	}
 
-	return p.client.KubermaticV1().Clusters().Delete(cluster.Name, &metav1.DeleteOptions{})
+	// Will delete all child's after the object is gone - otherwise the etcd might be deleted before all machines are gone
+	// See https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#controlling-how-the-garbage-collector-deletes-dependents
+	policy := metav1.DeletePropagationBackground
+	opts := metav1.DeleteOptions{PropagationPolicy: &policy}
+	return p.client.KubermaticV1().Clusters().Delete(cluster.Name, &opts)
 }
 
 // UpdateCluster updates a cluster

--- a/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
+++ b/api/pkg/provider/kubernetes/rbac-compliant-cluster.go
@@ -160,7 +160,11 @@ func (p *RBACCompliantClusterProvider) Delete(userInfo *provider.UserInfo, clust
 		return err
 	}
 
-	return seedImpersonatedClient.Clusters().Delete(clusterName, &metav1.DeleteOptions{})
+	// Will delete all child's after the object is gone - otherwise the etcd might be deleted before all machines are gone
+	// See https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#controlling-how-the-garbage-collector-deletes-dependents
+	policy := metav1.DeletePropagationBackground
+	opts := metav1.DeleteOptions{PropagationPolicy: &policy}
+	return seedImpersonatedClient.Clusters().Delete(clusterName, &opts)
 }
 
 // Update updates a cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
Use correct deletion policy to prevent race conditions.
Prevents deletion of cluster components before all finalizers have been removed.
See https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#controlling-how-the-garbage-collector-deletes-dependents

**Release note**:
```release-note
NONE
```
