### PR TITLE
kubernetes api deployment can setup openID connect

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -365,7 +365,10 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 		false,
 		false,
 		"",
-		nil), nil
+		nil,
+		false,
+		"",
+		""), nil
 }
 
 func createNamedSecrets(secretNames []string) *corev1.SecretList {

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -366,7 +366,7 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 		false,
 		"",
 		nil,
-		false,
+		"",
 		"",
 		""), nil
 }

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -130,6 +130,9 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.kubeInformerFactory.Rbac().V1().RoleBindings(),
 		ctrlCtx.kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
 		ctrlCtx.kubeInformerFactory.Policy().V1beta1().PodDisruptionBudgets(),
+		ctrlCtx.runOptions.oidcConnectEnable,
+		ctrlCtx.runOptions.oidcURL,
+		ctrlCtx.runOptions.oidcIssuerClientID,
 	)
 }
 

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -130,8 +130,8 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.kubeInformerFactory.Rbac().V1().RoleBindings(),
 		ctrlCtx.kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
 		ctrlCtx.kubeInformerFactory.Policy().V1beta1().PodDisruptionBudgets(),
-		ctrlCtx.runOptions.oidcConnectEnable,
-		ctrlCtx.runOptions.oidcURL,
+		ctrlCtx.runOptions.oidcCAFile,
+		ctrlCtx.runOptions.oidcIssuerURL,
 		ctrlCtx.runOptions.oidcIssuerClientID,
 	)
 }

--- a/api/cmd/kubermatic-controller-manager/features.go
+++ b/api/cmd/kubermatic-controller-manager/features.go
@@ -1,0 +1,9 @@
+package main
+
+const (
+	// All features for the kubermatic-controller-manager are defined below.
+
+	// OpenIDConnectTokens if enabled configures the flags on the API server to use
+	// OAuth2 identity providers.
+	OpenIDConnectTokens = "OpenIDConnectTokens"
+)

--- a/api/cmd/kubermatic-controller-manager/features.go
+++ b/api/cmd/kubermatic-controller-manager/features.go
@@ -3,7 +3,7 @@ package main
 const (
 	// All features for the kubermatic-controller-manager are defined below.
 
-	// OpenIDConnectTokens if enabled configures the flags on the API server to use
+	// OpenIDAuthPlugin if enabled configures the flags on the API server to use
 	// OAuth2 identity providers.
-	OpenIDConnectTokens = "OpenIDConnectTokens"
+	OpenIDAuthPlugin = "OpenIDAuthPlugin"
 )

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -49,10 +49,6 @@ func main() {
 		glog.Fatalf("incorrect flags were passed to the controller, err  = %v", err)
 	}
 
