### PR TITLE
Move feature gates to a separate pkg

### DIFF
--- a/api/cmd/kubermatic-api/features.go
+++ b/api/cmd/kubermatic-api/features.go
@@ -1,47 +1,8 @@
 package main
 
-import (
-	"fmt"
-	"strconv"
-	"strings"
-)
-
 const (
+	// All features for the kubermatic-api are defined below.
+
 	// PrometheusEndpoint if enabled exposes cluster's metrics HTTP endpoint
 	PrometheusEndpoint = "PrometheusEndpoint"
 )
-
-type featureGate map[string]bool
-
-func newFeatures(rawFeatures string) (featureGate, error) {
-	fGate := featureGate{}
-	for _, s := range strings.Split(rawFeatures, ",") {
-		if len(s) == 0 {
-			continue
-		}
-
-		arr := strings.SplitN(s, "=", 2)
-		if len(arr) != 2 {
-			return nil, fmt.Errorf("missing bool value for feature gate key = %s", s)
-		}
-
-		k := strings.TrimSpace(arr[0])
-		v := strings.TrimSpace(arr[1])
-
-		boolValue, err := strconv.ParseBool(v)
-		if err != nil {
-			return nil, fmt.Errorf("invalid value %v for feature gate key = %s, use true|false instead", v, k)
-		}
-		fGate[k] = boolValue
-	}
-
-	return fGate, nil
-}
-
-func (f featureGate) enabled(feature string) bool {
-	if enabled, ok := f[feature]; ok {
-		return enabled
-	}
-
-	return false
-}

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -163,7 +163,7 @@ func createAuthenticator(options serverRunOptions) (handler.Authenticator, error
 
 func createAPIHandler(options serverRunOptions, prov providers, authenticator handler.Authenticator, updateManager *version.Manager) (http.HandlerFunc, error) {
 	var prometheusClient prometheusapi.Client
-	if options.featureGates.enabled(PrometheusEndpoint) {
+	if options.featureGates.Enabled(PrometheusEndpoint) {
 		var err error
 		if prometheusClient, err = prometheusapi.NewClient(prometheusapi.Config{
 			Address: options.prometheusURL,

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 
+	"github.com/kubermatic/kubermatic/api/pkg/features"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 )
 
@@ -19,7 +20,7 @@ type serverRunOptions struct {
 	tokenIssuer              string
 	clientID                 string
 	tokenIssuerSkipTLSVerify bool
-	featureGates             featureGate
+	featureGates             features.FeatureGate
 }
 
 func newServerRunOptions() (serverRunOptions, error) {
@@ -41,7 +42,7 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&rawFeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for various features.")
 	flag.Parse()
 
-	featureGates, err := newFeatures(rawFeatureGates)
+	featureGates, err := features.NewFeatures(rawFeatureGates)
 	if err != nil {
 		return s, err
 	}

--- a/api/pkg/features/features.go
+++ b/api/pkg/features/features.go
@@ -1,0 +1,46 @@
+package features
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// FeatureGate is map of key=value pairs that enables/disables various features.
+type FeatureGate map[string]bool
+
+// NewFeatures takes comma separated key=value pairs for features
+// and returns a FeatureGate.
+func NewFeatures(rawFeatures string) (FeatureGate, error) {
+	fGate := FeatureGate{}
+	for _, s := range strings.Split(rawFeatures, ",") {
+		if len(s) == 0 {
+			continue
+		}
+
+		arr := strings.SplitN(s, "=", 2)
+		if len(arr) != 2 {
+			return nil, fmt.Errorf("missing bool value for feature gate key = %s", s)
+		}
+
+		k := strings.TrimSpace(arr[0])
+		v := strings.TrimSpace(arr[1])
+
+		boolValue, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value %v for feature gate key = %s, use true|false instead", v, k)
+		}
+		fGate[k] = boolValue
+	}
+
+	return fGate, nil
+}
+
+// Enabled returns true if the feature gate value of a particular feature is true.
+func (f FeatureGate) Enabled(feature string) bool {
+	if enabled, ok := f[feature]; ok {
+		return enabled
+	}
+
+	return false
+}

--- a/api/pkg/features/features_test.go
+++ b/api/pkg/features/features_test.go
@@ -1,4 +1,4 @@
-package main
+package features
 
 import (
 	"testing"
@@ -22,12 +22,12 @@ func TestFeatureGates(t *testing.T) {
 
 	for _, tc := range scenarios {
 		t.Run(tc.name, func(t *testing.T) {
-			target, err := newFeatures(tc.input)
+			target, err := NewFeatures(tc.input)
 			if err != nil {
 				t.Fatal(err)
 			}
 			for feature, shouldBeEnabled := range tc.output {
-				isEnabled := target.enabled(feature)
+				isEnabled := target.Enabled(feature)
 				if isEnabled != shouldBeEnabled {
 					t.Fatalf("expected feature = %s to be set to %v but was set to %v", feature, shouldBeEnabled, isEnabled)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**: Moving feature gates implemented in the apiserver to a dedicated package can help in using it in different places. For example, in controller-manager.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2289 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
