### PR TITLE
make fluentd crash configuration more stable

### DIFF
--- a/config/logging/fluentd/templates/fluentd-daemonset.yaml
+++ b/config/logging/fluentd/templates/fluentd-daemonset.yaml
@@ -21,13 +21,6 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        command:
-        - /bin/sh
-        - -c
-        - >-
-            sed -i 's;#!/usr/bin/dumb-init.*;#!/bin/sh;g' /fluentd/entrypoint.sh &&
-            if ! grep -q supervisor /fluentd/entrypoint.sh; then sed -i 's;--gemfile;--no-supervisor --gemfile;g' /fluentd/entrypoint.sh; fi &&
-            exec /fluentd/entrypoint.sh
         image: '{{ .Values.logging.fluentd.image.repository }}:{{ .Values.logging.fluentd.image.tag }}'
         imagePullPolicy: {{ .Values.logging.fluentd.image.pullPolicy }}
         securityContext:
@@ -41,6 +34,10 @@ spec:
             value: "http"
           - name: FLUENT_UID
             value: "0"
+          # make sure that crashes actually terminate the pod
+          # and make it visible to external monitoring
+          - name: FLUENTD_OPT
+            value: "--no-supervisor"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up to #2444. It improves two points:

* The `no-supervisor` flag can be specified by using the `FLUENTD_OPT` variable used by the [entrypoint.sh](https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/docker-image/v1.3/debian-elasticsearch/entrypoint.sh).
* dumb-init itself does not restart processes, so it's not required to remove it from the entrypoint script at all.

Putting the two together allows us to remove the customizations to the entrypoint script alltogether.

**Release note**:
```release-note
NONE
```
