### PR TITLE
Update metrics-server addon to 0.3.1

### DIFF
--- a/addons/metrics-server/aggregated-metrics-reader.yaml
+++ b/addons/metrics-server/aggregated-metrics-reader.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]

--- a/addons/metrics-server/metrics-server-deployment.yaml
+++ b/addons/metrics-server/metrics-server-deployment.yaml
@@ -29,10 +29,11 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         command:
         - /metrics-server
-        - '--source=kubernetes.summary_api:https://kubernetes.default.svc?kubeletHttps=true&kubeletPort=10250&insecure=true'
+        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-insecure-tls
         imagePullPolicy: Always
         volumeMounts:
         - name: tmp-dir


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes https://github.com/kubernetes-incubator/metrics-server/issues/27 which is spamming the apiserver logs quite a bit

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update metrics-server to 0.3.1
```
