### PR TITLE
Increase resource limits

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -24,8 +24,8 @@ var (
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
-			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+			corev1.ResourceCPU:    resource.MustParse("2"),
 		},
 	}
 )
@@ -135,9 +135,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 		return nil, err
 	}
 
-	resourceRequirements := defaultResourceRequirements
+	resourceRequirements := defaultResourceRequirements.DeepCopy()
 	if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
-		resourceRequirements = *data.Cluster().Spec.ComponentsOverride.Apiserver.Resources
+		resourceRequirements = data.Cluster().Spec.ComponentsOverride.Apiserver.Resources
 	}
 
 	dep.Spec.Template.Spec.Containers = []corev1.Container{
@@ -152,7 +152,7 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			Args:                     flags,
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-			Resources:                resourceRequirements,
+			Resources:                *resourceRequirements,
 			Ports: []corev1.ContainerPort{
 				{
 					ContainerPort: externalNodePort,

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -24,8 +24,8 @@ var (
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+			corev1.ResourceCPU:    resource.MustParse("2"),
 		},
 	}
 )

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -23,8 +23,8 @@ var (
 			corev1.ResourceCPU:    resource.MustParse("50m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+			corev1.ResourceCPU:    resource.MustParse("2"),
 		},
 	}
 )

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -20,8 +20,8 @@ var (
 			corev1.ResourceCPU:    resource.MustParse("10m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("128Mi"),
-			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 	}
 )

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -14,10 +14,16 @@ import (
 )
 
 var (
-	defaultMemoryRequest = resource.MustParse("16Mi")
-	defaultCPURequest    = resource.MustParse("5m")
-	defaultMemoryLimit   = resource.MustParse("32Mi")
-	defaultCPULimit      = resource.MustParse("25m")
+	defaultResourceRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("16Mi"),
+			corev1.ResourceCPU:    resource.MustParse("5m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+	}
 )
 
 const (
@@ -127,16 +133,7 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			},
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: defaultMemoryRequest,
-					corev1.ResourceCPU:    defaultCPURequest,
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: defaultMemoryLimit,
-					corev1.ResourceCPU:    defaultCPULimit,
-				},
-			},
+			Resources:                defaultResourceRequirements,
 		},
 	}
 
@@ -182,16 +179,7 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: resources.Bool(true),
 			},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: defaultMemoryRequest,
-					corev1.ResourceCPU:    defaultCPURequest,
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: defaultMemoryLimit,
-					corev1.ResourceCPU:    defaultCPULimit,
-				},
-			},
+			Resources: defaultResourceRequirements,
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -22,10 +22,16 @@ const (
 )
 
 var (
-	defaultCPURequest    = resource.MustParse("50m")
-	defaultMemoryRequest = resource.MustParse("128Mi")
-	defaultCPULimit      = resource.MustParse("100m")
-	defaultMemoryLimit   = resource.MustParse("512Mi")
+	defaultResourceRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+	}
 )
 
 // StatefulSet returns the prometheus StatefulSet
@@ -93,16 +99,7 @@ func StatefulSet(data resources.StatefulSetDataProvider, existing *appsv1.Statef
 					Protocol:      corev1.ProtocolTCP,
 				},
 			},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    defaultCPURequest,
-					corev1.ResourceMemory: defaultMemoryRequest,
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    defaultCPULimit,
-					corev1.ResourceMemory: defaultMemoryLimit,
-				},
-			},
+			Resources: defaultResourceRequirements,
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      volumeConfigName,

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/kubermatic/kubermatic/api/pkg/semver"
 	"net"
 	"net/url"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/golang/glog"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	admissionv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -694,6 +694,9 @@ func ClusterIPForService(name, namespace string, serviceLister corev1lister.Serv
 
 // DeepEqual compares both objects for equality
 func DeepEqual(a, b metav1.Object) bool {
+	// Kubernetes Objects can be deeper than the default 10 levels.
+	deep.MaxDepth = 20
+
 	//TODO: Check why equality.Semantic.DeepEqual returns a different result than deep.Equal
 	// Reproducible by changing the code to use equality.Semantic.DeepEqual & create a cluster.
 	// The ensureDeployments & ensureStatefulSets function in the cluster controller will update the resources on each sync

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -24,8 +24,8 @@ var (
 			corev1.ResourceCPU:    resource.MustParse("20m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("128Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 		},
 	}
 )

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -257,8 +257,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -164,8 +164,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -257,8 +257,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -164,8 +164,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -257,8 +257,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -164,8 +164,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -257,8 +257,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -164,8 +164,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -257,8 +257,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -167,8 +167,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -134,8 +134,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -253,8 +253,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -164,8 +164,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -257,8 +257,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -164,8 +164,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -257,8 +257,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -164,8 +164,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -158,8 +158,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -134,8 +134,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -154,8 +154,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -134,8 +134,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -240,8 +240,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -154,8 +154,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -134,8 +134,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -240,8 +240,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -151,8 +151,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -158,8 +158,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -134,8 +134,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -158,8 +158,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -134,8 +134,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -244,8 +244,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -97,11 +97,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -125,8 +125,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -248,8 +248,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 100m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -91,11 +91,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -155,8 +155,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 250m
-            memory: 512Mi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
@@ -85,11 +85,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 20Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -54,8 +54,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 100m
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 12Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-metrics-server.yaml
@@ -102,11 +102,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -130,8 +130,8 @@ spec:
         name: dnat-controller
         resources:
           limits:
