### PR TITLE
Only enable node metrics from kube-state-metrics

### DIFF
--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -78,6 +78,7 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 				"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 				"--port", "8080",
 				"--telemetry-port", "8081",
+				"--collectors", "nodes",
 			},
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,


### PR DESCRIPTION
**What this PR does / why we need it**:
Only enable node metrics from kube-state-metrics, because we do not care about the rest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2201

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
kube-state-metrics enable only node stats
```
