### PR TITLE
extend errors in the rbac controller

### DIFF
--- a/api/pkg/controller/rbac/sync_project_test.go
+++ b/api/pkg/controller/rbac/sync_project_test.go
@@ -115,7 +115,7 @@ func TestEnsureProjectInitialized(t *testing.T) {
 			// act
 			target := Controller{}
 			target.masterClusterProvider = fakeMasterClusterProvider
-			err := target.ensureProjectInitialized(test.projectToSync)
+			err := target.ensureCleanupFinalizerExists(test.projectToSync)
 
 			// validate
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Extend errors in the rbac controller.
The reason here is that we see errors in production but cannot tell where they originate. This PR should improve debugging.

**Release note**:
```release-note
NONE
```
