### PR TITLE
add missing default values & fix StatefulSet comparisons

### DIFF
--- a/api/pkg/resources/compare.go
+++ b/api/pkg/resources/compare.go
@@ -1,0 +1,32 @@
+package resources
+
+import (
+	"github.com/go-test/deep"
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+	// Kubernetes Objects can be deeper than the default 10 levels.
+	deep.MaxDepth = 20
+	deep.LogErrors = true
+}
+
+// DeepEqual compares both objects for equality
+func DeepEqual(a, b metav1.Object) bool {
+	if equality.Semantic.DeepEqual(a, b) {
+		return true
+	}
+
+	// For informational purpose we use deep.equal as it tells us what the difference is.
+	// We need to calculate the difference in both ways as deep.equal only does a one-way comparison
+	diff := deep.Equal(a, b)
+	if diff == nil {
+		diff = deep.Equal(b, a)
+	}
+
+	glog.V(4).Infof("Object %T %s/%s differs from the one, generated: %v", a, a.GetNamespace(), a.GetName(), diff)
+	return false
+}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -159,8 +159,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.FromInt(10252),
+						Path:   "/healthz",
+						Port:   intstr.FromInt(10252),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 				FailureThreshold: 3,
@@ -172,8 +173,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 				FailureThreshold: 8,
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.FromInt(10252),
+						Path:   "/healthz",
+						Port:   intstr.FromInt(10252),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 				InitialDelaySeconds: 15,

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -110,8 +110,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/health",
-						Port: intstr.FromInt(8080),
+						Path:   "/health",
+						Port:   intstr.FromInt(8080),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 				InitialDelaySeconds: 2,
@@ -139,6 +140,7 @@ func getVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.DNSResolverConfigMapName,
 					},
+					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
 				},
 			},
 		},

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -105,8 +105,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.FromInt(8080),
+						Path:   "/healthz",
+						Port:   intstr.FromInt(8080),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 				FailureThreshold: 3,

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -110,8 +110,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/ready",
-						Port: intstr.FromInt(8085),
+						Path:   "/ready",
+						Port:   intstr.FromInt(8085),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 				FailureThreshold: 3,
@@ -123,8 +124,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 				FailureThreshold: 8,
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/live",
-						Port: intstr.FromInt(8085),
+						Path:   "/live",
+						Port:   intstr.FromInt(8085),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 				InitialDelaySeconds: 15,

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -129,8 +129,9 @@ func StatefulSet(data resources.StatefulSetDataProvider, existing *appsv1.Statef
 				SuccessThreshold:    1,
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/-/healthy",
-						Port: intstr.FromString("web"),
+						Path:   "/-/healthy",
+						Port:   intstr.FromString("web"),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 			},
@@ -142,8 +143,9 @@ func StatefulSet(data resources.StatefulSetDataProvider, existing *appsv1.Statef
 				SuccessThreshold:    1,
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/-/healthy",
-						Port: intstr.FromString("web"),
+						Path:   "/-/healthy",
+						Port:   intstr.FromString("web"),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 			},
@@ -164,6 +166,7 @@ func getVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.PrometheusConfigConfigMapName,
 					},
+					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
 				},
 			},
 		},

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-test/deep"
 	"github.com/golang/glog"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -690,23 +689,6 @@ func ClusterIPForService(name, namespace string, serviceLister corev1lister.Serv
 	}
 
 	return &ip, nil
-}
-
-// DeepEqual compares both objects for equality
-func DeepEqual(a, b metav1.Object) bool {
-	// Kubernetes Objects can be deeper than the default 10 levels.
-	deep.MaxDepth = 20
-
-	//TODO: Check why equality.Semantic.DeepEqual returns a different result than deep.Equal
-	// Reproducible by changing the code to use equality.Semantic.DeepEqual & create a cluster.
-	// The ensureDeployments & ensureStatefulSets function in the cluster controller will update the resources on each sync
-	diff := deep.Equal(a, b)
-	if diff == nil {
-		return true
-	}
-
-	glog.V(8).Infof("Object %T %s/%s differs from the one, generated: %v", a, a.GetNamespace(), a.GetName(), diff)
-	return false
 }
 
 // GetAbsoluteServiceDNSName returns the absolute DNS name for the given service and the given cluster. Absolute means a trailing dot will be appended to the DNS name

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -131,8 +131,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.FromInt(10251),
+						Path:   "/healthz",
+						Port:   intstr.FromInt(10251),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 				FailureThreshold: 3,
@@ -144,8 +145,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 				FailureThreshold: 8,
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
-						Port: intstr.FromInt(10251),
+						Path:   "/healthz",
+						Port:   intstr.FromInt(10251),
+						Scheme: corev1.URISchemeHTTP,
 					},
 				},
 				InitialDelaySeconds: 15,

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -149,6 +149,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -159,6 +160,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -149,6 +149,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -159,6 +160,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -149,6 +149,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -159,6 +160,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -149,6 +149,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -159,6 +160,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -152,6 +152,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -162,6 +163,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -119,6 +119,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -129,6 +130,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -149,6 +149,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -159,6 +160,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -149,6 +149,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -159,6 +160,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -149,6 +149,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -159,6 +160,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -143,6 +143,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -153,6 +154,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -119,6 +119,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -129,6 +130,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -139,6 +139,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -149,6 +150,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -119,6 +119,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -129,6 +130,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -52,6 +52,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -62,6 +63,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -55,6 +55,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -65,6 +66,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -55,6 +55,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -65,6 +66,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -55,6 +55,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -65,6 +66,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -55,6 +55,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -65,6 +66,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -139,6 +139,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -149,6 +150,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -55,6 +55,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -65,6 +66,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -119,6 +119,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -129,6 +130,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -55,6 +55,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -65,6 +66,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -55,6 +55,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -65,6 +66,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -136,6 +136,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -146,6 +147,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -55,6 +55,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -65,6 +66,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -63,6 +63,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -73,6 +74,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -63,6 +63,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -73,6 +74,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -63,6 +63,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -73,6 +74,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -63,6 +63,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -73,6 +74,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -143,6 +143,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -153,6 +154,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -63,6 +63,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -73,6 +74,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -119,6 +119,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -129,6 +130,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -63,6 +63,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -73,6 +74,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -63,6 +63,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -73,6 +74,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -63,6 +63,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -73,6 +74,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -143,6 +143,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -153,6 +154,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -119,6 +119,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -129,6 +130,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -140,6 +140,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -150,6 +151,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10252
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-dns-resolver.yaml
@@ -109,6 +109,7 @@ spec:
           httpGet:
             path: /health
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
           successThreshold: 1
@@ -130,6 +131,7 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
+          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-kube-state-metrics.yaml
@@ -49,6 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -57,6 +57,7 @@ spec:
           httpGet:
             path: /live
             port: 8085
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -67,6 +68,7 @@ spec:
           httpGet:
             path: /ready
             port: 8085
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -117,6 +117,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1
@@ -127,6 +128,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10251
+            scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 15

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.8.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.9.10-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.8.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.9.10-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.8.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.9.10-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.8.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.9.10-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.8.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.9.10-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.8.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.0-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.9.10-prometheus.yaml
@@ -45,6 +45,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -59,6 +60,7 @@ spec:
           httpGet:
             path: /-/healthy
             port: web
+            scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
@@ -95,6 +97,7 @@ spec:
       terminationGracePeriodSeconds: 600
       volumes:
       - configMap:
+          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing default values & fix StatefulSet comparisons.
In the old code, changes in the StatefulSet resources where not identified and no update was triggered.

**Release note**:
```release-note
NONE
```
