### PR TITLE
CI: deploy 2.8 on run.kubermatic.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -400,7 +400,7 @@ pipeline:
     values:
     - values
     when:
-      branch: release/v2.7
+      branch: release/v2.8
   slack:
     channel: dev
     group: slack


### PR DESCRIPTION
**What this PR does / why we need it**:
A step towards #2334, although it requires backports to v2.8 and v2.7 branches as well.

```release-note
NONE
```
