### PR TITLE
enable HPA support

### DIFF
--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -97,12 +97,12 @@ func Deployment(data *resources.TemplateData, existing *appsv1.Deployment) (*app
 	}
 	dep.Spec.Template.Spec.Containers = []corev1.Container{
 		{
-			Name:                     name,
-			Image:                    data.ImageRegistry("gcr.io") + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
-			ImagePullPolicy:          corev1.PullIfNotPresent,
-			Command:                  []string{"/hyperkube", "controller-manager"},
-			Args:                     flags,
-			Env:                      getEnvVars(data),
+			Name:            name,
+			Image:           data.ImageRegistry("gcr.io") + "/google_containers/hyperkube-amd64:v" + data.Cluster.Spec.Version,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/hyperkube", "controller-manager"},
+			Args:            flags,
+			Env:             getEnvVars(data),
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 			Resources: corev1.ResourceRequirements{

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         - --cloud-provider
         - aws
         - --cloud-config

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         - --cloud-provider
         - aws
         - --cloud-config

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         - --cloud-provider
         - azure
         - --cloud-config

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         - --cloud-provider
         - azure
         - --cloud-config

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         - --cloud-provider
         - openstack
         - --cloud-config

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         - --cloud-provider
         - openstack
         - --cloud-config

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         - --cloud-provider
         - vsphere
         - --cloud-config

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - '*,bootstrapsigner,tokencleaner'
         - --v
         - "4"
+        - horizontal-pod-autoscaler-use-rest-clients=false
         - --cloud-provider
         - vsphere
         - --cloud-config


### PR DESCRIPTION
**What this PR does / why we need it**:
Set `horizontal-pod-autoscaler-use-rest-clients=false` for all clusters >=v1.9 as it defaults to `true` for those versions. 
This flag(when `true`) will instruct tha HPA to use the new metrics-api which requires the metrics-server (Introduced in kubermatic v2.7).
It needs to be set to `false` the HPA will use Heapster.

**Release note**:
```release-note
Enable the usage of Heapster for the HorizontalPodAutoscaler
```
