### PR TITLE
Increase resource limits

### DIFF
--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -20,7 +20,7 @@ var (
 			corev1.ResourceCPU:    resource.MustParse("10m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
 			corev1.ResourceCPU:    resource.MustParse("50m"),
 		},
 	}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -126,10 +126,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 20Mi
+            memory: 64Mi
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 16Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/vpnsidecar/dnatController.go
+++ b/api/pkg/resources/vpnsidecar/dnatController.go
@@ -10,11 +10,11 @@ import (
 var (
 	defaultResourceRequirements = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceMemory: resource.MustParse("16Mi"),
 			corev1.ResourceCPU:    resource.MustParse("5m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("20Mi"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
 			corev1.ResourceCPU:    resource.MustParse("20m"),
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase resource limits for the dnat-controller & kube-state-metrics.

Fixes #2280

**Release note**:
```release-note
NONE
```
