### PR TITLE
Revert "be explicit about where to store minio data (#2192)"

### DIFF
--- a/config/minio/templates/pvc.yaml
+++ b/config/minio/templates/pvc.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: minio
 spec:
-  storageClassName: kubermatic-fast
   accessModes:
     - ReadWriteOnce
   resources:

--- a/config/minio/templates/pvc.yaml
+++ b/config/minio/templates/pvc.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: minio
 spec:
+  storageClassName: {{ .Values.minio.storageClass | quote }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -3,6 +3,7 @@ minio:
     repository: "minio/minio"
     tag: "RELEASE.2018-06-09T03-43-35Z"
   storeSize: "100Gi"
+  storageClass: ""
   credentials:
     accessKey: "wtupllWfpMg414ZM5YkzZiUmgjh1vZdk"
     secretKey: "r89xkN9JvHJQppb5v7SEfkNkiC1vDcMySQFKxg6uDkE3gZfCeB7ZBfECyUOTywym"


### PR DESCRIPTION
This reverts commit 8dc4189aa5c5555131c425debb0f8eea928f3076.

**What this PR does / why we need it**:
Setting the storageclass is technically the right thing to do, but we cannot change it on existing deployments. To prevent all further deployments to fail / require all customers to re-deploy the minio volume, we shift the burden of ensuring a proper environment for minio to the installer.

**Release note**:
```release-note
NONE
```
