### PR TITLE
extend error message by error type for debug purpose

### DIFF
--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -182,19 +182,19 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 	if kubernetes.HasFinalizer(cluster, networkCleanupFinalizer) {
 		if _, err = detachSubnetFromRouter(netClient, cluster.Spec.Cloud.Openstack.SubnetID, cluster.Spec.Cloud.Openstack.RouterID); err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); !ok {
-				return nil, fmt.Errorf("failed to detach subnet from router: %v", err)
+				return nil, fmt.Errorf("failed to detach subnet from router: %T %v", err, err)
 			}
 		}
 
 		if err = deleteNetworkByName(netClient, cluster.Spec.Cloud.Openstack.Network); err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); !ok {
-				return nil, fmt.Errorf("failed delete network %q: %v", cluster.Spec.Cloud.Openstack.Network, err)
+				return nil, fmt.Errorf("failed delete network %q: %T %v", cluster.Spec.Cloud.Openstack.Network, err, err)
 			}
 		}
 
 		if err = deleteRouter(netClient, cluster.Spec.Cloud.Openstack.RouterID); err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); !ok {
-				return nil, fmt.Errorf("failed delete router %q: %v", cluster.Spec.Cloud.Openstack.RouterID, err)
+				return nil, fmt.Errorf("failed delete router %q: %T %v", cluster.Spec.Cloud.Openstack.RouterID, err, err)
 			}
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Extend error message by error type for debug purpose.
We're somehow hitting the error case and the message from OpenStack is `not found` which makes the type castings fairly useless

**Release note**:
```release-note
NONE
```
