### PR TITLE
increase QPS for user cluster interaction

### DIFF
--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -58,7 +58,17 @@ func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster) (*restclient.Config,
 		&clientcmd.ConfigOverrides{},
 		nil,
 	)
-	return iconfig.ClientConfig()
+
+	clientConfig, err := iconfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Avoid blocking of the controller by increasing the QPS for user cluster interaction
+	clientConfig.QPS = 20
+	clientConfig.Burst = 50
+
+	return clientConfig, err
 }
 
 // GetClient returns a kubernetes client to interact with the given cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to reduce the process time of a cluster within the cluster controller.
The cluster controller reconciles resources inside the seed cluster as well as inside the user cluster.
For resources inside the seed cluster the controller uses Lister for `GET` operations.
For resources inside the user cluster it issues a `GET` request against the API.

The cluster controller does currently 32 requests to the user cluster API server per sync.
This number does only include the `GET` requests, no the `PUT/POST` requests which happen when differences between desired&current state are found.

Each cluster takes currently ~1-3 seconds per sync - with an increasing number of clusters is a fatal bottleneck.
We're planning to fix this by having a own controller for those resources for each cluster.
But in the meantime, increasing the QPS sounds like a quick improvement.

**Release note**:
```release-note
NONE
```
