### PR TITLE
add release branch tip build for v2.8

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,6 +73,20 @@ pipeline:
     - ${DRONE_COMMIT}
     when:
       branch: master
+  kubermatic-docker-release-v28:
+    context: api
+    dockerfile: api/Dockerfile
+    group: push-master
+    image: plugins/docker
+    pull: true
+    repo: kubermatic/api
+    secrets:
+    - docker_username
+    - docker_password
+    tags:
+    - ${DRONE_COMMIT}
+    when:
+      branch: release/v2.8
   kubermatic-docker-release:
     context: api
     dockerfile: api/Dockerfile
@@ -158,9 +172,9 @@ pipeline:
       namespace: logging
       path: config/logging/kibana/
     helm: upgrade --install --wait --timeout 300 --tiller-namespace=kubermatic-installer
-      --set=kubermatic.controller.image.tag=${DRONE_COMMIT_SHA}
-      --set=kubermatic.api.image.tag=${DRONE_COMMIT_SHA}
-      --set=kubermatic.rbac.image.tag=${DRONE_COMMIT_SHA}
+      --set=kubermatic.controller.image.tag=${DRONE_COMMIT}
+      --set=kubermatic.api.image.tag=${DRONE_COMMIT}
+      --set=kubermatic.rbac.image.tag=${DRONE_COMMIT}
     image: kubeciio/helm
     pull: true
     secrets:

--- a/.drone.yml
+++ b/.drone.yml
@@ -73,6 +73,8 @@ pipeline:
     - ${DRONE_COMMIT}
     when:
       branch: master
+  # this will build docker images for every release/v2.8 commit
+  # to be immediately deployed on run.kubermatic.io
   kubermatic-docker-release-v28:
     context: api
     dockerfile: api/Dockerfile
@@ -171,6 +173,7 @@ pipeline:
     - name: kibana
       namespace: logging
       path: config/logging/kibana/
+    # depends on 'kubermatic-docker-master' step to build the images
     helm: upgrade --install --wait --timeout 300 --tiller-namespace=kubermatic-installer
       --set=kubermatic.controller.image.tag=${DRONE_COMMIT}
       --set=kubermatic.api.image.tag=${DRONE_COMMIT}
@@ -219,6 +222,7 @@ pipeline:
       namespace: logging
       path: config/logging/kibana/
     group: deploy-cloud
+    # depends on 'kubermatic-docker-master' step to build the images
     helm: upgrade --install --wait --timeout 300 --kube-context=asia-east1-a-1 --tiller-namespace=kubermatic-installer
       --set=kubermatic.isMaster=false
       --set=kubermatic.controller.image.tag=${DRONE_COMMIT_SHA}
@@ -286,6 +290,7 @@ pipeline:
       namespace: logging
       path: config/logging/kibana/
     group: deploy-cloud
+    # depends on 'kubermatic-docker-master' step to build the images
     helm: upgrade --install --wait --timeout 300 --kube-context=europe-west3-c-1 --tiller-namespace=kubermatic-installer
       --set=kubermatic.controller.image.tag=${DRONE_COMMIT_SHA}
       --set=kubermatic.api.image.tag=${DRONE_COMMIT_SHA}
@@ -334,6 +339,7 @@ pipeline:
       namespace: logging
       path: config/logging/kibana/
     group: deploy-cloud
+    # depends on 'kubermatic-docker-master' step to build the images
     helm: upgrade --install --wait --timeout 300 --kube-context=us-central1-c-1 --tiller-namespace=kubermatic-installer
       --set=kubermatic.isMaster=false
       --set=kubermatic.controller.image.tag=${DRONE_COMMIT_SHA}
@@ -400,6 +406,7 @@ pipeline:
     - name: kibana
       namespace: logging
       path: config/logging/kibana/
+    # depends on 'kubermatic-docker-release-v28' step to build the images
     helm: upgrade --install --wait --timeout 300
       --set=kubermatic.controller.image.tag=${DRONE_COMMIT_SHA}
       --set=kubermatic.api.image.tag=${DRONE_COMMIT_SHA}


### PR DESCRIPTION
Replicates the v2.7 from https://github.com/kubermatic/kubermatic/blob/785093fd4ac59921cfe1998e2c6b5f49f62e6680/.drone.yml#L74..L87 thus allowing to run v2.8 branch tip on run.kubermatic.io


```release-note
NONE
```
