### PR TITLE
Mitigate prometheus RAM flooding (#2020)

### DIFF
--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -84,6 +84,7 @@ func TestConfigMapCreatorsKeepAdditionalData(t *testing.T) {
 	cluster := &kubermaticv1.Cluster{}
 	cluster.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"10.10.0.0/8"}
 	cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.11.0.0/8"}
+	cluster.Spec.Version = "v1.11.0"
 	dc := &provider.DatacenterMeta{}
 	templateData := resources.NewTemplateData(cluster, dc, "", nil, nil, nil, "", "", "10.12.0.0/8", resource.Quantity{}, "", false, false, "", nil)
 

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -117,6 +117,13 @@ scrape_configs:
       names:
       - "{{ $.TemplateData.Cluster.Status.NamespaceName }}"
 
+{{- if semverCompare ">=1.11.0, <= 1.11.3" $.TemplateData.Cluster.Spec.Version }}
+  metric_relabel_configs:
+  - source_labels: [job, __name__]
+    regex: 'controller-manager;rest_.*'
+    action: drop
+{{- end }}
+
   relabel_configs:
   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_{{ $i }}_scrape]
     action: keep

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -35,6 +35,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_0_scrape]
@@ -66,6 +70,10 @@ data:
         namespaces:
           names:
           - "cluster-de-test-01"
+      metric_relabel_configs:
+      - source_labels: [job, __name__]
+        regex: 'controller-manager;rest_.*'
+        action: drop
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_1_scrape]


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick of https://github.com/kubermatic/kubermatic/pull/2020

**Release note**:
```release-note
Version v1.11.0 - 1.11.3 Clusters will no longer gather `rest_*` metrics from the controller-manager due to a [bug in kubernetes](https://github.com/kubernetes/kubernetes/pull/68530)
```
