### PR TITLE
adds "kubernetes" suffix to a directory name

### DIFF
--- a/containers/conformance-tests/install.sh
+++ b/containers/conformance-tests/install.sh
@@ -9,7 +9,7 @@ apt update && apt install -y git-crypt curl
 TMP_ROOT="./.install-tmp"
 
 for VERSION in 1.10 1.11 1.12; do
-    DIRECTORY="${ROOT_DIR}/${VERSION}"
+    DIRECTORY="${ROOT_DIR}/${VERSION}-kubernetes"
     if [ ! -d "${DIRECTORY}" ]; then
 
         FULL_VERSION=$(curl -Ss https://storage.googleapis.com/kubernetes-release/release/stable-${VERSION}.txt)


### PR DESCRIPTION
**What this PR does / why we need it**: turns out that `kubetest` assumes that the last
part of that path contains "kubernetes". If not then it complains `directory: must run from kubernetes directory root`. 

See: https://github.com/kubernetes/test-infra/blob/master/kubetest/main.go#L216


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
