### PR TITLE
getting uninitialised projects doesn't produce errors (#2157)

### DIFF
--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -70,7 +70,7 @@ func newClusterEndpoint(sshKeysProvider provider.SSHKeyProvider, cloudProviders 
 	}
 }
 
-func newCreateClusterEndpoint(sshKeyProvider provider.NewSSHKeyProvider, cloudProviders map[string]provider.CloudProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
+func newCreateClusterEndpoint(cloudProviders map[string]provider.CloudProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(NewCreateClusterReq)
 		clusterProvider := ctx.Value(newClusterProviderContextKey).(provider.NewClusterProvider)

--- a/api/pkg/handler/project.go
+++ b/api/pkg/handler/project.go
@@ -52,7 +52,7 @@ func listProjectsEndpoint(projectProvider provider.ProjectProvider, memberMapper
 		projects := []*apiv1.Project{}
 		for _, pg := range user.Spec.Projects {
 			userInfo := &provider.UserInfo{Email: user.Spec.Email, Group: pg.Group}
-			projectInternal, err := projectProvider.Get(userInfo, pg.Name, &provider.ProjectGetOptions{})
+			projectInternal, err := projectProvider.Get(userInfo, pg.Name, &provider.ProjectGetOptions{IncludeUninitialized: true})
 			if err != nil {
 				return nil, kubernetesErrorToHTTPError(err)
 			}
@@ -78,7 +78,7 @@ func listProjectsEndpoint(projectProvider provider.ProjectProvider, memberMapper
 				continue
 			}
 			userInfo := &provider.UserInfo{Email: mapping.Spec.UserEmail, Group: mapping.Spec.Group}
-			projectInternal, err := projectProvider.Get(userInfo, mapping.Spec.ProjectID, &provider.ProjectGetOptions{})
+			projectInternal, err := projectProvider.Get(userInfo, mapping.Spec.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
 			if err != nil {
 				return nil, kubernetesErrorToHTTPError(err)
 			}
@@ -113,31 +113,21 @@ func updateProjectEndpoint() endpoint.Endpoint {
 
 func getProjectEndpoint(projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		kubermaticProject, err := getKubermaticProject(ctx, projectProvider, request)
+		req, ok := request.(GetProjectRq)
+		if !ok {
+			return nil, errors.NewBadRequest("invalid request")
+		}
+		if len(req.ProjectID) == 0 {
+			return nil, errors.NewBadRequest("the name of the project cannot be empty")
+		}
+
+		userInfo := ctx.Value(userInfoContextKey).(*provider.UserInfo)
+		kubermaticProject, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
 		if err != nil {
 			return nil, kubernetesErrorToHTTPError(err)
 		}
 		return convertInternalProjectToExternal(kubermaticProject), nil
 	}
-}
-
-func getKubermaticProject(ctx context.Context, projectProvider provider.ProjectProvider, request interface{}) (*kubermaticapiv1.Project, error) {
-	req, ok := request.(GetProjectRq)
-
-	if !ok {
-		return nil, errors.NewBadRequest("invalid request")
-	}
-
-	if len(req.ProjectID) == 0 {
-		return nil, errors.NewBadRequest("the name of the project cannot be empty")
-	}
-
-	userInfo := ctx.Value(userInfoContextKey).(*provider.UserInfo)
-	kubermaticProject, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
-	if err != nil {
-		return nil, kubernetesErrorToHTTPError(err)
-	}
-	return kubermaticProject, nil
 }
 
 func convertInternalProjectToExternal(kubermaticProject *kubermaticapiv1.Project) *apiv1.Project {

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -817,7 +817,7 @@ func (r Routing) newCreateCluster() http.Handler {
 			r.userSaverMiddleware(),
 			r.newDatacenterMiddleware(),
 			r.userInfoMiddleware(),
-		)(newCreateClusterEndpoint(r.newSSHKeyProvider, r.cloudProviders, r.projectProvider)),
+		)(newCreateClusterEndpoint(r.cloudProviders, r.projectProvider)),
 		newDecodeCreateClusterReq,
 		setStatusCreatedHeader(encodeJSON),
 		r.defaultServerOptions()...,


### PR DESCRIPTION
**What this PR does / why we need it**: before the API explicitly checked the status field and responded with 503 HTTP error. It seems like we could relax the validation when a caller just wants to read projects.

**Special notes for your reviewer**: This is a cherry_pick of https://github.com/kubermatic/kubermatic/pull/2157

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
API doesn't respond with 503 (Service Unavailable) when getting or reading uninitialised projects.
```
