### PR TITLE
Set higher timeout on etcd defrag command

### DIFF
--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -102,6 +102,7 @@ func defraggerCommand(data *resources.TemplateData) ([]string, error) {
 const (
 	defraggerCommandTpl = `etcdctl() {
 ETCDCTL_API=3 /usr/local/bin/etcdctl \
+  --command-timeout=60s \
   --endpoints https://$1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local.:2379 \
   --cacert /etc/etcd/pki/client/{{ .CACertFile }} \
   --cert /etc/etcd/pki/client/{{ .CertFile }} \

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.8.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.9.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.9.10-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.8.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.9.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.9.10-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.8.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.9.10-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.8.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.9.10-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.8.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.9.10-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.8.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.8.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.0-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.10-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.9.10-etcd-defragger.yaml
@@ -25,6 +25,7 @@ spec:
             - |-
               etcdctl() {
               ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
                 --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
                 --cacert /etc/etcd/pki/client/ca.crt \
                 --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \


### PR DESCRIPTION
**What this PR does / why we need it**:
Set a timeout on the `etcdctl defrag` command as the default is `1s`, which leads to timeouts on bigger clusters.

**Release note**:
```release-note
NONE
```
