### PR TITLE
update the kubermatic dashboard

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -55,7 +55,7 @@ kubermatic:
     replicas: 2
     image:
       repository: "kubermatic/ui-v2"
-      tag: "v1.0.1"
+      tag: "v1.0.2"
       pullPolicy: "IfNotPresent"
     config: |
       {


### PR DESCRIPTION
**What this PR does / why we need it**:
update the kubermatic dashboard to v1.0.2. Fixes duplicate node feature.

**Release note**:
```release-note
Updated the kubermatic dashboard to `v1.0.2`
```
