### PR TITLE
empty storageclass is different from an unset sc

### DIFF
--- a/config/minio/templates/pvc.yaml
+++ b/config/minio/templates/pvc.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     app: minio
 spec:
-  storageClassName: {{ .Values.minio.storageClass | quote }}
+  {{ with .Values.minio.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{ end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/config/minio/templates/pvc.yaml
+++ b/config/minio/templates/pvc.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app: minio
 spec:
-  {{ with .Values.minio.storageClass }}
+  {{- with .Values.minio.storageClass }}
   storageClassName: {{ . | quote }}
-  {{ end }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -3,8 +3,13 @@ minio:
     repository: "minio/minio"
     tag: "RELEASE.2018-06-09T03-43-35Z"
   storeSize: "100Gi"
-  storageClass: null
   credentials:
     accessKey: "wtupllWfpMg414ZM5YkzZiUmgjh1vZdk"
     secretKey: "r89xkN9JvHJQppb5v7SEfkNkiC1vDcMySQFKxg6uDkE3gZfCeB7ZBfECyUOTywym"
   backups: true
+
+  # If your cluster does not have a default storage class,
+  # you can specify the class to use for Minio. Note that
+  # you cannot change this later on without purging the
+  # chart and losing data.
+  #storageClass: hdd

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -3,7 +3,7 @@ minio:
     repository: "minio/minio"
     tag: "RELEASE.2018-06-09T03-43-35Z"
   storeSize: "100Gi"
-  storageClass: ""
+  storageClass: null
   credentials:
     accessKey: "wtupllWfpMg414ZM5YkzZiUmgjh1vZdk"
     secretKey: "r89xkN9JvHJQppb5v7SEfkNkiC1vDcMySQFKxg6uDkE3gZfCeB7ZBfECyUOTywym"


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous attempt to handle unset storageClasses still failed, because `""` != `null`. This PR should ensure unset SCs are never put into the PVC template.

**Release note**:
```release-note
NONE
```
