### PR TITLE
only build docker images on master and release branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,6 +73,14 @@ pipeline:
     - vault_role_id
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+    when:
+      branch:
+        exclude:
+        - release/v1.*
+        - release/*cherry*
+        include:
+        - release/*
+        - master
   sync-charts:
     commands:
     - apk add --no-cache -U git bash openssh


### PR DESCRIPTION
**What this PR does / why we need it**:
Only build docker images on master and release branches

**Release note**:
```release-note
NONE
```
