### PR TITLE
Set authentication kubeconfig

### DIFF
--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -243,12 +243,18 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
 	}
 
+	// New flag in v1.12 which gets used to perform permission checks
+	if clusterVersionSemVer.Minor() >= 12 {
+		flags = append(flags, "--authentication-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig")
+	}
+
 	// This is required in 1.12.0 as a workaround for
 	// https://github.com/kubernetes/kubernetes/issues/68986, the patch
 	// got cherry-picked onto 1.12.1
 	if clusterVersionSemVer.Minor() == 12 && clusterVersionSemVer.Patch() == 0 {
 		flags = append(flags, "--authentication-skip-lookup=true")
 	}
+
 	return flags, nil
 }
 

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -130,6 +130,8 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --authentication-kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -130,6 +130,8 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --authentication-kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -126,6 +126,8 @@ spec:
         - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
+        - --authentication-kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -126,6 +126,8 @@ spec:
         - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
+        - --authentication-kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -130,6 +130,8 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --authentication-kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -130,6 +130,8 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --authentication-kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-skip-lookup=true
         command:
         - /hyperkube


### PR DESCRIPTION
**What this PR does / why we need it**:
Set authentication kubeconfig to fix kubernetes v1.12 support.
The flag got introduced in v1.12 and is used for permission checks. If not set, it will use the in-cluster client - which in our case would end up at the seed cluster apiserver.

**Release note**:
```release-note
NONE
```
