### PR TITLE
Set no_parent_owners on all Owners files

### DIFF
--- a/api/cmd/OWNERS
+++ b/api/cmd/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-lifecycle
+
+options:
+  no_parent_owners: true

--- a/api/cmd/kubermatic-api/OWNERS
+++ b/api/cmd/kubermatic-api/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-ui
+
+options:
+  no_parent_owners: true

--- a/api/cmd/projects-migrator/OWNERS
+++ b/api/cmd/projects-migrator/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-ui
+
+options:
+  no_parent_owners: true

--- a/api/cmd/rbac-generator/OWNERS
+++ b/api/cmd/rbac-generator/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-ui
+
+options:
+  no_parent_owners: true

--- a/api/pkg/api/OWNERS
+++ b/api/pkg/api/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-ui
+
+options:
+  no_parent_owners: true

--- a/api/pkg/controller/OWNERS
+++ b/api/pkg/controller/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-lifecycle
+
+options:
+  no_parent_owners: true

--- a/api/pkg/controller/monitoring/OWNERS
+++ b/api/pkg/controller/monitoring/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-seed
+
+options:
+  no_parent_owners: true

--- a/api/pkg/controller/rbac/OWNERS
+++ b/api/pkg/controller/rbac/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-ui
+
+options:
+  no_parent_owners: true

--- a/api/pkg/exporters/s3/OWNERS
+++ b/api/pkg/exporters/s3/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-lifecycle
+
+options:
+  no_parent_owners: true

--- a/api/pkg/handler/OWNERS
+++ b/api/pkg/handler/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-ui
+
+options:
+  no_parent_owners: true

--- a/api/pkg/provider/cloud/OWNERS
+++ b/api/pkg/provider/cloud/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-lifecycle
+
+options:
+  no_parent_owners: true

--- a/api/pkg/provider/kubernetes/OWNERS
+++ b/api/pkg/provider/kubernetes/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-ui
+
+options:
+  no_parent_owners: true

--- a/api/pkg/resources/OWNERS
+++ b/api/pkg/resources/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-lifecycle
+
+options:
+  no_parent_owners: true

--- a/api/pkg/resources/kubestatemetrics/OWNERS
+++ b/api/pkg/resources/kubestatemetrics/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-seed
+
+options:
+  no_parent_owners: true

--- a/api/pkg/resources/metrics-server/OWNERS
+++ b/api/pkg/resources/metrics-server/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-lifecycle
+
+options:
+  no_parent_owners: true

--- a/api/pkg/resources/prometheus/OWNERS
+++ b/api/pkg/resources/prometheus/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-seed
+
+options:
+  no_parent_owners: true

--- a/config/backup/OWNERS
+++ b/config/backup/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-seed
+
+options:
+  no_parent_owners: true

--- a/config/logging/OWNERS
+++ b/config/logging/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-seed
+
+options:
+  no_parent_owners: true

--- a/config/monitoring/OWNERS
+++ b/config/monitoring/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-seed
+
+options:
+  no_parent_owners: true

--- a/config/s3-exporter/OWNERS
+++ b/config/s3-exporter/OWNERS
@@ -5,3 +5,6 @@ approvers:
 
 reviewers:
   - team-seed
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, an OWNER listed in a root OWNERS file can approve changes to all nested files. To prevent this, we can use the `no_parent_owners` option which will prevent someone listed as an OWNER in `a/b` to approve `a/b/c`.

Ref: https://go.k8s.io/owners

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
