### PR TITLE
Explicitly enable ip forwarding

### DIFF
--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -110,6 +110,9 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			Args: []string{
 				"-c",
 				`
+                # Always set IP forwarding
+                sysctl -w net.ipv4.ip_forward=1
+
 				# do not give a 10.20.0.0/24 route to clients (nodes) but
 				# masquerade to openvpn-server's IP instead:
 				iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -108,26 +108,24 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"/bin/bash"},
 			Args: []string{
-				"-c",
-				`
-                # Always set IP forwarding
-                sysctl -w net.ipv4.ip_forward=1
+				"-c", `# Always set IP forwarding
+sysctl -w net.ipv4.ip_forward=1
 
-				# do not give a 10.20.0.0/24 route to clients (nodes) but
-				# masquerade to openvpn-server's IP instead:
-				iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+# do not give a 10.20.0.0/24 route to clients (nodes) but
+# masquerade to openvpn-server's IP instead:
+iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
 
-				# Only allow outbound traffic to services, pods, nodes
-				iptables -P FORWARD DROP
-				iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
-				iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d ` + podNet.String() + ` -j ACCEPT
-				iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d ` + serviceNet.String() + ` -j ACCEPT
-				iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d ` + nodeAccessNetwork.String() + ` -j ACCEPT
+# Only allow outbound traffic to services, pods, nodes
+iptables -P FORWARD DROP
+iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d ` + podNet.String() + ` -j ACCEPT
+iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d ` + serviceNet.String() + ` -j ACCEPT
+iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d ` + nodeAccessNetwork.String() + ` -j ACCEPT
 
-				iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-				iptables -A INPUT -i tun0 -p icmp -j ACCEPT
-				iptables -A INPUT -i tun0 -j DROP
-				`,
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+iptables -A INPUT -i tun0 -j DROP
+`,
 			},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
@@ -132,17 +132,24 @@ spec:
       initContainers:
       - args:
         - -c
-        - "\n\t\t\t\t# do not give a 10.20.0.0/24 route to clients (nodes) but\n\t\t\t\t#
-          masquerade to openvpn-server's IP instead:\n\t\t\t\tiptables -t nat -A POSTROUTING
-          -o tun0 -s 10.20.0.0/24 -j MASQUERADE\n\n\t\t\t\t# Only allow outbound traffic
-          to services, pods, nodes\n\t\t\t\tiptables -P FORWARD DROP\n\t\t\t\tiptables
-          -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT\n\t\t\t\tiptables
-          -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT\n\n\t\t\t\tiptables
-          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n\t\t\t\tiptables
-          -A INPUT -i tun0 -p icmp -j ACCEPT\n\t\t\t\tiptables -A INPUT -i tun0 -j
-          DROP\n\t\t\t\t"
+        - |
+          # Always set IP forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
         image: docker.io/kubermatic/openvpn:v0.4


### PR DESCRIPTION
**What this PR does / why we need it**:
Explicitly enable IP forwarding.
This will ensure the VPN will work regardless if the host of the seed cluster has IP forwarding enabled or not.
This can eliminate useless debugging.

**Release note**:
```release-note bugfix
Fixed an issue with kubelets being unreachable by the apiserver on some OS configurations.
```
