### PR TITLE
Support deleting LoadBalancer services on cluster deletion

### DIFF
--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -24,6 +24,9 @@ const (
 	subnetCleanupFinalizer           = "kubermatic.io/cleanup-openstack-subnet-v2"
 	routerCleanupFinalizer           = "kubermatic.io/cleanup-openstack-router-v2"
 	routerSubnetLinkCleanupFinalizer = "kubermatic.io/cleanup-openstack-router-subnet-link-v2"
+
+	// LoadBalancerCleanupFinalizer for cleaning up load balancers, used in deleting.go
+	LoadBalancerCleanupFinalizer = "kubermatic.io/cleanup-load-balancers"
 )
 
 // Provider is a struct that implements CloudProvider interface
@@ -122,6 +125,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.Openstack.Network = network.Name
 			cluster.Finalizers = kubernetes.AddFinalizer(cluster.Finalizers, networkCleanupFinalizer)
+			cluster.Finalizers = kubernetes.AddFinalizer(cluster.Finalizers, LoadBalancerCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

On OpenStack any LoadBalancer services need to be deleted on cluster
deletion, because otherwise the OpenStack network can not be deleted
since there is still a LoadBalancer, Security Group and Floating IP
attached to it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1985

**Special notes for your reviewer**:
I'm not quite sure, if I'm adding this logic in the right place. Especially using the constant in two different packages is not really nice.
 On the one hand it's fairly related to OpenStack, on the other hand, the function just talks with the Kubernetes API and may be also necessary or at least not hurting for other providers.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Delete OpenStack LoadBalancers on cluster deletion to prevent errors deleting the OpenStack network
```
