### PR TITLE
CI: deploy 2.8 on run.kubermatic.io (#2371)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -367,7 +367,7 @@ pipeline:
     values:
     - values
     when:
-      branch: release/v2.7
+      branch: release/v2.8
   e2e-on-master:
     commands:
     - echo "$KUBECONFIG" | base64 -d > /tmp/kubeconfig


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick #2371

```release-note
NONE
```
