### PR TITLE
be explicit about where to store minio data

### DIFF
--- a/config/minio/templates/pvc.yaml
+++ b/config/minio/templates/pvc.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: minio
 spec:
+  storageClassName: kubermatic-fast
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Amazon EKS clusters do not have a default storage class like GKE. Installing the minio chart therefore fails because of unbound PVCs. Seed-team decided that for now we would move Minio to kubermatic-fast and in the future should use actual S3 and leave the chart out entirely on EKS.

Ideally this should be cherry-picked into 2.8.

**Release note**:
```release-note
NONE
```
