### PR TITLE
Update machine-controller to v0.10.3

### DIFF
--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -29,7 +29,7 @@ var (
 const (
 	name = "machine-controller"
 
-	tag = "v0.10.0"
+	tag = "v0.10.3"
 )
 
 // Deployment returns the machine-controller Deployment

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-machine-controller.yaml
@@ -45,7 +45,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-machine-controller.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v0.10.0
+        image: docker.io/kubermatic/machine-controller:v0.10.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8


### PR DESCRIPTION
**What this PR does / why we need it**:
Update machine-controller to v0.10.3.

The PR targeting the client code is blocked currently, but that should not prevent us from updating the controller itself.

**Release note**:
```release-note
Updated the machine-controller to `v0.10.3`
```
