### PR TITLE
Use v1beta1 apiregistration to still support 1.9

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1910,7 +1910,7 @@
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
     "k8s.io/gengo/examples/defaulter-gen/generators",
-    "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1",
+    "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1",
     "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset",
     "sigs.k8s.io/cluster-api/pkg/apis/cluster/common",
     "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1",

--- a/api/pkg/controller/cluster/userclusterresources.go
+++ b/api/pkg/controller/cluster/userclusterresources.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 )
 
 func (cc *Controller) reconcileUserClusterResources(cluster *kubermaticv1.Cluster, client kubernetes.Interface) (*kubermaticv1.Cluster, error) {
@@ -508,16 +508,16 @@ func (cc *Controller) userClusterEnsureAPIServices(c *kubermaticv1.Cluster) erro
 	}
 
 	for _, create := range GetAPIServiceCreators() {
-		var existing *apiregistrationv1.APIService
+		var existing *apiregistrationv1beta1.APIService
 		apiService, err := create(nil)
 		if err != nil {
 			return fmt.Errorf("failed to build APIService: %v", err)
 		}
-		if existing, err = client.ApiregistrationV1().APIServices().Get(apiService.Name, metav1.GetOptions{}); err != nil {
+		if existing, err = client.ApiregistrationV1beta1().APIServices().Get(apiService.Name, metav1.GetOptions{}); err != nil {
 			if !errors.IsNotFound(err) {
 				return err
 			}
-			if _, err = client.ApiregistrationV1().APIServices().Create(apiService); err != nil {
+			if _, err = client.ApiregistrationV1beta1().APIServices().Create(apiService); err != nil {
 				return fmt.Errorf("failed to create APIService %s: %v", apiService.Name, err)
 			}
 			glog.V(4).Infof("Created APIService %s inside user cluster %s", apiService.Name, c.Name)
@@ -533,7 +533,7 @@ func (cc *Controller) userClusterEnsureAPIServices(c *kubermaticv1.Cluster) erro
 			continue
 		}
 
-		if _, err = client.ApiregistrationV1().APIServices().Update(apiService); err != nil {
+		if _, err = client.ApiregistrationV1beta1().APIServices().Update(apiService); err != nil {
 			return fmt.Errorf("failed to update APIService %s: %v", apiService.Name, err)
 		}
 		glog.V(4).Infof("Updated APIService %s inside user cluster %s", apiService.Name, c.Name)

--- a/api/pkg/resources/metrics-server/apiservice.go
+++ b/api/pkg/resources/metrics-server/apiservice.go
@@ -2,23 +2,23 @@ package metricsserver
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
 // APIService returns a APIService for the metrics server - used inside the user cluster
-func APIService(existing *apiregistrationv1.APIService) (*apiregistrationv1.APIService, error) {
+func APIService(existing *apiregistrationv1beta1.APIService) (*apiregistrationv1beta1.APIService, error) {
 	se := existing
 	if se == nil {
-		se = &apiregistrationv1.APIService{}
+		se = &apiregistrationv1beta1.APIService{}
 	}
 
 	se.Name = resources.MetricsServerAPIServiceName
 	labels := resources.BaseAppLabel(name, nil)
 	se.Labels = labels
 
-	se.Spec.Service = &apiregistrationv1.ServiceReference{
+	se.Spec.Service = &apiregistrationv1beta1.ServiceReference{
 		Namespace: metav1.NamespaceSystem,
 		Name:      resources.MetricsServerExternalNameServiceName,
 	}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -31,7 +31,7 @@ import (
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/cert/triple"
-	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 )
 
 // KUBERMATICCOMMIT is a magic variable containing the git commit hash of the current (as in currently executing) kubermatic api. It gets feeded by Makefile as a ldflag.
@@ -393,7 +393,7 @@ type CronJobCreator = func(data *TemplateData, existing *batchv1beta1.CronJob) (
 type CRDCreateor = func(version semver.Semver, existing *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error)
 
 // APIServiceCreator defines an interface to create/update APIService's
-type APIServiceCreator = func(existing *apiregistrationv1.APIService) (*apiregistrationv1.APIService, error)
+type APIServiceCreator = func(existing *apiregistrationv1beta1.APIService) (*apiregistrationv1beta1.APIService, error)
 
 // MutatingWebhookConfigurationCreator defines an interface to create/update MutatingWebhookConfigurations
 type MutatingWebhookConfigurationCreator = func(cluster *kubermaticv1.Cluster, data *TemplateData, existing *admissionregistrationv1beta1.MutatingWebhookConfiguration) (*admissionregistrationv1beta1.MutatingWebhookConfiguration, error)


### PR DESCRIPTION
**What this PR does / why we need it**:
Use v1beta1 apiregistration to still support 1.9.
As the API was marked as stable with 1.10.

Currently this leads to "Not found" errors during the reconciling of the metrics-server APIService

**Release note**:
```release-note
NONE
```
