### PR TITLE
changes kubeconfig file name

### DIFF
--- a/api/pkg/handler/kubeconfig.go
+++ b/api/pkg/handler/kubeconfig.go
@@ -40,11 +40,11 @@ func getClusterKubeconfig(projectProvider provider.ProjectProvider) endpoint.End
 		if err != nil {
 			return nil, kubernetesErrorToHTTPError(err)
 		}
-		adminClientCfg, err :=  clusterProvider.GetAdminKubeconfigForCustomerCluster(cluster)
+		adminClientCfg, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(cluster)
 		if err != nil {
 			return nil, kubernetesErrorToHTTPError(err)
 		}
-		return &encodeKubeConifgResponse{clientCfg:adminClientCfg, filePrefix: "admin"}, nil
+		return &encodeKubeConifgResponse{clientCfg: adminClientCfg, filePrefix: "admin"}, nil
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: If the oidc authentication is enabled it is possible to generate kubeconfig that doesn't contain the admin credentials. The name of the file will be exactly the same as the one downloaded when clicking on "Download config". To distinguish them this commit adds a prefix "-admin" to the config with the admin credentials. For example after this pull it will be possible to download `kubeconfig-8fsgtzqzjr` and  `kubeconfig-admin-8fsgtzqzjr`

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
