### PR TITLE
Disable apiserver insecure-port

### DIFF
--- a/api/pkg/resources/prometheus/clusterrole.go
+++ b/api/pkg/resources/prometheus/clusterrole.go
@@ -61,6 +61,12 @@ func ClusterRole(_ resources.ClusterRoleDataProvider, existing *rbacv1.ClusterRo
 			},
 			Verbs: []string{"list", "watch"},
 		},
+		{
+			NonResourceURLs: []string{
+				"/metrics",
+			},
+			Verbs: []string{"get"},
+		},
 	}
 	return r, nil
 }

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -162,10 +162,6 @@ scrape_configs:
     regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: $1:$2
     target_label: __address__
-  - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
-    action: replace
-    target_label: job
-    separator: ''
   - source_labels: [__meta_kubernetes_namespace]
     action: replace
     target_label: namespace

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -240,7 +236,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -249,13 +246,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -240,7 +236,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -249,13 +246,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -240,7 +236,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -249,13 +246,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -240,7 +236,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -249,13 +246,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -240,7 +236,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -249,13 +246,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -236,7 +232,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -245,13 +242,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -240,7 +236,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -249,13 +246,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -240,7 +236,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -249,13 +246,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -223,7 +219,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -232,13 +229,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -223,7 +219,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -232,13 +229,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -227,7 +223,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -236,13 +233,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8080"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape-apiserver: "true"
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"
@@ -147,10 +147,6 @@ spec:
         - "30000"
         - --kubernetes-service-node-port
         - "30000"
-        - --insecure-bind-address
-        - 0.0.0.0
-        - --insecure-port
-        - "8080"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -231,7 +227,8 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -240,13 +237,12 @@ spec:
         ports:
         - containerPort: 30000
           protocol: TCP
-        - containerPort: 8080
-          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 8080
+            port: 30000
+            scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 15


### PR DESCRIPTION
…
**What this PR does / why we need it**:
This PR disables the insecure-port on the kubernetes apiserver and changes the prometheus scrape config and kubernetes probes accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2187 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
