### PR TITLE
return to avoid installing addon manifests for an deleted addon

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -281,6 +281,7 @@ func (c *Controller) sync(key string) error {
 		if err := c.removeCleanupFinalizer(addon); err != nil {
 			return fmt.Errorf("failed to ensure that the cleanup finalizer got removed from the addon: %v", err)
 		}
+		return nil
 	}
 
 	// Reconciling


### PR DESCRIPTION
**What this PR does / why we need it**:
Return to avoid installing addon manifests for an deleted addon.
Before the controller was installing the manifests after deleting them :man_facepalming: 

**Release note**:
```release-note
NONE
```
