### PR TITLE
Add "share_kubeconfig" config

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -58,6 +58,7 @@ kubermatic:
       pullPolicy: "IfNotPresent"
     config: |
       {
+        "share_kubeconfig": false,
         "show_demo_info": false,
         "show_terms_of_service": false
       }


### PR DESCRIPTION
**What this PR does / why we need it**: Adds possibility if option to share kubeconfig should be available or not. Related to https://github.com/kubermatic/dashboard-v2/pull/857.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
