### PR TITLE
set cluster cidr in kube-proxy config

### DIFF
--- a/addons/kube-proxy/configmap.yaml
+++ b/addons/kube-proxy/configmap.yaml
@@ -15,7 +15,7 @@ data:
       contentType: application/vnd.kubernetes.protobuf
       kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
       qps: 5
-    clusterCIDR: ""
+    clusterCIDR: "{{ index .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks 1 }}"
     configSyncPeriod: 15m0s
     conntrack:
       max: null

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.1.14-dev1
+export TAG=v0.1.14
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.1.13
+export TAG=v0.1.14-dev1
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -32,7 +32,7 @@ kubermatic:
     addons:
       image:
         repository: "quay.io/kubermatic/addons"
-        tag: "v0.1.13"
+        tag: "v0.1.14-dev1"
         pullPolicy: "IfNotPresent"
       # list of Addons to install into every user-cluster. All need to exist in the addons image
       defaultAddons:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -32,7 +32,7 @@ kubermatic:
     addons:
       image:
         repository: "quay.io/kubermatic/addons"
-        tag: "v0.1.14-dev1"
+        tag: "v0.1.14"
         pullPolicy: "IfNotPresent"
       # list of Addons to install into every user-cluster. All need to exist in the addons image
       defaultAddons:


### PR DESCRIPTION
**What this PR does / why we need it**:
Set cluster cidr in kube-proxy config, to prevent the error message: `clusterCIDR not specified, unable to distinguish between internal and external traffic`

**Release note**:
```release-note
NONE
```
