### PR TITLE
Add missing ca-certificates in s3-exporter

### DIFF
--- a/api/cmd/s3-exporter/Dockerfile
+++ b/api/cmd/s3-exporter/Dockerfile
@@ -1,3 +1,5 @@
 FROM alpine:3.7
 
+RUN apk add --no-cache ca-certificates
+
 COPY ./s3-exporter /usr/local/bin/

--- a/api/hack/publish-s3-exporter.sh
+++ b/api/hack/publish-s3-exporter.sh
@@ -3,7 +3,7 @@
 export REGISTRY=quay.io/kubermatic/s3-exporter
 export TAG=v0.2
 
-make -C $(dirname $0)/../ s3-exporter
+GOOS=linux GOARCH=amd64 make -C $(dirname $0)/../ s3-exporter
 
 mv $(dirname $0)/../_build/s3-exporter $(dirname $0)/../cmd/s3-exporter/
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing ca-certificates to s3-exporter image, so that TLS works properly. This fixes "failed to load system roots and no roots provided" when connecting to S3 over HTTPS.

I also added that the `publish-s3-exporter.sh` script always compiles s3-exporter for Linux, since it does not make any sense to add for example a Mac binary into the docker image.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note bugfix
Missing ca-certificates have been added to s3-exporter image
```
