### PR TITLE
Replace Machine with MachineDeployment resources

### DIFF
--- a/api/cmd/kubermatic-cli/cluster_creator.go
+++ b/api/cmd/kubermatic-cli/cluster_creator.go
@@ -217,7 +217,7 @@ func (ctl *clusterCreator) createMachineDeployment(restConfig *rest.Config, dc p
 	}
 
 	machineReplicas := int32(ctl.runOpts.Nodes)
-	machineDeployment := clusterClient.ClusterV1alpha1().MachineDeployments(metav1.NamespaceSystem)
+	machineDeploymentClient := clusterClient.ClusterV1alpha1().MachineDeployments(metav1.NamespaceSystem)
 
 	nd := apiv1.NodeDeployment{
 		ObjectMeta: apiv1.ObjectMeta{
@@ -234,7 +234,7 @@ func (ctl *clusterCreator) createMachineDeployment(restConfig *rest.Config, dc p
 		return err
 	}
 
-	md, err := machineDeployment.Create(template)
+	md, err := machineDeploymentClient.Create(template)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in #2364 here is version with MachineDeployment resources

**Release note**:
```release-note
NONE
```