### PR TITLE
Make fluentd crashes visible

### DIFF
--- a/config/logging/fluentd/templates/fluentd-daemonset.yaml
+++ b/config/logging/fluentd/templates/fluentd-daemonset.yaml
@@ -21,6 +21,13 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
+        command:
+        - /bin/sh
+        - -c
+        - >-
+            sed -i 's;#!/usr/bin/dumb-init.*;#!/bin/sh;g' /fluentd/entrypoint.sh &&
+            if ! grep -q supervisor /fluentd/entrypoint.sh; then sed -i 's;--gemfile;--no-supervisor --gemfile;g' /fluentd/entrypoint.sh; fi &&
+            exec /fluentd/entrypoint.sh
         image: '{{ .Values.logging.fluentd.image.repository }}:{{ .Values.logging.fluentd.image.tag }}'
         imagePullPolicy: {{ .Values.logging.fluentd.image.pullPolicy }}
         securityContext:


### PR DESCRIPTION
So far we've used a fluentd image that contained a supervisor
and on top of that had fluentds own supervising capabiltiy enabled.

That meant that whenever the fluentd worker crashed it would get
restarted, which made the restartCount of the pod stay at zero
even after the process got repeatedly oom-killed by the kernel.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

CC @p0lyn0mial @mrIncompetent @xrstf 