### PR TITLE
updates callback url flag name for api server

### DIFF
--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -36,7 +36,7 @@ spec:
           - -master-resources=/opt/master-files
           # the following flags enable oidc kubeconfig feature/endpoint
           - -feature-gates={{ .Values.kubermatic.api.featureGates }}
-          - -oidc-issuer-redirect={{ .Values.kubermatic.auth.issuerRedirectURL }}
+          - -oidc-issuer-redirect-uri={{ .Values.kubermatic.auth.issuerRedirectURL }}
           - -oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
           - -oidc-issuer-client-secret={{ .Values.kubermatic.auth.issuerClientSecret }}
           - -oidc-issuer-cookie-hash-key={{ .Values.kubermatic.auth.issuerCookieKey }}


### PR DESCRIPTION
**What this PR does / why we need it**: fixes deployment by changing the wrong flag name (`oidc-issuer-redirect`)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
