### PR TITLE
add missing validation for kubeconfig endpoint

### DIFF
--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -77,6 +77,9 @@ func (o serverRunOptions) validate() error {
 		if len(o.oidcIssuerCookieHashKey) == 0 {
 			return fmt.Errorf("%s feature is enabled but \"oidc-issuer-cookie-hash-key\" flag was not specified", OIDCKubeCfgEndpoint)
 		}
+		if len(o.oidcIssuerClientID) == 0 {
+			return fmt.Errorf("%s feature is enabled but \"oidc-issuer-client-id\" flag was not specified", OIDCKubeCfgEndpoint)
+		}
 	}
 	return nil
 }

--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -11,6 +11,9 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
 # Please make sure to set -feature-gates=PrometheusEndpoint=true if you want to use that endpoint.
 
+# Please make sure to set -feature-gates=OIDCKubeCfgEndpoint=true if you want to use that endpoint.
+# Note that you would have to pass a few additional flags as well.
+
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 ./_build/kubermatic-api \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \


### PR DESCRIPTION
**What this PR does / why we need it**: add minor code improvements:
 - add validation for `oidc-issuer-client-id` flag
 - add comment for `OIDCKubeCfgEndpoint` feature

```release-note
NONE
```
