### PR TITLE
update supported versions and fix update path

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -18,8 +18,7 @@ updates:
 # ======= 1.10 =======
 # Allow to change to any patch version
 - from: 1.10.*
-  #We need to skip 1.10.0 as it broke OpenStack.
-  to: ^1.10.1
+  to: 1.10.*
   automatic: false
 - from: 1.10.*
   to: 1.11.0

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -39,10 +39,10 @@ versions:
 - version: "1.9.10"
   default: false
   allowedNodeVersions: *node-versions
-# Kubernetes 1.10
-- version: "1.10.0"
+- version: "1.9.11"
   default: false
   allowedNodeVersions: *node-versions
+# Kubernetes 1.10
 - version: "1.10.1"
   default: false
   allowedNodeVersions: *node-versions
@@ -59,13 +59,13 @@ versions:
   default: false
   allowedNodeVersions: *node-versions
 - version: "1.10.6"
-  default: true
+  default: false
   allowedNodeVersions: *node-versions
 - version: "1.10.7"
-  default: true
+  default: false
   allowedNodeVersions: *node-versions
 - version: "1.10.8"
-  default: true
+  default: false
   allowedNodeVersions: *node-versions
 # Kubernetes 1.11
 - version: "1.11.0"
@@ -78,7 +78,7 @@ versions:
   default: false
   allowedNodeVersions: *node-versions
 - version: "1.11.3"
-  default: false
+  default: true
   allowedNodeVersions: *node-versions
 # Kubernetes 1.12
 - version: "1.12.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update supported versions and fix update path.

The Fix: The update path allowed to updated from 1.10 -> 1.12.1


**Release note**:
```release-note
NONE
```
