### PR TITLE
move cluster-info user cluster resources

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1822,7 +1822,6 @@
     "k8s.io/api/core/v1",
     "k8s.io/api/policy/v1beta1",
     "k8s.io/api/rbac/v1",
-    "k8s.io/api/rbac/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apimachinery/pkg/api/equality",

--- a/api/pkg/controller/cluster/launching.go
+++ b/api/pkg/controller/cluster/launching.go
@@ -9,13 +9,8 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/openvpn"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/api/rbac/v1beta1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/util/cert"
 )
 
 // clusterIsReachable checks if the cluster is reachable via its external name
@@ -32,101 +27,6 @@ func (cc *Controller) clusterIsReachable(c *kubermaticv1.Cluster) (bool, error) 
 	}
 
 	return true, nil
-}
-
-// Creates cluster-info ConfigMap in customer cluster
-//see https://kubernetes.io/docs/admin/bootstrap-tokens/
-func (cc *Controller) launchingCreateClusterInfoConfigMap(c *kubermaticv1.Cluster) error {
-	caKp, err := resources.GetClusterRootCA(c, cc.secretLister)
-	if err != nil {
-		return err
-	}
-
-	client, err := cc.userClusterConnProvider.GetClient(c)
-	if err != nil {
-		return err
-	}
-
-	name := "cluster-info"
-	_, err = client.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(name, metav1.GetOptions{})
-	if err != nil {
-		if kubeerrors.IsNotFound(err) {
-			config := clientcmdapi.Config{}
-			config.Clusters = map[string]*clientcmdapi.Cluster{
-				"": {
-					Server:                   c.Address.URL,
-					CertificateAuthorityData: cert.EncodeCertPEM(caKp.Cert),
-				},
-			}
-			cm := v1.ConfigMap{}
-			cm.Name = name
-			bconfig, err := clientcmd.Write(config)
-			if err != nil {
-				return fmt.Errorf("failed to encode kubeconfig: %v", err)
-			}
-			cm.Data = map[string]string{"kubeconfig": string(bconfig)}
-			_, err = client.CoreV1().ConfigMaps(metav1.NamespacePublic).Create(&cm)
-			if err != nil {
-				return fmt.Errorf("failed to create cluster-info configmap in client cluster: %v", err)
-			}
-		} else {
-			return fmt.Errorf("failed to load cluster-info configmap from client cluster: %v", err)
-		}
-	}
-
-	_, err = client.RbacV1beta1().Roles(metav1.NamespacePublic).Get(name, metav1.GetOptions{})
-	if err != nil {
-		if kubeerrors.IsNotFound(err) {
-			role := &v1beta1.Role{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Rules: []v1beta1.PolicyRule{
-					{
-						APIGroups:     []string{""},
-						ResourceNames: []string{name},
-						Resources:     []string{"configmaps"},
-						Verbs:         []string{"get"},
-					},
-				},
-			}
-			if _, err = client.RbacV1beta1().Roles(metav1.NamespacePublic).Create(role); err != nil {
-				return fmt.Errorf("failed to create cluster-info role")
-			}
-		} else {
-			return fmt.Errorf("failed to load cluster-info role from client cluster: %v", err)
-		}
-	}
-
-	_, err = client.RbacV1beta1().RoleBindings(metav1.NamespacePublic).Get(name, metav1.GetOptions{})
-	if err != nil {
-		if kubeerrors.IsNotFound(err) {
-			rolebinding := &v1beta1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				RoleRef: v1beta1.RoleRef{
-					Name:     name,
-					Kind:     "Role",
-					APIGroup: v1beta1.GroupName,
-				},
-				Subjects: []v1beta1.Subject{
-					{
-						APIGroup: v1beta1.GroupName,
-						Kind:     v1beta1.UserKind,
-						Name:     "system:anonymous",
-					},
-				},
-			}
-			if _, err = client.RbacV1beta1().RoleBindings(metav1.NamespacePublic).Create(rolebinding); err != nil {
-				return fmt.Errorf("failed to create cluster-info rolebinding")
-			}
-		} else {
-			return fmt.Errorf("failed to load cluster-info rolebinding from client cluster: %v", err)
-		}
-	}
-
-	return nil
 }
 
 func (cc *Controller) launchingCreateOpenVPNClientCertificates(c *kubermaticv1.Cluster) error {

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -69,55 +69,14 @@ func (cc *Controller) reconcileCluster(cluster *kubermaticv1.Cluster) (*kubermat
 			}
 		}
 