-	if options.featureGates.Enabled(OpenIDConnectTokens) {
-		options.oidcConnectEnable = true
-	}
-
 	config, err := clientcmd.BuildConfigFromFlags(options.masterURL, options.kubeconfig)
 	if err != nil {
 		glog.Fatal(err)

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"errors"
-	"flag"
+
 	"fmt"
 	"net/http"
 	"time"
@@ -14,21 +14,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/kubermatic/kubermatic/api/pkg/collectors"
-	backupcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/backup"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/leaderelection"
 	"github.com/kubermatic/kubermatic/api/pkg/metrics"
-	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/signals"
 	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/net"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -39,119 +35,25 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-type controllerRunOptions struct {
-	kubeconfig   string
-	masterURL    string
-	internalAddr string
-
-	masterResources                                  string
-	externalURL                                      string
-	dc                                               string
-	dcFile                                           string
-	workerName                                       string
-	versionsFile                                     string
-	updatesFile                                      string
-	workerCount                                      int
-	overwriteRegistry                                string
-	nodePortRange                                    string
-	nodeAccessNetwork                                string
-	addonsPath                                       string
-	addonsList                                       string
-	backupContainerFile                              string
-	cleanupContainerFile                             string
-	backupContainerImage                             string
-	backupInterval                                   string
-	etcdDiskSize                                     string
-	inClusterPrometheusRulesFile                     string
-	inClusterPrometheusDisableDefaultRules           bool
-	inClusterPrometheusDisableDefaultScrapingConfigs bool
-	inClusterPrometheusScrapingConfigsFile           string
-	monitoringScrapeAnnotationPrefix                 string
-	dockerPullConfigJSONFile                         string
-}
-
-type controllerContext struct {
-	runOptions                controllerRunOptions
-	stopCh                    <-chan struct{}
-	kubeClient                kubernetes.Interface
-	kubermaticClient          kubermaticclientset.Interface
-	kubermaticInformerFactory kubermaticinformers.SharedInformerFactory
-	kubeInformerFactory       kubeinformers.SharedInformerFactory
-}
-
 const (
 	controllerName = "kubermatic-controller-manager"
 )
 
 func main() {
-	runOp := controllerRunOptions{}
-	flag.StringVar(&runOp.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&runOp.masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&runOp.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the internal server is running on")
-	flag.StringVar(&runOp.masterResources, "master-resources", "", "The path to the master resources (Required).")
-	flag.StringVar(&runOp.externalURL, "external-url", "", "The external url for the apiserver host and the the dc.(Required)")
-	flag.StringVar(&runOp.dc, "datacenter-name", "", "The name of the seed datacenter, the controller is running in. It will be used to build the absolute url for a customer cluster.")
-	flag.StringVar(&runOp.dcFile, "datacenters", "datacenters.yaml", "The datacenters.yaml file path")
-	flag.StringVar(&runOp.workerName, "worker-name", "", "The name of the worker that will only processes resources with label=worker-name.")
-	flag.StringVar(&runOp.versionsFile, "versions", "versions.yaml", "The versions.yaml file path")
-	flag.StringVar(&runOp.updatesFile, "updates", "updates.yaml", "The updates.yaml file path")
-	flag.IntVar(&runOp.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
-	flag.StringVar(&runOp.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
-	flag.StringVar(&runOp.nodePortRange, "nodeport-range", "30000-32767", "NodePort range to use for new clusters. It must be within the NodePort range of the seed-cluster")
-	flag.StringVar(&runOp.nodeAccessNetwork, "node-access-network", "10.254.0.0/16", "A network which allows direct access to nodes via VPN. Uses CIDR notation.")
-	flag.StringVar(&runOp.addonsPath, "addons-path", "/opt/addons", "Path to addon manifests. Should contain sub-folders for each addon")
-	flag.StringVar(&runOp.addonsList, "addons-list", "canal,dashboard,dns,kube-proxy,openvpn,rbac,kubelet-configmap,default-storage-class", "Comma separated list of Addons to install into every user-cluster")
-	flag.StringVar(&runOp.backupContainerFile, "backup-container", "", fmt.Sprintf("[Required] Filepath of a backup container yaml. It must mount a volume named %s from which it reads the etcd backups", backupcontroller.SharedVolumeName))
-	flag.StringVar(&runOp.cleanupContainerFile, "cleanup-container", "", "[Required] Filepath of a cleanup container yaml. The container will be used to cleanup the backup directory for a cluster after it got deleted.")
-	flag.StringVar(&runOp.backupContainerImage, "backup-container-init-image", backupcontroller.DefaultBackupContainerImage, "Docker image to use for the init container in the backup job, must be an etcd v3 image. Only set this if your cluster can not use the public quay.io registry")
-	flag.StringVar(&runOp.backupInterval, "backup-interval", backupcontroller.DefaultBackupInterval, "Interval in which the etcd gets backed up")
-	flag.StringVar(&runOp.etcdDiskSize, "etcd-disk-size", "5Gi", "Size for the etcd PV's. Only applies to new clusters.")
-	flag.StringVar(&runOp.inClusterPrometheusRulesFile, "in-cluster-prometheus-rules-file", "", "The file containing the custom alerting rules for the prometheus running in the cluster-foo namespaces.")
-	flag.BoolVar(&runOp.inClusterPrometheusDisableDefaultRules, "in-cluster-prometheus-disable-default-rules", false, "A flag indicating whether the default rules for the prometheus running in the cluster-foo namespaces should be deployed.")
-	flag.StringVar(&runOp.dockerPullConfigJSONFile, "docker-pull-config-json-file", "config.json", "The file containing the docker auth config.")
-	flag.BoolVar(&runOp.inClusterPrometheusDisableDefaultScrapingConfigs, "in-cluster-prometheus-disable-default-scraping-configs", false, "A flag indicating whether the default scraping configs for the prometheus running in the cluster-foo namespaces should be deployed.")
-	flag.StringVar(&runOp.inClusterPrometheusScrapingConfigsFile, "in-cluster-prometheus-scraping-configs-file", "", "The file containing the custom scraping configs for the prometheus running in the cluster-foo namespaces.")
-	flag.StringVar(&runOp.monitoringScrapeAnnotationPrefix, "monitoring-scrape-annotation-prefix", "monitoring.kubermatic.io", "The prefix for monitoring annotations in the user cluster. Default: monitoring.kubermatic.io -> monitoring.kubermatic.io/port, monitoring.kubermatic.io/path")
-	flag.Parse()
 
-	if runOp.masterResources == "" {
-		glog.Fatal("master-resources path is undefined\n\n")
-	}
-
-	if runOp.externalURL == "" {
-		glog.Fatal("external-url is undefined\n\n")
-	}
-
-	if runOp.dc == "" {
-		glog.Fatal("datacenter-name is undefined")
-	}
-
-	if runOp.backupContainerFile == "" {
-		glog.Fatal("backup-container is undefined")
-	}
-
-	if runOp.dockerPullConfigJSONFile == "" {
-		glog.Fatal("docker-pull-config-json-file is undefined")
-	}
-
-	if runOp.monitoringScrapeAnnotationPrefix == "" {
-		glog.Fatal("moniotring-scrape-annotation-prefix is undefined")
-	}
-
-	// Validate etcd disk size
-	resource.MustParse(runOp.etcdDiskSize)
-
-	// Validate node-port range
-	net.ParsePortRangeOrDie(runOp.nodePortRange)
-
-	// dcFile, versionFile, updatesFile are required by cluster controller
-	// the following code ensures that the files are available and fails fast if not.
-	_, err := provider.LoadDatacentersMeta(runOp.dcFile)
+	options, err := newControllerRunOptions()
 	if err != nil {
-		glog.Fatalf("failed to load datacenter yaml %q: %v", runOp.dcFile, err)
+		glog.Fatalf("failed to create controller run options due to = %v", err)
+	}
+	if err := options.validate(); err != nil {
+		glog.Fatalf("incorrect flags were passed to the controller, err  = %v", err)
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags(runOp.masterURL, runOp.kubeconfig)
+	if options.featureGates.Enabled(OpenIDConnectTokens) {
+		options.oidcConnectEnable = true
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags(options.masterURL, options.kubeconfig)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -173,7 +75,7 @@ func main() {
 	defer ctxDone()
 
 	// Create Context
-	ctrlCtx, err := newControllerContext(runOp, ctx.Done(), kubeClient, kubermaticClient)
+	ctrlCtx, err := newControllerContext(options, ctx.Done(), kubeClient, kubermaticClient)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -211,14 +113,14 @@ func main() {
 		m.Handle("/metrics", promhttp.Handler())
 
 		s := http.Server{
-			Addr:         runOp.internalAddr,
+			Addr:         options.internalAddr,
 			Handler:      m,
 			ReadTimeout:  5 * time.Second,
 			WriteTimeout: 10 * time.Second,
 		}
 
 		g.Add(func() error {
-			glog.Infof("Starting the internal http server: %s\n", runOp.internalAddr)
+			glog.Infof("Starting the internal http server: %s\n", options.internalAddr)
 			err := s.ListenAndServe()
 			if err != nil {
 				return fmt.Errorf("internal http server failed: %v", err)
@@ -257,8 +159,8 @@ func main() {
 			}
 
 			leaderName := controllerName
-			if runOp.workerName != "" {
-				leaderName = runOp.workerName + "-" + leaderName
+			if options.workerName != "" {
+				leaderName = options.workerName + "-" + leaderName
 			}
 			leader, err := leaderelection.New(leaderName, leaderElectionClient, recorder, callbacks)
 			if err != nil {

--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+
+	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/net"
+	kubeinformers "k8s.io/client-go/informers"
+
+	"github.com/kubermatic/kubermatic/api/pkg/features"
+
+	backupcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/backup"
+)
+
+type controllerRunOptions struct {
+	kubeconfig   string
+	masterURL    string
+	internalAddr string
+
+	masterResources                                  string
+	externalURL                                      string
+	dc                                               string
+	dcFile                                           string
+	workerName                                       string
+	versionsFile                                     string
+	updatesFile                                      string
+	workerCount                                      int
+	overwriteRegistry                                string
+	nodePortRange                                    string
+	nodeAccessNetwork                                string
+	addonsPath                                       string
+	addonsList                                       string
+	backupContainerFile                              string
+	cleanupContainerFile                             string
+	backupContainerImage                             string
+	backupInterval                                   string
+	etcdDiskSize                                     string
+	inClusterPrometheusRulesFile                     string
+	inClusterPrometheusDisableDefaultRules           bool
+	inClusterPrometheusDisableDefaultScrapingConfigs bool
+	inClusterPrometheusScrapingConfigsFile           string
+	monitoringScrapeAnnotationPrefix                 string
+	dockerPullConfigJSONFile                         string
+
+	// OIDC configuration
+	oidcConnectEnable  bool
+	oidcURL            string
+	oidcIssuerClientID string
+
+	featureGates features.FeatureGate
+}
+
+func newControllerRunOptions() (controllerRunOptions, error) {
+	c := controllerRunOptions{}
+	var rawFeatureGates string
+
+	flag.StringVar(&c.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&c.masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&c.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the internal server is running on")
+	flag.StringVar(&c.masterResources, "master-resources", "", "The path to the master resources (Required).")
+	flag.StringVar(&c.externalURL, "external-url", "", "The external url for the apiserver host and the the dc.(Required)")
+	flag.StringVar(&c.dc, "datacenter-name", "", "The name of the seed datacenter, the controller is running in. It will be used to build the absolute url for a customer cluster.")
+	flag.StringVar(&c.dcFile, "datacenters", "datacenters.yaml", "The datacenters.yaml file path")
+	flag.StringVar(&c.workerName, "worker-name", "", "The name of the worker that will only processes resources with label=worker-name.")
+	flag.StringVar(&c.versionsFile, "versions", "versions.yaml", "The versions.yaml file path")
+	flag.StringVar(&c.updatesFile, "updates", "updates.yaml", "The updates.yaml file path")
+	flag.IntVar(&c.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
+	flag.StringVar(&c.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
+	flag.StringVar(&c.nodePortRange, "nodeport-range", "30000-32767", "NodePort range to use for new clusters. It must be within the NodePort range of the seed-cluster")
+	flag.StringVar(&c.nodeAccessNetwork, "node-access-network", "10.254.0.0/16", "A network which allows direct access to nodes via VPN. Uses CIDR notation.")
+	flag.StringVar(&c.addonsPath, "addons-path", "/opt/addons", "Path to addon manifests. Should contain sub-folders for each addon")
+	flag.StringVar(&c.addonsList, "addons-list", "canal,dashboard,dns,kube-proxy,openvpn,rbac,kubelet-configmap,default-storage-class", "Comma separated list of Addons to install into every user-cluster")
+	flag.StringVar(&c.backupContainerFile, "backup-container", "", fmt.Sprintf("[Required] Filepath of a backup container yaml. It must mount a volume named %s from which it reads the etcd backups", backupcontroller.SharedVolumeName))
+	flag.StringVar(&c.cleanupContainerFile, "cleanup-container", "", "[Required] Filepath of a cleanup container yaml. The container will be used to cleanup the backup directory for a cluster after it got deleted.")
+	flag.StringVar(&c.backupContainerImage, "backup-container-init-image", backupcontroller.DefaultBackupContainerImage, "Docker image to use for the init container in the backup job, must be an etcd v3 image. Only set this if your cluster can not use the public quay.io registry")
+	flag.StringVar(&c.backupInterval, "backup-interval", backupcontroller.DefaultBackupInterval, "Interval in which the etcd gets backed up")
+	flag.StringVar(&c.etcdDiskSize, "etcd-disk-size", "5Gi", "Size for the etcd PV's. Only applies to new clusters.")
+	flag.StringVar(&c.inClusterPrometheusRulesFile, "in-cluster-prometheus-rules-file", "", "The file containing the custom alerting rules for the prometheus running in the cluster-foo namespaces.")
+	flag.BoolVar(&c.inClusterPrometheusDisableDefaultRules, "in-cluster-prometheus-disable-default-rules", false, "A flag indicating whether the default rules for the prometheus running in the cluster-foo namespaces should be deployed.")
+	flag.StringVar(&c.dockerPullConfigJSONFile, "docker-pull-config-json-file", "config.json", "The file containing the docker auth config.")
+	flag.BoolVar(&c.inClusterPrometheusDisableDefaultScrapingConfigs, "in-cluster-prometheus-disable-default-scraping-configs", false, "A flag indicating whether the default scraping configs for the prometheus running in the cluster-foo namespaces should be deployed.")
+	flag.StringVar(&c.inClusterPrometheusScrapingConfigsFile, "in-cluster-prometheus-scraping-configs-file", "", "The file containing the custom scraping configs for the prometheus running in the cluster-foo namespaces.")
+	flag.StringVar(&c.monitoringScrapeAnnotationPrefix, "monitoring-scrape-annotation-prefix", "monitoring.kubermatic.io", "The prefix for monitoring annotations in the user cluster. Default: monitoring.kubermatic.io -> monitoring.kubermatic.io/port, monitoring.kubermatic.io/path")
+	flag.StringVar(&rawFeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for various features.")
+	flag.StringVar(&c.oidcURL, "oidc-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
+	flag.StringVar(&c.oidcIssuerClientID, "oidc-issuer-client-id", "", "Issuer client ID")
+	flag.Parse()
+
+	featureGates, err := features.NewFeatures(rawFeatureGates)
+	if err != nil {
+		return c, err
+	}
+	c.featureGates = featureGates
+	return c, nil
+}
+
+func (o controllerRunOptions) validate() error {
+
+	if o.featureGates.Enabled(OpenIDConnectTokens) {
+		if len(o.oidcURL) == 0 {
+			return fmt.Errorf("%s feature is enabled but \"oidc-url\" flag was not specified", OpenIDConnectTokens)
+		}
+		if len(o.oidcIssuerClientID) == 0 {
+			return fmt.Errorf("%s feature is enabled but \"oidc-issuer-client-id\" flag was not specified", OpenIDConnectTokens)
+		}
+	}
+
+	if o.masterResources == "" {
+		return fmt.Errorf("master-resources path is undefined")
+	}
+
+	if o.externalURL == "" {
+		return fmt.Errorf("external-url is undefined")
+	}
+
+	if o.dc == "" {
+		return fmt.Errorf("datacenter-name is undefined")
+	}
+
+	if o.backupContainerFile == "" {
+		return fmt.Errorf("backup-container is undefined")
+	}
+
+	if o.dockerPullConfigJSONFile == "" {
+		return fmt.Errorf("docker-pull-config-json-file is undefined")
+	}
+
+	if o.monitoringScrapeAnnotationPrefix == "" {
+		return fmt.Errorf("moniotring-scrape-annotation-prefix is undefined")
+	}
+
+	// Validate etcd disk size
+	resource.MustParse(o.etcdDiskSize)
+
+	// Validate node-port range
+	net.ParsePortRangeOrDie(o.nodePortRange)
+
+	// dcFile, versionFile, updatesFile are required by cluster controller
+	// the following code ensures that the files are available and fails fast if not.
+	_, err := provider.LoadDatacentersMeta(o.dcFile)
+	if err != nil {
+		return fmt.Errorf("failed to load datacenter yaml %q: %v", o.dcFile, err)
+	}
+	return nil
+}
+
+type controllerContext struct {
+	runOptions                controllerRunOptions
+	stopCh                    <-chan struct{}
+	kubeClient                kubernetes.Interface
+	kubermaticClient          kubermaticclientset.Interface
+	kubermaticInformerFactory kubermaticinformers.SharedInformerFactory
+	kubeInformerFactory       kubeinformers.SharedInformerFactory
+}

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -89,6 +89,10 @@ type Controller struct {
 	roleBindingLister         rbacb1lister.RoleBindingLister
 	clusterRoleBindingLister  rbacb1lister.ClusterRoleBindingLister
 	podDisruptionBudgetLister policyv1beta1lister.PodDisruptionBudgetLister
+
+	oidcConnectTemplateEnable bool
+	oidcURL                   string
+	oidcIssuerClientID        string
 }
 
 // NewController creates a cluster controller.
@@ -125,7 +129,10 @@ func NewController(
 	roleInformer rbacv1informer.RoleInformer,
 	roleBindingInformer rbacv1informer.RoleBindingInformer,
 	clusterRoleBindingInformer rbacv1informer.ClusterRoleBindingInformer,
-	podDisruptionBudgetInformer policyv1beta1informers.PodDisruptionBudgetInformer) (*Controller, error) {
+	podDisruptionBudgetInformer policyv1beta1informers.PodDisruptionBudgetInformer,
+	oidcConnectTemplateEnable bool,
+	oidcURL string,
+	oidcIssuerClientID string) (*Controller, error) {
 	cc := &Controller{
 		kubermaticClient:        kubermaticClient,
 		kubeClient:              kubeClient,
@@ -148,6 +155,10 @@ func NewController(
 		dc:          dc,
 		dcs:         dcs,
 		cps:         cps,
+
+		oidcConnectTemplateEnable: oidcConnectTemplateEnable,
+		oidcURL:                   oidcURL,
+		oidcIssuerClientID:        oidcIssuerClientID,
 	}
 
 	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -90,9 +90,9 @@ type Controller struct {
 	clusterRoleBindingLister  rbacb1lister.ClusterRoleBindingLister
 	podDisruptionBudgetLister policyv1beta1lister.PodDisruptionBudgetLister
 
-	oidcConnectTemplateEnable bool
-	oidcURL                   string
-	oidcIssuerClientID        string
+	oidcCAFile         string
+	oidcIssuerURL      string
+	oidcIssuerClientID string
 }
 
 // NewController creates a cluster controller.
@@ -130,8 +130,8 @@ func NewController(
 	roleBindingInformer rbacv1informer.RoleBindingInformer,
 	clusterRoleBindingInformer rbacv1informer.ClusterRoleBindingInformer,
 	podDisruptionBudgetInformer policyv1beta1informers.PodDisruptionBudgetInformer,
-	oidcConnectTemplateEnable bool,
-	oidcURL string,
+	oidcCAFile string,
+	oidcIssuerURL string,
 	oidcIssuerClientID string) (*Controller, error) {
 	cc := &Controller{
 		kubermaticClient:        kubermaticClient,
@@ -156,9 +156,9 @@ func NewController(
 		dcs:         dcs,
 		cps:         cps,
 
-		oidcConnectTemplateEnable: oidcConnectTemplateEnable,
-		oidcURL:                   oidcURL,
-		oidcIssuerClientID:        oidcIssuerClientID,
+		oidcCAFile:         oidcCAFile,
+		oidcIssuerURL:      oidcIssuerURL,
+		oidcIssuerClientID: oidcIssuerClientID,
 	}
 
 	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/api/pkg/controller/cluster/cluster_controller_test.go
+++ b/api/pkg/controller/cluster/cluster_controller_test.go
@@ -65,7 +65,7 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		kubeInformerFactory.Rbac().V1().RoleBindings(),
 		kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
 		kubeInformerFactory.Policy().V1beta1().PodDisruptionBudgets(),
-		false,
+		"",
 		"",
 		"",
 	)

--- a/api/pkg/controller/cluster/cluster_controller_test.go
+++ b/api/pkg/controller/cluster/cluster_controller_test.go
@@ -65,6 +65,9 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		kubeInformerFactory.Rbac().V1().RoleBindings(),
 		kubeInformerFactory.Rbac().V1().ClusterRoleBindings(),
 		kubeInformerFactory.Policy().V1beta1().PodDisruptionBudgets(),
+		false,
+		"",
+		"",
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -93,8 +93,8 @@ func (cc *Controller) getClusterTemplateData(c *kubermaticv1.Cluster) (*resource
 		cc.inClusterPrometheusDisableDefaultScrapingConfigs,
 		cc.inClusterPrometheusScrapingConfigsFile,
 		cc.dockerPullConfigJSON,
-		cc.oidcConnectTemplateEnable,
-		cc.oidcURL,
+		cc.oidcCAFile,
+		cc.oidcIssuerURL,
 		cc.oidcIssuerClientID,
 	), nil
 }

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -93,6 +93,9 @@ func (cc *Controller) getClusterTemplateData(c *kubermaticv1.Cluster) (*resource
 		cc.inClusterPrometheusDisableDefaultScrapingConfigs,
 		cc.inClusterPrometheusScrapingConfigsFile,
 		cc.dockerPullConfigJSON,
+		cc.oidcConnectTemplateEnable,
+		cc.oidcURL,
+		cc.oidcIssuerClientID,
 	), nil
 }
 

--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -88,7 +88,7 @@ func TestConfigMapCreatorsKeepAdditionalData(t *testing.T) {
 	cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.11.0.0/8"}
 	cluster.Spec.Version = *semver.NewSemverOrDie("v1.11.1")
 	dc := &provider.DatacenterMeta{}
-	templateData := resources.NewTemplateData(cluster, dc, "", nil, nil, nil, "", "", "10.12.0.0/8", resource.Quantity{}, "", "", false, false, "", nil)
+	templateData := resources.NewTemplateData(cluster, dc, "", nil, nil, nil, "", "", "10.12.0.0/8", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
 
 	for _, create := range GetConfigMapCreators(templateData) {
 		existing := &corev1.ConfigMap{
@@ -181,7 +181,7 @@ func TestSecretV2CreatorsKeepAdditionalData(t *testing.T) {
 	}
 	serviceLister := listerscorev1.NewServiceLister(serviceIndexer)
 
-	templateData := resources.NewTemplateData(cluster, dc, "", secretLister, nil, serviceLister, "", "", "", resource.Quantity{}, "", "", false, false, "", nil)
+	templateData := resources.NewTemplateData(cluster, dc, "", secretLister, nil, serviceLister, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
 
 	for _, op := range GetSecretCreatorOperations([]byte{}) {
 		existing := &corev1.Secret{

--- a/api/pkg/controller/cluster/resources_test.go
+++ b/api/pkg/controller/cluster/resources_test.go
@@ -88,7 +88,7 @@ func TestConfigMapCreatorsKeepAdditionalData(t *testing.T) {
 	cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.11.0.0/8"}
 	cluster.Spec.Version = *semver.NewSemverOrDie("v1.11.1")
 	dc := &provider.DatacenterMeta{}
-	templateData := resources.NewTemplateData(cluster, dc, "", nil, nil, nil, "", "", "10.12.0.0/8", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
+	templateData := resources.NewTemplateData(cluster, dc, "", nil, nil, nil, "", "", "10.12.0.0/8", resource.Quantity{}, "", "", false, false, "", nil, "", "", "")
 
 	for _, create := range GetConfigMapCreators(templateData) {
 		existing := &corev1.ConfigMap{
@@ -181,7 +181,7 @@ func TestSecretV2CreatorsKeepAdditionalData(t *testing.T) {
 	}
 	serviceLister := listerscorev1.NewServiceLister(serviceIndexer)
 
-	templateData := resources.NewTemplateData(cluster, dc, "", secretLister, nil, serviceLister, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
+	templateData := resources.NewTemplateData(cluster, dc, "", secretLister, nil, serviceLister, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, "", "", "")
 
 	for _, op := range GetSecretCreatorOperations([]byte{}) {
 		existing := &corev1.Secret{

--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -33,6 +33,9 @@ func (c *Controller) getClusterTemplateData(cluster *kubermaticv1.Cluster) (*res
 		c.inClusterPrometheusDisableDefaultScrapingConfigs,
 		c.inClusterPrometheusScrapingConfigsFile,
 		c.dockerPullConfigJSON,
+		false,
+		"",
+		"",
 	), nil
 }
 

--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -33,7 +33,7 @@ func (c *Controller) getClusterTemplateData(cluster *kubermaticv1.Cluster) (*res
 		c.inClusterPrometheusDisableDefaultScrapingConfigs,
 		c.inClusterPrometheusScrapingConfigsFile,
 		c.dockerPullConfigJSON,
-		false,
+		"",
 		"",
 		"",
 	), nil

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -318,10 +318,13 @@ func getApiserverFlags(data resources.DeploymentDataProvider, externalNodePort i
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
 	}
 
-	if data.OIDCConnectEnable() {
-		flags = append(flags, "--oidc-issuer-url", "https://dev.kubermatic.io/dex")
-		flags = append(flags, "--oidc-client-id", "kubermaticIssuer")
+	if data.OIDCAuthPluginEnabled() {
+		flags = append(flags, "--oidc-issuer-url", data.OIDCIssuerURL())
+		flags = append(flags, "--oidc-client-id", data.OIDCIssuerClientID())
 		flags = append(flags, "--oidc-username-claim", "email")
+		if len(data.OIDCCAFile()) > 0 {
+			flags = append(flags, "--oidc-ca-file", data.OIDCCAFile())
+		}
 	}
 
 	return flags, nil

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -318,6 +318,12 @@ func getApiserverFlags(data resources.DeploymentDataProvider, externalNodePort i
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
 	}
 
+	if data.OIDCConnectEnable() {
+		flags = append(flags, "--oidc-issuer-url", "https://dev.kubermatic.io/dex")
+		flags = append(flags, "--oidc-client-id", "kubermaticIssuer")
+		flags = append(flags, "--oidc-username-claim", "email")
+	}
+
 	return flags, nil
 }
 

--- a/api/pkg/resources/apiserver/deployment_test.go
+++ b/api/pkg/resources/apiserver/deployment_test.go
@@ -38,7 +38,7 @@ func TestGetAdmissionControlFlags(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		templateData := resources.NewTemplateData(&kubermaticv1.Cluster{}, nil, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
+		templateData := resources.NewTemplateData(&kubermaticv1.Cluster{}, nil, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, "", "", "")
 		templateData.Cluster().Spec.Version = *semver.NewSemverOrDie(test.kubernetesVersion)
 
 		admissionControlFlagName, admissionControlFlagValue := getAdmissionControlFlags(templateData)

--- a/api/pkg/resources/apiserver/deployment_test.go
+++ b/api/pkg/resources/apiserver/deployment_test.go
@@ -38,7 +38,7 @@ func TestGetAdmissionControlFlags(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		templateData := resources.NewTemplateData(&kubermaticv1.Cluster{}, nil, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil)
+		templateData := resources.NewTemplateData(&kubermaticv1.Cluster{}, nil, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
 		templateData.Cluster().Spec.Version = *semver.NewSemverOrDie(test.kubernetesVersion)
 
 		admissionControlFlagName, admissionControlFlagValue := getAdmissionControlFlags(templateData)

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -34,8 +34,8 @@ type TemplateData struct {
 	inClusterPrometheusDisableDefaultRules           bool
 	inClusterPrometheusDisableDefaultScrapingConfigs bool
 	inClusterPrometheusScrapingConfigsFile           string
-	oidcConnectEnable                                bool
-	oidcURL                                          string
+	oidcCAFile                                       string
+	oidcIssuerURL                                    string
 	oidcIssuerClientID                               string
 	DockerPullConfigJSON                             []byte
 }
@@ -125,8 +125,9 @@ type DeploymentDataProvider interface {
 	ImageRegistry(string) string
 	Cluster() *kubermaticv1.Cluster
 	DC() *provider.DatacenterMeta
-	OIDCConnectEnable() bool
-	OIDCURL() string
+	OIDCAuthPluginEnabled() bool
+	OIDCCAFile() string
+	OIDCIssuerURL() string
 	OIDCIssuerClientID() string
 }
 
@@ -153,7 +154,7 @@ func NewTemplateData(
 	inClusterPrometheusDisableDefaultScrapingConfigs bool,
 	inClusterPrometheusScrapingConfigsFile string,
 	dockerPullConfigJSON []byte,
-	oidcConnectEnable bool,
+	oidcCAFile string,
 	oidcURL string,
 	oidcIssuerClientID string) *TemplateData {
 	return &TemplateData{
@@ -173,20 +174,25 @@ func NewTemplateData(
 		inClusterPrometheusDisableDefaultScrapingConfigs: inClusterPrometheusDisableDefaultScrapingConfigs,
 		inClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
 		DockerPullConfigJSON:                             dockerPullConfigJSON,
-		oidcConnectEnable:                                oidcConnectEnable,
-		oidcURL:                                          oidcURL,
+		oidcCAFile:                                       oidcCAFile,
+		oidcIssuerURL:                                    oidcURL,
 		oidcIssuerClientID:                               oidcIssuerClientID,
 	}
 }
 
-// OIDCConnectEnable returns flag to indicate if OpenID connect enabled
-func (d *TemplateData) OIDCConnectEnable() bool {
-	return d.oidcConnectEnable
+// OIDCAuthPluginEnabled returns flag to indicate if OpenID auth plugin enabled
+func (d *TemplateData) OIDCAuthPluginEnabled() bool {
+	return len(d.oidcIssuerURL) > 0 && len(d.oidcIssuerClientID) > 0
 }
 
-// OIDCURL returns URL of the OpenID token issuer
-func (d *TemplateData) OIDCURL() string {
-	return d.oidcURL
+// OIDCCAFile return CA file
+func (d *TemplateData) OIDCCAFile() string {
+	return d.oidcCAFile
+}
+
+// OIDCIssuerURL returns URL of the OpenID token issuer
+func (d *TemplateData) OIDCIssuerURL() string {
+	return d.oidcIssuerURL
 }
 
 // OIDCIssuerClientID return the issuer client ID

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -34,6 +34,9 @@ type TemplateData struct {
 	inClusterPrometheusDisableDefaultRules           bool
 	inClusterPrometheusDisableDefaultScrapingConfigs bool
 	inClusterPrometheusScrapingConfigsFile           string
+	oidcConnectEnable                                bool
+	oidcURL                                          string
+	oidcIssuerClientID                               string
 	DockerPullConfigJSON                             []byte
 }
 
@@ -122,6 +125,9 @@ type DeploymentDataProvider interface {
 	ImageRegistry(string) string
 	Cluster() *kubermaticv1.Cluster
 	DC() *provider.DatacenterMeta
+	OIDCConnectEnable() bool
+	OIDCURL() string
+	OIDCIssuerClientID() string
 }
 
 // StatefulSetDataProvider provides data
@@ -146,7 +152,10 @@ func NewTemplateData(
 	inClusterPrometheusDisableDefaultRules bool,
 	inClusterPrometheusDisableDefaultScrapingConfigs bool,
 	inClusterPrometheusScrapingConfigsFile string,
-	dockerPullConfigJSON []byte) *TemplateData {
+	dockerPullConfigJSON []byte,
+	oidcConnectEnable bool,
+	oidcURL string,
+	oidcIssuerClientID string) *TemplateData {
 	return &TemplateData{
 		cluster:                                cluster,
 		dC:                                     dc,
@@ -164,7 +173,25 @@ func NewTemplateData(
 		inClusterPrometheusDisableDefaultScrapingConfigs: inClusterPrometheusDisableDefaultScrapingConfigs,
 		inClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
 		DockerPullConfigJSON:                             dockerPullConfigJSON,
+		oidcConnectEnable:                                oidcConnectEnable,
+		oidcURL:                                          oidcURL,
+		oidcIssuerClientID:                               oidcIssuerClientID,
 	}
+}
+
+// OIDCConnectEnable returns flag to indicate if OpenID connect enabled
+func (d *TemplateData) OIDCConnectEnable() bool {
+	return d.oidcConnectEnable
+}
+
+// OIDCURL returns URL of the OpenID token issuer
+func (d *TemplateData) OIDCURL() string {
+	return d.oidcURL
+}
+
+// OIDCIssuerClientID return the issuer client ID
+func (d *TemplateData) OIDCIssuerClientID() string {
+	return d.oidcIssuerClientID
 }
 
 // Cluster returns the cluster

--- a/api/pkg/resources/machine/machine.go
+++ b/api/pkg/resources/machine/machine.go
@@ -55,7 +55,7 @@ func Machine(c *kubermaticv1.Cluster, node *apiv1.Node, dc provider.DatacenterMe
 		// We use OverwriteCloudConfig for Vsphere to ensure we always
 		// use the credentials passed in via frontend for the cloud-provider
 		// functionality
-		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil)
+		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
 		overwriteCloudConfig, err := cloudconfig.CloudConfig(templateData)
 		if err != nil {
 			return nil, err

--- a/api/pkg/resources/machine/machine.go
+++ b/api/pkg/resources/machine/machine.go
@@ -55,7 +55,7 @@ func Machine(c *kubermaticv1.Cluster, node *apiv1.Node, dc provider.DatacenterMe
 		// We use OverwriteCloudConfig for Vsphere to ensure we always
 		// use the credentials passed in via frontend for the cloud-provider
 		// functionality
-		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
+		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, "", "", "")
 		overwriteCloudConfig, err := cloudconfig.CloudConfig(templateData)
 		if err != nil {
 			return nil, err

--- a/api/pkg/resources/machine/machinedeployment.go
+++ b/api/pkg/resources/machine/machinedeployment.go
@@ -76,7 +76,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc provider.D
 		// We use OverwriteCloudConfig for Vsphere to ensure we always
 		// use the credentials passed in via frontend for the cloud-provider
 		// functionality
-		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
+		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, "", "", "")
 		overwriteCloudConfig, err := cloudconfig.CloudConfig(templateData)
 		if err != nil {
 			return nil, err

--- a/api/pkg/resources/machine/machinedeployment.go
+++ b/api/pkg/resources/machine/machinedeployment.go
@@ -76,7 +76,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc provider.D
 		// We use OverwriteCloudConfig for Vsphere to ensure we always
 		// use the credentials passed in via frontend for the cloud-provider
 		// functionality
-		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil)
+		templateData := resources.NewTemplateData(c, &dc, "", nil, nil, nil, "", "", "", resource.Quantity{}, "", "", false, false, "", nil, false, "", "")
 		overwriteCloudConfig, err := cloudconfig.CloudConfig(templateData)
 		if err != nil {
 			return nil, err

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -494,6 +494,9 @@ func TestLoadFiles(t *testing.T) {
 					false,
 					tmpFilePath,
 					nil,
+					false,
+					"",
+					"",
 				)
 				kubeInformerFactory.Start(wait.NeverStop)
 				kubeInformerFactory.WaitForCacheSync(wait.NeverStop)

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -494,7 +494,7 @@ func TestLoadFiles(t *testing.T) {
 					false,
 					tmpFilePath,
 					nil,
-					false,
+					"",
 					"",
 					"",
 				)


### PR DESCRIPTION
**What this PR does / why we need it**: configure k8s API server settings in clusters to accept OpenID. The OIDC settings are optional and can be enabled by passing additional command line flags.

```release-note
Kubernetes API servers can now be used with OpenID authentication
[ACTION REQUIRED] to enable the OpenID for kubernetes API server the users must set `-feature-gates=OpenIDConnectTokens=true` and provide `-oidc-issuer-url`, `-oidc-issuer-client-id` when running the controller.
```