### PR TITLE
replaces auth.url field in api server deployment

### DIFF
--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -26,7 +26,7 @@ spec:
           - -v=4
           - -logtostderr
           - -datacenters=/opt/datacenter/datacenters.yaml
-          - -oidc-url={{ .Values.kubermatic.auth.url }}
+          - -oidc-url={{ .Values.kubermatic.auth.tokenIssuer }}
           - -oidc-authenticator-client-id={{ .Values.kubermatic.auth.clientID }}
           - -oidc-skip-tls-verify={{ default false .Values.kubermatic.auth.skipTokenIssuerTLSVerify }}
           - -versions=/opt/master-files/versions.yaml


### PR DESCRIPTION
**What this PR does / why we need it**: uses existing `auth.tokenIssuer` field in api server deployment.

**Special notes for your reviewer**: My original idea was to rename that field to `auth.url` but I have noticed is scattered all over and I'm not sure if it safe to change the deployment. I'd to ask @mrIncompetent about that.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
