### PR TITLE
Disable debug logs on control plane

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -284,7 +284,6 @@ func getApiserverFlags(data resources.DeploymentDataProvider, externalNodePort i
 		"--client-ca-file", "/etc/kubernetes/pki/ca/ca.crt",
 		"--kubelet-client-certificate", "/etc/kubernetes/kubelet/kubelet-client.crt",
 		"--kubelet-client-key", "/etc/kubernetes/kubelet/kubelet-client.key",
-		"--v", "4",
 		"--requestheader-client-ca-file", "/etc/kubernetes/pki/front-proxy/ca/ca.crt",
 		"--requestheader-allowed-names", "apiserver-aggregator",
 		"--requestheader-extra-headers-prefix", "X-Remote-Extra-",

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -204,7 +204,6 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 		"--allocate-node-cidrs=true",
 		"--controllers", "*,bootstrapsigner,tokencleaner",
 		"--use-service-account-credentials=true",
-		"--v", "4",
 	}
 
 	featureGates := []string{"RotateKubeletClientCertificate=true",

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -204,7 +204,6 @@ func getVolumes() []corev1.Volume {
 func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 	flags := []string{
 		"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-		"--v", "4",
 	}
 
 	var featureGates []string

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         - --feature-gates
         - ScheduleDaemonSetPods=false
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         - --feature-gates
         - ScheduleDaemonSetPods=false
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --authentication-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         - --feature-gates
         - ScheduleDaemonSetPods=false
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --authentication-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         - --feature-gates
         - ScheduleDaemonSetPods=false
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         - --feature-gates
         - ScheduleDaemonSetPods=false
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         - --feature-gates
         - ScheduleDaemonSetPods=false
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-apiserver.yaml
@@ -197,8 +197,6 @@ spec:
         - /etc/kubernetes/kubelet/kubelet-client.crt
         - --kubelet-client-key
         - /etc/kubernetes/kubelet/kubelet-client.key
-        - --v
-        - "4"
         - --requestheader-client-ca-file
         - /etc/kubernetes/pki/front-proxy/ca/ca.crt
         - --requestheader-allowed-names

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-controller-manager.yaml
@@ -122,8 +122,6 @@ spec:
         - --controllers
         - '*,bootstrapsigner,tokencleaner'
         - --use-service-account-credentials=true
-        - --v
-        - "4"
         - --feature-gates
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
         - --cloud-provider

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-scheduler.yaml
@@ -105,8 +105,6 @@ spec:
       - args:
         - --kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --v
-        - "4"
         command:
         - /hyperkube
         - scheduler


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable debug logs on control plane.

This will dramatically reduce the number of logs the control plane components will emit.

So far i was under the impression that `--v=4` is the default "info" log level - which is wrong.
Its just the level of verbosity - actually fairly obvious.

Looking at kubeadm, it does not specify the `--v` flag at all.

```
# Before the change:
~3200 messages/minute
# After the change:
~55 messages/second
```

**Release note**:
```release-note
Control plane components are no longer logging at debug level
```
