### PR TITLE
Reduce openvpn resources

### DIFF
--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -14,15 +14,10 @@ import (
 )
 
 var (
-	defaultInitMemoryRequest = resource.MustParse("128Mi")
-	defaultInitCPURequest    = resource.MustParse("250m")
-	defaultInitMemoryLimit   = resource.MustParse("512Mi")
-	defaultInitCPULimit      = resource.MustParse("500m")
-
-	defaultMemoryRequest = resource.MustParse("64Mi")
-	defaultCPURequest    = resource.MustParse("25m")
-	defaultMemoryLimit   = resource.MustParse("256Mi")
-	defaultCPULimit      = resource.MustParse("250m")
+	defaultMemoryRequest = resource.MustParse("16Mi")
+	defaultCPURequest    = resource.MustParse("5m")
+	defaultMemoryLimit   = resource.MustParse("32Mi")
+	defaultCPULimit      = resource.MustParse("25m")
 )
 
 const (
@@ -133,12 +128,12 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: defaultInitMemoryRequest,
-					corev1.ResourceCPU:    defaultInitCPURequest,
+					corev1.ResourceMemory: defaultMemoryRequest,
+					corev1.ResourceCPU:    defaultCPURequest,
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: defaultInitMemoryLimit,
-					corev1.ResourceCPU:    defaultInitCPULimit,
+					corev1.ResourceMemory: defaultMemoryLimit,
+					corev1.ResourceCPU:    defaultCPULimit,
 				},
 			},
 		},

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
@@ -108,11 +108,11 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 250m
-            memory: 256Mi
-          requests:
             cpu: 25m
-            memory: 64Mi
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -148,11 +148,11 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 25m
+            memory: 32Mi
           requests:
-            cpu: 250m
-            memory: 128Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
**What this PR does / why we need it**:
As we removed the dh-parameter generation, the init container does not need that much resources anymore. Additionally openvpn in general needs way less resources than expected.
Thus this PR will reduce the requests & limits.

**Release note**:
```release-note
NONE
```
