### PR TITLE
enables oidc kubeconfig feature/endpoint on api server

### DIFF
--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -26,14 +26,20 @@ spec:
           - -v=4
           - -logtostderr
           - -datacenters=/opt/datacenter/datacenters.yaml
-          - -oidc-url={{ .Values.kubermatic.auth.tokenIssuer }}
+          - -oidc-url={{ .Values.kubermatic.auth.url }}
           - -oidc-authenticator-client-id={{ .Values.kubermatic.auth.clientID }}
+          - -oidc-skip-tls-verify={{ default false .Values.kubermatic.auth.skipTokenIssuerTLSVerify }}
           - -versions=/opt/master-files/versions.yaml
           - -updates=/opt/master-files/updates.yaml
           - -internal-address=0.0.0.0:8085
           - -kubeconfig=/opt/.kube/kubeconfig
           - -master-resources=/opt/master-files
-          - -oidc-skip-tls-verify={{ default false .Values.kubermatic.auth.skipTokenIssuerTLSVerify }}
+          # the following flags enable oidc kubeconfig feature/endpoint
+          - -feature-gates={{ .Values.kubermatic.api.featureGates }}
+          - -oidc-issuer-redirect={{ .Values.kubermatic.auth.issuerRedirectURL }}
+          - -oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
+          - -oidc-issuer-client-secret={{ .Values.kubermatic.auth.issuerClientSecret }}
+          - -oidc-issuer-cookie-hash-key={{ .Values.kubermatic.auth.issuerCookieKey }}
           image: '{{ .Values.kubermatic.api.image.repository }}:{{.Values.kubermatic.api.image.tag}}'
           imagePullPolicy: {{.Values.kubermatic.api.image.pullPolicy}}
           ports:


### PR DESCRIPTION
**What this PR does / why we need it**: updates api server deployment to enable `oidc kubeconfg` feature.

**Special notes for your reviewer**: merge blocked by https://github.com/kubermatic/secrets/pull/196

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
