### PR TITLE
Update default dex version to 2.12.0

### DIFF
--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -2,7 +2,7 @@
 dex:
   image:
     repository: "quay.io/dexidp/dex"
-    tag: "v2.11.0"
+    tag: "v2.12.0"
   replicas: 1
   ingress:
     host: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Update default dex version to 2.12.0

Changelog https://github.com/dexidp/dex/releases/tag/v2.12.0
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update dex to 2.12.0
```
