### PR TITLE
set fluentd Daemonset update strategy to RollingUpdate

### DIFF
--- a/config/logging/fluentd/templates/fluentd-daemonset.yaml
+++ b/config/logging/fluentd/templates/fluentd-daemonset.yaml
@@ -7,6 +7,11 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Set fluentd Daemonset update strategy to RollingUpdate.
The default update strategy is "Recreate", which won't update any pod - instead only new pods will have the new config.

**Release note**:
```release-note
NONE
```
