### PR TITLE
cleanup PVCs and LB's during cluster deletion

### DIFF
--- a/api/pkg/controller/cluster/deleting.go
+++ b/api/pkg/controller/cluster/deleting.go
@@ -3,14 +3,24 @@ package cluster
 import (
 	"fmt"
 
+	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/azure"
+
+	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/openstack"
+
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
 	"github.com/kubermatic/machine-controller/pkg/node/eviction"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+)
+
+const (
+	inClusterPVCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-pv"
+	inClusterLBCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-lb"
 )
 
 // cleanupCluster is the function which handles clusters in the deleting phase.
@@ -27,8 +37,120 @@ func (cc *Controller) cleanupCluster(c *kubermaticv1.Cluster) (*kubermaticv1.Clu
 		return c, nil
 	}
 
+	// Delete Volumes and LB's inside the user cluster
+	if c, err = cc.cleanupInClusterResources(c); err != nil {
+		return c, err
+	}
+
+	// Do not run the cloud provider cleanup until we finished the PV & LB cleanup.
+	// Otherwise we risk deleting those resources as well
+	if kuberneteshelper.HasFinalizer(c, inClusterLBCleanupFinalizer) || kuberneteshelper.HasFinalizer(c, inClusterPVCleanupFinalizer) {
+		return c, nil
+	}
+
 	if c, err = cc.deletingCloudProviderCleanup(c); err != nil {
 		return c, err
+	}
+
+	return c, nil
+}
+
+func (cc *Controller) cleanupInClusterResources(c *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
+	shouldDeleteLBs := kuberneteshelper.HasFinalizer(c, inClusterLBCleanupFinalizer)
+	shouldDeletePVs := kuberneteshelper.HasFinalizer(c, inClusterPVCleanupFinalizer)
+
+	// If no relevant finalizer exists, directly return
+	if !shouldDeleteLBs && !shouldDeletePVs {
+		return c, nil
+	}
+
+	client, err := cc.userClusterConnProvider.GetClient(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubernetes client: %v", err)
+	}
+
+	// We'll set this to true in case we deleted something. This is meant to requeue as long as all resources are really gone
+	// We'll use it for LB's and PV's as well, so the Kubernetes controller manager does the cleanup of all resources in parallel
+	var deletedSomeResource bool
+
+	if shouldDeleteLBs {
+		serviceList, err := client.CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list Service's from user cluster: %v", err)
+		}
+
+		for _, service := range serviceList.Items {
+			if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+				if err := client.CoreV1().Services(service.Namespace).Delete(service.Name, &metav1.DeleteOptions{}); err != nil {
+					return nil, fmt.Errorf("failed to delete Service '%s/%s' from user cluster: %v", service.Namespace, service.Name, err)
+				}
+				deletedSomeResource = true
+			}
+		}
+	}
+
+	if shouldDeletePVs {
+		// Delete PVC's
+		pvcList, err := client.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list services from user cluster: %v", err)
+		}
+
+		for _, pvc := range pvcList.Items {
+			if err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, &metav1.DeleteOptions{}); err != nil {
+				return nil, fmt.Errorf("failed to delete PVC '%s/%s' from user cluster: %v", pvc.Namespace, pvc.Name, err)
+			}
+			deletedSomeResource = true
+		}
+
+		// Delete PV's
+		pvList, err := client.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list services from user cluster: %v", err)
+		}
+
+		for _, pv := range pvList.Items {
+			if err := client.CoreV1().PersistentVolumes().Delete(pv.Name, &metav1.DeleteOptions{}); err != nil {
+				return nil, fmt.Errorf("failed to delete PV '%s' from user cluster: %v", pv.Name, err)
+			}
+			deletedSomeResource = true
+		}
+	}
+
+	if deletedSomeResource {
+		return c, nil
+	}
+
+	c, err = cc.updateCluster(c.Name, func(c *kubermaticv1.Cluster) {
+		// In case we should keep the LB's, we must remove some cloud provider specific finalizers.
+		// Otherwise we might break the LB
+		if !shouldDeleteLBs {
+			// OpenStack
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, openstack.OldNetworkCleanupFinalizer)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, openstack.NetworkCleanupFinalizer)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, openstack.SubnetCleanupFinalizer)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, openstack.RouterCleanupFinalizer)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, openstack.RouterSubnetLinkCleanupFinalizer)
+
+			// Azure
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, azure.FinalizerRouteTable)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, azure.FinalizerSubnet)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, azure.FinalizerSubnet)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, azure.FinalizerVNet)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, azure.FinalizerResourceGroup)
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, azure.FinalizerAvailabilitySet)
+		}
+
+		if !shouldDeletePVs {
+			// Azure
+			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, azure.FinalizerResourceGroup)
+		}
+
+		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, inClusterLBCleanupFinalizer)
+		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, inClusterPVCleanupFinalizer)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return c, nil