-            cpu: 20m
-            memory: 64Mi
+            cpu: 100m
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
@@ -108,8 +108,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi
@@ -150,8 +150,8 @@ spec:
         name: iptables-init
         resources:
           limits:
-            cpu: 25m
-            memory: 32Mi
+            cpu: 100m
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 16Mi

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -89,11 +89,11 @@ spec:
         name: openvpn-client
         resources:
           limits:
-            cpu: 40m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 5m
+            memory: 16Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -132,8 +132,8 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 512Mi
           requests:
             cpu: 20m
             memory: 64Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-etcd.yaml
@@ -113,8 +113,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 1Gi
+            cpu: "2"
+            memory: 2Gi
           requests:
             cpu: 50m
             memory: 256Mi

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-prometheus.yaml
@@ -66,7 +66,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 128Mi

--- a/api/pkg/resources/vpnsidecar/dnatController.go
+++ b/api/pkg/resources/vpnsidecar/dnatController.go
@@ -8,14 +8,14 @@ import (
 )
 
 var (
-	defaultResourceRequirements = corev1.ResourceRequirements{
+	dnatControllerResourceRequirements = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("16Mi"),
 			corev1.ResourceCPU:    resource.MustParse("5m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
-			corev1.ResourceCPU:    resource.MustParse("20m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 	}
 )
@@ -40,7 +40,7 @@ func DnatControllerContainer(data resources.DeploymentDataProvider, name string)
 		},
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		Resources:                defaultResourceRequirements,
+		Resources:                dnatControllerResourceRequirements,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: "/etc/kubernetes/kubeconfig",

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -8,10 +8,16 @@ import (
 )
 
 var (
-	defaultOpenVPNMemoryRequest = resource.MustParse("30Mi")
-	defaultOpenVPNCPURequest    = resource.MustParse("10m")
-	defaultOpenVPNMemoryLimit   = resource.MustParse("64Mi")
-	defaultOpenVPNCPULimit      = resource.MustParse("40m")
+	vpnClientResourceRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("16Mi"),
+			corev1.ResourceCPU:    resource.MustParse("5m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+	}
 )
 
 // OpenVPNSidecarContainer returns a `corev1.Container` for
@@ -51,16 +57,7 @@ func OpenVPNSidecarContainer(data resources.DeploymentDataProvider, name string)
 		},
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: defaultOpenVPNMemoryRequest,
-				corev1.ResourceCPU:    defaultOpenVPNCPURequest,
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: defaultOpenVPNMemoryLimit,
-				corev1.ResourceCPU:    defaultOpenVPNCPULimit,
-			},
-		},
+		Resources:                vpnClientResourceRequirements,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: "/etc/openvpn/pki/client",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will very aggressively increase the container resource limits.
The purpose of the limits is to avoid containers going "crazy".
For actual resource planning, the current resource request should be used (Which will be maintained by the VerticalPodAutoscaler - which will come as a follow up).

This PR also fixes the DeepEqual comparisons of Deployments & StatefulSets, by increasing the `MaxDepth` of the DeepEqual check from 10 to 20. This will now correctly identify changes of the container resources and trigger finally an update.

**Release note**:
```release-note
[ACTION REQUIRED] Resource limits for control plane containers have been increased. This might require additional resources for the seed cluster
```
