### PR TITLE
Add missing permissions to kube-state-metrics ClusterRole

### DIFF
--- a/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -5,6 +5,8 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
+  - configmaps
+  - secrets
   - nodes
   - pods
   - services


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing permissions to kube-state-metrics ClusterRole

See https://github.com/kubernetes/kube-state-metrics/commit/a30fefa304f1367919df9a48fdd3eb4fbc645f74

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note bugfix
Fixd missing permissions in kube-state-metrics ClusterRole
```