-		if err = cc.launchingCreateClusterInfoConfigMap(cluster); err != nil {
-			return nil, err
-		}
-
-		if err = cc.launchingCreateOpenVPNClientCertificates(cluster); err != nil {
-			return nil, err
-		}
-
 		client, err := cc.userClusterConnProvider.GetClient(cluster)
 		if err != nil {
 			return nil, err
 		}
 
-		if len(cluster.Spec.MachineNetworks) > 0 {
-			if err = cc.userClusterEnsureInitializerConfiguration(cluster, client); err != nil {
-				return nil, err
-			}
-		}
-
-		if err = cc.userClusterEnsureRoles(cluster, client); err != nil {
-			return nil, err
-		}
-
-		if err = cc.userClusterEnsureConfigMaps(cluster, client); err != nil {
-			return nil, err
-		}
-
-		if err = cc.userClusterEnsureRoleBindings(cluster, client); err != nil {
-			return nil, err
-		}
-
-		if err = cc.userClusterEnsureClusterRoles(cluster, client); err != nil {
-			return nil, err
-		}
-
-		if err = cc.userClusterEnsureClusterRoleBindings(cluster, client); err != nil {
-			return nil, err
-		}
-
-		if err = cc.userClusterEnsureCustomResourceDefinitions(cluster); err != nil {
-			return nil, err
-		}
-
-		if err = cc.userClusterEnsureAPIServices(cluster); err != nil {
-			return nil, err
-		}
-
-		if err = cc.userClusterEnsureServices(cluster); err != nil {
-			return nil, err
+		// TODO: Move into own controller
+		if cluster, err = cc.reconcileUserClusterResources(cluster, client); err != nil {
+			return nil, fmt.Errorf("failed to reconcile user cluster resources: %v", err)
 		}
 	}
 

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -78,6 +78,7 @@ type ServiceAccountDataProvider interface {
 type ConfigMapDataProvider interface {
 	GetClusterRef() metav1.OwnerReference
 	Cluster() *kubermaticv1.Cluster
+	GetRootCA() (*triple.KeyPair, error)
 	TemplateData() interface{}
 	ServiceLister() corev1lister.ServiceLister
 	NodeAccessNetwork() string

--- a/api/pkg/resources/machinecontroller/cluster-info-configmap.go
+++ b/api/pkg/resources/machinecontroller/cluster-info-configmap.go
@@ -1,0 +1,51 @@
+package machinecontroller
+
+import (
+	"fmt"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/util/cert"
+)
+
+// ClusterInfoConfigMapCreator returns a ConfigMap containing the config for the OpenVPN client. It lives inside the user-cluster
+func ClusterInfoConfigMapCreator(data resources.ConfigMapDataProvider) resources.ConfigMapCreator {
+	return func(existing *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+		cm := existing
+		if cm == nil {
+			cm = &corev1.ConfigMap{}
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+
+		cm.Name = resources.ClusterInfoConfigMapName
+		cm.Namespace = metav1.NamespacePublic
+		cm.Labels = resources.BaseAppLabel(name, nil)
+
+		caKp, err := data.GetRootCA()
+		if err != nil {
+			return nil, err
+		}
+
+		kubeconfig := clientcmdapi.Config{}
+		kubeconfig.Clusters = map[string]*clientcmdapi.Cluster{
+			"": {
+				Server:                   data.Cluster().Address.URL,
+				CertificateAuthorityData: cert.EncodeCertPEM(caKp.Cert),
+			},
+		}
+
+		bconfig, err := clientcmd.Write(kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode kubeconfig: %v", err)
+		}
+		cm.Data["kubeconfig"] = string(bconfig)
+
+		return cm, nil
+	}
+}

--- a/api/pkg/resources/machinecontroller/role.go
+++ b/api/pkg/resources/machinecontroller/role.go
@@ -49,7 +49,7 @@ func KubeSystemRole(data resources.RoleDataProvider, existing *rbacv1.Role) (*rb
 
 // KubePublicRole returns a role for the machine controller. This
 // role has to be put in the user-cluster and carries a namespace.
-func KubePublicRole(data resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
+func KubePublicRole(_ resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
 	var r *rbacv1.Role
 	if existing != nil {
 		r = existing
@@ -75,9 +75,9 @@ func KubePublicRole(data resources.RoleDataProvider, existing *rbacv1.Role) (*rb
 	return r, nil
 }
 
-// Role returns a role for the machine controller. This
+// EndpointReaderRole returns a role for the machine controller. This
 // role has to be put in the user-cluster and carries a namespace.
-func Role(data resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
+func EndpointReaderRole(_ resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
 	var r *rbacv1.Role
 	if existing != nil {
 		r = existing
@@ -98,6 +98,30 @@ func Role(data resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role,
 				"list",
 				"watch",
 			},
+		},
+	}
+	return r, nil
+}
+
+// ClusterInfoReaderRole returns a role to read the cluster-info ConfigMap. This
+// role has to be put in the user-cluster and carries a namespace.
+func ClusterInfoReaderRole(_ resources.RoleDataProvider, existing *rbacv1.Role) (*rbacv1.Role, error) {
+	var r *rbacv1.Role
+	if existing != nil {
+		r = existing
+	} else {
+		r = &rbacv1.Role{}
+	}
+
+	r.Name = resources.ClusterInfoReaderRoleName
+	r.Namespace = metav1.NamespacePublic
+
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups:     []string{""},
+			ResourceNames: []string{"cluster-info"},
+			Resources:     []string{"configmaps"},
+			Verbs:         []string{"get"},
 		},
 	}
 	return r, nil

--- a/api/pkg/resources/machinecontroller/rolebinding.go
+++ b/api/pkg/resources/machinecontroller/rolebinding.go
@@ -53,3 +53,31 @@ func createRoleBinding(existing *rbacv1.RoleBinding, namespace string) (*rbacv1.
 	}
 	return rb, nil
 }
+
+// ClusterInfoAnonymousRoleBinding will return a RoleBinding giving access to the cluster-info ConfigMap for anonymous users
+func ClusterInfoAnonymousRoleBinding(_ resources.RoleBindingDataProvider, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+	var rb *rbacv1.RoleBinding
+	if existing != nil {
+		rb = existing
+	} else {
+		rb = &rbacv1.RoleBinding{}
+	}
+
+	rb.Name = resources.ClusterInfoAnonymousRoleBindingName
+	rb.Namespace = metav1.NamespacePublic
+
+	rb.RoleRef = rbacv1.RoleRef{
+		Name:     resources.ClusterInfoReaderRoleName,
+		Kind:     "Role",
+		APIGroup: rbacv1.GroupName,
+	}
+	rb.Subjects = []rbacv1.Subject{
+		{
+			APIGroup: rbacv1.GroupName,
+			Kind:     rbacv1.UserKind,
+			Name:     "system:anonymous",
+		},
+	}
+
+	return rb, nil
+}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -138,6 +138,8 @@ const (
 	OpenVPNClientConfigsConfigMapName = "openvpn-client-configs"
 	//OpenVPNClientConfigConfigMapName is the name for the ConfigMap containing the OpenVPN client config used by the client inside the user cluster
 	OpenVPNClientConfigConfigMapName = "openvpn-client-config"
+	//ClusterInfoConfigMapName is the name for the ConfigMap containing the cluster-info used by the bootstrap token machanism
+	ClusterInfoConfigMapName = "cluster-info"
 	//PrometheusConfigConfigMapName is the name for the configmap containing the prometheus config
 	PrometheusConfigConfigMapName = "prometheus"
 
@@ -188,10 +190,14 @@ const (
 	// KubeletDnatControllerClusterRoleBindingName is the name for the KubeletDnatController clusterrolebinding
 	KubeletDnatControllerClusterRoleBindingName = "system:kubermatic-kubeletdnat-controller"
 
+	//ClusterInfoReaderRoleName is the name for the role which allows reading the cluster-info ConfigMap
+	ClusterInfoReaderRoleName = "cluster-info"
 	//MachineControllerRoleName is the name for the MachineController roles
 	MachineControllerRoleName = "machine-controller"
 	//MachineControllerRoleBindingName is the name for the MachineController rolebinding
 	MachineControllerRoleBindingName = "machine-controller"
+	//ClusterInfoAnonymousRoleBindingName is the name for the RoleBinding giving access to the cluster-info ConfigMap to anonymous users
+	ClusterInfoAnonymousRoleBindingName = "cluster-info"
 	//MetricsServerAuthReaderRoleName is the name for the metrics server role
 	MetricsServerAuthReaderRoleName = "metrics-server-auth-reader"
 	//MachineControllerClusterRoleName is the name for the MachineController cluster role


### PR DESCRIPTION
**What this PR does / why we need it**:
Move cluster-info resources (ConfigMap, Role, RoleBinding) into dedicated resource functions to utilize the reconciling.
The old code was just creating the resources if they do not exist.

**Release note**:
```release-note
NONE
```
