### PR TITLE
add function to check for a NotFound error from the openstack api

### DIFF
--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -369,10 +369,7 @@ func getSubnetForNetwork(netClient *gophercloud.ServiceClient, networkID string)
 }
 
 func isNotFoundErr(err error) bool {
-	if _, ok := err.(gophercloud.ErrDefault404); ok {
-		return true
-	}
-	if strings.Contains(err.Error(), "not found") {
+	if _, ok := err.(gophercloud.ErrDefault404); ok || strings.Contains(err.Error(), "not found") {
 		return true
 	}
 	return false

--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
@@ -365,4 +366,14 @@ func getSubnetForNetwork(netClient *gophercloud.ServiceClient, networkID string)
 	}
 
 	return allSubnets, nil
+}
+
+func isNotFoundErr(err error) bool {
+	if _, ok := err.(gophercloud.ErrDefault404); ok {
+		return true
+	}
+	if strings.Contains(err.Error(), "not found") {
+		return true
+	}
+	return false
 }

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -181,20 +181,20 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 
 	if kubernetes.HasFinalizer(cluster, networkCleanupFinalizer) {
 		if _, err = detachSubnetFromRouter(netClient, cluster.Spec.Cloud.Openstack.SubnetID, cluster.Spec.Cloud.Openstack.RouterID); err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); !ok {
-				return nil, fmt.Errorf("failed to detach subnet from router: %T %v", err, err)
+			if !isNotFoundErr(err) {
+				return nil, fmt.Errorf("failed to detach subnet from router: %v", err)
 			}
 		}
 
 		if err = deleteNetworkByName(netClient, cluster.Spec.Cloud.Openstack.Network); err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); !ok {
-				return nil, fmt.Errorf("failed delete network %q: %T %v", cluster.Spec.Cloud.Openstack.Network, err, err)
+			if !isNotFoundErr(err) {
+				return nil, fmt.Errorf("failed delete network %q: %v", cluster.Spec.Cloud.Openstack.Network, err)
 			}
 		}
 
 		if err = deleteRouter(netClient, cluster.Spec.Cloud.Openstack.RouterID); err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); !ok {
-				return nil, fmt.Errorf("failed delete router %q: %T %v", cluster.Spec.Cloud.Openstack.RouterID, err, err)
+			if !isNotFoundErr(err) {
+				return nil, fmt.Errorf("failed delete router %q: %v", cluster.Spec.Cloud.Openstack.RouterID, err)
 			}
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add function to check for a NotFound error from the openstack api.
Not happy with it, but the error we're currently facing is just a generic `*errors.errorString`

**Release note**:
```release-note
NONE
```
