### PR TITLE
removes api.LegacyUser

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3432,29 +3432,6 @@
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },
-    "LegacyUser": {
-      "description": "Depreciated: use User instead",
-      "type": "object",
-      "title": "LegacyUser represents an API user that is used for authentication.",
-      "properties": {
-        "Email": {
-          "type": "string"
-        },
-        "ID": {
-          "type": "string"
-        },
-        "Name": {
-          "type": "string"
-        },
-        "Roles": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "object"
-          }
-        }
-      },
-      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-    },
     "MachineDeploymentStatus": {
       "description": "[MachineDeploymentStatus]\nMachineDeploymentStatus defines the observed state of MachineDeployment",
       "type": "object",

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -160,15 +160,6 @@ type SSHKeySpec struct {
 	PublicKey   string `json:"publicKey"`
 }
 
-// LegacyUser represents an API user that is used for authentication.
-// Depreciated: use User instead
-type LegacyUser struct {
-	ID    string
-	Name  string
-	Email string
-	Roles map[string]struct{}
-}
-
 // User represent an API user
 // swagger:model User
 type User struct {

--- a/api/pkg/handler/authentication_test.go
+++ b/api/pkg/handler/authentication_test.go
@@ -29,9 +29,9 @@ const (
 
 var _ OIDCIssuerVerifier = FakeIssuerVerifier{}
 
-// testAuthenticator is a test stub that mocks apiv1.LegacyUser
+// testAuthenticator is a test stub that mocks apiv1.User
 type testAuthenticator struct {
-	user apiv1.LegacyUser
+	user apiv1.User
 }
 
 // FakeOicdProvider is a test stub that mocks *oidc.Provider
@@ -41,16 +41,16 @@ type FakeOicdProvider struct {
 }
 
 // NewFakeAuthenticator returns an testing authentication middleware
-func NewFakeAuthenticator(user apiv1.LegacyUser) OIDCAuthenticator {
+func NewFakeAuthenticator(user apiv1.User) OIDCAuthenticator {
 	return testAuthenticator{user: user}
 }
 
 // Verifier is a convenient middleware that extracts the ID Token from the request,
-// verifies it's been signed by the provider and creates apiv1.LegacyUser from it
+// verifies it's been signed by the provider and creates apiv1.User from it
 func (o testAuthenticator) Verifier() endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-			_, ok := ctx.Value(apiUserContextKey).(apiv1.LegacyUser)
+			_, ok := ctx.Value(authenticatedUserContextKey).(apiv1.User)
 			if !ok {
 				return nil, k8cerrors.NewNotAuthorized()
 			}
@@ -62,7 +62,7 @@ func (o testAuthenticator) Verifier() endpoint.Middleware {
 // Extractor knows how to extract the ID token from the request
 func (o testAuthenticator) Extractor() transporthttp.RequestFunc {
 	return func(ctx context.Context, _ *http.Request) context.Context {
-		return context.WithValue(ctx, apiUserContextKey, o.user)
+		return context.WithValue(ctx, authenticatedUserContextKey, o.user)
 	}
 }
 

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -31,7 +31,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 		ProjectToSync                 string
 		ClusterToSync                 string
 		ExistingKubermaticObjs        []runtime.Object
-		ExistingAPIUser               *apiv1.LegacyUser
+		ExistingAPIUser               *apiv1.User
 		ExpectedSSHKeys               []*kubermaticv1.UserSSHKey
 		ExpectedListClusterKeysStatus int
 	}{
@@ -176,7 +176,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 		ClusterToSync                   string
 		ExpectedDeleteResponse          string
 		ExpectedDeleteHTTPStatus        int
-		ExistingAPIUser                 *apiv1.LegacyUser
+		ExistingAPIUser                 *apiv1.User
 		ExistingSSHKeys                 []*kubermaticv1.UserSSHKey
 		ExistingKubermaticObjs          []runtime.Object
 		ExpectedResponseOnGetAfterDelte string
@@ -291,7 +291,7 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 		HTTPStatus             int
 		ExistingProject        *kubermaticv1.Project
 		ExistingKubermaticUser *kubermaticv1.User
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingCluster        *kubermaticv1.Cluster
 		ExistingSSHKeys        []*kubermaticv1.UserSSHKey
 		ExistingKubermaticObjs []runtime.Object
@@ -401,7 +401,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 		HTTPStatus             int
 		ProjectToSync          string
 		ClusterToSync          string
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingKubermaticObjs []runtime.Object
 		ExpectedSSHKeys        []*kubermaticv1.UserSSHKey
 	}{
@@ -523,7 +523,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		HTTPStatus             int
 		ProjectToSync          string
 		ExistingProject        *kubermaticv1.Project
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingKubermaticObjs []runtime.Object
 		RewriteClusterID       bool
 	}{
@@ -571,7 +571,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			HTTPStatus:             http.StatusForbidden,
 			ProjectToSync:          genDefaultProject().Name,
 			ExistingKubermaticObjs: genDefaultKubermaticObjects(),
-			ExistingAPIUser: func() *apiv1.LegacyUser {
+			ExistingAPIUser: func() *apiv1.User {
 				defaultUser := genDefaultAPIUser()
 				defaultUser.Email = "john@acme.com"
 				return defaultUser
@@ -642,7 +642,7 @@ func TestGetClusterHealth(t *testing.T) {
 		HTTPStatus             int
 		ClusterToGet           string
 		ProjectToSync          string
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingKubermaticObjs []runtime.Object
 	}{
 		// scenario 1
@@ -710,7 +710,7 @@ func TestPatchCluster(t *testing.T) {
 		HTTPStatus                int
 		cluster                   string
 		project                   string
-		ExistingAPIUser           *apiv1.LegacyUser
+		ExistingAPIUser           *apiv1.User
 		ExistingKubermaticObjects []runtime.Object
 	}{
 		// scenario 1
@@ -768,7 +768,7 @@ func TestGetCluster(t *testing.T) {
 		ExpectedResponse       string
 		HTTPStatus             int
 		ClusterToGet           string
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingKubermaticObjs []runtime.Object
 	}{
 		// scenario 1
@@ -827,7 +827,7 @@ func TestListClusters(t *testing.T) {
 		Name                   string
 		ExpectedClusters       []apiv1.Cluster
 		HTTPStatus             int
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingKubermaticObjs []runtime.Object
 	}{
 		// scenario 1

--- a/api/pkg/handler/datacenter.go
+++ b/api/pkg/handler/datacenter.go
@@ -14,8 +14,6 @@ import (
 
 func datacentersEndpoint(dcs map[string]provider.DatacenterMeta) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		user := ctx.Value(apiUserContextKey).(apiv1.LegacyUser)
-
 		var adcs []apiv1.Datacenter
 		var keys []string
 		for k := range dcs {
@@ -25,11 +23,6 @@ func datacentersEndpoint(dcs map[string]provider.DatacenterMeta) endpoint.Endpoi
 
 		for _, dcName := range keys {
 			dc := dcs[dcName]
-
-			if dc.Private && !IsAdmin(user) {
-				glog.V(7).Infof("Hiding dc %q for non-admin user %q", dcName, user.ID)
-				continue
-			}
 
 			spec, err := apiSpec(&dc)
 			if err != nil {

--- a/api/pkg/handler/datacenter_test.go
+++ b/api/pkg/handler/datacenter_test.go
@@ -24,7 +24,7 @@ func TestDatacentersEndpoint(t *testing.T) {
 		t.Fatalf("Expected route to return code 200, got %d: %s", res.Code, res.Body.String())
 	}
 
-	compareWithResult(t, res, `[{"metadata":{"name":"regular-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"}}},{"metadata":{"name":"us-central1","resourceVersion":"1"},"spec":{"seed":"","country":"US","location":"us-central","provider":"digitalocean","digitalocean":{"region":"ams2"}},"seed":true}]`)
+	compareWithResult(t, res, `[{"metadata":{"name":"private-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"}}},{"metadata":{"name":"regular-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"}}},{"metadata":{"name":"us-central1","resourceVersion":"1"},"spec":{"seed":"","country":"US","location":"us-central","provider":"digitalocean","digitalocean":{"region":"ams2"}},"seed":true}]`)
 }
 
 func TestDatacenterEndpointNotFound(t *testing.T) {

--- a/api/pkg/handler/kubeconfig_test.go
+++ b/api/pkg/handler/kubeconfig_test.go
@@ -118,7 +118,7 @@ func TestCreateOIDCKubeconfig(t *testing.T) {
 			reqURL := fmt.Sprintf("/api/v1/kubeconfig?cluster_id=%s&project_id=%s&user_id=%s&datacenter=%s", tc.ClusterID, tc.ProjectID, tc.UserID, tc.Datacenter)
 			req := httptest.NewRequest("GET", reqURL, strings.NewReader(""))
 			res := httptest.NewRecorder()
-			ep, err := createTestEndpoint(apiv1.LegacyUser{}, []runtime.Object{}, tc.ExistingKubermaticObjects, nil, nil)
+			ep, err := createTestEndpoint(apiv1.User{}, []runtime.Object{}, tc.ExistingKubermaticObjects, nil, nil)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -31,7 +31,7 @@ func TestDeleteNodeForCluster(t *testing.T) {
 		NodeIDToDelete          string
 		ClusterIDToSync         string
 		ProjectIDToSync         string
-		ExistingAPIUser         *apiv1.LegacyUser
+		ExistingAPIUser         *apiv1.User
 		ExistingNodes           []*corev1.Node
 		ExistingMachines        []*clusterv1alpha1.Machine
 		ExistingKubermaticObjs  []runtime.Object
@@ -165,7 +165,7 @@ func TestListNodesForCluster(t *testing.T) {
 		ClusterIDToSync        string
 		ExistingProject        *kubermaticv1.Project
 		ExistingKubermaticUser *kubermaticv1.User
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingCluster        *kubermaticv1.Cluster
 		ExistingNodes          []*corev1.Node
 		ExistingMachines       []*clusterv1alpha1.Machine
@@ -417,7 +417,7 @@ func TestGetNodeForCluster(t *testing.T) {
 		NodeIDToSync           string
 		ClusterIDToSync        string
 		ProjectIDToSync        string
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingNodes          []*corev1.Node
 		ExistingMachines       []*clusterv1alpha1.Machine
 		ExistingKubermaticObjs []runtime.Object
@@ -492,7 +492,7 @@ func TestCreateNodeForCluster(t *testing.T) {
 		RewriteClusterNameAndNamespaceName bool
 		ExistingProject                    *kubermaticv1.Project
 		ExistingKubermaticUser             *kubermaticv1.User
-		ExistingAPIUser                    *apiv1.LegacyUser
+		ExistingAPIUser                    *apiv1.User
 		ExistingCluster                    *kubermaticv1.Cluster
 		ExistingKubermaticObjs             []runtime.Object
 	}{
@@ -570,7 +570,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 		HTTPStatus             int
 		ExistingProject        *kubermaticv1.Project
 		ExistingKubermaticUser *kubermaticv1.User
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingCluster        *kubermaticv1.Cluster
 		ExistingKubermaticObjs []runtime.Object
 	}{
@@ -647,7 +647,7 @@ func TestListNodeDeployments(t *testing.T) {
 		ClusterIDToSync            string
 		ExistingProject            *kubermaticv1.Project
 		ExistingKubermaticUser     *kubermaticv1.User
-		ExistingAPIUser            *apiv1.LegacyUser
+		ExistingAPIUser            *apiv1.User
 		ExistingCluster            *kubermaticv1.Cluster
 		ExistingMachineDeployments []*clusterv1alpha1.MachineDeployment
 		ExistingKubermaticObjs     []runtime.Object
@@ -768,7 +768,7 @@ func TestGetNodeDeployment(t *testing.T) {
 		ClusterIDToSync            string
 		ExistingProject            *kubermaticv1.Project
 		ExistingKubermaticUser     *kubermaticv1.User
-		ExistingAPIUser            *apiv1.LegacyUser
+		ExistingAPIUser            *apiv1.User
 		ExistingCluster            *kubermaticv1.Cluster
 		ExistingMachineDeployments []*clusterv1alpha1.MachineDeployment
 		ExistingKubermaticObjs     []runtime.Object
@@ -863,7 +863,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 		HTTPStatus                 int
 		cluster                    string
 		project                    string
-		ExistingAPIUser            *apiv1.LegacyUser
+		ExistingAPIUser            *apiv1.User
 		NodeDeploymentID           string
 		ExistingMachineDeployments []*clusterv1alpha1.MachineDeployment
 		ExistingKubermaticObjs     []runtime.Object
@@ -945,7 +945,7 @@ func TestDeleteNodeDeployment(t *testing.T) {
 		NodeIDToDelete             string
 		ClusterIDToSync            string
 		ProjectIDToSync            string
-		ExistingAPIUser            *apiv1.LegacyUser
+		ExistingAPIUser            *apiv1.User
 		ExistingNodes              []*corev1.Node
 		ExistingMachineDeployments []*clusterv1alpha1.MachineDeployment
 		ExistingKubermaticObjs     []runtime.Object

--- a/api/pkg/handler/project_test.go
+++ b/api/pkg/handler/project_test.go
@@ -24,7 +24,7 @@ func TestListProjectEndpoint(t *testing.T) {
 		ExpectedResponse          []apiv1.Project
 		HTTPStatus                int
 		ExistingKubermaticObjects []runtime.Object
-		ExistingAPIUser           apiv1.LegacyUser
+		ExistingAPIUser           apiv1.User
 	}{
 		{
 			Name:       "scenario 1: list projects that John is the member of",
@@ -41,8 +41,10 @@ func TestListProjectEndpoint(t *testing.T) {
 				genBinding("my-first-project-ID", "john@acme.com", "owners"),
 				genBinding("my-third-project-ID", "john@acme.com", "editors"),
 			},
-			ExistingAPIUser: apiv1.LegacyUser{
-				ID:    testUserName,
+			ExistingAPIUser: apiv1.User{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID: testUserName,
+				},
 				Email: testUserEmail,
 			},
 			ExpectedResponse: []apiv1.Project{
@@ -105,7 +107,7 @@ func TestGetProjectEndpoint(t *testing.T) {
 		HTTPStatus                int
 		ExistingKubermaticUser    *kubermaticapiv1.User
 		ExistingKubermaticObjects []runtime.Object
-		ExistingAPIUser           *apiv1.LegacyUser
+		ExistingAPIUser           *apiv1.User
 	}{
 		{
 			Name:                      "scenario 1: get an existing project assigned to the given user",
@@ -149,7 +151,7 @@ func TestCreateProjectEndpoint(t *testing.T) {
 		ExpectedResponse          string
 		HTTPStatus                int
 		ExistingKubermaticObjects []runtime.Object
-		ExistingAPIUser           *apiv1.LegacyUser
+		ExistingAPIUser           *apiv1.User
 	}{
 		{
 			Name:             "scenario 1: a user doesn't have any projects, thus creating one succeeds",
@@ -214,7 +216,7 @@ func TestDeleteProjectEndpoint(t *testing.T) {
 		HTTPStatus                int
 		ProjectToSync             string
 		ExistingKubermaticObjects []runtime.Object
-		ExistingAPIUser           *apiv1.LegacyUser
+		ExistingAPIUser           *apiv1.User
 	}{
 		{
 			Name:                      "scenario 1: the owner of the project can delete the project",
@@ -235,8 +237,10 @@ func TestDeleteProjectEndpoint(t *testing.T) {
 				// make John the editor of the project
 				genBinding("my-second-project-ID", "john@acme.com", "editors"),
 			},
-			ExistingAPIUser: &apiv1.LegacyUser{
-				ID:    "JohnID",
+			ExistingAPIUser: &apiv1.User{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID: "JohnID",
+				},
 				Email: "john@acme.com",
 			},
 		},

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -15,12 +15,12 @@ import (
 type ContextKey string
 
 const (
-	rawToken                  ContextKey = "raw-auth-token"
-	apiUserContextKey         ContextKey = "api-user"
-	userCRContextKey          ContextKey = "user-cr"
-	userInfoContextKey        ContextKey = "user-info"
-	datacenterContextKey      ContextKey = "datacenter"
-	clusterProviderContextKey ContextKey = "cluster-provider"
+	rawToken                    ContextKey = "raw-auth-token"
+	authenticatedUserContextKey ContextKey = "authenticated-user"
+	userCRContextKey            ContextKey = "user-cr"
+	userInfoContextKey          ContextKey = "user-info"
+	datacenterContextKey        ContextKey = "datacenter"
+	clusterProviderContextKey   ContextKey = "cluster-provider"
 )
 
 // UpdateManager specifies a set of methods to handle cluster versions & updates

--- a/api/pkg/handler/routing_test.go
+++ b/api/pkg/handler/routing_test.go
@@ -40,7 +40,7 @@ import (
 	fakeclusterclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
 )
 
-func createTestEndpointAndGetClients(user apiv1.LegacyUser, dc map[string]provider.DatacenterMeta, kubeObjects, machineObjects, kubermaticObjects []runtime.Object, versions []*version.MasterVersion, updates []*version.MasterUpdate) (http.Handler, *clientsSets, error) {
+func createTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.DatacenterMeta, kubeObjects, machineObjects, kubermaticObjects []runtime.Object, versions []*version.MasterVersion, updates []*version.MasterUpdate) (http.Handler, *clientsSets, error) {
 	datacenters := dc
 	if datacenters == nil {
 		datacenters = buildDatacenterMeta()
@@ -112,7 +112,7 @@ func createTestEndpointAndGetClients(user apiv1.LegacyUser, dc map[string]provid
 	return mainRouter, &clientsSets{kubermaticClient, fakeMachineClient}, nil
 }
 
-func createTestEndpoint(user apiv1.LegacyUser, kubeObjects, kubermaticObjects []runtime.Object, versions []*version.MasterVersion, updates []*version.MasterUpdate) (http.Handler, error) {
+func createTestEndpoint(user apiv1.User, kubeObjects, kubermaticObjects []runtime.Object, versions []*version.MasterVersion, updates []*version.MasterUpdate) (http.Handler, error) {
 	router, _, err := createTestEndpointAndGetClients(user, nil, kubeObjects, nil, kubermaticObjects, versions, updates)
 	return router, err
 }
@@ -198,22 +198,18 @@ const (
 	testUserEmail = "john@acme.com"
 )
 
-func getUser(email, id, name string, admin bool) apiv1.LegacyUser {
-	u := apiv1.LegacyUser{
-		ID:    id,
-		Name:  name,
-		Email: email,
-		Roles: map[string]struct{}{
-			"user": {},
+func getUser(email, id, name string, admin bool) apiv1.User {
+	u := apiv1.User{
+		ObjectMeta: apiv1.ObjectMeta{
+			ID:   id,
+			Name: name,
 		},
-	}
-	if admin {
-		u.Roles[AdminRoleKey] = struct{}{}
+		Email: email,
 	}
 	return u
 }
 
-func apiUserToKubermaticUser(user apiv1.LegacyUser) *kubermaticapiv1.User {
+func apiUserToKubermaticUser(user apiv1.User) *kubermaticapiv1.User {
 	return &kubermaticapiv1.User{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: kubermaticapiv1.UserSpec{

--- a/api/pkg/handler/ssh_test.go
+++ b/api/pkg/handler/ssh_test.go
@@ -24,7 +24,7 @@ func TestDeleteSSHKey(t *testing.T) {
 		HTTPStatus             int
 		SSHKeyToDelete         string
 		ExistingKubermaticObjs []runtime.Object
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingSSHKeys        []*kubermaticv1.UserSSHKey
 	}{
 		// scenario 1
@@ -106,7 +106,7 @@ func TestListSSHKeys(t *testing.T) {
 		ExistingProject        *kubermaticv1.Project
 		ExistingKubermaticUser *kubermaticv1.User
 		ExistingKubermaticObjs []runtime.Object
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 		ExistingCluster        *kubermaticv1.Cluster
 		ExistingSSHKeys        []*kubermaticv1.UserSSHKey
 	}{
@@ -186,7 +186,7 @@ func TestCreateSSHKeysEndpoint(t *testing.T) {
 		ExistingProject        *kubermaticv1.Project
 		ExistingKubermaticUser *kubermaticv1.User
 		ExistingKubermaticObjs []runtime.Object
-		ExistingAPIUser        *apiv1.LegacyUser
+		ExistingAPIUser        *apiv1.User
 	}{
 		// scenario 1
 		{

--- a/api/pkg/handler/upgrade_test.go
+++ b/api/pkg/handler/upgrade_test.go
@@ -24,7 +24,7 @@ func TestGetClusterUpgradesV1(t *testing.T) {
 		name                   string
 		cluster                *kubermaticv1.Cluster
 		existingKubermaticObjs []runtime.Object
-		apiUser                apiv1.LegacyUser
+		apiUser                apiv1.User
 		versions               []*version.MasterVersion
 		updates                []*version.MasterUpdate
 		wantUpdates            []*apiv1.MasterVersion

--- a/api/pkg/handler/user_test.go
+++ b/api/pkg/handler/user_test.go
@@ -29,7 +29,7 @@ func TestGetUsersForProject(t *testing.T) {
 		ExpectedUserAfterInvitation *kubermaticapiv1.User
 		ProjectToGet                string
 		HTTPStatus                  int
-		ExistingAPIUser             apiv1.LegacyUser
+		ExistingAPIUser             apiv1.User
 		ExistingKubermaticObjs      []runtime.Object
 	}{
 		{
@@ -179,7 +179,7 @@ func TestDeleteUserFromProject(t *testing.T) {
 		ProjectToSync                string
 		UserIDToDelete               string
 		HTTPStatus                   int
-		ExistingAPIUser              apiv1.LegacyUser
+		ExistingAPIUser              apiv1.User
 		ExistingKubermaticObjs       []runtime.Object
 	}{
 		// scenario 1
@@ -330,7 +330,7 @@ func TestEditUserInProject(t *testing.T) {
 		ProjectToSync              string
 		UserIDToUpdate             string
 		HTTPStatus                 int
-		ExistingAPIUser            apiv1.LegacyUser
+		ExistingAPIUser            apiv1.User
 		ExistingKubermaticObjs     []runtime.Object
 	}{
 		// scenario 1
@@ -516,7 +516,7 @@ func TestAddUserToProject(t *testing.T) {
 		ExpectedBindingAfterInvitation *kubermaticapiv1.UserProjectBinding
 		ProjectToSync                  string
 		HTTPStatus                     int
-		ExistingAPIUser                apiv1.LegacyUser
+		ExistingAPIUser                apiv1.User
 		ExistingKubermaticObjs         []runtime.Object
 	}{
 		{
@@ -759,7 +759,7 @@ func TestGetCurrentUser(t *testing.T) {
 		ExpectedResponse       string
 		ExpectedStatus         int
 		ExistingKubermaticObjs []runtime.Object
-		ExistingAPIUser        apiv1.LegacyUser
+		ExistingAPIUser        apiv1.User
 	}{
 		{
 			Name: "scenario 1: get john's profile (no projects assigned)",
@@ -818,7 +818,7 @@ func TestNewUser(t *testing.T) {
 		ExpectedResponse          string
 		ExpectedKubermaticUser    *kubermaticapiv1.User
 		ExistingKubermaticObjects []runtime.Object
-		ExistingAPIUser           *apiv1.LegacyUser
+		ExistingAPIUser           *apiv1.User
 	}{
 		{
 			Name:             "scenario 1: successfully creates a new user resource",
@@ -838,7 +838,7 @@ func TestNewUser(t *testing.T) {
 			Name:             "scenario 2: fails when creating a user without an email address",
 			ExpectedResponse: `{"error":{"code":400,"message":"Email, ID and Name cannot be empty when creating a new user resource"}}`,
 			HTTPStatus:       http.StatusBadRequest,
-			ExistingAPIUser: func() *apiv1.LegacyUser {
+			ExistingAPIUser: func() *apiv1.User {
 				apiUser := genDefaultAPIUser()
 				apiUser.Email = ""
 				return apiUser
@@ -917,19 +917,23 @@ func genDefaultUser() *kubermaticapiv1.User {
 	return genUser("", "Bob", userEmail)
 }
 
-func genAPIUser(name, email string) *apiv1.LegacyUser {
+func genAPIUser(name, email string) *apiv1.User {
 	usr := genUser("", name, email)
-	return &apiv1.LegacyUser{
-		ID:    usr.Name,
-		Name:  usr.Spec.Name,
+	return &apiv1.User{
+		ObjectMeta: apiv1.ObjectMeta{
+			ID:   usr.Name,
+			Name: usr.Spec.Name,
+		},
 		Email: usr.Spec.Email,
 	}
 }
 
-func genDefaultAPIUser() *apiv1.LegacyUser {
-	return &apiv1.LegacyUser{
-		ID:    genDefaultUser().Name,
-		Name:  genDefaultUser().Spec.Name,
+func genDefaultAPIUser() *apiv1.User {
+	return &apiv1.User{
+		ObjectMeta: apiv1.ObjectMeta{
+			ID:   genDefaultUser().Name,
+			Name: genDefaultUser().Spec.Name,
+		},
 		Email: genDefaultUser().Spec.Email,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: simply removes unused `api.LegacyUser` type.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2260 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
