### PR TITLE
get encoded Values.dex.caBundle value

### DIFF
--- a/config/kubermatic/templates/dex-ca-secret.yaml
+++ b/config/kubermatic/templates/dex-ca-secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: dex-ca
 type: Opaque
 data:
-  caBundle.pem: "{{ .Values.dex.caBundle | b64enc }}"
+  caBundle.pem: "{{ .Values.dex.caBundle }}"


### PR DESCRIPTION
**What this PR does / why we need it**: disable base64 encoding for dex-ca-secret template



```release-note
NONE
```
