### PR TITLE
Increase etcd readiness timeout

### DIFF
--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -132,14 +132,16 @@ func StatefulSet(data resources.StatefulSetDataProvider, existing *appsv1.Statef
 			},
 			Resources: resourceRequirements,
 			ReadinessProbe: &corev1.Probe{
-				TimeoutSeconds:   1,
-				PeriodSeconds:    10,
-				SuccessThreshold: 1,
-				FailureThreshold: 3,
+				TimeoutSeconds:      10,
+				PeriodSeconds:       30,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+				InitialDelaySeconds: 15,
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
 							"/usr/local/bin/etcdctl",
+							"--command-timeout", "10s",
 							"--cacert", "/etc/etcd/pki/ca/ca.crt",
 							"--cert", "/etc/etcd/pki/client/apiserver-etcd-client.crt",
 							"--key", "/etc/etcd/pki/client/apiserver-etcd-client.key",

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
@@ -94,6 +94,8 @@ spec:
           exec:
             command:
             - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
             - --cacert
             - /etc/etcd/pki/ca/ca.crt
             - --cert
@@ -105,9 +107,10 @@ spec:
             - endpoint
             - health
           failureThreshold: 3
-          periodSeconds: 10
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 10
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase timeout of the readiness check timeout.
With a heavy loaded `etcd`, a restarting `etcd` pod can cause the readiness check to exceed the `1s` timeout (default) - resulting in all etcd pods becoming not-ready.
This will result in the API server not being able to communicate with `etcd`.

This PR also sets the `initialDelaySeconds` on the ReadinessProbe to accomodate for etcd's initial member communication. As this should not count against the initial failure threshold. 

**Release note**:
```release-note
etcd readiness check timeouts have been increased
```
