### PR TITLE
Cleanup scrape config

### DIFF
--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -174,6 +174,7 @@ func (c *Controller) ensureStatefulSets(cluster *kubermaticv1.Cluster, data *res
 func GetServiceCreators() []resources.ServiceCreator {
 	return []resources.ServiceCreator{
 		prometheus.Service,
+		kubestatemetrics.Service,
 	}
 }
 

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -83,9 +83,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 	dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 		Labels: podLabels,
 		Annotations: map[string]string{
-			"prometheus.io-0/scrape": "true",
-			"prometheus.io-0/path":   "/metrics",
-			"prometheus.io-0/port":   "10252",
+			"prometheus.io/scrape": "true",
+			"prometheus.io/path":   "/metrics",
+			"prometheus.io/port":   "10252",
 		},
 	}
 

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -58,14 +58,6 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 
 	dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 		Labels: podLabels,
-		Annotations: map[string]string{
-			"prometheus.io-0/scrape": "true",
-			"prometheus.io-0/path":   "/metrics",
-			"prometheus.io-0/port":   "8080",
-			"prometheus.io-1/scrape": "true",
-			"prometheus.io-1/path":   "/metrics",
-			"prometheus.io-1/port":   "8081",
-		},
 	}
 
 	dep.Spec.Template.Spec.Volumes = volumes
@@ -94,6 +86,18 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 					Name:      resources.KubeStateMetricsKubeconfigSecretName,
 					MountPath: "/etc/kubernetes/kubeconfig",
 					ReadOnly:  true,
+				},
+			},
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          "metrics",
+					ContainerPort: 8080,
+					Protocol:      corev1.ProtocolTCP,
+				},
+				{
+					Name:          "telemetry",
+					ContainerPort: 8081,
+					Protocol:      corev1.ProtocolTCP,
 				},
 			},
 			Resources: defaultResourceRequirements,

--- a/api/pkg/resources/kubestatemetrics/service.go
+++ b/api/pkg/resources/kubestatemetrics/service.go
@@ -1,0 +1,46 @@
+package kubestatemetrics
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Service returns a service for kube-state-metrics
+func Service(data resources.ServiceDataProvider, existing *corev1.Service) (*corev1.Service, error) {
+	se := existing
+	if se == nil {
+		se = &corev1.Service{}
+	}
+
+	se.Name = resources.KubeStateMetricsServiceName
+	se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
+	se.Labels = resources.BaseAppLabel(name, nil)
+	se.Annotations = map[string]string{
+		"prometheus.io/scrape": "true",
+	}
+
+	se.Spec.ClusterIP = "None"
+	se.Spec.Selector = map[string]string{
+		resources.AppLabelKey: name,
+		"cluster":             data.Cluster().Name,
+	}
+	se.Spec.Ports = []corev1.ServicePort{
+		{
+			Name:       "metrics",
+			Port:       8080,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromString("metrics"),
+		},
+		{
+			Name:       "telemetry",
+			Port:       8081,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromString("telemetry"),
+		},
+	}
+
+	return se, nil
+}

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -58,9 +58,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 	dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 		Labels: podLabels,
 		Annotations: map[string]string{
-			"prometheus.io-0/scrape": "true",
-			"prometheus.io-0/path":   "/metrics",
-			"prometheus.io-0/port":   "8085",
+			"prometheus.io/scrape": "true",
+			"prometheus.io/path":   "/metrics",
+			"prometheus.io/port":   "8085",
 		},
 	}
 

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -181,6 +181,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
     action: keep
     regex: true
+  - source_labels: [__meta_kubernetes_endpoint_ready]
+    action: keep
+    regex: true
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
     action: replace
     target_label: __metrics_path__
@@ -190,7 +193,7 @@ scrape_configs:
     regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: $1:$2
     target_label: __address__
-  - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
+  - source_labels: [__meta_kubernetes_endpoints_name, __meta_kubernetes_endpoint_port_name]
     action: replace
     target_label: job
     separator: ''

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -193,10 +193,12 @@ scrape_configs:
     regex: ([^:]+)(?::\d+)?;(\d+)
     replacement: $1:$2
     target_label: __address__
-  - source_labels: [__meta_kubernetes_endpoints_name, __meta_kubernetes_endpoint_port_name]
+  - source_labels: [__meta_kubernetes_endpoint_name]
     action: replace
     target_label: job
-    separator: ''
+  - source_labels: [__meta_kubernetes_endpoint_port_name]
+    action: replace
+    target_label: port_name
   - source_labels: [__meta_kubernetes_namespace]
     action: replace
     target_label: namespace

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -65,6 +65,8 @@ const (
 	ApiserverInternalServiceName = "apiserver"
 	//PrometheusServiceName is the name for the prometheus service
 	PrometheusServiceName = "prometheus"
+	// KubeStateMetricsServiceName is the name for the kube-state-metrics service
+	KubeStateMetricsServiceName = "kube-state-metrics"
 	//EtcdServiceName is the name for the etcd service
 	EtcdServiceName = "etcd"
 	//EtcdDefragCronJobName is the name for the defrag cronjob deployment

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -82,9 +82,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 	dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 		Labels: podLabels,
 		Annotations: map[string]string{
-			"prometheus.io-0/scrape": "true",
-			"prometheus.io-0/path":   "/metrics",
-			"prometheus.io-0/port":   "10251",
+			"prometheus.io/scrape": "true",
+			"prometheus.io/path":   "/metrics",
+			"prometheus.io/port":   "10251",
 		},
 	}
 

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10252"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10252"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "8085"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: machine-controller

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -23,9 +23,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io-0/path: /metrics
-        prometheus.io-0/port: "10251"
-        prometheus.io-0/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10251"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: scheduler


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cleans up the prometheus scraping configuration to get rid of the duplicated `prometheus.io-0` and `prometheus.io-1` annotations, by using service endpoint discovery for `kube-state-metrics`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
