### PR TITLE
make it possible to allow oauth users to edit dashboards

### DIFF
--- a/config/monitoring/grafana/config/grafana.ini
+++ b/config/monitoring/grafana/config/grafana.ini
@@ -13,3 +13,8 @@ enabled = true
 header_name = X-Auth-Username
 header_property = username
 auto_sign_up = true
+
+{{ with .Values.grafana.provisioning.configuration.auto_assign_org_role }}
+[users]
+auto_assign_org_role = {{ . }}
+{{ end }}

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -37,6 +37,12 @@ grafana:
       #  version: 1
       #  editable: false
 
+    # override Grafana configuration flags
+    configuration:
+      # change this to "Editor" to allow OAuth-authenticated users
+      # to add and edit the dashboards
+      auto_assign_org_role: Viewer
+
   # If you manage your dashboards via your own configmaps,
   # you can add them here to have them automatically be
   # mounted in Grafana. For each volume, specify either a


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we do not login as admins anymore, we lost the ability to edit dashboards in Grafana. This is unfortunate and makes developing dashboards needlessly cumbersome.

This PR allows the operator to configure their Grafana to make all users Editors by default.

**Release note**:
```release-note
NONE
```
