### PR TITLE
Update cluster API

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1750,6 +1750,7 @@
     "github.com/coreos/go-oidc",
     "github.com/davecgh/go-spew/spew",
     "github.com/digitalocean/godo",
+    "github.com/evanphx/json-patch",
     "github.com/ghodss/yaml",
     "github.com/go-kit/kit/endpoint",
     "github.com/go-kit/kit/log",

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -148,6 +148,10 @@ required = [
   name = "github.com/onsi/ginkgo"
   version = "v1.6.0"
 
+[[constraint]]
+  name = "github.com/evanphx/json-patch"
+  version = "v4.1.0"
+
 # Otherwise dep panics: https://github.com/golang/dep/issues/1799
 [[override]]
   name = "gopkg.in/fsnotify.v1"

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3827,6 +3827,194 @@
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },
+    "PublicAWSCloudSpec": {
+      "type": "object",
+      "title": "PublicAWSCloudSpec is a public counterpart of kubermaticv1.AWSCloudSpec.",
+      "properties": {
+        "availabilityZone": {
+          "type": "string",
+          "x-go-name": "AvailabilityZone"
+        },
+        "instanceProfileName": {
+          "type": "string",
+          "x-go-name": "InstanceProfileName"
+        },
+        "roleName": {
+          "type": "string",
+          "x-go-name": "RoleName"
+        },
+        "routeTableId": {
+          "type": "string",
+          "x-go-name": "RouteTableID"
+        },
+        "securityGroupID": {
+          "type": "string",
+          "x-go-name": "SecurityGroupID"
+        },
+        "subnetId": {
+          "type": "string",
+          "x-go-name": "SubnetID"
+        },
+        "vpcId": {
+          "type": "string",
+          "x-go-name": "VPCID"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "PublicAzureCloudSpec": {
+      "type": "object",
+      "title": "PublicAzureCloudSpec is a public counterpart of kubermaticv1.AzureCloudSpec.",
+      "properties": {
+        "availabilitySet": {
+          "type": "string",
+          "x-go-name": "AvailabilitySet"
+        },
+        "resourceGroup": {
+          "type": "string",
+          "x-go-name": "ResourceGroup"
+        },
+        "routeTable": {
+          "type": "string",
+          "x-go-name": "RouteTableName"
+        },
+        "securityGroup": {
+          "type": "string",
+          "x-go-name": "SecurityGroup"
+        },
+        "subnet": {
+          "type": "string",
+          "x-go-name": "SubnetName"
+        },
+        "subscriptionID": {
+          "type": "string",
+          "x-go-name": "SubscriptionID"
+        },
+        "tenantID": {
+          "type": "string",
+          "x-go-name": "TenantID"
+        },
+        "vnet": {
+          "type": "string",
+          "x-go-name": "VNetName"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "PublicBringYourOwnCloudSpec": {
+      "type": "object",
+      "title": "PublicBringYourOwnCloudSpec is a public counterpart of kubermaticv1.BringYourOwnCloudSpec.",
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "PublicCloudSpec": {
+      "type": "object",
+      "title": "PublicCloudSpec is a public counterpart of kubermaticv1.CloudSpec.",
+      "properties": {
+        "aws": {
+          "$ref": "#/definitions/PublicAWSCloudSpec"
+        },
+        "azure": {
+          "$ref": "#/definitions/PublicAzureCloudSpec"
+        },
+        "bringyourown": {
+          "$ref": "#/definitions/PublicBringYourOwnCloudSpec"
+        },
+        "dc": {
+          "type": "string",
+          "x-go-name": "DatacenterName"
+        },
+        "digitalocean": {
+          "$ref": "#/definitions/PublicDigitaloceanCloudSpec"
+        },
+        "fake": {
+          "$ref": "#/definitions/PublicFakeCloudSpec"
+        },
+        "hetzner": {
+          "$ref": "#/definitions/PublicHetznerCloudSpec"
+        },
+        "openstack": {
+          "$ref": "#/definitions/PublicOpenstackCloudSpec"
+        },
+        "vsphere": {
+          "$ref": "#/definitions/PublicVSphereCloudSpec"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "PublicDigitaloceanCloudSpec": {
+      "type": "object",
+      "title": "PublicDigitaloceanCloudSpec is a public counterpart of kubermaticv1.DigitaloceanCloudSpec.",
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "PublicFakeCloudSpec": {
+      "type": "object",
+      "title": "PublicFakeCloudSpec is a public counterpart of kubermaticv1.FakeCloudSpec.",
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "PublicHetznerCloudSpec": {
+      "type": "object",
+      "title": "PublicHetznerCloudSpec is a public counterpart of kubermaticv1.HetznerCloudSpec.",
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "PublicOpenstackCloudSpec": {
+      "type": "object",
+      "title": "PublicOpenstackCloudSpec is a public counterpart of kubermaticv1.OpenstackCloudSpec.",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "x-go-name": "Domain"
+        },
+        "floatingIpPool": {
+          "type": "string",
+          "x-go-name": "FloatingIPPool"
+        },
+        "network": {
+          "type": "string",
+          "x-go-name": "Network"
+        },
+        "routerID": {
+          "type": "string",
+          "x-go-name": "RouterID"
+        },
+        "securityGroups": {
+          "type": "string",
+          "x-go-name": "SecurityGroups"
+        },
+        "subnetID": {
+          "type": "string",
+          "x-go-name": "SubnetID"
+        },
+        "tenant": {
+          "type": "string",
+          "x-go-name": "Tenant"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "PublicVSphereCloudSpec": {
+      "type": "object",
+      "title": "PublicVSphereCloudSpec is a public counterpart of kubermaticv1.VSphereCloudSpec.",
+      "properties": {
+        "vmNetName": {
+          "type": "string",
+          "x-go-name": "VMNetName"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "RSAKeys": {
+      "type": "object",
+      "title": "RSAKeys is a pair of private and public key where the key is not published to the API client.",
+      "properties": {
+        "privateKey": {
+          "$ref": "#/definitions/Bytes"
+        },
+        "publicKey": {
+          "$ref": "#/definitions/Bytes"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+    },
     "RawExtension": {
       "description": "To use this, make a field which has RawExtension as its type in your external, versioned\nstruct, and Object in your internal struct. You also need to register your\nvarious plugin types.\n\nInternal package:\ntype MyAPIObject struct {\nruntime.TypeMeta `json:\",inline\"`\nMyPlugin runtime.Object `json:\"myPlugin\"`\n}\ntype PluginA struct {\nAOption string `json:\"aOption\"`\n}\n\nExternal package:\ntype MyAPIObject struct {\nruntime.TypeMeta `json:\",inline\"`\nMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n}\ntype PluginA struct {\nAOption string `json:\"aOption\"`\n}\n\nOn the wire, the JSON will look something like this:\n{\n\"kind\":\"MyAPIObject\",\n\"apiVersion\":\"v1\",\n\"myPlugin\": {\n\"kind\":\"PluginA\",\n\"aOption\":\"foo\",\n},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into\nyour external MyAPIObject. That causes the raw JSON to be stored, but not unpacked.\nThe next step is to copy (using pkg/conversion) into the internal struct. The runtime\npackage's DefaultScheme has conversion functions installed which will unpack the\nJSON stored in RawExtension, turning it into the correct object type, and storing it\nin the Object. (TODO: In the case where the object is of an unknown type, a\nruntime.Unknown object will be created and stored.)\n\n+k8s:deepcopy-gen=true\n+protobuf=true\n+k8s:openapi-gen=true",
       "type": "object",

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -518,7 +518,41 @@
           "project"
         ],
         "summary": "Patches the given cluster using JSON Merge Patch method (https://tools.ietf.org/html/rfc7396).",
-        "operationId": "newPatchCluster",
+        "operationId": "patchCluster",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Patch",
+            "in": "body",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint8"
+              }
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Cluster",
@@ -2686,7 +2720,7 @@
           "x-go-name": "MachineNetworks"
         },
         "version": {
-          "description": "Version desired version of the kubernetes master components",
+          "description": "Version desired version of the kubernetes master components.",
           "type": "string",
           "x-go-name": "Version"
         }
@@ -3856,7 +3890,7 @@
     },
     "PublicAWSCloudSpec": {
       "type": "object",
-      "title": "PublicAWSCloudSpec is a public counterpart of kubermaticv1.AWSCloudSpec.",
+      "title": "PublicAWSCloudSpec is a public counterpart of apiv1.AWSCloudSpec.",
       "properties": {
         "availabilityZone": {
           "type": "string",
@@ -3891,7 +3925,7 @@
     },
     "PublicAzureCloudSpec": {
       "type": "object",
-      "title": "PublicAzureCloudSpec is a public counterpart of kubermaticv1.AzureCloudSpec.",
+      "title": "PublicAzureCloudSpec is a public counterpart of apiv1.AzureCloudSpec.",
       "properties": {
         "availabilitySet": {
           "type": "string",
@@ -3930,12 +3964,12 @@
     },
     "PublicBringYourOwnCloudSpec": {
       "type": "object",
-      "title": "PublicBringYourOwnCloudSpec is a public counterpart of kubermaticv1.BringYourOwnCloudSpec.",
+      "title": "PublicBringYourOwnCloudSpec is a public counterpart of apiv1.BringYourOwnCloudSpec.",
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },
     "PublicCloudSpec": {
       "type": "object",
-      "title": "PublicCloudSpec is a public counterpart of kubermaticv1.CloudSpec.",
+      "title": "PublicCloudSpec is a public counterpart of apiv1.CloudSpec.",
       "properties": {
         "aws": {
           "$ref": "#/definitions/PublicAWSCloudSpec"
@@ -3970,22 +4004,22 @@
     },
     "PublicDigitaloceanCloudSpec": {
       "type": "object",
-      "title": "PublicDigitaloceanCloudSpec is a public counterpart of kubermaticv1.DigitaloceanCloudSpec.",
+      "title": "PublicDigitaloceanCloudSpec is a public counterpart of apiv1.DigitaloceanCloudSpec.",
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },
     "PublicFakeCloudSpec": {
       "type": "object",
-      "title": "PublicFakeCloudSpec is a public counterpart of kubermaticv1.FakeCloudSpec.",
+      "title": "PublicFakeCloudSpec is a public counterpart of apiv1.FakeCloudSpec.",
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },
     "PublicHetznerCloudSpec": {
       "type": "object",
-      "title": "PublicHetznerCloudSpec is a public counterpart of kubermaticv1.HetznerCloudSpec.",
+      "title": "PublicHetznerCloudSpec is a public counterpart of apiv1.HetznerCloudSpec.",
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },
     "PublicOpenstackCloudSpec": {
       "type": "object",
-      "title": "PublicOpenstackCloudSpec is a public counterpart of kubermaticv1.OpenstackCloudSpec.",
+      "title": "PublicOpenstackCloudSpec is a public counterpart of apiv1.OpenstackCloudSpec.",
       "properties": {
         "domain": {
           "type": "string",
@@ -4020,7 +4054,7 @@
     },
     "PublicVSphereCloudSpec": {
       "type": "object",
-      "title": "PublicVSphereCloudSpec is a public counterpart of kubermaticv1.VSphereCloudSpec.",
+      "title": "PublicVSphereCloudSpec is a public counterpart of apiv1.VSphereCloudSpec.",
       "properties": {
         "vmNetName": {
           "type": "string",

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -509,6 +509,33 @@
             "$ref": "#/responses/errorResponse"
           }
         }
+      },
+      "patch": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "project"
+        ],
+        "summary": "Patches the given cluster.",
+        "operationId": "newPatchCluster",
+        "responses": {
+          "200": {
+            "description": "Cluster",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
       }
     },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/health": {
@@ -4001,19 +4028,6 @@
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-    },
-    "RSAKeys": {
-      "type": "object",
-      "title": "RSAKeys is a pair of private and public key where the key is not published to the API client.",
-      "properties": {
-        "privateKey": {
-          "$ref": "#/definitions/Bytes"
-        },
-        "publicKey": {
-          "$ref": "#/definitions/Bytes"
-        }
-      },
-      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
     },
     "RawExtension": {
       "description": "To use this, make a field which has RawExtension as its type in your external, versioned\nstruct, and Object in your internal struct. You also need to register your\nvarious plugin types.\n\nInternal package:\ntype MyAPIObject struct {\nruntime.TypeMeta `json:\",inline\"`\nMyPlugin runtime.Object `json:\"myPlugin\"`\n}\ntype PluginA struct {\nAOption string `json:\"aOption\"`\n}\n\nExternal package:\ntype MyAPIObject struct {\nruntime.TypeMeta `json:\",inline\"`\nMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n}\ntype PluginA struct {\nAOption string `json:\"aOption\"`\n}\n\nOn the wire, the JSON will look something like this:\n{\n\"kind\":\"MyAPIObject\",\n\"apiVersion\":\"v1\",\n\"myPlugin\": {\n\"kind\":\"PluginA\",\n\"aOption\":\"foo\",\n},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into\nyour external MyAPIObject. That causes the raw JSON to be stored, but not unpacked.\nThe next step is to copy (using pkg/conversion) into the internal struct. The runtime\npackage's DefaultScheme has conversion functions installed which will unpack the\nJSON stored in RawExtension, turning it into the correct object type, and storing it\nin the Object. (TODO: In the case where the object is of an unknown type, a\nruntime.Unknown object will be created and stored.)\n\n+k8s:deepcopy-gen=true\n+protobuf=true\n+k8s:openapi-gen=true",

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -517,7 +517,7 @@
         "tags": [
           "project"
         ],
-        "summary": "Patches the given cluster.",
+        "summary": "Patches the given cluster using JSON Merge Patch method (https://tools.ietf.org/html/rfc7396).",
         "operationId": "newPatchCluster",
         "responses": {
           "200": {

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -246,7 +246,7 @@ type OpenstackNetwork struct {
 	// Name is the name of the network
 	Name string `json:"name"`
 	// External set if network is the external network
-	External bool `json:"external,omitempty"`
+	External bool `json:"external"`
 }
 
 // OpenstackSecurityGroup is the object representing a openstack security group.

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -296,9 +296,7 @@ type ClusterSpec struct {
 // that will be returned in the API responses (see: PublicCloudSpec struct).
 func (cs *NewClusterSpec) MarshalJSON() ([]byte, error) {
 	ret, err := json.Marshal(struct {
-		// Overshadows kubermaticv1.CloudSpec to keep sensitive data out of API responses.
-		Cloud PublicCloudSpec `json:"cloud"`
-
+		Cloud           PublicCloudSpec                        `json:"cloud"`
 		MachineNetworks []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
 		Version         string                                 `json:"version"`
 	}{
@@ -320,7 +318,7 @@ func (cs *NewClusterSpec) MarshalJSON() ([]byte, error) {
 	return ret, err
 }
 
-// PublicCloudSpec is a public counterpart of kubermaticv1.CloudSpec.
+// PublicCloudSpec is a public counterpart of apiv1.CloudSpec.
 type PublicCloudSpec struct {
 	DatacenterName string                       `json:"dc"`
 	Fake           *PublicFakeCloudSpec         `json:"fake,omitempty"`
@@ -333,7 +331,7 @@ type PublicCloudSpec struct {
 	VSphere        *PublicVSphereCloudSpec      `json:"vsphere,omitempty"`
 }
 
-// PublicFakeCloudSpec is a public counterpart of kubermaticv1.FakeCloudSpec.
+// PublicFakeCloudSpec is a public counterpart of apiv1.FakeCloudSpec.
 type PublicFakeCloudSpec struct{}
 
 func newPublicFakeCloudSpec(internal *kubermaticv1.FakeCloudSpec) (public *PublicFakeCloudSpec) {
@@ -344,7 +342,7 @@ func newPublicFakeCloudSpec(internal *kubermaticv1.FakeCloudSpec) (public *Publi
 	return &PublicFakeCloudSpec{}
 }
 
-// PublicDigitaloceanCloudSpec is a public counterpart of kubermaticv1.DigitaloceanCloudSpec.
+// PublicDigitaloceanCloudSpec is a public counterpart of apiv1.DigitaloceanCloudSpec.
 type PublicDigitaloceanCloudSpec struct{}
 
 func newPublicDigitaloceanCloudSpec(internal *kubermaticv1.DigitaloceanCloudSpec) (public *PublicDigitaloceanCloudSpec) {
@@ -355,7 +353,7 @@ func newPublicDigitaloceanCloudSpec(internal *kubermaticv1.DigitaloceanCloudSpec
 	return &PublicDigitaloceanCloudSpec{}
 }
 
-// PublicHetznerCloudSpec is a public counterpart of kubermaticv1.HetznerCloudSpec.
+// PublicHetznerCloudSpec is a public counterpart of apiv1.HetznerCloudSpec.
 type PublicHetznerCloudSpec struct{}
 
 func newPublicHetznerCloudSpec(internal *kubermaticv1.HetznerCloudSpec) (public *PublicHetznerCloudSpec) {
@@ -366,7 +364,7 @@ func newPublicHetznerCloudSpec(internal *kubermaticv1.HetznerCloudSpec) (public 
 	return &PublicHetznerCloudSpec{}
 }
 
-// PublicAzureCloudSpec is a public counterpart of kubermaticv1.AzureCloudSpec.
+// PublicAzureCloudSpec is a public counterpart of apiv1.AzureCloudSpec.
 type PublicAzureCloudSpec struct {
 	TenantID        string `json:"tenantID"`
 	SubscriptionID  string `json:"subscriptionID"`
@@ -395,7 +393,7 @@ func newPublicAzureCloudSpec(internal *kubermaticv1.AzureCloudSpec) (public *Pub
 	}
 }
 
-// PublicVSphereCloudSpec is a public counterpart of kubermaticv1.VSphereCloudSpec.
+// PublicVSphereCloudSpec is a public counterpart of apiv1.VSphereCloudSpec.
 type PublicVSphereCloudSpec struct {
 	VMNetName string `json:"vmNetName"`
 }
@@ -410,7 +408,7 @@ func newPublicVSphereCloudSpec(internal *kubermaticv1.VSphereCloudSpec) (public 
 	}
 }
 
-// PublicBringYourOwnCloudSpec is a public counterpart of kubermaticv1.BringYourOwnCloudSpec.
+// PublicBringYourOwnCloudSpec is a public counterpart of apiv1.BringYourOwnCloudSpec.
 type PublicBringYourOwnCloudSpec struct{}
 
 func newPublicBringYourOwnCloudSpec(internal *kubermaticv1.BringYourOwnCloudSpec) (public *PublicBringYourOwnCloudSpec) {
@@ -421,7 +419,7 @@ func newPublicBringYourOwnCloudSpec(internal *kubermaticv1.BringYourOwnCloudSpec
 	return &PublicBringYourOwnCloudSpec{}
 }
 
-// PublicAWSCloudSpec is a public counterpart of kubermaticv1.AWSCloudSpec.
+// PublicAWSCloudSpec is a public counterpart of apiv1.AWSCloudSpec.
 type PublicAWSCloudSpec struct {
 	VPCID               string `json:"vpcId"`
 	SubnetID            string `json:"subnetId"`
@@ -448,7 +446,7 @@ func newPublicAWSCloudSpec(internal *kubermaticv1.AWSCloudSpec) (public *PublicA
 	}
 }
 
-// PublicOpenstackCloudSpec is a public counterpart of kubermaticv1.OpenstackCloudSpec.
+// PublicOpenstackCloudSpec is a public counterpart of apiv1.OpenstackCloudSpec.
 type PublicOpenstackCloudSpec struct {
 	Tenant         string `json:"tenant"`
 	Domain         string `json:"domain"`

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -8,7 +9,6 @@ import (
 	apiv2 "github.com/kubermatic/kubermatic/api/pkg/api/v2"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 
-	"encoding/json"
 	cmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 )
 

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -296,11 +296,11 @@ type ClusterSpec struct {
 // that will be returned in the API responses (see: PublicCloudSpec struct).
 func (cs *NewClusterSpec) MarshalJSON() ([]byte, error) {
 	ret, err := json.Marshal(struct {
-		MachineNetworks []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
-		Version         string                                 `json:"version"`
-
 		// Overshadows kubermaticv1.CloudSpec to keep sensitive data out of API responses.
 		Cloud PublicCloudSpec `json:"cloud"`
+
+		MachineNetworks []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
+		Version         string                                 `json:"version"`
 	}{
 		Cloud: PublicCloudSpec{
 			DatacenterName: cs.Cloud.DatacenterName,

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -288,7 +288,7 @@ type ClusterSpec struct {
 	// MachineNetworks optionally specifies the parameters for IPAM.
 	MachineNetworks []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
 
-	// Version desired version of the kubernetes master components
+	// Version desired version of the kubernetes master components.
 	Version string `json:"version"`
 }
 

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -292,24 +292,26 @@ type ClusterSpec struct {
 	Version string `json:"version"`
 }
 
+// MarshalJSON marshals NewClusterSpec object into JSON. It is overwritten to control data
+// that will be returned in the API responses (see: PublicCloudSpec struct).
 func (cs *NewClusterSpec) MarshalJSON() ([]byte, error) {
 	ret, err := json.Marshal(struct {
 		MachineNetworks []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
 		Version         string                                 `json:"version"`
 
-		// Overshadows kubermaticv1.CloudSpec to avoid putting sensitive data in API responses.
+		// Overshadows kubermaticv1.CloudSpec to keep sensitive data out of API responses.
 		Cloud PublicCloudSpec `json:"cloud"`
 	}{
 		Cloud: PublicCloudSpec{
 			DatacenterName: cs.Cloud.DatacenterName,
-			Fake:           NewPublicFakeCloudSpec(cs.Cloud.Fake),
-			Digitalocean:   NewPublicDigitaloceanCloudSpec(cs.Cloud.Digitalocean),
-			BringYourOwn:   NewPublicBringYourOwnCloudSpec(cs.Cloud.BringYourOwn),
-			AWS:            NewPublicAWSCloudSpec(cs.Cloud.AWS),
-			Azure:          NewPublicAzureCloudSpec(cs.Cloud.Azure),
-			Openstack:      NewPublicOpenstackCloudSpec(cs.Cloud.Openstack),
-			Hetzner:        NewPublicHetznerCloudSpec(cs.Cloud.Hetzner),
-			VSphere:        NewPublicVSphereCloudSpec(cs.Cloud.VSphere),
+			Fake:           newPublicFakeCloudSpec(cs.Cloud.Fake),
+			Digitalocean:   newPublicDigitaloceanCloudSpec(cs.Cloud.Digitalocean),
+			BringYourOwn:   newPublicBringYourOwnCloudSpec(cs.Cloud.BringYourOwn),
+			AWS:            newPublicAWSCloudSpec(cs.Cloud.AWS),
+			Azure:          newPublicAzureCloudSpec(cs.Cloud.Azure),
+			Openstack:      newPublicOpenstackCloudSpec(cs.Cloud.Openstack),
+			Hetzner:        newPublicHetznerCloudSpec(cs.Cloud.Hetzner),
+			VSphere:        newPublicVSphereCloudSpec(cs.Cloud.VSphere),
 		},
 		Version:         cs.Version,
 		MachineNetworks: cs.MachineNetworks,
@@ -318,7 +320,7 @@ func (cs *NewClusterSpec) MarshalJSON() ([]byte, error) {
 	return ret, err
 }
 
-// NewCloudSpec overshadows kubermaticv1.CloudSpec to avoid putting sensitive data in API responses.
+// PublicCloudSpec is a public counterpart of kubermaticv1.CloudSpec.
 type PublicCloudSpec struct {
 	DatacenterName string                       `json:"dc"`
 	Fake           *PublicFakeCloudSpec         `json:"fake,omitempty"`
@@ -331,9 +333,10 @@ type PublicCloudSpec struct {
 	VSphere        *PublicVSphereCloudSpec      `json:"vsphere,omitempty"`
 }
 
+// PublicFakeCloudSpec is a public counterpart of kubermaticv1.FakeCloudSpec.
 type PublicFakeCloudSpec struct{}
 
-func NewPublicFakeCloudSpec(internal *kubermaticv1.FakeCloudSpec) (public *PublicFakeCloudSpec) {
+func newPublicFakeCloudSpec(internal *kubermaticv1.FakeCloudSpec) (public *PublicFakeCloudSpec) {
 	if internal == nil {
 		return nil
 	}
@@ -341,9 +344,10 @@ func NewPublicFakeCloudSpec(internal *kubermaticv1.FakeCloudSpec) (public *Publi
 	return &PublicFakeCloudSpec{}
 }
 
+// PublicDigitaloceanCloudSpec is a public counterpart of kubermaticv1.DigitaloceanCloudSpec.
 type PublicDigitaloceanCloudSpec struct{}
 
-func NewPublicDigitaloceanCloudSpec(internal *kubermaticv1.DigitaloceanCloudSpec) (public *PublicDigitaloceanCloudSpec) {
+func newPublicDigitaloceanCloudSpec(internal *kubermaticv1.DigitaloceanCloudSpec) (public *PublicDigitaloceanCloudSpec) {
 	if internal == nil {
 		return nil
 	}
@@ -351,9 +355,10 @@ func NewPublicDigitaloceanCloudSpec(internal *kubermaticv1.DigitaloceanCloudSpec
 	return &PublicDigitaloceanCloudSpec{}
 }
 
+// PublicHetznerCloudSpec is a public counterpart of kubermaticv1.HetznerCloudSpec.
 type PublicHetznerCloudSpec struct{}
 
-func NewPublicHetznerCloudSpec(internal *kubermaticv1.HetznerCloudSpec) (public *PublicHetznerCloudSpec) {
+func newPublicHetznerCloudSpec(internal *kubermaticv1.HetznerCloudSpec) (public *PublicHetznerCloudSpec) {
 	if internal == nil {
 		return nil
 	}
@@ -361,6 +366,7 @@ func NewPublicHetznerCloudSpec(internal *kubermaticv1.HetznerCloudSpec) (public 
 	return &PublicHetznerCloudSpec{}
 }
 
+// PublicAzureCloudSpec is a public counterpart of kubermaticv1.AzureCloudSpec.
 type PublicAzureCloudSpec struct {
 	TenantID        string `json:"tenantID"`
 	SubscriptionID  string `json:"subscriptionID"`
@@ -372,7 +378,7 @@ type PublicAzureCloudSpec struct {
 	AvailabilitySet string `json:"availabilitySet"`
 }
 
-func NewPublicAzureCloudSpec(internal *kubermaticv1.AzureCloudSpec) (public *PublicAzureCloudSpec) {
+func newPublicAzureCloudSpec(internal *kubermaticv1.AzureCloudSpec) (public *PublicAzureCloudSpec) {
 	if internal == nil {
 		return nil
 	}
@@ -389,11 +395,12 @@ func NewPublicAzureCloudSpec(internal *kubermaticv1.AzureCloudSpec) (public *Pub
 	}
 }
 
+// PublicVSphereCloudSpec is a public counterpart of kubermaticv1.VSphereCloudSpec.
 type PublicVSphereCloudSpec struct {
 	VMNetName string `json:"vmNetName"`
 }
 
-func NewPublicVSphereCloudSpec(internal *kubermaticv1.VSphereCloudSpec) (public *PublicVSphereCloudSpec) {
+func newPublicVSphereCloudSpec(internal *kubermaticv1.VSphereCloudSpec) (public *PublicVSphereCloudSpec) {
 	if internal == nil {
 		return nil
 	}
@@ -403,9 +410,10 @@ func NewPublicVSphereCloudSpec(internal *kubermaticv1.VSphereCloudSpec) (public 
 	}
 }
 
+// PublicBringYourOwnCloudSpec is a public counterpart of kubermaticv1.BringYourOwnCloudSpec.
 type PublicBringYourOwnCloudSpec struct{}
 
-func NewPublicBringYourOwnCloudSpec(internal *kubermaticv1.BringYourOwnCloudSpec) (public *PublicBringYourOwnCloudSpec) {
+func newPublicBringYourOwnCloudSpec(internal *kubermaticv1.BringYourOwnCloudSpec) (public *PublicBringYourOwnCloudSpec) {
 	if internal == nil {
 		return nil
 	}
@@ -413,6 +421,7 @@ func NewPublicBringYourOwnCloudSpec(internal *kubermaticv1.BringYourOwnCloudSpec
 	return &PublicBringYourOwnCloudSpec{}
 }
 
+// PublicAWSCloudSpec is a public counterpart of kubermaticv1.AWSCloudSpec.
 type PublicAWSCloudSpec struct {
 	VPCID               string `json:"vpcId"`
 	SubnetID            string `json:"subnetId"`
@@ -423,7 +432,7 @@ type PublicAWSCloudSpec struct {
 	AvailabilityZone    string `json:"availabilityZone"`
 }
 
-func NewPublicAWSCloudSpec(internal *kubermaticv1.AWSCloudSpec) (public *PublicAWSCloudSpec) {
+func newPublicAWSCloudSpec(internal *kubermaticv1.AWSCloudSpec) (public *PublicAWSCloudSpec) {
 	if internal == nil {
 		return nil
 	}
@@ -439,6 +448,7 @@ func NewPublicAWSCloudSpec(internal *kubermaticv1.AWSCloudSpec) (public *PublicA
 	}
 }
 
+// PublicOpenstackCloudSpec is a public counterpart of kubermaticv1.OpenstackCloudSpec.
 type PublicOpenstackCloudSpec struct {
 	Tenant         string `json:"tenant"`
 	Domain         string `json:"domain"`
@@ -449,7 +459,7 @@ type PublicOpenstackCloudSpec struct {
 	SubnetID       string `json:"subnetID"`
 }
 
-func NewPublicOpenstackCloudSpec(internal *kubermaticv1.OpenstackCloudSpec) (public *PublicOpenstackCloudSpec) {
+func newPublicOpenstackCloudSpec(internal *kubermaticv1.OpenstackCloudSpec) (public *PublicOpenstackCloudSpec) {
 	if internal == nil {
 		return nil
 	}

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -294,7 +294,7 @@ type ClusterSpec struct {
 
 // MarshalJSON marshals NewClusterSpec object into JSON. It is overwritten to control data
 // that will be returned in the API responses (see: PublicCloudSpec struct).
-func (cs *NewClusterSpec) MarshalJSON() ([]byte, error) {
+func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 	ret, err := json.Marshal(struct {
 		Cloud           PublicCloudSpec                        `json:"cloud"`
 		MachineNetworks []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`

--- a/api/pkg/api/v1/types_test.go
+++ b/api/pkg/api/v1/types_test.go
@@ -1,0 +1,138 @@
+package v1_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	. "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+)
+
+func TestNewClusterSpec_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	const valueToBeFiltered = "_______VALUE_TO_BE_FILTERED_______"
+
+	cases := []struct {
+		name    string
+		cluster NewClusterSpec
+	}{
+		{
+			"case 1: filter username and password from OpenStack",
+			NewClusterSpec{
+				Version: "1.2.3",
+				Cloud: kubermaticv1.CloudSpec{
+					DatacenterName: "OpenstackDatacenter",
+					Openstack: &kubermaticv1.OpenstackCloudSpec{
+						Username:       valueToBeFiltered,
+						Password:       valueToBeFiltered,
+						SubnetID:       "subnetID",
+						Domain:         "domain",
+						FloatingIPPool: "floatingIPPool",
+						Network:        "network",
+						RouterID:       "routerID",
+						SecurityGroups: "securityGroups",
+						Tenant:         "tenant",
+					},
+				},
+			},
+		},
+		{
+			"case 2: client ID and client secret from Azure",
+			NewClusterSpec{
+				Version: "1.2.3",
+				Cloud: kubermaticv1.CloudSpec{
+					Azure: &kubermaticv1.AzureCloudSpec{
+						ClientID:        valueToBeFiltered,
+						ClientSecret:    valueToBeFiltered,
+						TenantID:        "tenantID",
+						AvailabilitySet: "availablitySet",
+						ResourceGroup:   "resourceGroup",
+						RouteTableName:  "routeTableName",
+						SecurityGroup:   "securityGroup",
+						SubnetName:      "subnetName",
+						SubscriptionID:  "subsciprionID",
+						VNetName:        "vnetname",
+					},
+				},
+			},
+		},
+		{
+			"case 1: filter token from Hetzner",
+			NewClusterSpec{
+				Version: "1.2.3",
+				Cloud: kubermaticv1.CloudSpec{
+					Hetzner: &kubermaticv1.HetznerCloudSpec{
+						Token: valueToBeFiltered,
+					},
+				},
+			},
+		},
+		{
+			"case 1: filter token from DigitalOcean",
+			NewClusterSpec{
+				Version: "1.2.3",
+				Cloud: kubermaticv1.CloudSpec{
+					Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
+						Token: valueToBeFiltered,
+					},
+				},
+			},
+		},
+		{
+			"case 1: filter usernames and passwords from VSphere",
+			NewClusterSpec{
+				Version: "1.2.3",
+				Cloud: kubermaticv1.CloudSpec{
+					VSphere: &kubermaticv1.VSphereCloudSpec{
+						Password: valueToBeFiltered,
+						Username: valueToBeFiltered,
+						InfraManagementUser: kubermaticv1.VSphereCredentials{
+							Username: valueToBeFiltered,
+							Password: valueToBeFiltered,
+						},
+						VMNetName: "vmNetName",
+					},
+				},
+			},
+		},
+		{
+			"case 1: filter access key ID and secret access key from AWS",
+			NewClusterSpec{
+				Version: "1.2.3",
+				Cloud: kubermaticv1.CloudSpec{
+					AWS: &kubermaticv1.AWSCloudSpec{
+						AccessKeyID:         valueToBeFiltered,
+						SecretAccessKey:     valueToBeFiltered,
+						SecurityGroupID:     "secuirtyGroupID",
+						AvailabilityZone:    "availablityZone",
+						InstanceProfileName: "instanceProfileName",
+						RoleName:            "roleName",
+						RouteTableID:        "routeTableID",
+						SubnetID:            "subnetID",
+						VPCID:               "vpcID",
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			jsonByteArray, err := c.cluster.MarshalJSON()
+			if err != nil {
+				t.Errorf("failed to marshal due to an error: %s", err)
+			}
+
+			if jsonString := string(jsonByteArray); strings.Contains(jsonString, valueToBeFiltered) {
+				t.Errorf("output JSON: %s should not contain: %s", jsonString, valueToBeFiltered)
+			}
+
+			var jsonObject NewClusterSpec
+			if err := json.Unmarshal(jsonByteArray, &jsonObject); err != nil {
+				t.Errorf("failed to unmarshal due to an error: %s", err)
+			}
+		})
+	}
+}

--- a/api/pkg/api/v1/types_test.go
+++ b/api/pkg/api/v1/types_test.go
@@ -59,7 +59,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 			},
 		},
 		{
-			"case 1: filter token from Hetzner",
+			"case 3: filter token from Hetzner",
 			NewClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
@@ -70,7 +70,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 			},
 		},
 		{
-			"case 1: filter token from DigitalOcean",
+			"case 4: filter token from DigitalOcean",
 			NewClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
@@ -81,7 +81,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 			},
 		},
 		{
-			"case 1: filter usernames and passwords from VSphere",
+			"case 5: filter usernames and passwords from VSphere",
 			NewClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
@@ -98,7 +98,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 			},
 		},
 		{
-			"case 1: filter access key ID and secret access key from AWS",
+			"case 6: filter access key ID and secret access key from AWS",
 			NewClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{

--- a/api/pkg/api/v1/types_test.go
+++ b/api/pkg/api/v1/types_test.go
@@ -16,11 +16,11 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 
 	cases := []struct {
 		name    string
-		cluster NewClusterSpec
+		cluster ClusterSpec
 	}{
 		{
 			"case 1: filter username and password from OpenStack",
-			NewClusterSpec{
+			ClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
 					DatacenterName: "OpenstackDatacenter",
@@ -40,7 +40,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		},
 		{
 			"case 2: client ID and client secret from Azure",
-			NewClusterSpec{
+			ClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
 					Azure: &kubermaticv1.AzureCloudSpec{
@@ -60,7 +60,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		},
 		{
 			"case 3: filter token from Hetzner",
-			NewClusterSpec{
+			ClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
 					Hetzner: &kubermaticv1.HetznerCloudSpec{
@@ -71,7 +71,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		},
 		{
 			"case 4: filter token from DigitalOcean",
-			NewClusterSpec{
+			ClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
 					Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
@@ -82,7 +82,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		},
 		{
 			"case 5: filter usernames and passwords from VSphere",
-			NewClusterSpec{
+			ClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
 					VSphere: &kubermaticv1.VSphereCloudSpec{
@@ -99,7 +99,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 		},
 		{
 			"case 6: filter access key ID and secret access key from AWS",
-			NewClusterSpec{
+			ClusterSpec{
 				Version: "1.2.3",
 				Cloud: kubermaticv1.CloudSpec{
 					AWS: &kubermaticv1.AWSCloudSpec{
@@ -129,7 +129,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 				t.Errorf("output JSON: %s should not contain: %s", jsonString, valueToBeFiltered)
 			}
 
-			var jsonObject NewClusterSpec
+			var jsonObject ClusterSpec
 			if err := json.Unmarshal(jsonByteArray, &jsonObject); err != nil {
 				t.Errorf("failed to unmarshal due to an error: %s", err)
 			}

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -259,36 +259,6 @@ func UpdateCloudSpec(updatedShared, existingShared CloudSpec) CloudSpec {
 	return *updated
 }
 
-// RemoveSensitiveDataFromCloudSpec remove credentials from cloud providers
-func RemoveSensitiveDataFromCloudSpec(spec CloudSpec) CloudSpec {
-	if spec.Digitalocean != nil {
-		spec.Digitalocean.Token = ""
-	}
-	if spec.AWS != nil {
-		spec.AWS.AccessKeyID = ""
-		spec.AWS.SecretAccessKey = ""
-	}
-	if spec.Azure != nil {
-		spec.Azure.ClientID = ""
-		spec.Azure.ClientSecret = ""
-	}
-	if spec.Openstack != nil {
-		spec.Openstack.Username = ""
-		spec.Openstack.Password = ""
-	}
-	if spec.Hetzner != nil {
-		spec.Hetzner.Token = ""
-	}
-	if spec.VSphere != nil {
-		spec.VSphere.Username = ""
-		spec.VSphere.Password = ""
-		spec.VSphere.InfraManagementUser.Username = ""
-		spec.VSphere.InfraManagementUser.Password = ""
-	}
-
-	return spec
-}
-
 // ClusterHealth stores health information of a cluster and the timestamp of the last change.
 type ClusterHealth struct {
 	ClusterHealthStatus `json:",inline"`

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -116,7 +116,7 @@ func updateCluster(cloudProviders map[string]provider.CloudProvider, projectProv
 func patchCluster(cloudProviders map[string]provider.CloudProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PatchClusterReq)
-		clusterProvider := ctx.Value(newClusterProviderContextKey).(provider.NewClusterProvider)
+		clusterProvider := ctx.Value(clusterProviderContextKey).(provider.ClusterProvider)
 		userInfo := ctx.Value(userInfoContextKey).(*provider.UserInfo)
 		_, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
 		if err != nil {
@@ -627,7 +627,7 @@ func decodeUpdateClusterReq(c context.Context, r *http.Request) (interface{}, er
 }
 
 // PatchClusterReq defines HTTP request for patchCluster endpoint
-// swagger:parameters patchClusterReq
+// swagger:parameters patchCluster
 type PatchClusterReq struct {
 	GetClusterReq
 

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -128,18 +128,18 @@ func patchCluster(cloudProviders map[string]provider.CloudProvider, projectProvi
 			return nil, kubernetesErrorToHTTPError(err)
 		}
 
-		existingClusterJson, err := json.Marshal(existingCluster)
+		existingClusterJSON, err := json.Marshal(existingCluster)
 		if err != nil {
 			return nil, errors.NewBadRequest("cannot decode existing cluster: %v", err)
 		}
 
-		patchedClusterJson, err := jsonpatch.MergePatch(existingClusterJson, req.Patch)
+		patchedClusterJSON, err := jsonpatch.MergePatch(existingClusterJSON, req.Patch)
 		if err != nil {
 			return nil, errors.NewBadRequest("cannot patch cluster: %v", err)
 		}
 
 		var patchedCluster *kubermaticapiv1.Cluster
-		err = json.Unmarshal(patchedClusterJson, &patchedCluster)
+		err = json.Unmarshal(patchedClusterJSON, &patchedCluster)
 		if err != nil {
 			return nil, errors.NewBadRequest("cannot decode patched cluster: %v", err)
 		}

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/evanphx/json-patch"
 	"io/ioutil"
 	"net/http"
 	"time"
 
+	"github.com/evanphx/json-patch"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 	prometheusapi "github.com/prometheus/client_golang/api"

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -303,7 +303,6 @@ func removeSensitiveDataFromCluster(cluster *kubermaticapiv1.Cluster) *kubermati
 	clusterCopy := cluster.DeepCopy()
 
 	clusterCopy.Address.AdminToken = ""
-	clusterCopy.Spec.Cloud = kubermaticapiv1.RemoveSensitiveDataFromCloudSpec(clusterCopy.Spec.Cloud)
 
 	return clusterCopy
 }

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -20,41 +20,6 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 )
 
-func TestRemoveSensitiveDataFromCluster(t *testing.T) {
-	t.Parallel()
-	genClusterWithAdminToken := func() *kubermaticv1.Cluster {
-		cluster := genDefaultCluster()
-		cluster.Address.AdminToken = "hfzj6l.w7hgc65nq9z4fxvl"
-		cluster.Address.ExternalName = "w225mx4z66.asia-east1-a-1.cloud.kubermatic.io"
-		cluster.Address.IP = "35.194.142.199"
-		cluster.Address.URL = "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"
-		return cluster
-	}
-	scenarios := []struct {
-		Name            string
-		ExistingCluster *kubermaticv1.Cluster
-		ExpectedCluster *kubermaticv1.Cluster
-	}{
-		{
-			Name:            "scenario 1: removes the admin token",
-			ExistingCluster: genClusterWithAdminToken(),
-			ExpectedCluster: func() *kubermaticv1.Cluster {
-				cluster := genClusterWithAdminToken()
-				cluster.Address.AdminToken = ""
-				return cluster
-			}(),
-		},
-	}
-	for _, tc := range scenarios {
-		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster := removeSensitiveDataFromCluster(tc.ExistingCluster)
-			if !equality.Semantic.DeepEqual(actualCluster, tc.ExpectedCluster) {
-				t.Fatalf("%v", diff.ObjectDiff(tc.ExpectedCluster, actualCluster))
-			}
-		})
-	}
-}
-
 func TestDeleteClusterEndpoint(t *testing.T) {
 	t.Parallel()
 	testcase := struct {
@@ -827,18 +792,14 @@ func TestPatchCluster(t *testing.T) {
 	}{
 		// scenario 1
 		{
-			Name:             "scenario 1: update the cluster version",
-			Body:             `{"spec":{"version":"1.2.3"}}`,
-			ExpectedResponse: `{"id":"keen-snyder","name":"clusterAbc","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"FakeDatacenter","fake":{}},"version":"1.2.3"},"status":{"version":"1.2.3","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
-			cluster:          "keen-snyder",
-			HTTPStatus:       http.StatusOK,
-			project:          genDefaultProject().Name,
-			ExistingAPIUser:  genDefaultAPIUser(),
-			ExistingKubermaticObjects: func() []runtime.Object {
-				defaultObjs := genDefaultKubermaticObjects()
-				defaultObjs = append(defaultObjs, genCluster("keen-snyder", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)))
-				return defaultObjs
-			}(),
+			Name:                      "scenario 1: update the cluster version",
+			Body:                      `{"spec":{"version":"1.2.3"}}`,
+			ExpectedResponse:          `{"id":"keen-snyder","name":"clusterAbc","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"FakeDatacenter","fake":{}},"version":"1.2.3"},"status":{"version":"1.2.3","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
+			cluster:                   "keen-snyder",
+			HTTPStatus:                http.StatusOK,
+			project:                   genDefaultProject().Name,
+			ExistingAPIUser:           genDefaultAPIUser(),
+			ExistingKubermaticObjects: genDefaultKubermaticObjects(genCluster("keen-snyder", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))),
 		},
 		// scenario 2
 		{

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -575,7 +575,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 2: cluster is created when valid spec and ssh key are passed",
 			Body:             `{"name":"keen-snyder","spec":{"version":"1.9.7","cloud":{"fake":{"token":"dummy_token"},"dc":"do-fra1"}}}`,
-			ExpectedResponse: `{"id":"%s","name":"keen-snyder","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"cloud":{"dc":"do-fra1","fake":{"token":"dummy_token"}},"version":"1.9.7"},"status":{"version":"1.9.7","url":""}}`,
+			ExpectedResponse: `{"id":"%s","name":"keen-snyder","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"cloud":{"dc":"do-fra1","fake":{}},"version":"1.9.7"},"status":{"version":"1.9.7","url":""}}`,
 			RewriteClusterID: true,
 			HTTPStatus:       http.StatusCreated,
 			ProjectToSync:    genDefaultProject().Name,
@@ -600,7 +600,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		// scenario 3
 		{
 			Name:                   "scenario 3: unable to create a cluster when the user doesn't belong to the project",
-			Body:                   `{"cluster":{"humanReadableName":"keen-snyder","version":"1.9.7","pause":false,"cloud":{"digitalocean":{"token":"dummy_token"},"dc":"do-fra1"}},"sshKeys":["key-c08aa5c7abf34504f18552846485267d-yafn"]}`,
+			Body:                   `{"cluster":{"humanReadableName":"keen-snyder","version":"1.9.7","pause":false,"cloud":{"digitalocean":{},"dc":"do-fra1"}},"sshKeys":["key-c08aa5c7abf34504f18552846485267d-yafn"]}`,
 			ExpectedResponse:       `{"error":{"code":403,"message":"forbidden: The user \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
 			HTTPStatus:             http.StatusForbidden,
 			ProjectToSync:          genDefaultProject().Name,
@@ -614,7 +614,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		// scenario 4
 		{
 			Name:             "scenario 4: unable to create a cluster when project is not ready",
-			Body:             `{"cluster":{"humanReadableName":"keen-snyder","version":"1.9.7","pause":false,"cloud":{"digitalocean":{"token":"dummy_token"},"dc":"do-fra1"}},"sshKeys":["key-c08aa5c7abf34504f18552846485267d-yafn"]}`,
+			Body:             `{"cluster":{"humanReadableName":"keen-snyder","version":"1.9.7","pause":false,"cloud":{"digitalocean":{},"dc":"do-fra1"}},"sshKeys":["key-c08aa5c7abf34504f18552846485267d-yafn"]}`,
 			ExpectedResponse: `{"error":{"code":503,"message":"Project is not initialized yet"}}`,
 			HTTPStatus:       http.StatusServiceUnavailable,
 			ExistingProject: func() *kubermaticv1.Project {
@@ -824,7 +824,7 @@ func TestGetCluster(t *testing.T) {
 		{
 			Name:             "scenario 1: gets cluster with the given name that belongs to the given project",
 			Body:             ``,
-			ExpectedResponse: `{"id":"defClusterID","name":"defClusterName","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"FakeDatacenter","fake":{"token":"SecretToken"}},"version":"9.9.9"},"status":{"version":"9.9.9","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
+			ExpectedResponse: `{"id":"defClusterID","name":"defClusterName","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"FakeDatacenter","fake":{}},"version":"9.9.9"},"status":{"version":"9.9.9","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
 			ClusterToGet:     genDefaultCluster().Name,
 			HTTPStatus:       http.StatusOK,
 			ExistingKubermaticObjs: genDefaultKubermaticObjects(
@@ -837,7 +837,7 @@ func TestGetCluster(t *testing.T) {
 		{
 			Name:             "scenario 2: gets cluster for Openstack and no sensitive data (credentials) are returned",
 			Body:             ``,
-			ExpectedResponse: `{"id":"defClusterID","name":"defClusterName","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"OpenstackDatacenter","openstack":{"username":"","password":"","tenant":"tenant","domain":"domain","network":"network","securityGroups":"securityGroups","floatingIpPool":"floatingIPPool","routerID":"routerID","subnetID":"subnetID"}},"version":"9.9.9"},"status":{"version":"9.9.9","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
+			ExpectedResponse: `{"id":"defClusterID","name":"defClusterName","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"OpenstackDatacenter","openstack":{"tenant":"tenant","domain":"domain","network":"network","securityGroups":"securityGroups","floatingIpPool":"floatingIPPool","routerID":"routerID","subnetID":"subnetID"}},"version":"9.9.9"},"status":{"version":"9.9.9","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
 			ClusterToGet:     genDefaultCluster().Name,
 			HTTPStatus:       http.StatusOK,
 			ExistingKubermaticObjs: genDefaultKubermaticObjects(
@@ -892,9 +892,7 @@ func TestListClusters(t *testing.T) {
 					Spec: apiv1.ClusterSpec{
 						Cloud: kubermaticv1.CloudSpec{
 							DatacenterName: "FakeDatacenter",
-							Fake: &kubermaticv1.FakeCloudSpec{
-								Token: "SecretToken",
-							},
+							Fake:           &kubermaticv1.FakeCloudSpec{},
 						},
 						Version: "9.9.9",
 					},
@@ -912,9 +910,7 @@ func TestListClusters(t *testing.T) {
 					Spec: apiv1.ClusterSpec{
 						Cloud: kubermaticv1.CloudSpec{
 							DatacenterName: "FakeDatacenter",
-							Fake: &kubermaticv1.FakeCloudSpec{
-								Token: "SecretToken",
-							},
+							Fake:           &kubermaticv1.FakeCloudSpec{},
 						},
 						Version: "9.9.9",
 					},

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -747,7 +747,7 @@ func TestUpdateCluster(t *testing.T) {
 		{
 			Name:             "scenario 1: update the cluster version for FakeDatacenter",
 			Body:             `{"name":"keen-snyder","spec":{"version":"0.0.1","cloud":{"fake":{"token":"dummy_token"},"dc":"FakeDatacenter"}}, "status":{"url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
-			ExpectedResponse: `{"id":"keen-snyder","name":"clusterAbc","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"FakeDatacenter","fake":{"token":"dummy_token"}},"version":"0.0.1"},"status":{"version":"0.0.1","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
+			ExpectedResponse: `{"id":"keen-snyder","name":"clusterAbc","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"FakeDatacenter","fake":{}},"version":"0.0.1"},"status":{"version":"0.0.1","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
 			ClusterToUpdate:  "keen-snyder",
 			HTTPStatus:       http.StatusOK,
 			ProjectToSync:    genDefaultProject().Name,
@@ -842,22 +842,7 @@ func TestPatchCluster(t *testing.T) {
 		},
 		// scenario 2
 		{
-			Name:             "scenario 2: update the cluster cloud dc",
-			Body:             `{"spec":{"cloud":{"dc":"dc1"}}}`,
-			ExpectedResponse: `{"id":"keen-snyder","name":"clusterAbc","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"dc1","fake":{}},"version":"9.9.9"},"status":{"version":"9.9.9","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
-			cluster:          "keen-snyder",
-			HTTPStatus:       http.StatusOK,
-			project:          genDefaultProject().Name,
-			ExistingAPIUser:  genDefaultAPIUser(),
-			ExistingKubermaticObjects: func() []runtime.Object {
-				defaultObjs := genDefaultKubermaticObjects()
-				defaultObjs = append(defaultObjs, genCluster("keen-snyder", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)))
-				return defaultObjs
-			}(),
-		},
-		// scenario 3
-		{
-			Name:             "scenario 3: fail on invalid patch json",
+			Name:             "scenario 2: fail on invalid patch json",
 			Body:             `{"spec":{"cloud":{"dc":"dc1"`,
 			ExpectedResponse: `{"error":{"code":400,"message":"cannot patch cluster: Invalid JSON Patch"}}`,
 			cluster:          "keen-snyder",

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -787,7 +787,7 @@ func TestPatchCluster(t *testing.T) {
 		HTTPStatus                int
 		cluster                   string
 		project                   string
-		ExistingAPIUser           *apiv1.User
+		ExistingAPIUser           *apiv1.LegacyUser
 		ExistingKubermaticObjects []runtime.Object
 	}{
 		// scenario 1

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -30,152 +30,17 @@ func TestRemoveSensitiveDataFromCluster(t *testing.T) {
 		cluster.Address.URL = "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"
 		return cluster
 	}
-	genClusterWithAWS := func() *kubermaticv1.Cluster {
-		cluster := genDefaultCluster()
-		cluster.Address.AdminToken = ""
-		cluster.Spec.Cloud = kubermaticv1.CloudSpec{
-			AWS: &kubermaticv1.AWSCloudSpec{
-				AccessKeyID:         "secretKeyID",
-				SecretAccessKey:     "secreatAccessKey",
-				SecurityGroupID:     "secuirtyGroupID",
-				AvailabilityZone:    "availablityZone",
-				InstanceProfileName: "instanceProfileName",
-				RoleName:            "roleName",
-				RouteTableID:        "routeTableID",
-				SubnetID:            "subnetID",
-				VPCID:               "vpcID",
-			},
-		}
-
-		return cluster
-	}
-	genClusterWithAzure := func() *kubermaticv1.Cluster {
-		cluster := genDefaultCluster()
-		cluster.Address.AdminToken = ""
-		cluster.Spec.Cloud = kubermaticv1.CloudSpec{
-			Azure: &kubermaticv1.AzureCloudSpec{
-				ClientID:        "clientID",
-				ClientSecret:    "clientSecret",
-				TenantID:        "tenantID",
-				AvailabilitySet: "availablitySet",
-				ResourceGroup:   "resourceGroup",
-				RouteTableName:  "routeTableName",
-				SecurityGroup:   "securityGroup",
-				SubnetName:      "subnetName",
-				SubscriptionID:  "subsciprionID",
-				VNetName:        "vnetname",
-			},
-		}
-		return cluster
-	}
-	genClusterWithHetzner := func() *kubermaticv1.Cluster {
-		cluster := genDefaultCluster()
-		cluster.Address.AdminToken = ""
-		cluster.Spec.Cloud = kubermaticv1.CloudSpec{
-			Hetzner: &kubermaticv1.HetznerCloudSpec{
-				Token: "token",
-			},
-		}
-		return cluster
-	}
-	genClusterWithDO := func() *kubermaticv1.Cluster {
-		cluster := genDefaultCluster()
-		cluster.Address.AdminToken = ""
-		cluster.Spec.Cloud = kubermaticv1.CloudSpec{
-			Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
-				Token: "token",
-			},
-		}
-		return cluster
-	}
-	genClusterWithVsphere := func() *kubermaticv1.Cluster {
-		cluster := genDefaultCluster()
-		cluster.Address.AdminToken = ""
-		cluster.Spec.Cloud = kubermaticv1.CloudSpec{
-			VSphere: &kubermaticv1.VSphereCloudSpec{
-				Password: "password",
-				Username: "username",
-				InfraManagementUser: kubermaticv1.VSphereCredentials{
-					Username: "infraUsername",
-					Password: "infraPassword",
-				},
-				VMNetName: "vmNetName",
-			},
-		}
-		return cluster
-	}
 	scenarios := []struct {
 		Name            string
 		ExistingCluster *kubermaticv1.Cluster
 		ExpectedCluster *kubermaticv1.Cluster
 	}{
 		{
-			Name:            "scenaio 1: removes the admin token",
+			Name:            "scenario 1: removes the admin token",
 			ExistingCluster: genClusterWithAdminToken(),
 			ExpectedCluster: func() *kubermaticv1.Cluster {
 				cluster := genClusterWithAdminToken()
 				cluster.Address.AdminToken = ""
-				return cluster
-			}(),
-		},
-		{
-			Name:            "scenario 2: removes AWS cloud provider secrets",
-			ExistingCluster: genClusterWithAWS(),
-			ExpectedCluster: func() *kubermaticv1.Cluster {
-				cluster := genClusterWithAWS()
-				cluster.Spec.Cloud.AWS.AccessKeyID = ""
-				cluster.Spec.Cloud.AWS.SecretAccessKey = ""
-				return cluster
-			}(),
-		},
-		{
-			Name:            "scenario 3: removes Azure cloud provider secrets",
-			ExistingCluster: genClusterWithAzure(),
-			ExpectedCluster: func() *kubermaticv1.Cluster {
-				cluster := genClusterWithAzure()
-				cluster.Spec.Cloud.Azure.ClientID = ""
-				cluster.Spec.Cloud.Azure.ClientSecret = ""
-				return cluster
-			}(),
-		},
-		{
-			Name:            "scenario 4: removes Openstack cloud provider secrets",
-			ExistingCluster: genClusterWithOpenstack(genDefaultCluster()),
-			ExpectedCluster: func() *kubermaticv1.Cluster {
-				cluster := genClusterWithOpenstack(genDefaultCluster())
-				cluster.Address.AdminToken = ""
-				cluster.Spec.Cloud.Openstack.Username = ""
-				cluster.Spec.Cloud.Openstack.Password = ""
-				return cluster
-			}(),
-		},
-		{
-			Name:            "scenario 5: removes Hetzner cloud provider secrets",
-			ExistingCluster: genClusterWithHetzner(),
-			ExpectedCluster: func() *kubermaticv1.Cluster {
-				cluster := genClusterWithHetzner()
-				cluster.Spec.Cloud.Hetzner.Token = ""
-				return cluster
-			}(),
-		},
-		{
-			Name:            "scenario 6: removes Digitalocean cloud provider secrets",
-			ExistingCluster: genClusterWithDO(),
-			ExpectedCluster: func() *kubermaticv1.Cluster {
-				cluster := genClusterWithDO()
-				cluster.Spec.Cloud.Digitalocean.Token = ""
-				return cluster
-			}(),
-		},
-		{
-			Name:            "scenario 7: removes Vsphere cloud provider secrets",
-			ExistingCluster: genClusterWithVsphere(),
-			ExpectedCluster: func() *kubermaticv1.Cluster {
-				cluster := genClusterWithVsphere()
-				cluster.Spec.Cloud.VSphere.Username = ""
-				cluster.Spec.Cloud.VSphere.Password = ""
-				cluster.Spec.Cloud.VSphere.InfraManagementUser.Password = ""
-				cluster.Spec.Cloud.VSphere.InfraManagementUser.Username = ""
 				return cluster
 			}(),
 		},

--- a/api/pkg/handler/openstack_test.go
+++ b/api/pkg/handler/openstack_test.go
@@ -181,8 +181,8 @@ func TestOpenstackEndpoints(t *testing.T) {
 			Name: "test networks endpoint",
 			URL:  "/api/v1/providers/openstack/networks",
 			ExpectedResponse: `[
-				{"id": "396f12f8-521e-4b91-8e21-2e003500433a", "name": "net3"},
-				{"id": "71c1e68c-171a-4aa2-aca5-50ea153a3718", "name": "net2"}
+				{"id": "396f12f8-521e-4b91-8e21-2e003500433a", "name": "net3", "external": false},
+				{"id": "71c1e68c-171a-4aa2-aca5-50ea153a3718", "name": "net2", "external": false}
 			]`,
 		},
 		{

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -789,7 +789,7 @@ func (r Routing) updateCluster() http.Handler {
 
 // swagger:route PATCH /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id} project newPatchCluster
 //
-//     Patches the given cluster.
+//     Patches the given cluster using JSON Merge Patch method (https://tools.ietf.org/html/rfc7396).
 //
 //     Produces:
 //     - application/json

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -119,6 +119,10 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}").
 		Handler(r.updateCluster())
 
+	mux.Methods(http.MethodPatch).
+		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}").
+		Handler(r.patchCluster())
+
 	mux.Methods(http.MethodGet).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/kubeconfig").
 		Handler(r.getClusterKubeconfig())
@@ -778,6 +782,32 @@ func (r Routing) updateCluster() http.Handler {
 			r.userInfoMiddleware(),
 		)(updateCluster(r.cloudProviders, r.projectProvider)),
 		decodeUpdateClusterReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route PATCH /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id} project newPatchCluster
+//
+//     Patches the given cluster.
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: Cluster
+//       401: empty
+//       403: empty
+func (r Routing) patchCluster() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.authenticator.Verifier(),
+			r.userSaverMiddleware(),
+			r.newDatacenterMiddleware(),
+			r.userInfoMiddleware(),
+		)(patchCluster(r.cloudProviders, r.projectProvider)),
+		decodePatchClusterReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -787,7 +787,7 @@ func (r Routing) updateCluster() http.Handler {
 	)
 }
 
-// swagger:route PATCH /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id} project newPatchCluster
+// swagger:route PATCH /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id} project patchCluster
 //
 //     Patches the given cluster using JSON Merge Patch method (https://tools.ietf.org/html/rfc7396).
 //
@@ -804,7 +804,7 @@ func (r Routing) patchCluster() http.Handler {
 		endpoint.Chain(
 			r.authenticator.Verifier(),
 			r.userSaverMiddleware(),
-			r.newDatacenterMiddleware(),
+			r.datacenterMiddleware(),
 			r.userInfoMiddleware(),
 		)(patchCluster(r.cloudProviders, r.projectProvider)),
 		decodePatchClusterReq,


### PR DESCRIPTION
**What this PR does / why we need it**: It refactors cluster API changing method used to filter sensitive information out of JSON responses and adds new PATCH endpoint. PATCH endpoint will be used to update only specific parts of cluster data and thanks to it sensitive information won't be overwritten during PUT calls.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes #2121.

**Special notes for your reviewer**: PATCH endpoint uses https://github.com/evanphx/json-patch library that implements https://tools.ietf.org/html/rfc7396. I will also create pull request to the Dashboard that will make it consume new endpoint.

**Documentation**: n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
