### PR TITLE
Update available Kubernetes versions (#2478)

### DIFF
--- a/api/pkg/version/manager.go
+++ b/api/pkg/version/manager.go
@@ -130,7 +130,7 @@ func (m *Manager) AutomaticUpdate(sfrom string) (*MasterVersion, error) {
 	}
 
 	if len(toVersions) > 1 {
-		return nil, fmt.Errorf("more than one automatic update found for version. Not allowed")
+		return nil, fmt.Errorf("more than one automatic update found for version. Not allowed. Automatic updates to: %v", toVersions)
 	}
 
 	mVersion, err := m.GetVersion(toVersions[0])

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -24,6 +24,10 @@ updates:
 - from: 1.10.*
   to: 1.11.0
   automatic: false
+# CVE-2018-1002105
+- from: <= 1.10.10
+  to: 1.10.11
+  automatic: true
 
 # ======= 1.11 =======
 # Allow to change to any patch version
@@ -34,9 +38,17 @@ updates:
 - from: 1.11.*
   to: 1.12.*
   automatic: false
+# CVE-2018-1002105
+- from: <= 1.11.4, >= 1.11.0
+  to: 1.11.5
+  automatic: true
 
 # ======= 1.12 =======
 # Allow to change to any patch version
 - from: 1.12.*
   to: 1.12.*
   automatic: false
+# CVE-2018-1002105
+- from: <= 1.12.2, >= 1.12.0
+  to: 1.12.3
+  automatic: true

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,89 +1,19 @@
 # We support 1.9,1.10,1.11 & kubernetes is able to handle the whole matrix of those versions
 allowed-node-versions: &node-versions
-- "1.9.*"
 - "1.10.*"
 - "1.11.*"
 - "1.12.*"
 
 versions:
-- version: "1.9.0"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.1"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.2"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.3"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.4"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.5"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.6"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.7"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.8"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.9"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.9.10"
-  default: false
-  allowedNodeVersions: *node-versions
 # Kubernetes 1.10
-- version: "1.10.0"
+- version: "1.10.11"
   default: false
-  allowedNodeVersions: *node-versions
-- version: "1.10.1"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.10.2"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.10.3"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.10.4"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.10.5"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.10.6"
-  default: true
-  allowedNodeVersions: *node-versions
-- version: "1.10.7"
-  default: true
-  allowedNodeVersions: *node-versions
-- version: "1.10.8"
-  default: true
   allowedNodeVersions: *node-versions
 # Kubernetes 1.11
-- version: "1.11.0"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.11.1"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.11.2"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.11.3"
-  default: false
+- version: "1.11.5"
+  default: true
   allowedNodeVersions: *node-versions
 # Kubernetes 1.12
-- version: "1.12.0"
-  default: false
-  allowedNodeVersions: *node-versions
-- version: "1.12.1"
+- version: "1.12.3"
   default: false
   allowedNodeVersions: *node-versions


### PR DESCRIPTION
* Update available Kubernetes versions

* Automatically update to a version that has a fix for CVE-2018-1002105

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Kubernetes will be automatically updated to versions that contain a fix for CVE-2018-1002105
```
