### PR TITLE
remove forgetting of controller keys in case it failed more than 5 times

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -205,36 +205,20 @@ func (c *Controller) processNextItem() bool {
 	}
 	defer c.queue.Done(key)
 
-	err := c.sync(key.(string))
-
-	c.handleErr(err, key)
-	return true
-}
-
-// handleErr checks if an error happened and makes sure we will retry later.
-func (c *Controller) handleErr(err error, key interface{}) {
-	if err == nil {
-		// Forget about the #AddRateLimited history of the key on every successful synchronization.
-		// This ensures that future processing of updates for this key is not delayed because of
-		// an outdated error history.
-		c.queue.Forget(key)
-		return
-	}
-
-	// This controller retries 5 times if something goes wrong. After that, it stops trying.
-	if c.queue.NumRequeues(key) < 5 {
+	if err := c.sync(key.(string)); err != nil {
 		glog.V(0).Infof("Error syncing %v: %v", key, err)
 
 		// Re-enqueue the key rate limited. Based on the rate limiter on the
 		// queue and the re-enqueue history, the key will be processed later again.
 		c.queue.AddRateLimited(key)
-		return
+		return true
 	}
 
+	// Forget about the #AddRateLimited history of the key on every successful synchronization.
+	// This ensures that future processing of updates for this key is not delayed because of
+	// an outdated error history.
 	c.queue.Forget(key)
-	// Report to an external entity that, even after several retries, we could not successfully process this key
-	utilruntime.HandleError(err)
-	glog.V(0).Infof("Dropping %q out of the queue: %v", key, err)
+	return true
 }
 
 func (c *Controller) enqueue(addon *kubermaticv1.Addon) {

--- a/api/pkg/controller/addoninstaller/addoninstaller_controller.go
+++ b/api/pkg/controller/addoninstaller/addoninstaller_controller.go
@@ -189,36 +189,20 @@ func (c *Controller) processNextItem() bool {
 	}
 	defer c.queue.Done(key)
 
-	err := c.sync(key.(string))
-
-	c.handleErr(err, key)
-	return true
-}
-
-// handleErr checks if an error happened and makes sure we will retry later.
-func (c *Controller) handleErr(err error, key interface{}) {
-	if err == nil {
-		// Forget about the #AddRateLimited history of the key on every successful synchronization.
-		// This ensures that future processing of updates for this key is not delayed because of
-		// an outdated error history.
-		c.queue.Forget(key)
-		return
-	}
-
-	// This controller retries 5 times if something goes wrong. After that, it stops trying.
-	if c.queue.NumRequeues(key) < 5 {
+	if err := c.sync(key.(string)); err != nil {
 		glog.V(0).Infof("Error syncing %v: %v", key, err)
 
 		// Re-enqueue the key rate limited. Based on the rate limiter on the
 		// queue and the re-enqueue history, the key will be processed later again.
 		c.queue.AddRateLimited(key)
-		return
+		return true
 	}
 
+	// Forget about the #AddRateLimited history of the key on every successful synchronization.
+	// This ensures that future processing of updates for this key is not delayed because of
+	// an outdated error history.
 	c.queue.Forget(key)
-	// Report to an external entity that, even after several retries, we could not successfully process this key
-	utilruntime.HandleError(err)
-	glog.V(0).Infof("Dropping %q out of the queue: %v", key, err)
+	return true
 }
 
 // make sure that all default addons are installed on cluster creation

--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -287,36 +287,20 @@ func (c *Controller) processNextItem() bool {
 	}
 	defer c.queue.Done(key)
 
-	err := c.sync(key.(string))
-
-	c.handleErr(err, key)
-	return true
-}
-
-// handleErr checks if an error happened and makes sure we will retry later.
-func (c *Controller) handleErr(err error, key interface{}) {
-	if err == nil {
-		// Forget about the #AddRateLimited history of the key on every successful synchronization.
-		// This ensures that future processing of updates for this key is not delayed because of
-		// an outdated error history.
-		c.queue.Forget(key)
-		return
-	}
-
-	// This controller retries 5 times if something goes wrong. After that, it stops trying.
-	if c.queue.NumRequeues(key) < 5 {
+	if err := c.sync(key.(string)); err != nil {
 		glog.V(0).Infof("Error syncing %v: %v", key, err)
 
 		// Re-enqueue the key rate limited. Based on the rate limiter on the
 		// queue and the re-enqueue history, the key will be processed later again.
 		c.queue.AddRateLimited(key)
-		return
+		return true
 	}
 
+	// Forget about the #AddRateLimited history of the key on every successful synchronization.
+	// This ensures that future processing of updates for this key is not delayed because of
+	// an outdated error history.
 	c.queue.Forget(key)
-	// Report to an external entity that, even after several retries, we could not successfully process this key
-	runtime.HandleError(err)
-	glog.V(0).Infof("Dropping %q out of the backup controller queue after exceeding max retries: %v", key, err)
+	return true
 }
 
 func (c *Controller) enqueue(cluster *kubermaticv1.Cluster) {

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -410,31 +410,22 @@ func (cc *Controller) processNextItem() bool {
 	if quit {
 		return false
 	}
-
 	defer cc.queue.Done(key)
 
-	err := cc.syncCluster(key.(string))
+	if err := cc.syncCluster(key.(string)); err != nil {
+		glog.V(0).Infof("Error syncing %v: %v", key, err)
 
-	cc.handleErr(err, key)
-	return true
-}
-
-// handleErr checks if an error happened and makes sure we will retry later.
-func (cc *Controller) handleErr(err error, key interface{}) {
-	if err == nil {
-		// Forget about the #AddRateLimited history of the key on every successful synchronization.
-		// This ensures that future processing of updates for this key is not delayed because of
-		// an outdated error history.
-		cc.queue.Forget(key)
-		return
+		// Re-enqueue the key rate limited. Based on the rate limiter on the
+		// queue and the re-enqueue history, the key will be processed later again.
+		cc.queue.AddRateLimited(key)
+		return true
 	}
 
-	glog.V(0).Infof("Error syncing cluster %v: %v", key, err)
-
-	// Re-enqueue the key rate limited. Based on the rate limiter on the
-	// queue and the re-enqueue history, the key will be processed later again.
-	cc.queue.AddRateLimited(key)
-	runtime.HandleError(err)
+	// Forget about the #AddRateLimited history of the key on every successful synchronization.
+	// This ensures that future processing of updates for this key is not delayed because of
+	// an outdated error history.
+	cc.queue.Forget(key)
+	return true
 }
 
 // Run starts the controller's worker routines. This method is blocking and ends when stopCh gets closed

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -219,36 +219,20 @@ func (c *Controller) processNextItem() bool {
 	}
 	defer c.queue.Done(key)
 
-	err := c.sync(key.(string))
-	c.handleErr(err, key)
-
-	return true
-}
-
-// handleErr checks if an error happened and makes sure we will retry later.
-func (c *Controller) handleErr(err error, key interface{}) {
-	if err == nil {
-		// Forget about the #AddRateLimited history of the key on every successful synchronization.
-		// This ensures that future processing of updates for this key is not delayed because of
-		// an outdated error history.
-		c.queue.Forget(key)
-		return
-	}
-
-	// This controller retries 5 times if something goes wrong. After that, it stops trying.
-	if c.queue.NumRequeues(key) < 5 {
+	if err := c.sync(key.(string)); err != nil {
 		glog.V(0).Infof("Error syncing %v: %v", key, err)
 
 		// Re-enqueue the key rate limited. Based on the rate limiter on the
 		// queue and the re-enqueue history, the key will be processed later again.
 		c.queue.AddRateLimited(key)
-		return
+		return true
 	}
 
+	// Forget about the #AddRateLimited history of the key on every successful synchronization.
+	// This ensures that future processing of updates for this key is not delayed because of
+	// an outdated error history.
 	c.queue.Forget(key)
-	// Report to an external entity that, even after several retries, we could not successfully process this key
-	runtime.HandleError(err)
-	glog.V(0).Infof("Dropping %q out of the monitoring controller queue after exceeding max retries: %v", key, err)
+	return true
 }
 
 func (c *Controller) enqueueAfter(cluster *kubermaticv1.Cluster, duration time.Duration) {

--- a/api/pkg/controller/monitoring/userclusterresources.go
+++ b/api/pkg/controller/monitoring/userclusterresources.go
@@ -30,8 +30,8 @@ func GetUserClusterRoleCreators(c *kubermaticv1.Cluster) []resources.ClusterRole
 	return creators
 }
 
-func (cc *Controller) userClusterEnsureClusterRoles(c *kubermaticv1.Cluster, data *resources.TemplateData, client kubernetes.Interface) error {
-	creators := GetUserClusterRoleCreators(c)
+func (c *Controller) userClusterEnsureClusterRoles(cluster *kubermaticv1.Cluster, data *resources.TemplateData, client kubernetes.Interface) error {
+	creators := GetUserClusterRoleCreators(cluster)
 
 	for _, create := range creators {
 		var existing *rbacv1.ClusterRole
@@ -48,7 +48,7 @@ func (cc *Controller) userClusterEnsureClusterRoles(c *kubermaticv1.Cluster, dat
 			if _, err = client.RbacV1().ClusterRoles().Create(cRole); err != nil {
 				return fmt.Errorf("failed to create ClusterRole %s: %v", cRole.Name, err)
 			}
-			glog.V(4).Infof("Created ClusterRole %s inside user-cluster %s", cRole.Name, c.Name)
+			glog.V(4).Infof("Created ClusterRole %s inside user-cluster %s", cRole.Name, cluster.Name)
 			continue
 		}
 
@@ -64,7 +64,7 @@ func (cc *Controller) userClusterEnsureClusterRoles(c *kubermaticv1.Cluster, dat
 		if _, err = client.RbacV1().ClusterRoles().Update(cRole); err != nil {
 			return fmt.Errorf("failed to update ClusterRole %s: %v", cRole.Name, err)
 		}
-		glog.V(4).Infof("Updated ClusterRole %s inside user-cluster %s", cRole.Name, c.Name)
+		glog.V(4).Infof("Updated ClusterRole %s inside user-cluster %s", cRole.Name, cluster.Name)
 	}
 
 	return nil
@@ -83,8 +83,8 @@ func GetUserClusterRoleBindingCreators(c *kubermaticv1.Cluster) []resources.Clus
 	return creators
 }
 
-func (cc *Controller) userClusterEnsureClusterRoleBindings(c *kubermaticv1.Cluster, data *resources.TemplateData, client kubernetes.Interface) error {
-	creators := GetUserClusterRoleBindingCreators(c)
+func (c *Controller) userClusterEnsureClusterRoleBindings(cluster *kubermaticv1.Cluster, data *resources.TemplateData, client kubernetes.Interface) error {
+	creators := GetUserClusterRoleBindingCreators(cluster)
 
 	for _, create := range creators {
 		var existing *rbacv1.ClusterRoleBinding
@@ -101,7 +101,7 @@ func (cc *Controller) userClusterEnsureClusterRoleBindings(c *kubermaticv1.Clust
 			if _, err = client.RbacV1().ClusterRoleBindings().Create(crb); err != nil {
 				return fmt.Errorf("failed to create ClusterRoleBinding %s: %v", crb.Name, err)
 			}
-			glog.V(4).Infof("Created ClusterRoleBinding %s inside user-cluster %s", crb.Name, c.Name)
+			glog.V(4).Infof("Created ClusterRoleBinding %s inside user-cluster %s", crb.Name, cluster.Name)
 			continue
 		}
 
@@ -117,7 +117,7 @@ func (cc *Controller) userClusterEnsureClusterRoleBindings(c *kubermaticv1.Clust
 		if _, err = client.RbacV1().ClusterRoleBindings().Update(crb); err != nil {
 			return fmt.Errorf("failed to update ClusterRoleBinding %s: %v", crb.Name, err)
 		}
-		glog.V(4).Infof("Updated ClusterRoleBinding %s inside user-cluster %s", crb.Name, c.Name)
+		glog.V(4).Infof("Updated ClusterRoleBinding %s inside user-cluster %s", crb.Name, cluster.Name)
 	}
 
 	return nil

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -237,20 +237,11 @@ func (c *Controller) handleProjectErr(err error, key interface{}) {
 		return
 	}
 
-	// This controller retries 5 times if something goes wrong. After that, it stops trying.
-	if c.projectQueue.NumRequeues(key) < 5 {
-		glog.V(0).Infof("Error syncing %v: %v", key, err)
+	glog.V(0).Infof("Error syncing %v: %v", key, err)
 
-		// Re-enqueueProject the key rate limited. Based on the rate limiter on the
-		// projectQueue and the re-enqueueProject history, the key will be processed later again.
-		c.projectQueue.AddRateLimited(key)
-		return
-	}
-
-	c.projectQueue.Forget(key)
-	// Report to an external entity that, even after several retries, we could not successfully process this key
-	runtime.HandleError(err)
-	glog.V(0).Infof("Dropping %q out of the projectQueue: %v", key, err)
+	// Re-enqueueProject the key rate limited. Based on the rate limiter on the
+	// projectQueue and the re-enqueueProject history, the key will be processed later again.
+	c.projectQueue.AddRateLimited(key)
 }
 
 func (c *Controller) enqueueProject(project *kubermaticv1.Project) {
@@ -292,20 +283,11 @@ func (c *Controller) handleProjectResourcesErr(err error, item *projectResourceQ
 		return
 	}
 
-	// This controller retries 5 times if something goes wrong. After that, it stops trying.
-	if c.projectResourcesQueue.NumRequeues(item) < 5 {
-		glog.V(0).Infof("Error syncing gvr %s, kind %s, err %v", item.gvr.String(), item.kind, err)
+	glog.V(0).Infof("Error syncing gvr %s, kind %s, err %v", item.gvr.String(), item.kind, err)
 
-		// Re-enqueueProject the key rate limited. Based on the rate limiter on the
-		// projectQueue and the re-enqueueProject history, the key will be processed later again.
-		c.projectResourcesQueue.AddRateLimited(item)
-		return
-	}
-
-	c.projectResourcesQueue.Forget(item)
-	// Report to an external entity that, even after several retries, we could not successfully process this key
-	runtime.HandleError(err)
-	glog.V(0).Infof("Dropping %q out of the projectResourcesQueue: %v", item, err)
+	// Re-enqueueProject the key rate limited. Based on the rate limiter on the
+	// projectQueue and the re-enqueueProject history, the key will be processed later again.
+	c.projectResourcesQueue.AddRateLimited(item)
 }
 
 func (c *Controller) enqueueProjectResource(obj interface{}, gvr schema.GroupVersionResource, kind string, clusterProvider *ClusterProvider) {

--- a/api/pkg/controller/update/update_controller.go
+++ b/api/pkg/controller/update/update_controller.go
@@ -125,36 +125,20 @@ func (c *Controller) processNextItem() bool {
 	}
 	defer c.queue.Done(key)
 
-	err := c.sync(key.(string))
-
-	c.handleErr(err, key)
-	return true
-}
-
-// handleErr checks if an error happened and makes sure we will retry later.
-func (c *Controller) handleErr(err error, key interface{}) {
-	if err == nil {
-		// Forget about the #AddRateLimited history of the key on every successful synchronization.
-		// This ensures that future processing of updates for this key is not delayed because of
-		// an outdated error history.
-		c.queue.Forget(key)
-		return
-	}
-
-	// This controller retries 5 times if something goes wrong. After that, it stops trying.
-	if c.queue.NumRequeues(key) < 5 {
+	if err := c.sync(key.(string)); err != nil {
 		glog.V(0).Infof("Error syncing %v: %v", key, err)
 
 		// Re-enqueue the key rate limited. Based on the rate limiter on the
 		// queue and the re-enqueue history, the key will be processed later again.
 		c.queue.AddRateLimited(key)
-		return
+		return true
 	}
 
+	// Forget about the #AddRateLimited history of the key on every successful synchronization.
+	// This ensures that future processing of updates for this key is not delayed because of
+	// an outdated error history.
 	c.queue.Forget(key)
-	// Report to an external entity that, even after several retries, we could not successfully process this key
-	runtime.HandleError(err)
-	glog.V(0).Infof("Dropping %q out of the queue: %v", key, err)
+	return true
 }
 
 func (c *Controller) enqueue(cluster *kubermaticv1.Cluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove forgetting of controller keys in case it failed more than 5 times.
This will ensure that we'll always retry with a configured backoff - potentially reaching the maximum backoff.

Fixes #1851

**Release note**:
```release-note
NONE
```
