### PR TITLE
increase readiness & liveness probe timeouts & initialdelayseconds toallow for some slow startups

### DIFF
--- a/config/logging/elasticsearch/templates/es-data-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-data-stateful.yaml
@@ -75,13 +75,15 @@ spec:
             httpGet:
               path: /_cluster/health
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
             periodSeconds: 10
           readinessProbe:
             tcpSocket:
               port: transport
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+            periodSeconds: 10
           volumeMounts:
             - name: storage
               mountPath: /usr/share/elasticsearch/data

--- a/config/logging/elasticsearch/templates/es-master-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-master-stateful.yaml
@@ -77,13 +77,15 @@ spec:
             httpGet:
               path: /_cluster/health
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
             periodSeconds: 10
           readinessProbe:
             tcpSocket:
               port: transport
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+            periodSeconds: 10
           volumeMounts:
             - name: storage
               mountPath: /usr/share/elasticsearch/data


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase readiness & liveness probe timeouts & initialDelaySeconds to allow for some slow startups.
Lesson learned from an ES cluster on preemtible nodes:
ES takes some time to recover from a cluster failure.

**Release note**:
```release-note
NONE
```
