### PR TITLE
enables oidc auth plugin on controller mgmt

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -57,6 +57,10 @@ spec:
           - -backup-container=/opt/backup/store-container.yaml
           - -cleanup-container=/opt/backup/cleanup-container.yaml
           - -docker-pull-config-json-file=/opt/docker/.dockerconfigjson
+          # the following flags enable oidc auth plugin on kube-API servers
+          - -oidc-issuer-url={{ .Values.kubermatic.auth.tokenIssuer }}
+          - -oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
+          - -feature-gates={{ .Values.kubermatic.controller.featureGates }}
           {{- if .Values.kubermatic.clusterNamespacePrometheus.disableDefaultRules }}
           - -in-cluster-prometheus-disable-default-rules=true
           {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: modifies controller manager deployment to enable oidc auth plugin on kube-API servers.

**Special notes for your reviewer**: I've already changed `secret` repo. This feature will be only enabled on dev environment. See https://github.com/kubermatic/secrets/pull/198

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
