### PR TITLE
adds feature gates

### DIFF
--- a/api/cmd/kubermatic-api/features.go
+++ b/api/cmd/kubermatic-api/features.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	// PrometheusEndpoint if enabled exposes cluster's metrics HTTP endpoint
+	PrometheusEndpoint = "PrometheusEndpoint"
+)
+
+type featureGate map[string]bool
+
+func newFeatures(rawFeatures string) (featureGate, error) {
+	fGate := featureGate{}
+	for _, s := range strings.Split(rawFeatures, ",") {
+		if len(s) == 0 {
+			continue
+		}
+
+		arr := strings.SplitN(s, "=", 2)
+		if len(arr) != 2 {
+			return nil, fmt.Errorf("missing bool value for feature gate key = %s", s)
+		}
+
+		k := strings.TrimSpace(arr[0])
+		v := strings.TrimSpace(arr[1])
+
+		boolValue, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value %v for feature gate key = %s, use true|false instead", v, k)
+		}
+		fGate[k] = boolValue
+	}
+
+	return fGate, nil
+}
+
+func (f featureGate) enabled(feature string) bool {
+	if enabled, ok := f[feature]; ok {
+		return enabled
+	}
+
+	return false
+}

--- a/api/cmd/kubermatic-api/features_test.go
+++ b/api/cmd/kubermatic-api/features_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFeatureGates(t *testing.T) {
+	scenarios := []struct {
+		name   string
+		input  string
+		output map[string]bool
+	}{
+		{
+			name:  "scenario 1: happy path provides valid input and makes sure it was parsed correctly",
+			input: "feature1=false,feature2=true",
+			output: map[string]bool{
+				"feature1": false,
+				"feature2": true,
+			},
+		},
+	}
+
+	for _, tc := range scenarios {
+		t.Run(tc.name, func(t *testing.T) {
+			target, err := newFeatures(tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for feature, shouldBeEnabled := range tc.output {
+				isEnabled := target.enabled(feature)
+				if isEnabled != shouldBeEnabled {
+					t.Fatalf("expected feature = %s to be set to %v but was set to %v", feature, shouldBeEnabled, isEnabled)
+				}
+			}
+		})
+	}
+}

--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -9,7 +9,7 @@ make -C $(dirname $0)/.. kubermatic-api
 
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
-# Please make sure to set -enable-prometheus-endpoint=true if you want to use that endpoint.
+# Please make sure to set -feature-gates=PrometheusEndpoint=true if you want to use that endpoint.
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 ./_build/kubermatic-api \


### PR DESCRIPTION
**What this PR does / why we need it**: features can be enabled/disabled by setting the new command line flag, for example setting `-feature-gates=PrometheusEndpoint=true` exposes cluster's metrics HTTP endpoint. Note that the changes introduced in this pull depreciate 'enable-prometheus-endpoint' flag.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
#2268 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
[ACTION REQUIRED] added a new command line flag to API server that accepts a set of key=value pairs that enables/disables various features. Existing `enable-prometheus-endpoint` flag is deprecated, the users should use `-feature-gates=PrometheusEndpoint=true` instead. 
``` 
