### PR TITLE
Start deploying monitoring again to asia and us cloud seeds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -174,6 +174,18 @@ pipeline:
     - name: minio
       namespace: minio
       path: config/minio/
+    - name: node-exporter
+      namespace: monitoring
+      path: config/monitoring/node-exporter/
+    - name: kube-state-metrics
+      namespace: monitoring
+      path: config/monitoring/kube-state-metrics/
+    - name: alertmanager
+      namespace: monitoring
+      path: config/monitoring/alertmanager/
+    - name: prometheus
+      namespace: monitoring
+      path: config/monitoring/prometheus/
     group: deploy-cloud
     helm: upgrade --install --wait --timeout 300 --kube-context=asia-east1-a-1 --tiller-namespace=kubermatic-installer
       --set=kubermatic.isMaster=false
@@ -259,6 +271,18 @@ pipeline:
     - name: minio
       namespace: minio
       path: config/minio/
+    - name: node-exporter
+      namespace: monitoring
+      path: config/monitoring/node-exporter/
+    - name: kube-state-metrics
+      namespace: monitoring
+      path: config/monitoring/kube-state-metrics/
+    - name: alertmanager
+      namespace: monitoring
+      path: config/monitoring/alertmanager/
+    - name: prometheus
+      namespace: monitoring
+      path: config/monitoring/prometheus/
     group: deploy-cloud
     helm: upgrade --install --wait --timeout 300 --kube-context=us-central1-c-1 --tiller-namespace=kubermatic-installer
       --set=kubermatic.isMaster=false


### PR DESCRIPTION
**What this PR does / why we need it**:
US and Asia seed `cloud` clusters have outdated monitoring and not getting monitoring charts updated currently.

Fixes #2204 #2162 

```release-note
NONE
```