### PR TITLE
.drone.yaml: remove incorrect tiller namespace setting (#2374)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -353,7 +353,7 @@ pipeline:
     - name: prometheus
       namespace: monitoring
       path: config/monitoring/prometheus/
-    helm: upgrade --install --wait --timeout 300 --tiller-namespace=kubermatic-installer
+    helm: upgrade --install --wait --timeout 300
       --set=kubermatic.controller.image.tag=${DRONE_COMMIT_SHA}
       --set=kubermatic.api.image.tag=${DRONE_COMMIT_SHA}
       --set=kubermatic.rbac.image.tag=${DRONE_COMMIT_SHA}


### PR DESCRIPTION
Cherry-pick #2374 

```release-note
NONE
```