--- a/api/pkg/controller/cluster/deleting.go
+++ b/api/pkg/controller/cluster/deleting.go
@@ -3,13 +3,11 @@ package cluster
 import (
 	"fmt"
 
-	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/azure"
-
-	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/openstack"
-
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/azure"
+	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/openstack"
 
 	"github.com/kubermatic/machine-controller/pkg/node/eviction"
 

--- a/api/pkg/provider/cloud/azure/provider.go
+++ b/api/pkg/provider/cloud/azure/provider.go
@@ -21,12 +21,18 @@ import (
 const (
 	clusterTagKey = "cluster"
 
-	finalizerSecurityGroup   = "kubermatic.io/cleanup-azure-security-group"
-	finalizerRouteTable      = "kubermatic.io/cleanup-azure-route-table"
-	finalizerSubnet          = "kubermatic.io/cleanup-azure-subnet"
-	finalizerVNet            = "kubermatic.io/cleanup-azure-vnet"
-	finalizerResourceGroup   = "kubermatic.io/cleanup-azure-resource-group"
-	finalizerAvailabilitySet = "kubermatic.io/cleanup-azure-availability-set"
+	// FinalizerSecurityGroup will instruct the deletion of the security group
+	FinalizerSecurityGroup = "kubermatic.io/cleanup-azure-security-group"
+	// FinalizerRouteTable will instruct the deletion of the route table
+	FinalizerRouteTable = "kubermatic.io/cleanup-azure-route-table"
+	// FinalizerSubnet will instruct the deletion of the subnet
+	FinalizerSubnet = "kubermatic.io/cleanup-azure-subnet"
+	// FinalizerVNet will instruct the deletion of the virtual network
+	FinalizerVNet = "kubermatic.io/cleanup-azure-vnet"
+	// FinalizerResourceGroup will instruct the deletion of the resource group
+	FinalizerResourceGroup = "kubermatic.io/cleanup-azure-resource-group"
+	// FinalizerAvailabilitySet will instruct the deletion of the availability set
+	FinalizerAvailabilitySet = "kubermatic.io/cleanup-azure-availability-set"
 )
 
 type azure struct {
@@ -149,7 +155,7 @@ func deleteSecurityGroup(cloud kubermaticv1.CloudSpec) error {
 
 func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	var err error
-	if kuberneteshelper.HasFinalizer(cluster, finalizerSecurityGroup) {
+	if kuberneteshelper.HasFinalizer(cluster, FinalizerSecurityGroup) {
 		glog.Infof("cluster %q: deleting security group %q", cluster.Name, cluster.Spec.Cloud.Azure.SecurityGroup)
 		if err := deleteSecurityGroup(cluster.Spec.Cloud); err != nil {
 			if detErr, ok := err.(autorest.DetailedError); !ok || detErr.StatusCode != http.StatusNotFound {
@@ -157,14 +163,14 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 			}
 		}
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, finalizerSecurityGroup)
+			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerSecurityGroup)
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if kuberneteshelper.HasFinalizer(cluster, finalizerRouteTable) {
+	if kuberneteshelper.HasFinalizer(cluster, FinalizerRouteTable) {
 		glog.Infof("cluster %q: deleting route table %q", cluster.Name, cluster.Spec.Cloud.Azure.RouteTableName)
 		if err := deleteRouteTable(cluster.Spec.Cloud); err != nil {
 			if detErr, ok := err.(autorest.DetailedError); !ok || detErr.StatusCode != http.StatusNotFound {
@@ -172,14 +178,14 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 			}
 		}
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, finalizerRouteTable)
+			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerRouteTable)
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if kuberneteshelper.HasFinalizer(cluster, finalizerSubnet) {
+	if kuberneteshelper.HasFinalizer(cluster, FinalizerSubnet) {
 		glog.Infof("cluster %q: deleting subnet %q", cluster.Name, cluster.Spec.Cloud.Azure.SubnetName)
 		if err := deleteSubnet(cluster.Spec.Cloud); err != nil {
 			if detErr, ok := err.(autorest.DetailedError); !ok || detErr.StatusCode != http.StatusNotFound {
@@ -187,14 +193,14 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 			}
 		}
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, finalizerSubnet)
+			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerSubnet)
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if kuberneteshelper.HasFinalizer(cluster, finalizerVNet) {
+	if kuberneteshelper.HasFinalizer(cluster, FinalizerVNet) {
 		glog.Infof("cluster %q: deleting vnet %q", cluster.Name, cluster.Spec.Cloud.Azure.VNetName)
 		if err := deleteVNet(cluster.Spec.Cloud); err != nil {
 			if detErr, ok := err.(autorest.DetailedError); !ok || detErr.StatusCode != http.StatusNotFound {
@@ -203,14 +209,14 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 		}
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, finalizerVNet)
+			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerVNet)
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if kuberneteshelper.HasFinalizer(cluster, finalizerResourceGroup) {
+	if kuberneteshelper.HasFinalizer(cluster, FinalizerResourceGroup) {
 		glog.Infof("cluster %q: deleting resource group %q", cluster.Name, cluster.Spec.Cloud.Azure.ResourceGroup)
 		if err := deleteResourceGroup(cluster.Spec.Cloud); err != nil {
 			if detErr, ok := err.(autorest.DetailedError); !ok || detErr.StatusCode != http.StatusNotFound {
@@ -219,14 +225,14 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 		}
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, finalizerResourceGroup)
+			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerResourceGroup)
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if kuberneteshelper.HasFinalizer(cluster, finalizerAvailabilitySet) {
+	if kuberneteshelper.HasFinalizer(cluster, FinalizerAvailabilitySet) {
 		glog.Infof("cluster %q: deleting availability set %q", cluster.Name, cluster.Spec.Cloud.Azure.AvailabilitySet)
 		if err := deleteAvailabilitySet(cluster.Spec.Cloud); err != nil {
 			if detErr, ok := err.(autorest.DetailedError); !ok || detErr.StatusCode != http.StatusNotFound {
@@ -235,7 +241,7 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 		}
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, finalizerAvailabilitySet)
+			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerAvailabilitySet)
 		})
 		if err != nil {
 			return nil, err
@@ -488,7 +494,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.ResourceGroup = cluster.Spec.Cloud.Azure.ResourceGroup
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, finalizerResourceGroup)
+			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerResourceGroup)
 		})
 		if err != nil {
 			return nil, err
@@ -505,7 +511,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.VNetName = cluster.Spec.Cloud.Azure.VNetName
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, finalizerVNet)
+			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerVNet)
 		})
 		if err != nil {
 			return nil, err
@@ -522,7 +528,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.SubnetName = cluster.Spec.Cloud.Azure.SubnetName
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, finalizerSubnet)
+			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerSubnet)
 		})
 		if err != nil {
 			return nil, err
@@ -539,7 +545,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.RouteTableName = cluster.Spec.Cloud.Azure.RouteTableName
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, finalizerRouteTable)
+			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerRouteTable)
 		})
 		if err != nil {
 			return nil, err
@@ -556,7 +562,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.SecurityGroup = cluster.Spec.Cloud.Azure.SecurityGroup
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, finalizerSecurityGroup)
+			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerSecurityGroup)
 		})
 		if err != nil {
 			return nil, err
@@ -573,7 +579,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.AvailabilitySet = asName
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, finalizerAvailabilitySet)
+			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerAvailabilitySet)
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Delete PVC's, PV's and LB's during cluster deletion if certain finalizers exist on the cluster object.

Fixes #2448 

The release note for this feature should be within the PR for the API changes, as mentioned: https://github.com/kubermatic/kubermatic/issues/2449

**Release note**:
```release-note
NONE
```
