### PR TITLE
do not put newlines after opaque secrets

### DIFF
--- a/config/kubermatic/templates/datacenter-yaml-secret.yaml
+++ b/config/kubermatic/templates/datacenter-yaml-secret.yaml
@@ -4,5 +4,4 @@ metadata:
   name: datacenters
 type: Opaque
 data:
-  datacenters.yaml: |
-{{ .Values.kubermatic.datacenters | indent 4 }}
+  datacenters.yaml: {{ .Values.kubermatic.datacenters }}

--- a/config/kubermatic/templates/kubeconfig-secret.yaml
+++ b/config/kubermatic/templates/kubeconfig-secret.yaml
@@ -4,5 +4,4 @@ metadata:
   name: kubeconfig
 type: Opaque
 data:
-  kubeconfig: |
-{{ .Values.kubermatic.kubeconfig  | indent 4 }}
+  kubeconfig: {{ .Values.kubermatic.kubeconfig }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Installating Kubermatic on EKS fails due to

```
Error from server (BadRequest): error when creating "bad.yaml": Secret in version "v1" cannot be handled as a Secret: v1.Secret: ObjectMeta: v1.ObjectMeta: TypeMeta: Kind: Data: decode base64: illegal base64 data at input byte 4, error found in #10 byte of ...|":"Zm9v\n"},"kind":"|..., bigger context ...|iVersion":"v1","data":{"datacenters.yaml":"Zm9v\n"},"kind":"Secret","metadata":{"name":"xrstf-test",|...
```

Since the data is already base64 encoded, there is no need to use YAML's multiline strings.

**Release note**:
```release-note
NONE
```
