### PR TITLE
Only set oidc flags when the OpenIDAuth feature is enabled

### DIFF
--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -36,10 +36,12 @@ spec:
           - -master-resources=/opt/master-files
           # the following flags enable oidc kubeconfig feature/endpoint
           - -feature-gates={{ .Values.kubermatic.api.featureGates }}
+          {{- if regexMatch ".*OpenIDAuthPlugin=true.*" (default "" .Values.kubermatic.controller.featureGates) }}
           - -oidc-issuer-redirect-uri={{ .Values.kubermatic.auth.issuerRedirectURL }}
           - -oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
           - -oidc-issuer-client-secret={{ .Values.kubermatic.auth.issuerClientSecret }}
           - -oidc-issuer-cookie-hash-key={{ .Values.kubermatic.auth.issuerCookieKey }}
+          {{- end }}
           image: '{{ .Values.kubermatic.api.image.repository }}:{{.Values.kubermatic.api.image.tag}}'
           imagePullPolicy: {{.Values.kubermatic.api.image.pullPolicy}}
           ports:

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -57,9 +57,11 @@ spec:
           - -backup-container=/opt/backup/store-container.yaml
           - -cleanup-container=/opt/backup/cleanup-container.yaml
           - -docker-pull-config-json-file=/opt/docker/.dockerconfigjson
+          {{- if regexMatch ".*OpenIDAuthPlugin=true.*" (default "" .Values.kubermatic.controller.featureGates) }}
           # the following flags enable oidc auth plugin on kube-API servers
           - -oidc-issuer-url={{ .Values.kubermatic.auth.tokenIssuer }}
           - -oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
+          {{- end }}
           - -feature-gates={{ .Values.kubermatic.controller.featureGates }}
           {{- if .Values.kubermatic.clusterNamespacePrometheus.disableDefaultRules }}
           - -in-cluster-prometheus-disable-default-rules=true


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Because of this the kubermatic controller manager on cloud asia and cloud us is currently crashlooping. On cloud euw we fortunately hit some issue with GKE with make port-forwarding not work, hence helm didn't do anything there. Please just merge this after approving it.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
