### PR TITLE
Cluster controller use feature flags

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -26,6 +26,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/kubermatic/kubermatic/api/pkg/features"
+
 	"github.com/golang/glog"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -184,7 +186,7 @@ func createOIDCAuthenticatorIssuer(options serverRunOptions) (handler.OIDCAuthen
 
 func createAPIHandler(options serverRunOptions, prov providers, oidcAuthenticator handler.OIDCAuthenticator, oidcIssuerVerifier handler.OIDCIssuerVerifier, updateManager *version.Manager) (http.HandlerFunc, error) {
 	var prometheusClient prometheusapi.Client
-	if options.featureGates.Enabled(PrometheusEndpoint) {
+	if options.featureGates.Enabled(features.PrometheusEndpoint) {
 		var err error
 		if prometheusClient, err = prometheusapi.NewClient(prometheusapi.Config{
 			Address: options.prometheusURL,
@@ -213,7 +215,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcAuthenticato
 	v1AlphaRouter := mainRouter.PathPrefix("/api/v1alpha").Subrouter()
 	r.RegisterV1(v1Router)
 	r.RegisterV1Optional(v1Router,
-		options.featureGates.Enabled(OIDCKubeCfgEndpoint),
+		options.featureGates.Enabled(features.OIDCKubeCfgEndpoint),
 		handler.OIDCConfiguration{
 			URL:                  options.oidcURL,
 			ClientID:             options.oidcIssuerClientID,

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -63,12 +63,12 @@ func newServerRunOptions() (serverRunOptions, error) {
 }
 
 func (o serverRunOptions) validate() error {
-	if o.featureGates.Enabled(OIDCKubeCfgEndpoint) {
+	if o.featureGates.Enabled(features.OIDCKubeCfgEndpoint) {
 		if len(o.oidcIssuerClientSecret) == 0 {
-			return fmt.Errorf("%s feature is enabled but \"oidc-client-secret\" flag was not specified", OIDCKubeCfgEndpoint)
+			return fmt.Errorf("%s feature is enabled but \"oidc-client-secret\" flag was not specified", features.OIDCKubeCfgEndpoint)
 		}
 		if len(o.oidcIssuerRedirectURI) == 0 {
-			return fmt.Errorf("%s feature is enabled but \"oidc-redirect-uri\" flag was not specified", OIDCKubeCfgEndpoint)
+			return fmt.Errorf("%s feature is enabled but \"oidc-redirect-uri\" flag was not specified", features.OIDCKubeCfgEndpoint)
 		}
 	}
 	return nil

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -114,6 +114,7 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.runOptions.inClusterPrometheusDisableDefaultScrapingConfigs,
 		ctrlCtx.runOptions.inClusterPrometheusScrapingConfigsFile,
 		dockerPullConfigJSON,
+		ctrlCtx.runOptions.featureGates,
 
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		ctrlCtx.kubeInformerFactory.Core().V1().Namespaces(),

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kubermatic/kubermatic/api/pkg/features"
+
 	"github.com/golang/glog"
 
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
@@ -73,6 +75,7 @@ type Controller struct {
 	inClusterPrometheusScrapingConfigsFile           string
 	monitoringScrapeAnnotationPrefix                 string
 	dockerPullConfigJSON                             []byte
+	featureGates                                     features.FeatureGate
 
 	clusterLister             kubermaticv1lister.ClusterLister
 	namespaceLister           corev1lister.NamespaceLister
@@ -110,6 +113,7 @@ func NewController(
 	inClusterPrometheusDisableDefaultScrapingConfigs bool,
 	inClusterPrometheusScrapingConfigsFile string,
 	dockerPullConfigJSON []byte,
+	featureGates features.FeatureGate,
 
 	clusterInformer kubermaticv1informers.ClusterInformer,
 	namespaceInformer corev1informers.NamespaceInformer,
@@ -143,6 +147,7 @@ func NewController(
 		inClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
 		monitoringScrapeAnnotationPrefix:                 monitoringScrapeAnnotationPrefix,
 		dockerPullConfigJSON:                             dockerPullConfigJSON,
+		featureGates:                                     featureGates,
 
 		externalURL: externalURL,
 		dc:          dc,

--- a/api/pkg/controller/cluster/cluster_controller_test.go
+++ b/api/pkg/controller/cluster/cluster_controller_test.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/kubermatic/kubermatic/api/pkg/features"
+
 	"github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	kubermaticfakeclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
@@ -49,6 +51,7 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		false,
 		"",
 		[]byte{},
+		features.FeatureGate{},
 
 		kubermaticInformerFactory.Kubermatic().V1().Clusters(),
 		kubeInformerFactory.Core().V1().Namespaces(),

--- a/api/pkg/features/available.go
+++ b/api/pkg/features/available.go
@@ -1,4 +1,4 @@
-package main
+package features
 
 const (
 	// All features for the kubermatic-api are defined below.


### PR DESCRIPTION
**What this PR does / why we need it**:
This moves the existing feature flags into the features package.
Additionally the featuresGates struct now gets used in the cluster-controller - to prepare for implementation of the OIDC feature.

**Release note**:
```release-note
NONE
```
