### PR TITLE
[release/v2.8] Backport conformance tests

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -834,6 +834,19 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:be28165aab86328e1a38feca9c9e644528e41cd89c06275353ae3837f7b750cc"
+  name = "github.com/onsi/ginkgo"
+  packages = [
+    "config",
+    "reporters",
+    "reporters/stenographer",
+    "types",
+  ]
+  pruneopts = "NUT"
+  revision = "2e1be8f7d90e9d3e3e58b0ce470f2f14d075406f"
+  version = "v1.7.0"
+
+[[projects]]
   digest = "1:cce3a18fb0b96b5015cd8ca03a57d20a662679de03c4dc4b6ff5f17ea2050fa6"
   name = "github.com/pborman/uuid"
   packages = ["."]
@@ -1766,6 +1779,7 @@
     "github.com/kubermatic/machine-controller/pkg/userdata/ubuntu",
     "github.com/minio/minio-go",
     "github.com/oklog/run",
+    "github.com/onsi/ginkgo/reporters",
     "github.com/pmezard/go-difflib/difflib",
     "github.com/prometheus/client_golang/api",
     "github.com/prometheus/client_golang/api/prometheus/v1",
@@ -1773,6 +1787,7 @@
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/common/model",
     "github.com/robfig/cron",
+    "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/ugorji/go/codec/codecgen",
     "github.com/urfave/cli",

--- a/api/Makefile
+++ b/api/Makefile
@@ -48,13 +48,7 @@ docker-push:
 		docker push $(REPO):$$tag; \
 	done
 
-vendor: Gopkg.lock Gopkg.toml
-ifndef HAS_GIT
-	$(error You must install git)
-endif
-ifndef HAS_DEP
-	go get -u github.com/golang/dep/cmd/dep
-endif
+vendor:
 	dep ensure -v
 
 gittag:

--- a/api/cmd/conformance-tests/README.md
+++ b/api/cmd/conformance-tests/README.md
@@ -1,0 +1,71 @@
+# E2E conformance tester
+
+Runs static test scenarios against a kubermatic cluster.
+
+The conformance tester will, by default, test all supported versions on providers using all supported operating systems.
+
+## Tests
+
+The command which will execute the following tests:
+- Simple PVC (Only: AWS, Azure, OpenStack, vSphere)
+  A StatefulSet with a PVC template will be created. The Pod, which mounts the PV has a ReadinessProbe in place
+  which will only report ready when the pod was able to write something to the mounted PV.
+  The PVC has no StorageClass set, so the default StorageClass, which gets deployed via the default kubermatic Addon `default-storage-class`, will be used.
+- Simple LB (Only: AWS & Azure)
+  The [Hello Kubernetes](https://kubernetes.io/docs/tasks/access-application-cluster/service-access-application-cluster/#creating-a-service-for-an-application-running-in-two-pods) Pod will be deployed with a Service of type LoadBalancer.
+  The test will wait until the LoadBalancer is available and only report a success when the "Hello Kubernetes" Pod could be reached via the LoadBalancer IP(Or DNS).
+- [Kubernetes Conformance tests](https://github.com/kubernetes/community/blob/master/contributors/devel/conformance-tests.md#running-conformance-tests) (First all parallel, afterwards all serial tests)
+
+## Caveats
+
+All providers have custom quota's.
+Hitting the quota is fairly easy when testing too many clusters at once.
+
+## Running
+
+### Locally
+
+**Requires**
+- `containers/conformance-tests/install.sh` to be run before
+- vault cli to be installed locally & configured for https://vault.loodse.com/
+
+#### Testing all providers
+```bash
+./run.sh
+```
+
+#### Common customizations
+
+**Debug logs**
+
+Setting `-debug` will enable the debug logs.
+
+**Only test a specific provider**
+
+The providers which should be covered can be set via the `-providers` flag.
+
+For example, setting `-providers=aws` will only test AWS clusters.
+
+**Parallelism**
+
+To configure the number of clusters which should be tested in parallel, the `-kubermatic-parallel-clusters=4` can be use.
+
+**Node count**
+
+More nodes tend to improve test performance by some degree, though a higher node count might lead to reaching the quota.
+
+The number of nodes, each cluster will have can be set via `-kubermatic-nodes=3`
+
+**Keep clusters after test**
+
+To be able to debug clusters, they must remain after a test has been run. 
+For this `-kubermatic-delete-cluster=false` can be specified, which will simply not delete the cluster after testing.
+
+**Delete existing clusters from a previous run**
+
+In case a previous run left some clusters behind - maybe due to the use of `-kubermatic-delete-cluster=false` - 
+they can be deleting during the next execution by setting `-cleanup-on-start=true`.  
+
+### Docker
+
+TODO: Define

--- a/api/cmd/conformance-tests/cleanup.go
+++ b/api/cmd/conformance-tests/cleanup.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	clusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/machine-controller/pkg/node/eviction"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+var (
+	protectedNamespaces = sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic)
+)
+
+func deleteAllNonDefaultNamespaces(log *logrus.Entry, kubeClient kubernetes.Interface) error {
+	return wait.Poll(defaultUserClusterPollInterval, defaultTimeout, func() (done bool, err error) {
+		namespaceList, err := kubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+		if err != nil {
+			log.Errorf("failed to list namespaces: %v", err)
+			return false, nil
+		}
+
+		// This check assumes no one deleted one of the protected namespaces
+		if len(namespaceList.Items) <= protectedNamespaces.Len() {
+			return true, nil
+		}
+
+		for _, namespace := range namespaceList.Items {
+			if protectedNamespaces.Has(namespace.Name) {
+				continue
+			}
+			log = log.WithFields(logrus.Fields{"namespace-to-delete": namespace.Name})
+
+			// If its not gone & the DeletionTimestamp is nil, delete it
+			if namespace.DeletionTimestamp == nil {
+				if err := kubeClient.CoreV1().Namespaces().Delete(namespace.Name, nil); err != nil {
+					log.Errorf("Failed to delete namespace: %v", err)
+				} else {
+					log.Debugf("Called delete on namespace")
+				}
+			}
+		}
+		return false, nil
+	})
+}
+
+func tryToDeleteClusterWithRetries(log *logrus.Entry, cluster *kubermaticv1.Cluster, clusterClientProvider *clusterclient.Provider, kubermaticClient kubermaticclientset.Interface) error {
+	const maxAttempts = 5
+	return retryNAttempts(maxAttempts, func(attempt int) error {
+		err := tryToDeleteCluster(log, cluster, clusterClientProvider, kubermaticClient)
+		if err != nil {
+			log.Warnf("[Attempt %d/%d] Failed to delete Cluster: %v", attempt, maxAttempts, err)
+		}
+		return err
+	})
+}
+
+// tryToDeleteCluster will try to delete all potential orphaned cloud provider resources like LB's & PVC's
+// After deleting them it will delete the kubermatic cluster object
+func tryToDeleteCluster(log *logrus.Entry, cluster *kubermaticv1.Cluster, clusterClientProvider *clusterclient.Provider, kubermaticClient kubermaticclientset.Interface) error {
+	log.Infof("Trying to delete cluster...")
+
+	kubeClient, err := clusterClientProvider.GetClient(cluster)
+	if err != nil {
+		return fmt.Errorf("failed to get the client for the cluster: %v", err)
+	}
+
+	if err := deleteAllNonDefaultNamespaces(log, kubeClient); err != nil {
+		return fmt.Errorf("failed to delete all namespaces: %v", err)
+	}
+
+	// Disable eviction on all nodes
+	nodes, err := kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
+	for _, node := range nodes.Items {
+		log.Debugf("Disabling eviction on node '%s' ...", node.Name)
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			// Get latest version of the node to prevent conflict errors
+			currentNode, err := kubeClient.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if currentNode.Annotations == nil {
+				currentNode.Annotations = map[string]string{}
+			}
+			node.Annotations[eviction.SkipEvictionAnnotationKey] = "true"
+
+			currentNode, err = kubeClient.CoreV1().Nodes().Update(&node)
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add the annotation '%s=true' to node '%s': %v", eviction.SkipEvictionAnnotationKey, node.Name, err)
+		}
+	}
+
+	log.Debug("Calling delete on the cluster resource...")
+	if err := kubermaticClient.KubermaticV1().Clusters().Delete(cluster.Name, &metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete cluster %s: %v. Make sure to delete it manually afterwards", cluster.Name, err)
+	}
+
+	log.Info("Finished deleting cluster")
+	return nil
+}

--- a/api/cmd/conformance-tests/custom_tests.go
+++ b/api/cmd/conformance-tests/custom_tests.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *testRunner) testPVC(log *logrus.Entry, kubeClient kubernetes.Interface) error {
+	log.Info("Testing support for PVC's...")
+
+	// We're creating a own namespace, so the cleanup routine will take care as fallback
+	const nsName = "pvc-test"
+	ns, err := kubeClient.CoreV1().Namespaces().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create namespace: %v", err)
+	}
+
+	defer func() {
+		if err := deleteAllNonDefaultNamespaces(log, kubeClient); err != nil {
+			log.Errorf("Failed to cleanup namespaces after the PVC test: %v", err)
+		}
+	}()
+
+	log.Info("Creating a StatefulSet with PVC...")
+	labels := map[string]string{"app": "data-writer"}
+	// Creating a simple StatefulSet with 1 replica which writes to the PV. That way we know if storage can be provisioned and consumed
+	set, err := kubeClient.AppsV1().StatefulSets(ns.Name).Create(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "data-writer",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "busybox",
+							Image: "k8s.gcr.io/busybox",
+							Args: []string{
+								"/bin/sh",
+								"-c",
+								`echo "alive" > /data/healthy; sleep 3600`,
+							},
+							ReadinessProbe: &corev1.Probe{
+								InitialDelaySeconds: 0,
+								SuccessThreshold:    3,
+								PeriodSeconds:       5,
+								TimeoutSeconds:      1,
+								FailureThreshold:    1,
+								Handler: corev1.Handler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"cat",
+											"/data/healthy",
+										},
+									},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "data",
+									MountPath: "/data",
+								},
+							},
+						},
+					},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "data",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create statefulset: %v", err)
+	}
+
+	log.Info("Waiting until the StatefulSet is ready...")
+	err = wait.Poll(10*time.Second, 10*time.Minute, func() (done bool, err error) {
+		currentSet, err := kubeClient.AppsV1().StatefulSets(ns.Name).Get(set.Name, metav1.GetOptions{})
+		if err != nil {
+			log.Warnf("failed to load StatefulSet %s/%s from API server during PVC test: %v", ns.Name, set.Name, err)
+			return false, nil
+		}
+		if currentSet.Status.ReadyReplicas == 1 {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check if StatefulSet is running: %v", err)
+	}
+
+	log.Info("Successfully validated PVC support")
+	return nil
+}
+
+func (r *testRunner) testLB(log *logrus.Entry, kubeClient kubernetes.Interface) error {
+	log.Info("Testing support for LB's...")
+
+	// We're creating a own namespace, so the cleanup routine will take care as fallback
+	const nsName = "lb-test"
+	ns, err := kubeClient.CoreV1().Namespaces().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create namespace: %v", err)
+	}
+
+	defer func() {
+		if err := deleteAllNonDefaultNamespaces(log, kubeClient); err != nil {
+			log.Errorf("Failed to cleanup namespaces after the PVC test: %v", err)
+		}
+	}()
+
+	log.Info("Creating a Service of type LoadBalancer...")
+	labels := map[string]string{"app": "hello"}
+	service, err := kubeClient.CoreV1().Services(ns.Name).Create(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeLoadBalancer,
+			Selector: labels,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create Service: %v", err)
+	}
+
+	_, err = kubeClient.CoreV1().Pods(ns.Name).Create(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "hello-kubernetes",
+			Labels: labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "hello-kubernetes",
+					Image: "gcr.io/google-samples/node-hello:1.0",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create Pod: %v", err)
+	}
+
+	var host string
+	log.Debug("Waiting until the Service has a public IP/Name...")
+	err = wait.Poll(10*time.Second, defaultTimeout, func() (done bool, err error) {
+		currentService, err := kubeClient.CoreV1().Services(ns.Name).Get(service.Name, metav1.GetOptions{})
+		if err != nil {
+			log.Warnf("failed to load Service %s/%s from API server during LB test: %v", ns.Name, service.Name, err)
+			return false, nil
+		}
+		if len(currentService.Status.LoadBalancer.Ingress) > 0 {
+			host = currentService.Status.LoadBalancer.Ingress[0].IP
+			if host == "" {
+				host = currentService.Status.LoadBalancer.Ingress[0].Hostname
+
+				// We wait until we can actually resolve the name
+				ips, err := net.LookupHost(host)
+				if err != nil || len(ips) == 0 {
+					return false, nil
+				}
+
+			}
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check if Service is ready: %v", err)
+	}
+	log.Debug("The Service has an external IP/Name")
+
+	url := fmt.Sprintf("http://%s:80", host)
+	log.Debug("Waiting until the pod is available via the LB...")
+	err = wait.Poll(30*time.Second, defaultTimeout, func() (done bool, err error) {
+		resp, err := http.Get(url)
+		if err != nil {
+			log.Warnf("Failed to call Pod via LB(%s) during LB test: %v", url, err)
+			return false, nil
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				log.Warnf("Failed to close response body from Hello-Kubernetes Pod during LB test (%s): %v", url, err)
+			}
+		}()
+		contents, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Warnf("Failed to read response body from Hello-Kubernetes Pod during LB test (%s): %v", url, err)
+			return false, nil
+		}
+
+		if strings.Contains(string(contents), "Hello Kubernetes!") {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check if Pod is available via LB: %v", err)
+	}
+
+	log.Info("Successfully validated LB support")
+	return nil
+}

--- a/api/cmd/conformance-tests/init.sh
+++ b/api/cmd/conformance-tests/init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+set -euo pipefail

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
@@ -28,7 +29,6 @@ import (
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
-	"github.com/kubermatic/kubermatic/api/pkg/semver"
 	kubermaticsignals "github.com/kubermatic/kubermatic/api/pkg/signals"
 	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
@@ -46,11 +46,11 @@ type excludeSelector struct {
 	Distributions map[providerconfig.OperatingSystem]bool
 }
 
-var supportedVersions = []*semver.Semver{
-	semver.NewSemverOrDie("v1.9.10"),
-	semver.NewSemverOrDie("v1.10.8"),
-	semver.NewSemverOrDie("v1.11.3"),
-	semver.NewSemverOrDie("v1.12.1"),
+var supportedVersions = []*semver.Version{
+	semver.MustParse("v1.9.10"),
+	semver.MustParse("v1.10.8"),
+	semver.MustParse("v1.11.3"),
+	semver.MustParse("v1.12.1"),
 }
 
 // Opts represent combination of flags and ENV options
@@ -211,7 +211,7 @@ func main() {
 
 	if opts.excludeKubernetesVersions != "" {
 		excludedKubernetesVersions := strings.Split(opts.excludeKubernetesVersions, ",")
-		var newSupportedVersions []*semver.Semver
+		var newSupportedVersions []*semver.Version
 	outer:
 		for _, supportedVersion := range supportedVersions {
 			for _, excludedKubernetesVersion := range excludedKubernetesVersions {

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -1,0 +1,455 @@
+package main
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+
+	clusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+	kubermaticsignals "github.com/kubermatic/kubermatic/api/pkg/signals"
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+//TODO: Move Kubernetes versions into this as well
+type excludeSelector struct {
+	// The value in this map is never used, we use the keys only to have a simple set mechanism
+	Distributions map[providerconfig.OperatingSystem]bool
+}
+
+var supportedVersions = []*semver.Semver{
+	semver.NewSemverOrDie("v1.9.10"),
+	semver.NewSemverOrDie("v1.10.8"),
+	semver.NewSemverOrDie("v1.11.3"),
+	semver.NewSemverOrDie("v1.12.1"),
+}
+
+// Opts represent combination of flags and ENV options
+type Opts struct {
+	namePrefix                     string
+	providers                      sets.String
+	controlPlaneReadyWaitTimeout   time.Duration
+	deleteClusterAfterTests        bool
+	kubeconfigPath                 string
+	nodeCount                      int
+	nodeReadyWaitTimeout           time.Duration
+	PublicKeys                     [][]byte
+	reportsRoot                    string
+	clusterLister                  kubermaticv1lister.ClusterLister
+	kubermaticClient               kubermaticclientset.Interface
+	kubeClient                     kubernetes.Interface
+	clusterClientProvider          *clusterclient.Provider
+	dcFile                         string
+	repoRoot                       string
+	dcs                            map[string]provider.DatacenterMeta
+	cleanupOnStart                 bool
+	clusterParallelCount           int
+	workerName                     string
+	HomeDir                        string
+	runKubermaticControllerManager bool
+	excludeKubernetesVersions      string
+	log                            *logrus.Entry
+	excludeSelector                excludeSelector
+	excludeSelectorRaw             string
+
+	secrets secrets
+}
+
+type secrets struct {
+	AWS struct {
+		AccessKeyID     string
+		SecretAccessKey string
+	}
+	Azure struct {
+		ClientID       string
+		ClientSecret   string
+		TenantID       string
+		SubscriptionID string
+	}
+	Digitalocean struct {
+		Token string
+	}
+	Hetzner struct {
+		Token string
+	}
+	OpenStack struct {
+		Domain   string
+		Tenant   string
+		Username string
+		Password string
+	}
+	VSphere struct {
+		Username string
+		Password string
+	}
+}
+
+const (
+	defaultTimeout                 = 30 * time.Minute
+	defaultUserClusterPollInterval = 10 * time.Second
+	defaultAPIRetries              = 100
+
+	controlPlaneReadyPollPeriod = 5 * time.Second
+	nodesReadyPollPeriod        = 5 * time.Second
+)
+
+var (
+	providers  string
+	pubKeyPath string
+	debug      bool
+)
+
+func main() {
+	mainLog := logrus.New()
+	mainLog.SetLevel(logrus.InfoLevel)
+
+	opts := Opts{
+		providers:  sets.NewString(),
+		PublicKeys: [][]byte{},
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		mainLog.Fatal(err)
+	}
+	pubkeyPath := path.Join(usr.HomeDir, ".ssh/id_rsa.pub")
+
+	flag.StringVar(&opts.kubeconfigPath, "kubeconfig", "/config/kubeconfig", "path to kubeconfig file")
+	flag.StringVar(&providers, "providers", "aws,digitalocean,openstack,hetzner,vsphere,azure", "comma separated list of providers to test")
+	flag.StringVar(&opts.namePrefix, "name-prefix", "", "prefix used for all cluster names")
+	flag.StringVar(&opts.repoRoot, "repo-root", "/opt/kube-test/", "Root path for the different kubernetes repositories")
+	flag.IntVar(&opts.nodeCount, "kubermatic-nodes", 3, "number of worker nodes")
+	flag.IntVar(&opts.clusterParallelCount, "kubermatic-parallel-clusters", 5, "number of clusters to test in parallel")
+	flag.StringVar(&opts.dcFile, "datacenters", "datacenters.yaml", "The datacenters.yaml file path")
+	flag.StringVar(&opts.reportsRoot, "reports-root", "/opt/reports", "Root for reports")
+	flag.BoolVar(&opts.cleanupOnStart, "cleanup-on-start", false, "Cleans up all clusters on start and exit afterwards - must be used with name-prefix.")
+	flag.DurationVar(&opts.controlPlaneReadyWaitTimeout, "kubermatic-cluster-timeout", defaultTimeout, "cluster creation timeout")
+	flag.DurationVar(&opts.nodeReadyWaitTimeout, "kubermatic-nodes-timeout", defaultTimeout, "nodes creation timeout")
+	flag.BoolVar(&opts.deleteClusterAfterTests, "kubermatic-delete-cluster", true, "delete test cluster at the exit")
+	flag.BoolVar(&debug, "debug", true, "Enable debug logs")
+	flag.StringVar(&pubKeyPath, "node-ssh-pub-key", pubkeyPath, "path to a public key which gets deployed onto every node")
+	flag.StringVar(&opts.workerName, "worker-name", "", "name of the worker, if set the 'worker-name' label will be set on all clusters")
+	flag.BoolVar(&opts.runKubermaticControllerManager, "run-kubermatic-controller-manager", true, "should the runner run the controller-manager")
+	flag.StringVar(&opts.excludeKubernetesVersions, "exclude-kubernetes-versions", "", "a comma-separated list of minor kubernetes versions that will get excluded from the tests, by default 1.9 - 1.12 are tested")
+	flag.StringVar(&opts.excludeSelectorRaw, "exclude-distributions", "", "a comma-separated list of distributions that will get excluded from the tests")
+
+	flag.StringVar(&opts.secrets.AWS.AccessKeyID, "aws-access-key-id", "", "AWS: AccessKeyID")
+	flag.StringVar(&opts.secrets.AWS.SecretAccessKey, "aws-secret-access-key", "", "AWS: SecretAccessKey")
+	flag.StringVar(&opts.secrets.Digitalocean.Token, "digitalocean-token", "", "Digitalocean: API Token")
+	flag.StringVar(&opts.secrets.Hetzner.Token, "hetzner-token", "", "Hetzner: API Token")
+	flag.StringVar(&opts.secrets.OpenStack.Domain, "openstack-domain", "", "OpenStack: Domain")
+	flag.StringVar(&opts.secrets.OpenStack.Tenant, "openstack-tenant", "", "OpenStack: Tenant")
+	flag.StringVar(&opts.secrets.OpenStack.Username, "openstack-username", "", "OpenStack: Username")
+	flag.StringVar(&opts.secrets.OpenStack.Password, "openstack-password", "", "OpenStack: Password")
+	flag.StringVar(&opts.secrets.VSphere.Username, "vsphere-username", "", "vSphere: Username")
+	flag.StringVar(&opts.secrets.VSphere.Password, "vsphere-password", "", "vSphere: Password")
+	flag.StringVar(&opts.secrets.Azure.ClientID, "azure-client-id", "", "Azure: ClientID")
+	flag.StringVar(&opts.secrets.Azure.ClientSecret, "azure-client-secret", "", "Azure: ClientSecret")
+	flag.StringVar(&opts.secrets.Azure.TenantID, "azure-tenant-id", "", "Azure: TenantID")
+	flag.StringVar(&opts.secrets.Azure.SubscriptionID, "azure-subscription-id", "", "Azure: SubscriptionID")
+
+	// We're not interested in the client-go logs here - they are just noise
+	if err := flag.CommandLine.Set("logtostderr", "0"); err != nil {
+		mainLog.Fatalf("failed to set logtostderr flag: %v\n", err)
+	}
+	if err := flag.CommandLine.Set("v", "0"); err != nil {
+		mainLog.Fatalf("failed to set loglevel flag: %v\n", err)
+	}
+	flag.Parse()
+
+	if debug {
+		mainLog.SetLevel(logrus.DebugLevel)
+	}
+
+	if opts.excludeSelectorRaw != "" {
+		excludedDistributions := strings.Split(opts.excludeSelectorRaw, ",")
+		if opts.excludeSelector.Distributions == nil {
+			opts.excludeSelector.Distributions = map[providerconfig.OperatingSystem]bool{}
+		}
+		for _, excludedDistribution := range excludedDistributions {
+			switch excludedDistribution {
+			case "ubuntu":
+				opts.excludeSelector.Distributions[providerconfig.OperatingSystemUbuntu] = true
+			case "centos":
+				opts.excludeSelector.Distributions[providerconfig.OperatingSystemCentOS] = true
+			case "coreos":
+				opts.excludeSelector.Distributions[providerconfig.OperatingSystemCoreos] = true
+			default:
+				mainLog.Fatalf("Unknown distribution '%s' in '-exclude-distributions' param", excludedDistribution)
+			}
+		}
+	}
+
+	if opts.excludeKubernetesVersions != "" {
+		excludedKubernetesVersions := strings.Split(opts.excludeKubernetesVersions, ",")
+		var newSupportedVersions []*semver.Semver
+	outer:
+		for _, supportedVersion := range supportedVersions {
+			for _, excludedKubernetesVersion := range excludedKubernetesVersions {
+				val, err := strconv.Atoi(excludedKubernetesVersion)
+				if err != nil {
+					mainLog.Fatalf("excluded kubernetes version '%s' cant not be parsed as an int: %v", excludedKubernetesVersion, err)
+				}
+				if supportedVersion.Minor() == int64(val) {
+					continue outer
+				}
+			}
+			mainLog.Infof("Adding %d as supported version", supportedVersion.Minor())
+			newSupportedVersions = append(newSupportedVersions, supportedVersion)
+		}
+		supportedVersions = newSupportedVersions
+	}
+
+	fields := logrus.Fields{}
+	if opts.workerName != "" {
+		fields["worker-name"] = opts.workerName
+	}
+	log := mainLog.WithFields(fields)
+	opts.log = log
+
+	for _, s := range strings.Split(providers, ",") {
+		opts.providers.Insert(strings.ToLower(strings.TrimSpace(s)))
+	}
+
+	if pubKeyPath != "" {
+		keyData, err := ioutil.ReadFile(pubKeyPath)
+		if err != nil {
+			log.Fatalf("failed to load ssh key: %v", err)
+		}
+		opts.PublicKeys = append(opts.PublicKeys, keyData)
+	}
+
+	homeDir, e2eTestPubKeyBytes, err := setupHomeDir(log)
+	if err != nil {
+		log.Fatalf("failed to setup temporary home dir: %v", err)
+	}
+	opts.PublicKeys = append(opts.PublicKeys, e2eTestPubKeyBytes)
+	opts.HomeDir = homeDir
+	log = logrus.WithFields(logrus.Fields{"home": homeDir})
+
+	stopCh := kubermaticsignals.SetupSignalHandler()
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+
+	if opts.runKubermaticControllerManager {
+		controllerManagerEnviron := os.Environ()
+		if opts.workerName != "" {
+			controllerManagerEnviron = append(controllerManagerEnviron, fmt.Sprintf("KUBERMATIC_WORKERNAME=%s", opts.workerName))
+		}
+		out, err := exec.Command("go", "env", "GOPATH").CombinedOutput()
+		if err != nil {
+			log.Fatalf("failed to execute command `go env GOPATH`: out=%s, err=%v", string(out), err)
+		}
+		gopath := strings.Replace(string(out), "\n", "", -1)
+		// We deliberately do not use `CommandContext` here because we expect this to be executed inside a container
+		// and we want the controller to run at least as long as the conformance tester and _not_ to be killed
+		// because the context for the latter got canceled, because otherwise we don't have cleanup
+		command := exec.Command(path.Join(gopath, "src/github.com/kubermatic/kubermatic/api/hack/run-controller.sh"))
+		command.Env = controllerManagerEnviron
+		go func() {
+			if out, err := command.CombinedOutput(); err != nil {
+				log.Fatalf("failed to run controller-manager: Output:\n---%s\n---\nerr=%v", string(out), err)
+			}
+		}()
+	}
+
+	go func() {
+		select {
+		case <-stopCh:
+			rootCancel()
+			log.Info("user requested to stop the application")
+		case <-rootCtx.Done():
+			log.Info("context has been closed")
+		}
+	}()
+
+	dcs, err := provider.LoadDatacentersMeta(opts.dcFile)
+	if err != nil {
+		log.Fatalf("failed to load datacenter yaml %q: %v", opts.dcFile, err)
+	}
+	opts.dcs = dcs
+
+	config, err := clientcmd.BuildConfigFromFlags("", opts.kubeconfigPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	kubermaticClient := kubermaticclientset.NewForConfigOrDie(config)
+	opts.kubermaticClient = kubermaticClient
+	kubeClient := kubernetes.NewForConfigOrDie(config)
+	opts.kubeClient = kubeClient
+
+	kubermaticInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticClient, informer.DefaultInformerResyncPeriod)
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, informer.DefaultInformerResyncPeriod)
+
+	opts.clusterLister = kubermaticInformerFactory.Kubermatic().V1().Clusters().Lister()
+
+	clusterClientProvider := clusterclient.New(kubeInformerFactory.Core().V1().Secrets().Lister())
+	opts.clusterClientProvider = clusterClientProvider
+
+	kubermaticInformerFactory.Start(rootCtx.Done())
+	kubeInformerFactory.Start(rootCtx.Done())
+	kubermaticInformerFactory.WaitForCacheSync(rootCtx.Done())
+	kubeInformerFactory.WaitForCacheSync(rootCtx.Done())
+
+	if opts.cleanupOnStart {
+		if opts.namePrefix == "" {
+			log.Fatalf("cleanup-on-start was specified but name-prefix is empty")
+		}
+
+		clusterList, err := kubermaticClient.KubermaticV1().Clusters().List(metav1.ListOptions{})
+		if err != nil {
+			log.Fatal(err)
+		}
+		var wg sync.WaitGroup
+		for _, cluster := range clusterList.Items {
+			if strings.HasPrefix(cluster.Name, opts.namePrefix) {
+				wg.Add(1)
+				go func(cluster v1.Cluster) {
+					clusterDeleteLog := logrus.WithFields(logrus.Fields{"cluster": cluster.Name})
+					defer wg.Done()
+					if err := tryToDeleteClusterWithRetries(clusterDeleteLog, &cluster, clusterClientProvider, kubermaticClient); err != nil {
+						clusterDeleteLog.Errorf("failed to delete cluster: %v", err)
+					}
+				}(cluster)
+			}
+		}
+		wg.Wait()
+
+		log.Info("Cleaned up all old clusters")
+	}
+
+	log.Info("Starting E2E tests...")
+
+	var scenarios []testScenario
+	if opts.providers.Has("aws") {
+		log.Info("Adding AWS scenarios")
+		scenarios = append(scenarios, getAWSScenarios(opts.excludeSelector)...)
+	}
+	if opts.providers.Has("digitalocean") {
+		log.Info("Adding Digitalocean scenarios")
+		scenarios = append(scenarios, getDigitaloceanScenarios()...)
+	}
+	if opts.providers.Has("hetzner") {
+		log.Info("Adding Hetzner scenarios")
+		scenarios = append(scenarios, getHetznerScenarios()...)
+	}
+	if opts.providers.Has("openstack") {
+		log.Info("Adding OpenStack scenarios")
+		scenarios = append(scenarios, getOpenStackScenarios()...)
+	}
+	if opts.providers.Has("vsphere") {
+		log.Info("Adding vSphere scenarios")
+		scenarios = append(scenarios, getVSphereScenarios()...)
+	}
+	if opts.providers.Has("azure") {
+		log.Info("Adding Azure scenarios")
+		scenarios = append(scenarios, getAzureScenarios()...)
+	}
+	// Shuffle scenarios - avoids timeouts caused by quota issues
+	scenarios = shuffle(scenarios)
+
+	runner := newRunner(scenarios, &opts)
+
+	start := time.Now()
+	if err := runner.Run(); err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("Whole suite took: %.2f seconds", time.Since(start).Seconds())
+}
+
+func setupHomeDir(log *logrus.Entry) (string, []byte, error) {
+	// Setup temporary home dir (Because the e2e tests have some filenames hardcoded - which might conflict with the user files)
+	// We'll set the env-var $HOME to this directory when executing the tests
+	homeDir, err := ioutil.TempDir("/tmp", "e2e-home-")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to setup temporary home dir: %v", err)
+	}
+	log.Infof("Setting up temporary home directory with ssh keys at %s...", homeDir)
+
+	if err := os.MkdirAll(path.Join(homeDir, ".ssh"), os.ModePerm); err != nil {
+		return "", nil, err
+	}
+
+	// Setup temporary home dir with filepath.Join(os.Getenv("HOME"), ".ssh")
+	// Make sure to create relevant ssh keys (because they are hardcoded in the e2e tests...). They must not be password protected
+	log.Debug("Generating ssh keys...")
+	// Private Key generation
+	privateKey, err := rsa.GenerateKey(cryptorand.Reader, 4096)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Validate Private Key
+	err = privateKey.Validate()
+	if err != nil {
+		return "", nil, err
+	}
+
+	privDER := x509.MarshalPKCS1PrivateKey(privateKey)
+
+	privBlock := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   privDER,
+	}
+
+	privatePEM := pem.EncodeToMemory(&privBlock)
+	// Needs to be google_compute_engine as its hardcoded in the kubernetes e2e tests
+	if err := ioutil.WriteFile(path.Join(homeDir, ".ssh", "google_compute_engine"), privatePEM, 0400); err != nil {
+		return "", nil, err
+	}
+
+	publicRsaKey, err := ssh.NewPublicKey(privateKey.Public())
+	if err != nil {
+		return "", nil, err
+	}
+
+	pubKeyBytes := ssh.MarshalAuthorizedKey(publicRsaKey)
+	if err := ioutil.WriteFile(path.Join(homeDir, ".ssh", "google_compute_engine.pub"), pubKeyBytes, 0400); err != nil {
+		return "", nil, err
+	}
+
+	log.Infof("Finished setting up temporary home dir %s", homeDir)
+	return homeDir, pubKeyBytes, nil
+}
+
+func shuffle(vals []testScenario) []testScenario {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	ret := make([]testScenario, len(vals))
+	n := len(vals)
+	for i := 0; i < n; i++ {
+		randIndex := r.Intn(len(vals))
+		ret[i] = vals[randIndex]
+		vals = append(vals[:randIndex], vals[randIndex+1:]...)
+	}
+	return ret
+}

--- a/api/cmd/conformance-tests/os.go
+++ b/api/cmd/conformance-tests/os.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/api/v2"
 )
 
-func getOSNameFromSpec(spec kubermaticapiv1.OperatingSystemSpec) string {
+func getOSNameFromSpec(spec v2.OperatingSystemSpec) string {
 	if spec.CentOS != nil {
 		return "centos"
 	}

--- a/api/cmd/conformance-tests/os.go
+++ b/api/cmd/conformance-tests/os.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+)
+
+func getOSNameFromSpec(spec kubermaticapiv1.OperatingSystemSpec) string {
+	if spec.CentOS != nil {
+		return "centos"
+	}
+	if spec.ContainerLinux != nil {
+		return "coreos"
+	}
+	if spec.Ubuntu != nil {
+		return "ubuntu"
+	}
+
+	return ""
+}

--- a/api/cmd/conformance-tests/reports.go
+++ b/api/cmd/conformance-tests/reports.go
@@ -67,6 +67,12 @@ func collectReports(name, reportsDir string, time time.Duration) (*reporters.JUn
 func printDetailedReport(report *reporters.JUnitTestSuite) {
 	testBuf := &bytes.Buffer{}
 
+	logIfFailed := func(_ int, err error) {
+		if err != nil {
+			fmt.Printf("failed to write to byte buffer: %v", err)
+		}
+	}
+
 	// Only print details errors in case we have a testcase which failed.
 	// Printing everything which has an error will print the errors from retried tests as for each attempt a TestCase entry exists.
 	if report.Failures > 0 || report.Errors > 0 {
@@ -75,22 +81,22 @@ func printDetailedReport(report *reporters.JUnitTestSuite) {
 				continue
 			}
 
-			fmt.Fprintln(testBuf, fmt.Sprintf("[FAIL] - %s", t.Name))
-			fmt.Fprintln(testBuf, fmt.Sprintf("      %s", t.FailureMessage.Message))
+			logIfFailed(fmt.Fprintln(testBuf, fmt.Sprintf("[FAIL] - %s", t.Name)))
+			logIfFailed(fmt.Fprintln(testBuf, fmt.Sprintf("      %s", t.FailureMessage.Message)))
 		}
 	}
 
 	buf := &bytes.Buffer{}
 	const separator = "============================================================="
-	fmt.Fprintln(buf, separator)
-	fmt.Fprintln(buf, fmt.Sprintf("Test results for: %s", report.Name))
+	logIfFailed(fmt.Fprintln(buf, separator))
+	logIfFailed(fmt.Fprintln(buf, fmt.Sprintf("Test results for: %s", report.Name)))
 
-	fmt.Fprint(buf, testBuf.String())
+	logIfFailed(fmt.Fprint(buf, testBuf.String()))
 
-	fmt.Fprintln(buf, "----------------------------")
-	fmt.Fprintln(buf, fmt.Sprintf("Passed: %d", report.Tests-report.Failures))
-	fmt.Fprintln(buf, fmt.Sprintf("Failed: %d", report.Failures))
-	fmt.Fprintln(buf, separator)
+	logIfFailed(fmt.Fprintln(buf, "----------------------------"))
+	logIfFailed(fmt.Fprintln(buf, fmt.Sprintf("Passed: %d", report.Tests-report.Failures)))
+	logIfFailed(fmt.Fprintln(buf, fmt.Sprintf("Failed: %d", report.Failures)))
+	logIfFailed(fmt.Fprintln(buf, separator))
 
 	fmt.Println(buf.String())
 }

--- a/api/cmd/conformance-tests/reports.go
+++ b/api/cmd/conformance-tests/reports.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func collectReports(name, reportsDir string, time time.Duration) (*reporters.JUnitTestSuite, error) {
+	files, err := ioutil.ReadDir(reportsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files in reportsDir '%s': %v", reportsDir, err)
+	}
+
+	resultSuite := reporters.JUnitTestSuite{
+		Time: time.Seconds(),
+	}
+	resultSuite.Name = name
+
+	var individualReportFiles []string
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+
+		if !strings.HasPrefix(f.Name(), "junit_") || !strings.HasSuffix(f.Name(), ".xml") {
+			continue
+		}
+
+		absName := path.Join(reportsDir, f.Name())
+		individualReportFiles = append(individualReportFiles, absName)
+
+		b, err := ioutil.ReadFile(absName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file '%s': %v", absName, err)
+		}
+
+		suite := &reporters.JUnitTestSuite{}
+		if err := xml.Unmarshal(b, suite); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal report file '%s': %v", absName, err)
+		}
+
+		resultSuite.Tests += suite.Tests
+		resultSuite.Errors += suite.Errors
+		resultSuite.Failures += suite.Failures
+		resultSuite.TestCases = append(resultSuite.TestCases, suite.TestCases...)
+	}
+	sort.Slice(resultSuite.TestCases, func(i, j int) bool { return resultSuite.TestCases[i].Name < resultSuite.TestCases[j].Name })
+
+	for _, f := range individualReportFiles {
+		if err := os.Remove(f); err != nil {
+			return nil, fmt.Errorf("failed to remove report file: %v", err)
+		}
+	}
+
+	return &resultSuite, nil
+}
+
+func printDetailedReport(report *reporters.JUnitTestSuite) {
+	testBuf := &bytes.Buffer{}
+
+	// Only print details errors in case we have a testcase which failed.
+	// Printing everything which has an error will print the errors from retried tests as for each attempt a TestCase entry exists.
+	if report.Failures > 0 || report.Errors > 0 {
+		for _, t := range report.TestCases {
+			if t.FailureMessage == nil {
+				continue
+			}
+
+			fmt.Fprintln(testBuf, fmt.Sprintf("[FAIL] - %s", t.Name))
+			fmt.Fprintln(testBuf, fmt.Sprintf("      %s", t.FailureMessage.Message))
+		}
+	}
+
+	buf := &bytes.Buffer{}
+	const separator = "============================================================="
+	fmt.Fprintln(buf, separator)
+	fmt.Fprintln(buf, fmt.Sprintf("Test results for: %s", report.Name))
+
+	fmt.Fprint(buf, testBuf.String())
+
+	fmt.Fprintln(buf, "----------------------------")
+	fmt.Fprintln(buf, fmt.Sprintf("Passed: %d", report.Tests-report.Failures))
+	fmt.Fprintln(buf, fmt.Sprintf("Failed: %d", report.Failures))
+	fmt.Fprintln(buf, separator)
+
+	fmt.Println(buf.String())
+}

--- a/api/cmd/conformance-tests/run.sh
+++ b/api/cmd/conformance-tests/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+cd $(dirname $0)
+
+cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic
+docker build -t conformance-tester-image containers/conformance-tests
+cd -
+
+go build github.com/kubermatic/kubermatic/api/cmd/conformance-tests
+
+docker run --rm -it \
+  -v $PWD:/bin/mounted \
+  -v $(go env GOPATH)/src/github.com/kubermatic/secrets/seed-clusters/dev.kubermatic.io/kubeconfig:/kubeconfig \
+  -v $(go env GOPATH)/src/github.com/kubermatic/secrets/seed-clusters/dev.kubermatic.io/datacenters.yaml:/datacenters.yaml \
+  -v $(go env GOPATH)/src/github.com/kubermatic/secrets:/go/src/github.com/kubermatic/secrets \
+  -v $(go env GOPATH)/src/github.com/kubermatic/kubermatic/reports:/reports \
+  -v $(go env GOPATH)/src/github.com/kubermatic/kubermatic:/go/src/github.com/kubermatic/kubermatic \
+  conformance-tester-image \
+    /bin/mounted/conformance-tests \
+        -debug \
+        -worker-name=$USER \
+        -kubeconfig=/kubeconfig \
+        -datacenters=/datacenters.yaml \
+        -kubermatic-nodes=3 \
+        -kubermatic-parallel-clusters=11 \
+        -kubermatic-delete-cluster=true \
+        -name-prefix=$USER-e2e \
+        -providers=aws \
+        -reports-root=/reports \
+        -cleanup-on-start=false \
+        -aws-access-key-id="$(vault kv get -field=accessKeyID dev/e2e-aws)" \
+        -aws-secret-access-key="$(vault kv get -field=secretAccessKey dev/e2e-aws)" \
+        -digitalocean-token="$(vault kv get -field=token dev/e2e-digitalocean)" \
+        -hetzner-token="$(vault kv get -field=token dev/e2e-hetzner)" \
+        -openstack-domain="$(vault kv get -field=OS_USER_DOMAIN_NAME dev/syseleven-openstack)" \
+        -openstack-tenant="$(vault kv get -field=OS_TENANT_NAME dev/syseleven-openstack)" \
+        -openstack-username="$(vault kv get -field=username dev/syseleven-openstack)" \
+        -openstack-password="$(vault kv get -field=password dev/syseleven-openstack)" \
+        -vsphere-username="$(vault kv get -field=username dev/vsphere)" \
+        -vsphere-password="$(vault kv get -field=password dev/vsphere)" \
+        -azure-client-id="$(vault kv get -field=clientID dev/e2e-azure)" \
+        -azure-client-secret="$(vault kv get -field=clientSecret dev/e2e-azure)" \
+        -azure-tenant-id="$(vault kv get -field=tenantID dev/e2e-azure)" \
+        -azure-subscription-id="$(vault kv get -field=subscriptionID dev/e2e-azure)" \
+        -exclude-kubernetes-versions="9,10,11" \
+        -exclude-distributions="ubuntu,centos"
+
+rm ./conformance-tests

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -1,0 +1,791 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/sirupsen/logrus"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	clusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/machine"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+type testScenario interface {
+	Name() string
+	Cluster(secrets secrets) *kubermaticv1.Cluster
+	Nodes(num int) []*kubermaticapiv1.Node
+}
+
+func newRunner(scenarios []testScenario, opts *Opts) *testRunner {
+	return &testRunner{
+		scenarios:                    scenarios,
+		clusterLister:                opts.clusterLister,
+		controlPlaneReadyWaitTimeout: opts.controlPlaneReadyWaitTimeout,
+		deleteClusterAfterTests:      opts.deleteClusterAfterTests,
+		kubermaticClient:             opts.kubermaticClient,
+		secrets:                      opts.secrets,
+		namePrefix:                   opts.namePrefix,
+		clusterClientProvider:        opts.clusterClientProvider,
+		nodesReadyWaitTimeout:        opts.nodeReadyWaitTimeout,
+		dcs:                          opts.dcs,
+		nodeCount:                    opts.nodeCount,
+		repoRoot:                     opts.repoRoot,
+		reportsRoot:                  opts.reportsRoot,
+		clusterParallelCount:         opts.clusterParallelCount,
+		PublicKeys:                   opts.PublicKeys,
+		workerName:                   opts.workerName,
+		homeDir:                      opts.HomeDir,
+		kubeClient:                   opts.kubeClient,
+		log:                          opts.log,
+	}
+}
+
+type testRunner struct {
+	scenarios   []testScenario
+	secrets     secrets
+	namePrefix  string
+	repoRoot    string
+	reportsRoot string
+	PublicKeys  [][]byte
+	workerName  string
+	homeDir     string
+	log         *logrus.Entry
+
+	controlPlaneReadyWaitTimeout time.Duration
+	deleteClusterAfterTests      bool
+	nodesReadyWaitTimeout        time.Duration
+	nodeCount                    int
+	clusterParallelCount         int
+
+	kubermaticClient      kubermaticclientset.Interface
+	kubeClient            kubernetes.Interface
+	clusterLister         kubermaticv1lister.ClusterLister
+	clusterClientProvider *clusterclient.Provider
+	dcs                   map[string]provider.DatacenterMeta
+}
+
+type testResult struct {
+	report   *reporters.JUnitTestSuite
+	err      error
+	scenario testScenario
+}
+
+func (t *testResult) Passed() bool {
+	if t.err != nil {
+		return false
+	}
+
+	if t.report == nil {
+		return false
+	}
+
+	if len(t.report.TestCases) == 0 {
+		return false
+	}
+
+	if t.report.Errors > 0 || t.report.Failures > 0 {
+		return false
+	}
+
+	return true
+}
+
+func (r *testRunner) worker(id int, scenarios <-chan testScenario, results chan<- testResult) {
+	for s := range scenarios {
+		scenarioLog := r.log.WithFields(logrus.Fields{
+			"scenario": s.Name(),
+			"worker":   id,
+		})
+		scenarioLog.Info("Starting to test scenario...")
+
+		report, err := r.executeScenario(scenarioLog, s)
+		res := testResult{
+			report:   report,
+			scenario: s,
+			err:      err,
+		}
+		if err != nil {
+			scenarioLog.Infof("Finished with error: %v", err)
+		} else {
+			scenarioLog.Info("Finished")
+		}
+
+		results <- res
+	}
+}
+
+func (r *testRunner) Run() error {
+	scenariosCh := make(chan testScenario, len(r.scenarios))
+	resultsCh := make(chan testResult, len(r.scenarios))
+
+	r.log.Infoln("Test suite:")
+	for _, scenario := range r.scenarios {
+		r.log.Infoln(scenario.Name())
+		scenariosCh <- scenario
+	}
+	r.log.Infoln(fmt.Sprintf("Total: %d tests", len(r.scenarios)))
+
+	for i := 1; i <= r.clusterParallelCount; i++ {
+		go r.worker(i, scenariosCh, resultsCh)
+	}
+
+	close(scenariosCh)
+
+	var results []testResult
+	for range r.scenarios {
+		results = append(results, <-resultsCh)
+		r.log.Infof("Finished %d/%d test cases", len(results), len(r.scenarios))
+	}
+
+	overallResultBuf := &bytes.Buffer{}
+	hadFailure := false
+	for _, result := range results {
+		prefix := "PASS"
+		if !result.Passed() {
+			prefix = "FAIL"
+			hadFailure = true
+		}
+		scenarioResultMsg := fmt.Sprintf("[%s] - %s", prefix, result.scenario.Name())
+		if result.err != nil {
+			scenarioResultMsg = fmt.Sprintf("%s : %v", scenarioResultMsg, result.err)
+		}
+
+		fmt.Fprintln(overallResultBuf, scenarioResultMsg)
+		if result.report != nil {
+			printDetailedReport(result.report)
+		}
+	}
+
+	fmt.Println("========================== RESULT ===========================")
+	fmt.Println(overallResultBuf.String())
+
+	if hadFailure {
+		return errors.New("some tests failed")
+	}
+	return nil
+}
+
+func (r *testRunner) executeScenario(log *logrus.Entry, scenario testScenario) (*reporters.JUnitTestSuite, error) {
+	cluster, err := r.setupCluster(log, scenario)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup cluster: %v", err)
+	}
+
+	providerName, err := provider.ClusterCloudProviderName(cluster.Spec.Cloud)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cloud provider name from cluster: %v", err)
+	}
+
+	log = log.WithFields(logrus.Fields{
+		"cluster":        cluster.Name,
+		"cloud-provider": providerName,
+		"version":        cluster.Spec.Version,
+	})
+
+	dc, found := r.dcs[cluster.Spec.Cloud.DatacenterName]
+	if !found {
+		return nil, fmt.Errorf("invalid cloud datacenter specified '%s'. Not found in datacenters list", cluster.Spec.Cloud.DatacenterName)
+	}
+
+	if r.deleteClusterAfterTests {
+		defer func() {
+			if err := tryToDeleteClusterWithRetries(log, cluster, r.clusterClientProvider, r.kubermaticClient); err != nil {
+				log.Errorf("failed to delete cluster: %v", err)
+				log.Errorf("Please manually cleanup the cluster. Either by restarting with `-cleanup-on-start=true` or by doing the cleanup by hand: %v", err)
+			}
+		}()
+	}
+
+	kubeconfigFilename, err := r.getKubeconfig(log, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig: %v", err)
+	}
+	log = log.WithFields(logrus.Fields{"kubeconfig": kubeconfigFilename})
+
+	cloudConfigFilename, err := r.getCloudConfig(log, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cloud config: %v", err)
+	}
+
+	clusterKubeClient, err := r.clusterClientProvider.GetClient(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the client for the cluster: %v", err)
+	}
+
+	apiNodes := scenario.Nodes(r.nodeCount)
+	if err := r.setupNodes(log, scenario.Name(), cluster, clusterKubeClient, apiNodes, dc); err != nil {
+		return nil, fmt.Errorf("failed to setup nodes: %v", err)
+	}
+
+	if err := r.waitUntilAllPodsAreReady(log, clusterKubeClient); err != nil {
+		return nil, fmt.Errorf("failed to wait until all pods are running after creating the cluster: %v", err)
+	}
+
+	report, err := r.testCluster(log, scenario.Name(), cluster, clusterKubeClient, apiNodes, dc, kubeconfigFilename, cloudConfigFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to test cluster: %v", err)
+	}
+
+	if report == nil {
+		return nil, errors.New("no report generated")
+	}
+
+	return report, nil
+}
+
+func retryNAttempts(maxAttempts int, f func(attempt int) error) error {
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err = f(attempt)
+		if err != nil {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("function did not succeeded after %d attempts: %v", maxAttempts, err)
+}
+
+func (r *testRunner) testCluster(
+	log *logrus.Entry,
+	scenarioName string,
+	cluster *kubermaticv1.Cluster,
+	clusterKubeClient kubernetes.Interface,
+	apiNodes []*kubermaticapiv1.Node,
+	dc provider.DatacenterMeta,
+	kubeconfigFilename string,
+	cloudConfigFilename string,
+) (*reporters.JUnitTestSuite, error) {
+	const maxTestAttempts = 3
+	var err error
+	totalStart := time.Now()
+
+	report := &reporters.JUnitTestSuite{
+		Name: scenarioName,
+	}
+	// Do a simple PVC test - with retries
+	if supportsStorage(cluster) {
+		testStart := time.Now()
+		testCase := reporters.JUnitTestCase{
+			Name:      "[CloudProvider] Test PVC support with the existing StorageClass",
+			ClassName: "Kubermatic custom tests",
+		}
+		err := retryNAttempts(maxTestAttempts, func(attempt int) error { return r.testPVC(log, clusterKubeClient) })
+		if err != nil {
+			report.Errors++
+			testCase.FailureMessage = &reporters.JUnitFailureMessage{Message: err.Error()}
+			log.Errorf("Failed to verify that PVC's work: %v", err)
+		}
+		testCase.Time = time.Since(testStart).Seconds()
+		report.TestCases = append(report.TestCases, testCase)
+		report.Tests++
+	}
+
+	// Do a simple LB test - with retries
+	if supportsLBs(cluster) {
+		testStart := time.Now()
+		testCase := reporters.JUnitTestCase{
+			Name:      "[CloudProvider] Test LB support",
+			ClassName: "Kubermatic custom tests",
+		}
+		err := retryNAttempts(maxTestAttempts, func(attempt int) error { return r.testLB(log, clusterKubeClient) })
+		if err != nil {
+			report.Errors++
+			testCase.FailureMessage = &reporters.JUnitFailureMessage{Message: err.Error()}
+			log.Errorf("Failed to verify that LB's work: %v", err)
+		}
+		testCase.Time = time.Since(testStart).Seconds()
+		report.TestCases = append(report.TestCases, testCase)
+		report.Tests++
+	}
+
+	var reportsDir string
+	var ginkgoReport *reporters.JUnitTestSuite
+	err = retryNAttempts(maxTestAttempts, func(attempt int) error {
+		startedE2E := time.Now()
+
+		reportsDir = path.Join(r.reportsRoot, scenarioName, fmt.Sprintf("attempt-%d", attempt))
+		if err := os.MkdirAll(reportsDir, 0755); err != nil {
+			return fmt.Errorf("failed to create reports dir: %v", err)
+		}
+
+		log.Infof("[Attempt: %d/%d] Starting E2E tests...", attempt, maxTestAttempts)
+		if err := r.runE2E(log, cluster, kubeconfigFilename, cloudConfigFilename, reportsDir, apiNodes, dc); err != nil {
+			log.Warnf("[Attempt: %d/%d] failed to run E2E tests: %v", attempt, maxTestAttempts, err)
+			return err
+		}
+		log.Infof("[Attempt: %d/%d] E2E tests finished after %.2f seconds", attempt, maxTestAttempts, time.Since(startedE2E).Seconds())
+
+		ginkgoReport, err = collectReports(scenarioName, reportsDir, time.Since(startedE2E))
+		if err != nil {
+			log.Warnf("[Attempt: %d/%d] failed to combine reports: %v. Restarting...", attempt, maxTestAttempts, err)
+			return err
+		}
+
+		if ginkgoReport.Errors > 0 || ginkgoReport.Failures > 0 {
+			log.Warnf("[Attempt: %d/%d] e2e tests had some failures (See %s for details). Restarting...", attempt, maxTestAttempts, reportsDir)
+			return errors.New("encountered partial errors during ginkgo run")
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Errorf("Failed to successfully run kubernetes e2e tests: %v", err)
+	}
+
+	if ginkgoReport != nil {
+		report.Time = time.Since(totalStart).Seconds()
+		report.Tests += ginkgoReport.Tests
+		report.Errors += ginkgoReport.Errors
+		report.Failures += ginkgoReport.Failures
+		report.TestCases = append(report.TestCases, ginkgoReport.TestCases...)
+	}
+
+	b, err := xml.Marshal(report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal combined report file: %v", err)
+	}
+
+	if err := ioutil.WriteFile(path.Join(reportsDir, "junit.xml"), b, 0644); err != nil {
+		return nil, fmt.Errorf("failed to wrte combined report file: %v", err)
+	}
+
+	return report, nil
+}
+
+func (r *testRunner) setupNodes(log *logrus.Entry, scenarioName string, cluster *kubermaticv1.Cluster, clusterKubeClient kubernetes.Interface, apiNodes []*kubermaticapiv1.Node, dc provider.DatacenterMeta) error {
+	log.Info("Creating machines...")
+	kubeMachineClient, err := r.clusterClientProvider.GetMachineClient(cluster)
+	if err != nil {
+		return fmt.Errorf("failed to get the machine client for the cluster: %v", err)
+	}
+
+	var keys []*kubermaticv1.UserSSHKey
+	for _, data := range r.PublicKeys {
+		keys = append(keys, &kubermaticv1.UserSSHKey{
+			Spec: kubermaticv1.SSHKeySpec{
+				PublicKey: string(data),
+			},
+		})
+	}
+
+	for i, node := range apiNodes {
+		m, err := machine.Machine(cluster, node, dc, keys)
+		if err != nil {
+			return fmt.Errorf("failed to create Machine from scenario node '%s': %v", node.Name, err)
+		}
+		// Make sure all nodes have different names across all scenarios - otherwise the Kubelet might not come up (OpenStack has this...)
+		m.Name = fmt.Sprintf("%s-machine-%d", scenarioName, i)
+		m.Spec.Name = strings.Replace(fmt.Sprintf("%s-node-%d", scenarioName, i), ".", "-", -1)
+
+		err = retryNAttempts(defaultAPIRetries, func(attempt int) error {
+			machineLog := log.WithFields(logrus.Fields{"machine": m.Name})
+			_, err := kubeMachineClient.ClusterV1alpha1().Machines(metav1.NamespaceSystem).Create(m)
+			if err != nil {
+				if kerrors.IsAlreadyExists(err) {
+					return nil
+				}
+
+				machineLog.Warnf("[Attempt %d/100] Failed to create the machine: %v. Retrying...", attempt, err)
+				time.Sleep(defaultUserClusterPollInterval)
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create machine '%s' after %d attempts: %v", m.Name, defaultAPIRetries, err)
+		}
+	}
+	log.Infof("Successfully created %d machine(s)!", len(apiNodes))
+
+	if err := r.waitForReadyNodes(log, clusterKubeClient, len(apiNodes)); err != nil {
+		return fmt.Errorf("failed waiting for nodes to become ready: %v", err)
+	}
+	return nil
+}
+
+func (r *testRunner) getKubeconfig(log *logrus.Entry, cluster *kubermaticv1.Cluster) (string, error) {
+	log.Debug("Getting kubeconfig...")
+	kubeconfig, err := r.clusterClientProvider.GetAdminKubeconfig(cluster)
+	if err != nil {
+		return "", fmt.Errorf("failed to load kubeconfig from cluster client provider: %v", err)
+	}
+	filename := path.Join(r.homeDir, fmt.Sprintf("%s-kubeconfig", cluster.Name))
+	if err := ioutil.WriteFile(filename, kubeconfig, 0644); err != nil {
+		return "", fmt.Errorf("failed to write kubeconfig to %s: %v", filename, err)
+	}
+
+	log.Infof("Successfully wrote kubeconfig to %s", filename)
+	return filename, nil
+}
+
+func (r *testRunner) getCloudConfig(log *logrus.Entry, cluster *kubermaticv1.Cluster) (string, error) {
+	log.Debug("Getting cloud-config...")
+
+	var cmData string
+	err := retryNAttempts(defaultAPIRetries, func(attempt int) error {
+		cm, err := r.kubeClient.CoreV1().ConfigMaps(cluster.Status.NamespaceName).Get(resources.CloudConfigConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to load cloud-config: %v", err)
+		}
+		cmData = cm.Data["config"]
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get cloud config ConfigMap: %v", err)
+	}
+
+	filename := path.Join(r.homeDir, fmt.Sprintf("%s-cloud-config", cluster.Name))
+	if err := ioutil.WriteFile(filename, []byte(cmData), 0644); err != nil {
+		return "", fmt.Errorf("failed to write cloud config: %v", err)
+	}
+
+	log.Infof("Successfully wrote cloud-config to %s", filename)
+	return filename, nil
+}
+
+func (r *testRunner) setupCluster(log *logrus.Entry, scenario testScenario) (*kubermaticv1.Cluster, error) {
+	// Always generate a random name
+	cluster := scenario.Cluster(r.secrets)
+	cluster.Name = rand.String(8)
+	if r.namePrefix != "" {
+		cluster.Name = fmt.Sprintf("%s-%s", r.namePrefix, cluster.Name)
+	}
+	log = logrus.WithFields(logrus.Fields{"cluster": cluster.Name})
+
+	if cluster.Labels == nil {
+		cluster.Labels = map[string]string{}
+	}
+	if r.workerName != "" {
+		cluster.Labels[kubermaticv1.WorkerNameLabelKey] = r.workerName
+	}
+
+	// We setting higher resource requests to avoid running into issues due to throttling
+	cluster.Spec.ComponentsOverride.Apiserver.Resources = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+		},
+	}
+
+	// We set the replicas for the control plane to 2 to avoid issues with "bind: address already in use" on control plane components.
+	// Somehow this happens for <1% of the pods - though this seems to be a GKE specific issue: https://github.com/kubernetes/kubernetes/issues/69364
+	var replicas int32 = 2
+	cluster.Spec.ComponentsOverride.Apiserver.Replicas = &replicas
+	cluster.Spec.ComponentsOverride.ControllerManager.Replicas = &replicas
+	cluster.Spec.ComponentsOverride.Scheduler.Replicas = &replicas
+
+	log.Info("Creating cluster...")
+	cluster, err := r.kubermaticClient.KubermaticV1().Clusters().Create(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the cluster resource: %v", err)
+	}
+	log.Debug("Successfully created cluster!")
+
+	cluster, err = r.waitForControlPlane(log, cluster.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed waiting for control plane to become ready: %v", err)
+	}
+
+	return cluster, nil
+}
+
+func (r *testRunner) waitForReadyNodes(log *logrus.Entry, client kubernetes.Interface, num int) error {
+	log.Info("Waiting for nodes to become ready...")
+	started := time.Now()
+
+	nodeIsReady := func(n corev1.Node) bool {
+		for _, condition := range n.Status.Conditions {
+			if condition.Type == corev1.NodeReady {
+				if condition.Status == corev1.ConditionTrue {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	err := wait.Poll(nodesReadyPollPeriod, r.nodesReadyWaitTimeout, func() (done bool, err error) {
+		nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to list nodes: %v", err)
+		}
+
+		if len(nodeList.Items) != num {
+			return false, nil
+		}
+
+		for _, node := range nodeList.Items {
+			if !nodeIsReady(node) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Nodes got ready after %.2f seconds", time.Since(started).Seconds())
+	return nil
+}
+
+func (r *testRunner) waitForControlPlane(log *logrus.Entry, clusterName string) (*kubermaticv1.Cluster, error) {
+	log.Debug("Waiting for control plane to become ready...")
+	started := time.Now()
+
+	err := wait.Poll(controlPlaneReadyPollPeriod, r.controlPlaneReadyWaitTimeout, func() (done bool, err error) {
+		cluster, err := r.clusterLister.Get(clusterName)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get the cluster %s from the lister: %v", clusterName, err)
+		}
+
+		return cluster.Status.Health.AllHealthy(), nil
+	})
+	// Timeout or other error
+	if err != nil {
+		return nil, err
+	}
+
+	// Get copy of latest version
+	cluster, err := r.clusterLister.Get(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("Control plane became ready after %.2f seconds", time.Since(started).Seconds())
+	return cluster.DeepCopy(), nil
+}
+
+func (r *testRunner) waitUntilAllPodsAreReady(log *logrus.Entry, client kubernetes.Interface) error {
+	log.Debug("Waiting for all pods to be ready...")
+	started := time.Now()
+
+	podIsReady := func(p *corev1.Pod) bool {
+		for _, c := range p.Status.Conditions {
+			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}
+
+	err := wait.Poll(defaultUserClusterPollInterval, defaultTimeout, func() (done bool, err error) {
+		podList, err := client.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
+		if err != nil {
+			log.Warnf("failed to load pod list while waiting until all pods are running: %v", err)
+			return false, nil
+		}
+
+		for _, pod := range podList.Items {
+			if !podIsReady(&pod) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("All pods became ready after %.2f seconds", time.Since(started).Seconds())
+	return nil
+}
+
+func (r *testRunner) runE2E(
+	log *logrus.Entry,
+	cluster *kubermaticv1.Cluster,
+	kubeconfigFilename,
+	cloudConfigFilename,
+	reportsDir string,
+	nodes []*kubermaticapiv1.Node,
+	dc provider.DatacenterMeta,
+) error {
+	kubeconfigFilename = path.Clean(kubeconfigFilename)
+	repoRoot := path.Clean(r.repoRoot)
+	MajorMinor := fmt.Sprintf("%d.%d", cluster.Spec.Version.Major(), cluster.Spec.Version.Minor())
+
+	// TODO: Figure out why they fail & potentially fix. Otherwise, explain why they are deactivated
+	//brokenTests := []string{
+	//	"should set TCP CLOSE_WAIT timeout",                // AWS
+	//	"should support exec through an HTTP proxy",        // AWS
+	//	"should proxy to cadvisor",                         // AWS
+	//	"should handle in-cluster config",                  // AWS
+	//	"should proxy to cadvisor using proxy subresource", // AWS
+	//	"should support exec through kubectl proxy",        // AWS
+	//}
+
+	runs := []struct {
+		name          string
+		ginkgoFocus   string
+		ginkgoSkip    string
+		parallelTests int
+	}{
+		{
+			name:          "parallel",
+			ginkgoFocus:   `\[Conformance\]`,
+			ginkgoSkip:    `\[Serial\]`,
+			parallelTests: 25,
+		},
+		{
+			name:          "serial",
+			ginkgoFocus:   `\[Serial\].*\[Conformance\]`,
+			ginkgoSkip:    ``,
+			parallelTests: 1,
+		},
+		// TODO: Enable more e2e tests
+		//{
+		//	name:          "parallel",
+		//	ginkgoFocus:   `.*`,
+		//	ginkgoSkip:    `\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|` + strings.Join(brokenTests, "|"),
+		//	parallelTests: 25,
+		//},
+		//{
+		//	name:          "serial",
+		//	ginkgoFocus:   `\[Serial\].*`,
+		//	ginkgoSkip:    `\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort` + strings.Join(brokenTests, "|"),
+		//	parallelTests: 1,
+		//},
+	}
+	versionRoot := path.Join(repoRoot, MajorMinor)
+	binRoot := path.Join(versionRoot, "/platforms/linux/amd64")
+	for _, run := range runs {
+		env := []string{
+			fmt.Sprintf("HOME=%s", r.homeDir),
+			fmt.Sprintf("AWS_SSH_KEY=%s", path.Join(r.homeDir, ".ssh", "google_compute_engine")),
+			fmt.Sprintf("LOCAL_SSH_KEY=%s", path.Join(r.homeDir, ".ssh", "google_compute_engine")),
+			fmt.Sprintf("KUBE_SSH_KEY=%s", path.Join(r.homeDir, ".ssh", "google_compute_engine")),
+		}
+
+		args := []string{
+			"-progress",
+			fmt.Sprintf("-nodes=%d", run.parallelTests),
+			"-noColor=true",
+			"-flakeAttempts=2",
+			fmt.Sprintf(`-focus=%s`, run.ginkgoFocus),
+			fmt.Sprintf(`-skip=%s`, run.ginkgoSkip),
+			path.Join(binRoot, "e2e.test"),
+			"--",
+			"--disable-log-dump",
+			fmt.Sprintf("--repo-root=%s", versionRoot),
+			fmt.Sprintf("--report-dir=%s", reportsDir),
+			fmt.Sprintf("--report-prefix=%s", run.name),
+			fmt.Sprintf("--kubectl-path=%s", path.Join(binRoot, "kubectl")),
+			fmt.Sprintf("--kubeconfig=%s", kubeconfigFilename),
+			fmt.Sprintf("--num-nodes=%d", len(nodes)),
+			fmt.Sprintf("--cloud-config-file=%s", cloudConfigFilename),
+		}
+
+		if cluster.Spec.Cloud.AWS != nil {
+			args = append(args, "--provider=aws")
+			args = append(args, fmt.Sprintf("--gce-zone=%s%s", dc.Spec.AWS.Region, dc.Spec.AWS.ZoneCharacter))
+		} else if cluster.Spec.Cloud.Azure != nil {
+			args = append(args, "--provider=azure")
+		} else if cluster.Spec.Cloud.Openstack != nil {
+			args = append(args, "--provider=openstack")
+		} else if cluster.Spec.Cloud.VSphere != nil {
+			args = append(args, "--provider=vsphere")
+		} else {
+			args = append(args, "--provider=local")
+		}
+
+		if nodes[0].Spec.OperatingSystem.Ubuntu != nil {
+			args = append(args, "--node-os-distro=ubuntu")
+			env = append(env, "KUBE_SSH_USER=ubuntu")
+		} else if nodes[0].Spec.OperatingSystem.CentOS != nil {
+			args = append(args, "--node-os-distro=centos")
+			env = append(env, "KUBE_SSH_USER=centos")
+		} else if nodes[0].Spec.OperatingSystem.ContainerLinux != nil {
+			args = append(args, "--node-os-distro=coreos")
+			env = append(env, "KUBE_SSH_USER=core")
+		}
+
+		cmd := exec.Command(path.Join(binRoot, "ginkgo"), args...)
+		cmd.Env = env
+
+		run := func() error {
+			logFile := path.Join(reportsDir, "e2e.log")
+			f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE, 0644)
+			if err != nil {
+				return fmt.Errorf("failed to open logfile: %v", err)
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					log.Errorf("failed to close file handle on '%s': %v", logFile, err)
+				}
+			}()
+
+			writer := bufio.NewWriter(f)
+			defer func() {
+				if err := writer.Flush(); err != nil {
+					log.Errorf("failed to flush log file buffer: %v", err)
+				}
+			}()
+
+			err = ioutil.WriteFile(
+				path.Join(reportsDir, fmt.Sprintf("script-%s.sh", run.name)),
+				[]byte(strings.Join(cmd.Args, ` \
+    `)),
+				0644,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to write script: %v", err)
+			}
+
+			log.Debugf("Starting ginkgo run '%s'...", run.name)
+
+			cmd.Stdout = writer
+			cmd.Stderr = writer
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("failed to execute ginkgo run '%s': %v. Output can be found at %s", run.name, err, logFile)
+			}
+			return nil
+		}
+
+		if err := run(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func supportsStorage(cluster *kubermaticv1.Cluster) bool {
+	return cluster.Spec.Cloud.Openstack != nil ||
+		cluster.Spec.Cloud.Azure != nil ||
+		cluster.Spec.Cloud.AWS != nil ||
+		cluster.Spec.Cloud.VSphere != nil
+}
+
+func supportsLBs(cluster *kubermaticv1.Cluster) bool {
+	return cluster.Spec.Cloud.Azure != nil ||
+		cluster.Spec.Cloud.AWS != nil
+}

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -175,7 +175,9 @@ func (r *testRunner) Run() error {
 			scenarioResultMsg = fmt.Sprintf("%s : %v", scenarioResultMsg, result.err)
 		}
 
-		fmt.Fprintln(overallResultBuf, scenarioResultMsg)
+		if _, err := fmt.Fprintln(overallResultBuf, scenarioResultMsg); err != nil {
+			fmt.Printf("failed to write to byte buffer: %v", err)
+		}
 		if result.report != nil {
 			printDetailedReport(result.report)
 		}

--- a/api/cmd/conformance-tests/scenarios_aws.go
+++ b/api/cmd/conformance-tests/scenarios_aws.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getAWSScenarios(es excludeSelector) []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		if _, ok := es.Distributions[providerconfig.OperatingSystemUbuntu]; !ok {
+			scenarios = append(scenarios, &awsScenario{
+				version: v,
+				nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+					Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+				},
+			})
+		}
+		// CoreOS
+		if _, ok := es.Distributions[providerconfig.OperatingSystemCoreos]; !ok {
+			scenarios = append(scenarios, &awsScenario{
+				version: v,
+				nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+					ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+						// Otherwise the nodes restart directly after creation - bad for tests
+						DisableAutoUpdate: true,
+					},
+				},
+			})
+		}
+		// CentOS
+		//TODO: Fix
+		// if _, ok := es.Distributions[providerconfig.OperatingSystemCentos]; !ok {
+		//scenarios = append(scenarios, &awsScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv2.CentOSSpec{},
+		//	},
+		//})
+		//}
+	}
+	return scenarios
+}
+
+type awsScenario struct {
+	version    *semver.Semver
+	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+}
+
+func (s *awsScenario) Name() string {
+	return fmt.Sprintf("aws-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *awsScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           *s.version,
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "aws-eu-central-1a",
+				AWS: &v1.AWSCloudSpec{
+					SecretAccessKey: secrets.AWS.SecretAccessKey,
+					AccessKeyID:     secrets.AWS.AccessKeyID,
+				},
+			},
+		},
+	}
+}
+
+func (s *awsScenario) Nodes(num int) []*kubermaticapiv1.Node {
+	var nodes []*kubermaticapiv1.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv1.Node{
+			ObjectMeta: kubermaticapiv1.ObjectMeta{},
+			Spec: kubermaticapiv1.NodeSpec{
+				Cloud: kubermaticapiv1.NodeCloudSpec{
+					AWS: &kubermaticapiv1.AWSNodeSpec{
+						InstanceType: "t2.medium",
+						VolumeType:   "gp2",
+						VolumeSize:   100,
+					},
+				},
+				Versions: kubermaticapiv1.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_azure.go
+++ b/api/cmd/conformance-tests/scenarios_azure.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/Masterminds/semver"
+	"github.com/kubermatic/kubermatic/api/pkg/api/v2"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,15 +17,15 @@ func getAzureScenarios() []testScenario {
 		// Ubuntu
 		scenarios = append(scenarios, &azureScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			nodeOsSpec: v2.OperatingSystemSpec{
+				Ubuntu: &v2.UbuntuSpec{},
 			},
 		})
 		// CoreOS
 		scenarios = append(scenarios, &azureScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+			nodeOsSpec: v2.OperatingSystemSpec{
+				ContainerLinux: &v2.ContainerLinuxSpec{
 					// Otherwise the nodes restart directly after creation - bad for tests
 					DisableAutoUpdate: true,
 				},
@@ -44,8 +44,8 @@ func getAzureScenarios() []testScenario {
 }
 
 type azureScenario struct {
-	version    *semver.Semver
-	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+	version    *semver.Version
+	nodeOsSpec v2.OperatingSystemSpec
 }
 
 func (s *azureScenario) Name() string {
@@ -56,7 +56,7 @@ func (s *azureScenario) Cluster(secrets secrets) *v1.Cluster {
 	return &v1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: v1.ClusterSpec{
-			Version:           *s.version,
+			Version:           s.version.String(),
 			HumanReadableName: s.Name(),
 			ClusterNetwork: v1.ClusterNetworkingConfig{
 				Services: v1.NetworkRanges{
@@ -80,18 +80,18 @@ func (s *azureScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *azureScenario) Nodes(num int) []*kubermaticapiv1.Node {
-	var nodes []*kubermaticapiv1.Node
+func (s *azureScenario) Nodes(num int) []*v2.Node {
+	var nodes []*v2.Node
 	for i := 0; i < num; i++ {
-		node := &kubermaticapiv1.Node{
-			ObjectMeta: kubermaticapiv1.ObjectMeta{},
-			Spec: kubermaticapiv1.NodeSpec{
-				Cloud: kubermaticapiv1.NodeCloudSpec{
-					Azure: &kubermaticapiv1.AzureNodeSpec{
+		node := &v2.Node{
+			Metadata: v2.ObjectMeta{},
+			Spec: v2.NodeSpec{
+				Cloud: v2.NodeCloudSpec{
+					Azure: &v2.AzureNodeSpec{
 						Size: "Standard_F1",
 					},
 				},
-				Versions: kubermaticapiv1.NodeVersionInfo{
+				Versions: v2.NodeVersionInfo{
 					Kubelet: s.version.String(),
 				},
 				OperatingSystem: s.nodeOsSpec,

--- a/api/cmd/conformance-tests/scenarios_azure.go
+++ b/api/cmd/conformance-tests/scenarios_azure.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getAzureScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &azureScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			},
+		})
+		// CoreOS
+		scenarios = append(scenarios, &azureScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+					// Otherwise the nodes restart directly after creation - bad for tests
+					DisableAutoUpdate: true,
+				},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &azureScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv1.CentOSSpec{},
+		//	},
+		//})
+	}
+	return scenarios
+}
+
+type azureScenario struct {
+	version    *semver.Semver
+	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+}
+
+func (s *azureScenario) Name() string {
+	return fmt.Sprintf("azure-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *azureScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           *s.version,
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "azure-westeurope",
+				Azure: &v1.AzureCloudSpec{
+					ClientID:       secrets.Azure.ClientID,
+					ClientSecret:   secrets.Azure.ClientSecret,
+					SubscriptionID: secrets.Azure.SubscriptionID,
+					TenantID:       secrets.Azure.TenantID,
+				},
+			},
+		},
+	}
+}
+
+func (s *azureScenario) Nodes(num int) []*kubermaticapiv1.Node {
+	var nodes []*kubermaticapiv1.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv1.Node{
+			ObjectMeta: kubermaticapiv1.ObjectMeta{},
+			Spec: kubermaticapiv1.NodeSpec{
+				Cloud: kubermaticapiv1.NodeCloudSpec{
+					Azure: &kubermaticapiv1.AzureNodeSpec{
+						Size: "Standard_F1",
+					},
+				},
+				Versions: kubermaticapiv1.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_digitalocean.go
+++ b/api/cmd/conformance-tests/scenarios_digitalocean.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/Masterminds/semver"
+	"github.com/kubermatic/kubermatic/api/pkg/api/v2"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,15 +17,15 @@ func getDigitaloceanScenarios() []testScenario {
 		// Ubuntu
 		scenarios = append(scenarios, &digitaloceanScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			nodeOsSpec: v2.OperatingSystemSpec{
+				Ubuntu: &v2.UbuntuSpec{},
 			},
 		})
 		// CoreOS
 		scenarios = append(scenarios, &digitaloceanScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+			nodeOsSpec: v2.OperatingSystemSpec{
+				ContainerLinux: &v2.ContainerLinuxSpec{
 					// Otherwise the nodes restart directly after creation - bad for tests
 					DisableAutoUpdate: true,
 				},
@@ -45,8 +45,8 @@ func getDigitaloceanScenarios() []testScenario {
 }
 
 type digitaloceanScenario struct {
-	version    *semver.Semver
-	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+	version    *semver.Version
+	nodeOsSpec v2.OperatingSystemSpec
 }
 
 func (s *digitaloceanScenario) Name() string {
@@ -57,7 +57,7 @@ func (s *digitaloceanScenario) Cluster(secrets secrets) *v1.Cluster {
 	return &v1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: v1.ClusterSpec{
-			Version:           *s.version,
+			Version:           s.version.String(),
 			HumanReadableName: s.Name(),
 			ClusterNetwork: v1.ClusterNetworkingConfig{
 				Services: v1.NetworkRanges{
@@ -78,18 +78,18 @@ func (s *digitaloceanScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *digitaloceanScenario) Nodes(num int) []*kubermaticapiv1.Node {
-	var nodes []*kubermaticapiv1.Node
+func (s *digitaloceanScenario) Nodes(num int) []*v2.Node {
+	var nodes []*v2.Node
 	for i := 0; i < num; i++ {
-		node := &kubermaticapiv1.Node{
-			ObjectMeta: kubermaticapiv1.ObjectMeta{},
-			Spec: kubermaticapiv1.NodeSpec{
-				Cloud: kubermaticapiv1.NodeCloudSpec{
-					Digitalocean: &kubermaticapiv1.DigitaloceanNodeSpec{
+		node := &v2.Node{
+			Metadata: v2.ObjectMeta{},
+			Spec: v2.NodeSpec{
+				Cloud: v2.NodeCloudSpec{
+					Digitalocean: &v2.DigitaloceanNodeSpec{
 						Size: "4gb",
 					},
 				},
-				Versions: kubermaticapiv1.NodeVersionInfo{
+				Versions: v2.NodeVersionInfo{
 					Kubelet: s.version.String(),
 				},
 				OperatingSystem: s.nodeOsSpec,

--- a/api/cmd/conformance-tests/scenarios_digitalocean.go
+++ b/api/cmd/conformance-tests/scenarios_digitalocean.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getDigitaloceanScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &digitaloceanScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			},
+		})
+		// CoreOS
+		scenarios = append(scenarios, &digitaloceanScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+					// Otherwise the nodes restart directly after creation - bad for tests
+					DisableAutoUpdate: true,
+				},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &digitaloceanScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv1.CentOSSpec{},
+		//	},
+		//})
+	}
+
+	return scenarios
+}
+
+type digitaloceanScenario struct {
+	version    *semver.Semver
+	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+}
+
+func (s *digitaloceanScenario) Name() string {
+	return fmt.Sprintf("digitalocean-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *digitaloceanScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           *s.version,
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "do-ams3",
+				Digitalocean: &v1.DigitaloceanCloudSpec{
+					Token: secrets.Digitalocean.Token,
+				},
+			},
+		},
+	}
+}
+
+func (s *digitaloceanScenario) Nodes(num int) []*kubermaticapiv1.Node {
+	var nodes []*kubermaticapiv1.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv1.Node{
+			ObjectMeta: kubermaticapiv1.ObjectMeta{},
+			Spec: kubermaticapiv1.NodeSpec{
+				Cloud: kubermaticapiv1.NodeCloudSpec{
+					Digitalocean: &kubermaticapiv1.DigitaloceanNodeSpec{
+						Size: "4gb",
+					},
+				},
+				Versions: kubermaticapiv1.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_hetzner.go
+++ b/api/cmd/conformance-tests/scenarios_hetzner.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/Masterminds/semver"
+	"github.com/kubermatic/kubermatic/api/pkg/api/v2"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,8 +17,8 @@ func getHetznerScenarios() []testScenario {
 		// Ubuntu
 		scenarios = append(scenarios, &hetznerScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			nodeOsSpec: v2.OperatingSystemSpec{
+				Ubuntu: &v2.UbuntuSpec{},
 			},
 		})
 		// CentOS
@@ -35,8 +35,8 @@ func getHetznerScenarios() []testScenario {
 }
 
 type hetznerScenario struct {
-	version    *semver.Semver
-	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+	version    *semver.Version
+	nodeOsSpec v2.OperatingSystemSpec
 }
 
 func (s *hetznerScenario) Name() string {
@@ -47,7 +47,7 @@ func (s *hetznerScenario) Cluster(secrets secrets) *v1.Cluster {
 	return &v1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: v1.ClusterSpec{
-			Version:           *s.version,
+			Version:           s.version.String(),
 			HumanReadableName: s.Name(),
 			ClusterNetwork: v1.ClusterNetworkingConfig{
 				Services: v1.NetworkRanges{
@@ -68,18 +68,18 @@ func (s *hetznerScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *hetznerScenario) Nodes(num int) []*kubermaticapiv1.Node {
-	var nodes []*kubermaticapiv1.Node
+func (s *hetznerScenario) Nodes(num int) []*v2.Node {
+	var nodes []*v2.Node
 	for i := 0; i < num; i++ {
-		node := &kubermaticapiv1.Node{
-			ObjectMeta: kubermaticapiv1.ObjectMeta{},
-			Spec: kubermaticapiv1.NodeSpec{
-				Cloud: kubermaticapiv1.NodeCloudSpec{
-					Hetzner: &kubermaticapiv1.HetznerNodeSpec{
+		node := &v2.Node{
+			Metadata: v2.ObjectMeta{},
+			Spec: v2.NodeSpec{
+				Cloud: v2.NodeCloudSpec{
+					Hetzner: &v2.HetznerNodeSpec{
 						Type: "cx31",
 					},
 				},
-				Versions: kubermaticapiv1.NodeVersionInfo{
+				Versions: v2.NodeVersionInfo{
 					Kubelet: s.version.String(),
 				},
 				OperatingSystem: s.nodeOsSpec,

--- a/api/cmd/conformance-tests/scenarios_hetzner.go
+++ b/api/cmd/conformance-tests/scenarios_hetzner.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getHetznerScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &hetznerScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &hetznerScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv1.CentOSSpec{},
+		//	},
+		//})
+	}
+
+	return scenarios
+}
+
+type hetznerScenario struct {
+	version    *semver.Semver
+	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+}
+
+func (s *hetznerScenario) Name() string {
+	return fmt.Sprintf("hetzner-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *hetznerScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           *s.version,
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "hetzner-fsn1",
+				Hetzner: &v1.HetznerCloudSpec{
+					Token: secrets.Hetzner.Token,
+				},
+			},
+		},
+	}
+}
+
+func (s *hetznerScenario) Nodes(num int) []*kubermaticapiv1.Node {
+	var nodes []*kubermaticapiv1.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv1.Node{
+			ObjectMeta: kubermaticapiv1.ObjectMeta{},
+			Spec: kubermaticapiv1.NodeSpec{
+				Cloud: kubermaticapiv1.NodeCloudSpec{
+					Hetzner: &kubermaticapiv1.HetznerNodeSpec{
+						Type: "cx31",
+					},
+				},
+				Versions: kubermaticapiv1.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_openstack.go
+++ b/api/cmd/conformance-tests/scenarios_openstack.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getOpenStackScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &openStackScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			},
+		})
+		// CoreOS
+		scenarios = append(scenarios, &openStackScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+					// Otherwise the nodes restart directly after creation - bad for tests
+					DisableAutoUpdate: true,
+				},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &openStackScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv1.CentOSSpec{},
+		//	},
+		//})
+	}
+
+	return scenarios
+}
+
+type openStackScenario struct {
+	version    *semver.Semver
+	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+}
+
+func (s *openStackScenario) Name() string {
+	return fmt.Sprintf("openstack-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *openStackScenario) Cluster(secrets secrets) *v1.Cluster {
+	return &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.ClusterSpec{
+			Version:           *s.version,
+			HumanReadableName: s.Name(),
+			ClusterNetwork: v1.ClusterNetworkingConfig{
+				Services: v1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: v1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: v1.CloudSpec{
+				DatacenterName: "syseleven-dbl1",
+				Openstack: &v1.OpenstackCloudSpec{
+					Domain:   secrets.OpenStack.Domain,
+					Tenant:   secrets.OpenStack.Tenant,
+					Username: secrets.OpenStack.Username,
+					Password: secrets.OpenStack.Password,
+				},
+			},
+		},
+	}
+}
+
+func (s *openStackScenario) Nodes(num int) []*kubermaticapiv1.Node {
+	osName := getOSNameFromSpec(s.nodeOsSpec)
+	var nodes []*kubermaticapiv1.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv1.Node{
+			ObjectMeta: kubermaticapiv1.ObjectMeta{},
+			Spec: kubermaticapiv1.NodeSpec{
+				Cloud: kubermaticapiv1.NodeCloudSpec{
+					Openstack: &kubermaticapiv1.OpenstackNodeSpec{
+						Flavor: "m1.small",
+						Image:  "kubermatic-e2e-" + osName,
+					},
+				},
+				Versions: kubermaticapiv1.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_openstack.go
+++ b/api/cmd/conformance-tests/scenarios_openstack.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/Masterminds/semver"
+	"github.com/kubermatic/kubermatic/api/pkg/api/v2"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,15 +17,15 @@ func getOpenStackScenarios() []testScenario {
 		// Ubuntu
 		scenarios = append(scenarios, &openStackScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			nodeOsSpec: v2.OperatingSystemSpec{
+				Ubuntu: &v2.UbuntuSpec{},
 			},
 		})
 		// CoreOS
 		scenarios = append(scenarios, &openStackScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+			nodeOsSpec: v2.OperatingSystemSpec{
+				ContainerLinux: &v2.ContainerLinuxSpec{
 					// Otherwise the nodes restart directly after creation - bad for tests
 					DisableAutoUpdate: true,
 				},
@@ -45,8 +45,8 @@ func getOpenStackScenarios() []testScenario {
 }
 
 type openStackScenario struct {
-	version    *semver.Semver
-	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+	version    *semver.Version
+	nodeOsSpec v2.OperatingSystemSpec
 }
 
 func (s *openStackScenario) Name() string {
@@ -57,7 +57,7 @@ func (s *openStackScenario) Cluster(secrets secrets) *v1.Cluster {
 	return &v1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: v1.ClusterSpec{
-			Version:           *s.version,
+			Version:           s.version.String(),
 			HumanReadableName: s.Name(),
 			ClusterNetwork: v1.ClusterNetworkingConfig{
 				Services: v1.NetworkRanges{
@@ -81,20 +81,20 @@ func (s *openStackScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *openStackScenario) Nodes(num int) []*kubermaticapiv1.Node {
+func (s *openStackScenario) Nodes(num int) []*v2.Node {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
-	var nodes []*kubermaticapiv1.Node
+	var nodes []*v2.Node
 	for i := 0; i < num; i++ {
-		node := &kubermaticapiv1.Node{
-			ObjectMeta: kubermaticapiv1.ObjectMeta{},
-			Spec: kubermaticapiv1.NodeSpec{
-				Cloud: kubermaticapiv1.NodeCloudSpec{
-					Openstack: &kubermaticapiv1.OpenstackNodeSpec{
+		node := &v2.Node{
+			Metadata: v2.ObjectMeta{},
+			Spec: v2.NodeSpec{
+				Cloud: v2.NodeCloudSpec{
+					Openstack: &v2.OpenstackNodeSpec{
 						Flavor: "m1.small",
 						Image:  "kubermatic-e2e-" + osName,
 					},
 				},
-				Versions: kubermaticapiv1.NodeVersionInfo{
+				Versions: v2.NodeVersionInfo{
 					Kubelet: s.version.String(),
 				},
 				OperatingSystem: s.nodeOsSpec,

--- a/api/cmd/conformance-tests/scenarios_vsphere.go
+++ b/api/cmd/conformance-tests/scenarios_vsphere.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns a matrix of (version x operating system)
+func getVSphereScenarios() []testScenario {
+	var scenarios []testScenario
+	for _, v := range supportedVersions {
+		// Ubuntu
+		scenarios = append(scenarios, &vSphereScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			},
+		})
+		// CoreOS
+		scenarios = append(scenarios, &vSphereScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+					// Otherwise the nodes restart directly after creation - bad for tests
+					DisableAutoUpdate: true,
+				},
+			},
+		})
+		// CentOS
+		//TODO: Fix
+		//scenarios = append(scenarios, &vSphereScenario{
+		//	version: v,
+		//	nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+		//		CentOS: &kubermaticapiv1.CentOSSpec{},
+		//	},
+		//})
+	}
+
+	return scenarios
+}
+
+type vSphereScenario struct {
+	version    *semver.Semver
+	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+}
+
+func (s *vSphereScenario) Name() string {
+	return fmt.Sprintf("vsphere-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+}
+
+func (s *vSphereScenario) Cluster(secrets secrets) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: kubermaticv1.ClusterSpec{
+			Version:           *s.version,
+			HumanReadableName: s.Name(),
+			ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+				Services: kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.0/24"},
+				},
+				Pods: kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain: "cluster.local",
+			},
+			Cloud: kubermaticv1.CloudSpec{
+				DatacenterName: "vsphere-hetzner",
+				VSphere: &kubermaticv1.VSphereCloudSpec{
+					Username: secrets.VSphere.Username,
+					Password: secrets.VSphere.Password,
+					InfraManagementUser: kubermaticv1.VSphereCredentials{
+						Username: secrets.VSphere.Username,
+						Password: secrets.VSphere.Password,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s *vSphereScenario) Nodes(num int) []*kubermaticapiv1.Node {
+	osName := getOSNameFromSpec(s.nodeOsSpec)
+	var nodes []*kubermaticapiv1.Node
+	for i := 0; i < num; i++ {
+		node := &kubermaticapiv1.Node{
+			ObjectMeta: kubermaticapiv1.ObjectMeta{},
+			Spec: kubermaticapiv1.NodeSpec{
+				Cloud: kubermaticapiv1.NodeCloudSpec{
+					VSphere: &kubermaticapiv1.VSphereNodeSpec{
+						Template: fmt.Sprintf("%s-template", osName),
+						CPUs:     2,
+						Memory:   2048,
+					},
+				},
+				Versions: kubermaticapiv1.NodeVersionInfo{
+					Kubelet: s.version.String(),
+				},
+				OperatingSystem: s.nodeOsSpec,
+			},
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}

--- a/api/cmd/conformance-tests/scenarios_vsphere.go
+++ b/api/cmd/conformance-tests/scenarios_vsphere.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/Masterminds/semver"
+	"github.com/kubermatic/kubermatic/api/pkg/api/v2"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,15 +17,15 @@ func getVSphereScenarios() []testScenario {
 		// Ubuntu
 		scenarios = append(scenarios, &vSphereScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			nodeOsSpec: v2.OperatingSystemSpec{
+				Ubuntu: &v2.UbuntuSpec{},
 			},
 		})
 		// CoreOS
 		scenarios = append(scenarios, &vSphereScenario{
 			version: v,
-			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+			nodeOsSpec: v2.OperatingSystemSpec{
+				ContainerLinux: &v2.ContainerLinuxSpec{
 					// Otherwise the nodes restart directly after creation - bad for tests
 					DisableAutoUpdate: true,
 				},
@@ -45,8 +45,8 @@ func getVSphereScenarios() []testScenario {
 }
 
 type vSphereScenario struct {
-	version    *semver.Semver
-	nodeOsSpec kubermaticapiv1.OperatingSystemSpec
+	version    *semver.Version
+	nodeOsSpec v2.OperatingSystemSpec
 }
 
 func (s *vSphereScenario) Name() string {
@@ -57,7 +57,7 @@ func (s *vSphereScenario) Cluster(secrets secrets) *kubermaticv1.Cluster {
 	return &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: kubermaticv1.ClusterSpec{
-			Version:           *s.version,
+			Version:           s.version.String(),
 			HumanReadableName: s.Name(),
 			ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 				Services: kubermaticv1.NetworkRanges{
@@ -83,21 +83,21 @@ func (s *vSphereScenario) Cluster(secrets secrets) *kubermaticv1.Cluster {
 	}
 }
 
-func (s *vSphereScenario) Nodes(num int) []*kubermaticapiv1.Node {
+func (s *vSphereScenario) Nodes(num int) []*v2.Node {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
-	var nodes []*kubermaticapiv1.Node
+	var nodes []*v2.Node
 	for i := 0; i < num; i++ {
-		node := &kubermaticapiv1.Node{
-			ObjectMeta: kubermaticapiv1.ObjectMeta{},
-			Spec: kubermaticapiv1.NodeSpec{
-				Cloud: kubermaticapiv1.NodeCloudSpec{
-					VSphere: &kubermaticapiv1.VSphereNodeSpec{
+		node := &v2.Node{
+			Metadata: v2.ObjectMeta{},
+			Spec: v2.NodeSpec{
+				Cloud: v2.NodeCloudSpec{
+					VSphere: &v2.VSphereNodeSpec{
 						Template: fmt.Sprintf("%s-template", osName),
 						CPUs:     2,
 						Memory:   2048,
 					},
 				},
-				Versions: kubermaticapiv1.NodeVersionInfo{
+				Versions: v2.NodeVersionInfo{
 					Kubelet: s.version.String(),
 				},
 				OperatingSystem: s.nodeOsSpec,

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export BUILD_ID=${BUILD_ID:-BUILD_ID_UNDEF}
+echo "Build ID is $BUILD_ID"
+
+cd $(dirname $0)/..
+
+echo "Unlocking secrets repo"
+cd $(go env GOPATH)/src/github.com/kubermatic/secrets
+echo $KUBERMATIC_SECRETS_GPG_KEY_BASE64 | base64 -d > /tmp/git-crypt-key
+git-crypt unlock /tmp/git-crypt-key
+cd -
+echo "Successfully unlocked secrets repo"
+
+
+echo "Building conformance-tests cli and kubermatic-controller-manager"
+go build github.com/kubermatic/kubermatic/api/cmd/conformance-tests
+make kubermatic-controller-manager
+echo "Finished building conformance-tests and kubermatic-controller-manager"
+
+function cleanup {
+  set +e
+  export KUBECONFIG="$(go env GOPATH)/src/github.com/kubermatic/secrets/seed-clusters/dev.kubermatic.io/kubeconfig"
+
+  # Delete addons from all clusters that have our worker-name label
+  kubectl get cluster -l worker-name=$BUILD_ID \
+     -o go-template='{{range .items}}{{.metadata.name}}{{end}}' \
+     |xargs -n 1 -I ^ kubectl label addon -n cluster-^ --all worker-name-
+
+  # Delete all clusters that have our worker-name label
+  kubectl delete cluster -l worker-name=$BUILD_ID --wait=false
+
+  # Remove the worker-name label from all clusters that have our worker-name
+  # label so the main cluster-controller will clean them up
+  kubectl get cluster -l worker-name=$BUILD_ID \
+    -o go-template='{{range .items}}{{.metadata.name}}{{end}}' \
+      |xargs -I ^ kubectl label cluster ^ worker-name-
+}
+trap cleanup EXIT
+
+echo "Starting conformance tests"
+./conformance-tests \
+  -debug \
+  -worker-name=$BUILD_ID \
+  -kubeconfig=$(go env GOPATH)/src/github.com/kubermatic/secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
+  -datacenters=$(go env GOPATH)/src/github.com/kubermatic/secrets/seed-clusters/dev.kubermatic.io/datacenters.yaml \
+  -kubermatic-nodes=3 \
+  -kubermatic-parallel-clusters=11 \
+  -kubermatic-delete-cluster=true \
+  -name-prefix=prow-e2e \
+  -reports-root=/reports \
+  -cleanup-on-start=false \
+  -aws-access-key-id="$AWS_E2E_TESTS_KEY_ID" \
+  -aws-secret-access-key="$AWS_E2E_TESTS_SECRET" \
+  -providers=aws \
+  -exclude-kubernetes-versions="9,10,11" \
+  -exclude-distributions="ubuntu,centos"

--- a/api/vendor/github.com/onsi/ginkgo/LICENSE
+++ b/api/vendor/github.com/onsi/ginkgo/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2013-2014 Onsi Fakhouri
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/api/vendor/github.com/onsi/ginkgo/config/config.go
+++ b/api/vendor/github.com/onsi/ginkgo/config/config.go
@@ -1,0 +1,200 @@
+/*
+Ginkgo accepts a number of configuration options.
+
+These are documented [here](http://onsi.github.io/ginkgo/#the_ginkgo_cli)
+
+You can also learn more via
+
+	ginkgo help
+
+or (I kid you not):
+
+	go test -asdf
+*/
+package config
+
+import (
+	"flag"
+	"time"
+
+	"fmt"
+)
+
+const VERSION = "1.7.0"
+
+type GinkgoConfigType struct {
+	RandomSeed         int64
+	RandomizeAllSpecs  bool
+	RegexScansFilePath bool
+	FocusString        string
+	SkipString         string
+	SkipMeasurements   bool
+	FailOnPending      bool
+	FailFast           bool
+	FlakeAttempts      int
+	EmitSpecProgress   bool
+	DryRun             bool
+	DebugParallel      bool
+
+	ParallelNode  int
+	ParallelTotal int
+	SyncHost      string
+	StreamHost    string
+}
+
+var GinkgoConfig = GinkgoConfigType{}
+
+type DefaultReporterConfigType struct {
+	NoColor           bool
+	SlowSpecThreshold float64
+	NoisyPendings     bool
+	NoisySkippings    bool
+	Succinct          bool
+	Verbose           bool
+	FullTrace         bool
+}
+
+var DefaultReporterConfig = DefaultReporterConfigType{}
+
+func processPrefix(prefix string) string {
+	if prefix != "" {
+		prefix = prefix + "."
+	}
+	return prefix
+}
+
+func Flags(flagSet *flag.FlagSet, prefix string, includeParallelFlags bool) {
+	prefix = processPrefix(prefix)
+	flagSet.Int64Var(&(GinkgoConfig.RandomSeed), prefix+"seed", time.Now().Unix(), "The seed used to randomize the spec suite.")
+	flagSet.BoolVar(&(GinkgoConfig.RandomizeAllSpecs), prefix+"randomizeAllSpecs", false, "If set, ginkgo will randomize all specs together.  By default, ginkgo only randomizes the top level Describe, Context and When groups.")
+	flagSet.BoolVar(&(GinkgoConfig.SkipMeasurements), prefix+"skipMeasurements", false, "If set, ginkgo will skip any measurement specs.")
+	flagSet.BoolVar(&(GinkgoConfig.FailOnPending), prefix+"failOnPending", false, "If set, ginkgo will mark the test suite as failed if any specs are pending.")
+	flagSet.BoolVar(&(GinkgoConfig.FailFast), prefix+"failFast", false, "If set, ginkgo will stop running a test suite after a failure occurs.")
+
+	flagSet.BoolVar(&(GinkgoConfig.DryRun), prefix+"dryRun", false, "If set, ginkgo will walk the test hierarchy without actually running anything.  Best paired with -v.")
+
+	flagSet.StringVar(&(GinkgoConfig.FocusString), prefix+"focus", "", "If set, ginkgo will only run specs that match this regular expression.")
+	flagSet.StringVar(&(GinkgoConfig.SkipString), prefix+"skip", "", "If set, ginkgo will only run specs that do not match this regular expression.")
+
+	flagSet.BoolVar(&(GinkgoConfig.RegexScansFilePath), prefix+"regexScansFilePath", false, "If set, ginkgo regex matching also will look at the file path (code location).")
+
+	flagSet.IntVar(&(GinkgoConfig.FlakeAttempts), prefix+"flakeAttempts", 1, "Make up to this many attempts to run each spec. Please note that if any of the attempts succeed, the suite will not be failed. But any failures will still be recorded.")
+
+	flagSet.BoolVar(&(GinkgoConfig.EmitSpecProgress), prefix+"progress", false, "If set, ginkgo will emit progress information as each spec runs to the GinkgoWriter.")
+
+	flagSet.BoolVar(&(GinkgoConfig.DebugParallel), prefix+"debug", false, "If set, ginkgo will emit node output to files when running in parallel.")
+
+	if includeParallelFlags {
+		flagSet.IntVar(&(GinkgoConfig.ParallelNode), prefix+"parallel.node", 1, "This worker node's (one-indexed) node number.  For running specs in parallel.")
+		flagSet.IntVar(&(GinkgoConfig.ParallelTotal), prefix+"parallel.total", 1, "The total number of worker nodes.  For running specs in parallel.")
+		flagSet.StringVar(&(GinkgoConfig.SyncHost), prefix+"parallel.synchost", "", "The address for the server that will synchronize the running nodes.")
+		flagSet.StringVar(&(GinkgoConfig.StreamHost), prefix+"parallel.streamhost", "", "The address for the server that the running nodes should stream data to.")
+	}
+
+	flagSet.BoolVar(&(DefaultReporterConfig.NoColor), prefix+"noColor", false, "If set, suppress color output in default reporter.")
+	flagSet.Float64Var(&(DefaultReporterConfig.SlowSpecThreshold), prefix+"slowSpecThreshold", 5.0, "(in seconds) Specs that take longer to run than this threshold are flagged as slow by the default reporter.")
+	flagSet.BoolVar(&(DefaultReporterConfig.NoisyPendings), prefix+"noisyPendings", true, "If set, default reporter will shout about pending tests.")
+	flagSet.BoolVar(&(DefaultReporterConfig.NoisySkippings), prefix+"noisySkippings", true, "If set, default reporter will shout about skipping tests.")
+	flagSet.BoolVar(&(DefaultReporterConfig.Verbose), prefix+"v", false, "If set, default reporter print out all specs as they begin.")
+	flagSet.BoolVar(&(DefaultReporterConfig.Succinct), prefix+"succinct", false, "If set, default reporter prints out a very succinct report")
+	flagSet.BoolVar(&(DefaultReporterConfig.FullTrace), prefix+"trace", false, "If set, default reporter prints out the full stack trace when a failure occurs")
+}
+
+func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultReporterConfigType) []string {
+	prefix = processPrefix(prefix)
+	result := make([]string, 0)
+
+	if ginkgo.RandomSeed > 0 {
+		result = append(result, fmt.Sprintf("--%sseed=%d", prefix, ginkgo.RandomSeed))
+	}
+
+	if ginkgo.RandomizeAllSpecs {
+		result = append(result, fmt.Sprintf("--%srandomizeAllSpecs", prefix))
+	}
+
+	if ginkgo.SkipMeasurements {
+		result = append(result, fmt.Sprintf("--%sskipMeasurements", prefix))
+	}
+
+	if ginkgo.FailOnPending {
+		result = append(result, fmt.Sprintf("--%sfailOnPending", prefix))
+	}
+
+	if ginkgo.FailFast {
+		result = append(result, fmt.Sprintf("--%sfailFast", prefix))
+	}
+
+	if ginkgo.DryRun {
+		result = append(result, fmt.Sprintf("--%sdryRun", prefix))
+	}
+
+	if ginkgo.FocusString != "" {
+		result = append(result, fmt.Sprintf("--%sfocus=%s", prefix, ginkgo.FocusString))
+	}
+
+	if ginkgo.SkipString != "" {
+		result = append(result, fmt.Sprintf("--%sskip=%s", prefix, ginkgo.SkipString))
+	}
+
+	if ginkgo.FlakeAttempts > 1 {
+		result = append(result, fmt.Sprintf("--%sflakeAttempts=%d", prefix, ginkgo.FlakeAttempts))
+	}
+
+	if ginkgo.EmitSpecProgress {
+		result = append(result, fmt.Sprintf("--%sprogress", prefix))
+	}
+
+	if ginkgo.DebugParallel {
+		result = append(result, fmt.Sprintf("--%sdebug", prefix))
+	}
+
+	if ginkgo.ParallelNode != 0 {
+		result = append(result, fmt.Sprintf("--%sparallel.node=%d", prefix, ginkgo.ParallelNode))
+	}
+
+	if ginkgo.ParallelTotal != 0 {
+		result = append(result, fmt.Sprintf("--%sparallel.total=%d", prefix, ginkgo.ParallelTotal))
+	}
+
+	if ginkgo.StreamHost != "" {
+		result = append(result, fmt.Sprintf("--%sparallel.streamhost=%s", prefix, ginkgo.StreamHost))
+	}
+
+	if ginkgo.SyncHost != "" {
+		result = append(result, fmt.Sprintf("--%sparallel.synchost=%s", prefix, ginkgo.SyncHost))
+	}
+
+	if ginkgo.RegexScansFilePath {
+		result = append(result, fmt.Sprintf("--%sregexScansFilePath", prefix))
+	}
+
+	if reporter.NoColor {
+		result = append(result, fmt.Sprintf("--%snoColor", prefix))
+	}
+
+	if reporter.SlowSpecThreshold > 0 {
+		result = append(result, fmt.Sprintf("--%sslowSpecThreshold=%.5f", prefix, reporter.SlowSpecThreshold))
+	}
+
+	if !reporter.NoisyPendings {
+		result = append(result, fmt.Sprintf("--%snoisyPendings=false", prefix))
+	}
+
+	if !reporter.NoisySkippings {
+		result = append(result, fmt.Sprintf("--%snoisySkippings=false", prefix))
+	}
+
+	if reporter.Verbose {
+		result = append(result, fmt.Sprintf("--%sv", prefix))
+	}
+
+	if reporter.Succinct {
+		result = append(result, fmt.Sprintf("--%ssuccinct", prefix))
+	}
+
+	if reporter.FullTrace {
+		result = append(result, fmt.Sprintf("--%strace", prefix))
+	}
+
+	return result
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
@@ -1,0 +1,84 @@
+/*
+Ginkgo's Default Reporter
+
+A number of command line flags are available to tweak Ginkgo's default output.
+
+These are documented [here](http://onsi.github.io/ginkgo/#running_tests)
+*/
+package reporters
+
+import (
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/onsi/ginkgo/types"
+)
+
+type DefaultReporter struct {
+	config        config.DefaultReporterConfigType
+	stenographer  stenographer.Stenographer
+	specSummaries []*types.SpecSummary
+}
+
+func NewDefaultReporter(config config.DefaultReporterConfigType, stenographer stenographer.Stenographer) *DefaultReporter {
+	return &DefaultReporter{
+		config:       config,
+		stenographer: stenographer,
+	}
+}
+
+func (reporter *DefaultReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	reporter.stenographer.AnnounceSuite(summary.SuiteDescription, config.RandomSeed, config.RandomizeAllSpecs, reporter.config.Succinct)
+	if config.ParallelTotal > 1 {
+		reporter.stenographer.AnnounceParallelRun(config.ParallelNode, config.ParallelTotal, reporter.config.Succinct)
+	} else {
+		reporter.stenographer.AnnounceNumberOfSpecs(summary.NumberOfSpecsThatWillBeRun, summary.NumberOfTotalSpecs, reporter.config.Succinct)
+	}
+}
+
+func (reporter *DefaultReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		reporter.stenographer.AnnounceBeforeSuiteFailure(setupSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	}
+}
+
+func (reporter *DefaultReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		reporter.stenographer.AnnounceAfterSuiteFailure(setupSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	}
+}
+
+func (reporter *DefaultReporter) SpecWillRun(specSummary *types.SpecSummary) {
+	if reporter.config.Verbose && !reporter.config.Succinct && specSummary.State != types.SpecStatePending && specSummary.State != types.SpecStateSkipped {
+		reporter.stenographer.AnnounceSpecWillRun(specSummary)
+	}
+}
+
+func (reporter *DefaultReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	switch specSummary.State {
+	case types.SpecStatePassed:
+		if specSummary.IsMeasurement {
+			reporter.stenographer.AnnounceSuccesfulMeasurement(specSummary, reporter.config.Succinct)
+		} else if specSummary.RunTime.Seconds() >= reporter.config.SlowSpecThreshold {
+			reporter.stenographer.AnnounceSuccesfulSlowSpec(specSummary, reporter.config.Succinct)
+		} else {
+			reporter.stenographer.AnnounceSuccesfulSpec(specSummary)
+		}
+	case types.SpecStatePending:
+		reporter.stenographer.AnnouncePendingSpec(specSummary, reporter.config.NoisyPendings && !reporter.config.Succinct)
+	case types.SpecStateSkipped:
+		reporter.stenographer.AnnounceSkippedSpec(specSummary, reporter.config.Succinct || !reporter.config.NoisySkippings, reporter.config.FullTrace)
+	case types.SpecStateTimedOut:
+		reporter.stenographer.AnnounceSpecTimedOut(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	case types.SpecStatePanicked:
+		reporter.stenographer.AnnounceSpecPanicked(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	case types.SpecStateFailed:
+		reporter.stenographer.AnnounceSpecFailed(specSummary, reporter.config.Succinct, reporter.config.FullTrace)
+	}
+
+	reporter.specSummaries = append(reporter.specSummaries, specSummary)
+}
+
+func (reporter *DefaultReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	reporter.stenographer.SummarizeFailures(reporter.specSummaries)
+	reporter.stenographer.AnnounceSpecRunCompletion(summary, reporter.config.Succinct)
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/fake_reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/fake_reporter.go
@@ -1,0 +1,59 @@
+package reporters
+
+import (
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+//FakeReporter is useful for testing purposes
+type FakeReporter struct {
+	Config config.GinkgoConfigType
+
+	BeginSummary         *types.SuiteSummary
+	BeforeSuiteSummary   *types.SetupSummary
+	SpecWillRunSummaries []*types.SpecSummary
+	SpecSummaries        []*types.SpecSummary
+	AfterSuiteSummary    *types.SetupSummary
+	EndSummary           *types.SuiteSummary
+
+	SpecWillRunStub     func(specSummary *types.SpecSummary)
+	SpecDidCompleteStub func(specSummary *types.SpecSummary)
+}
+
+func NewFakeReporter() *FakeReporter {
+	return &FakeReporter{
+		SpecWillRunSummaries: make([]*types.SpecSummary, 0),
+		SpecSummaries:        make([]*types.SpecSummary, 0),
+	}
+}
+
+func (fakeR *FakeReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	fakeR.Config = config
+	fakeR.BeginSummary = summary
+}
+
+func (fakeR *FakeReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	fakeR.BeforeSuiteSummary = setupSummary
+}
+
+func (fakeR *FakeReporter) SpecWillRun(specSummary *types.SpecSummary) {
+	if fakeR.SpecWillRunStub != nil {
+		fakeR.SpecWillRunStub(specSummary)
+	}
+	fakeR.SpecWillRunSummaries = append(fakeR.SpecWillRunSummaries, specSummary)
+}
+
+func (fakeR *FakeReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	if fakeR.SpecDidCompleteStub != nil {
+		fakeR.SpecDidCompleteStub(specSummary)
+	}
+	fakeR.SpecSummaries = append(fakeR.SpecSummaries, specSummary)
+}
+
+func (fakeR *FakeReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	fakeR.AfterSuiteSummary = setupSummary
+}
+
+func (fakeR *FakeReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	fakeR.EndSummary = summary
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
@@ -1,0 +1,152 @@
+/*
+
+JUnit XML Reporter for Ginkgo
+
+For usage instructions: http://onsi.github.io/ginkgo/#generating_junit_xml_output
+
+*/
+
+package reporters
+
+import (
+	"encoding/xml"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+type JUnitTestSuite struct {
+	XMLName   xml.Name        `xml:"testsuite"`
+	TestCases []JUnitTestCase `xml:"testcase"`
+	Name      string          `xml:"name,attr"`
+	Tests     int             `xml:"tests,attr"`
+	Failures  int             `xml:"failures,attr"`
+	Errors    int             `xml:"errors,attr"`
+	Time      float64         `xml:"time,attr"`
+}
+
+type JUnitTestCase struct {
+	Name           string               `xml:"name,attr"`
+	ClassName      string               `xml:"classname,attr"`
+	FailureMessage *JUnitFailureMessage `xml:"failure,omitempty"`
+	Skipped        *JUnitSkipped        `xml:"skipped,omitempty"`
+	Time           float64              `xml:"time,attr"`
+	SystemOut      string               `xml:"system-out,omitempty"`
+}
+
+type JUnitFailureMessage struct {
+	Type    string `xml:"type,attr"`
+	Message string `xml:",chardata"`
+}
+
+type JUnitSkipped struct {
+	XMLName xml.Name `xml:"skipped"`
+}
+
+type JUnitReporter struct {
+	suite         JUnitTestSuite
+	filename      string
+	testSuiteName string
+}
+
+//NewJUnitReporter creates a new JUnit XML reporter.  The XML will be stored in the passed in filename.
+func NewJUnitReporter(filename string) *JUnitReporter {
+	return &JUnitReporter{
+		filename: filename,
+	}
+}
+
+func (reporter *JUnitReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	reporter.suite = JUnitTestSuite{
+		Name:      summary.SuiteDescription,
+		TestCases: []JUnitTestCase{},
+	}
+	reporter.testSuiteName = summary.SuiteDescription
+}
+
+func (reporter *JUnitReporter) SpecWillRun(specSummary *types.SpecSummary) {
+}
+
+func (reporter *JUnitReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("BeforeSuite", setupSummary)
+}
+
+func (reporter *JUnitReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("AfterSuite", setupSummary)
+}
+
+func failureMessage(failure types.SpecFailure) string {
+	return fmt.Sprintf("%s\n%s\n%s", failure.ComponentCodeLocation.String(), failure.Message, failure.Location.String())
+}
+
+func (reporter *JUnitReporter) handleSetupSummary(name string, setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		testCase := JUnitTestCase{
+			Name:      name,
+			ClassName: reporter.testSuiteName,
+		}
+
+		testCase.FailureMessage = &JUnitFailureMessage{
+			Type:    reporter.failureTypeForState(setupSummary.State),
+			Message: failureMessage(setupSummary.Failure),
+		}
+		testCase.SystemOut = setupSummary.CapturedOutput
+		testCase.Time = setupSummary.RunTime.Seconds()
+		reporter.suite.TestCases = append(reporter.suite.TestCases, testCase)
+	}
+}
+
+func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	testCase := JUnitTestCase{
+		Name:      strings.Join(specSummary.ComponentTexts[1:], " "),
+		ClassName: reporter.testSuiteName,
+	}
+	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
+		testCase.FailureMessage = &JUnitFailureMessage{
+			Type:    reporter.failureTypeForState(specSummary.State),
+			Message: failureMessage(specSummary.Failure),
+		}
+		testCase.SystemOut = specSummary.CapturedOutput
+	}
+	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {
+		testCase.Skipped = &JUnitSkipped{}
+	}
+	testCase.Time = specSummary.RunTime.Seconds()
+	reporter.suite.TestCases = append(reporter.suite.TestCases, testCase)
+}
+
+func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	reporter.suite.Tests = summary.NumberOfSpecsThatWillBeRun
+	reporter.suite.Time = math.Trunc(summary.RunTime.Seconds()*1000) / 1000
+	reporter.suite.Failures = summary.NumberOfFailedSpecs
+	reporter.suite.Errors = 0
+	file, err := os.Create(reporter.filename)
+	if err != nil {
+		fmt.Printf("Failed to create JUnit report file: %s\n\t%s", reporter.filename, err.Error())
+	}
+	defer file.Close()
+	file.WriteString(xml.Header)
+	encoder := xml.NewEncoder(file)
+	encoder.Indent("  ", "    ")
+	err = encoder.Encode(reporter.suite)
+	if err != nil {
+		fmt.Printf("Failed to generate JUnit report\n\t%s", err.Error())
+	}
+}
+
+func (reporter *JUnitReporter) failureTypeForState(state types.SpecState) string {
+	switch state {
+	case types.SpecStateFailed:
+		return "Failure"
+	case types.SpecStateTimedOut:
+		return "Timeout"
+	case types.SpecStatePanicked:
+		return "Panic"
+	default:
+		return ""
+	}
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/reporter.go
@@ -1,0 +1,15 @@
+package reporters
+
+import (
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+type Reporter interface {
+	SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary)
+	BeforeSuiteDidRun(setupSummary *types.SetupSummary)
+	SpecWillRun(specSummary *types.SpecSummary)
+	SpecDidComplete(specSummary *types.SpecSummary)
+	AfterSuiteDidRun(setupSummary *types.SetupSummary)
+	SpecSuiteDidEnd(summary *types.SuiteSummary)
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/console_logging.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/console_logging.go
@@ -1,0 +1,64 @@
+package stenographer
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (s *consoleStenographer) colorize(colorCode string, format string, args ...interface{}) string {
+	var out string
+
+	if len(args) > 0 {
+		out = fmt.Sprintf(format, args...)
+	} else {
+		out = format
+	}
+
+	if s.color {
+		return fmt.Sprintf("%s%s%s", colorCode, out, defaultStyle)
+	} else {
+		return out
+	}
+}
+
+func (s *consoleStenographer) printBanner(text string, bannerCharacter string) {
+	fmt.Fprintln(s.w, text)
+	fmt.Fprintln(s.w, strings.Repeat(bannerCharacter, len(text)))
+}
+
+func (s *consoleStenographer) printNewLine() {
+	fmt.Fprintln(s.w, "")
+}
+
+func (s *consoleStenographer) printDelimiter() {
+	fmt.Fprintln(s.w, s.colorize(grayColor, "%s", strings.Repeat("-", 30)))
+}
+
+func (s *consoleStenographer) print(indentation int, format string, args ...interface{}) {
+	fmt.Fprint(s.w, s.indent(indentation, format, args...))
+}
+
+func (s *consoleStenographer) println(indentation int, format string, args ...interface{}) {
+	fmt.Fprintln(s.w, s.indent(indentation, format, args...))
+}
+
+func (s *consoleStenographer) indent(indentation int, format string, args ...interface{}) string {
+	var text string
+
+	if len(args) > 0 {
+		text = fmt.Sprintf(format, args...)
+	} else {
+		text = format
+	}
+
+	stringArray := strings.Split(text, "\n")
+	padding := ""
+	if indentation >= 0 {
+		padding = strings.Repeat("  ", indentation)
+	}
+	for i, s := range stringArray {
+		stringArray[i] = fmt.Sprintf("%s%s", padding, s)
+	}
+
+	return strings.Join(stringArray, "\n")
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/fake_stenographer.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/fake_stenographer.go
@@ -1,0 +1,142 @@
+package stenographer
+
+import (
+	"sync"
+
+	"github.com/onsi/ginkgo/types"
+)
+
+func NewFakeStenographerCall(method string, args ...interface{}) FakeStenographerCall {
+	return FakeStenographerCall{
+		Method: method,
+		Args:   args,
+	}
+}
+
+type FakeStenographer struct {
+	calls []FakeStenographerCall
+	lock  *sync.Mutex
+}
+
+type FakeStenographerCall struct {
+	Method string
+	Args   []interface{}
+}
+
+func NewFakeStenographer() *FakeStenographer {
+	stenographer := &FakeStenographer{
+		lock: &sync.Mutex{},
+	}
+	stenographer.Reset()
+	return stenographer
+}
+
+func (stenographer *FakeStenographer) Calls() []FakeStenographerCall {
+	stenographer.lock.Lock()
+	defer stenographer.lock.Unlock()
+
+	return stenographer.calls
+}
+
+func (stenographer *FakeStenographer) Reset() {
+	stenographer.lock.Lock()
+	defer stenographer.lock.Unlock()
+
+	stenographer.calls = make([]FakeStenographerCall, 0)
+}
+
+func (stenographer *FakeStenographer) CallsTo(method string) []FakeStenographerCall {
+	stenographer.lock.Lock()
+	defer stenographer.lock.Unlock()
+
+	results := make([]FakeStenographerCall, 0)
+	for _, call := range stenographer.calls {
+		if call.Method == method {
+			results = append(results, call)
+		}
+	}
+
+	return results
+}
+
+func (stenographer *FakeStenographer) registerCall(method string, args ...interface{}) {
+	stenographer.lock.Lock()
+	defer stenographer.lock.Unlock()
+
+	stenographer.calls = append(stenographer.calls, NewFakeStenographerCall(method, args...))
+}
+
+func (stenographer *FakeStenographer) AnnounceSuite(description string, randomSeed int64, randomizingAll bool, succinct bool) {
+	stenographer.registerCall("AnnounceSuite", description, randomSeed, randomizingAll, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceAggregatedParallelRun(nodes int, succinct bool) {
+	stenographer.registerCall("AnnounceAggregatedParallelRun", nodes, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceParallelRun(node int, nodes int, succinct bool) {
+	stenographer.registerCall("AnnounceParallelRun", node, nodes, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceNumberOfSpecs(specsToRun int, total int, succinct bool) {
+	stenographer.registerCall("AnnounceNumberOfSpecs", specsToRun, total, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceTotalNumberOfSpecs(total int, succinct bool) {
+	stenographer.registerCall("AnnounceTotalNumberOfSpecs", total, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecRunCompletion(summary *types.SuiteSummary, succinct bool) {
+	stenographer.registerCall("AnnounceSpecRunCompletion", summary, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecWillRun(spec *types.SpecSummary) {
+	stenographer.registerCall("AnnounceSpecWillRun", spec)
+}
+
+func (stenographer *FakeStenographer) AnnounceBeforeSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceBeforeSuiteFailure", summary, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) AnnounceAfterSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceAfterSuiteFailure", summary, succinct, fullTrace)
+}
+func (stenographer *FakeStenographer) AnnounceCapturedOutput(output string) {
+	stenographer.registerCall("AnnounceCapturedOutput", output)
+}
+
+func (stenographer *FakeStenographer) AnnounceSuccesfulSpec(spec *types.SpecSummary) {
+	stenographer.registerCall("AnnounceSuccesfulSpec", spec)
+}
+
+func (stenographer *FakeStenographer) AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool) {
+	stenographer.registerCall("AnnounceSuccesfulSlowSpec", spec, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool) {
+	stenographer.registerCall("AnnounceSuccesfulMeasurement", spec, succinct)
+}
+
+func (stenographer *FakeStenographer) AnnouncePendingSpec(spec *types.SpecSummary, noisy bool) {
+	stenographer.registerCall("AnnouncePendingSpec", spec, noisy)
+}
+
+func (stenographer *FakeStenographer) AnnounceSkippedSpec(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSkippedSpec", spec, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecTimedOut(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSpecTimedOut", spec, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecPanicked(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSpecPanicked", spec, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) AnnounceSpecFailed(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	stenographer.registerCall("AnnounceSpecFailed", spec, succinct, fullTrace)
+}
+
+func (stenographer *FakeStenographer) SummarizeFailures(summaries []*types.SpecSummary) {
+	stenographer.registerCall("SummarizeFailures", summaries)
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/stenographer.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/stenographer.go
@@ -1,0 +1,572 @@
+/*
+The stenographer is used by Ginkgo's reporters to generate output.
+
+Move along, nothing to see here.
+*/
+
+package stenographer
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+
+	"github.com/onsi/ginkgo/types"
+)
+
+const defaultStyle = "\x1b[0m"
+const boldStyle = "\x1b[1m"
+const redColor = "\x1b[91m"
+const greenColor = "\x1b[32m"
+const yellowColor = "\x1b[33m"
+const cyanColor = "\x1b[36m"
+const grayColor = "\x1b[90m"
+const lightGrayColor = "\x1b[37m"
+
+type cursorStateType int
+
+const (
+	cursorStateTop cursorStateType = iota
+	cursorStateStreaming
+	cursorStateMidBlock
+	cursorStateEndBlock
+)
+
+type Stenographer interface {
+	AnnounceSuite(description string, randomSeed int64, randomizingAll bool, succinct bool)
+	AnnounceAggregatedParallelRun(nodes int, succinct bool)
+	AnnounceParallelRun(node int, nodes int, succinct bool)
+	AnnounceTotalNumberOfSpecs(total int, succinct bool)
+	AnnounceNumberOfSpecs(specsToRun int, total int, succinct bool)
+	AnnounceSpecRunCompletion(summary *types.SuiteSummary, succinct bool)
+
+	AnnounceSpecWillRun(spec *types.SpecSummary)
+	AnnounceBeforeSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool)
+	AnnounceAfterSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool)
+
+	AnnounceCapturedOutput(output string)
+
+	AnnounceSuccesfulSpec(spec *types.SpecSummary)
+	AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool)
+	AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool)
+
+	AnnouncePendingSpec(spec *types.SpecSummary, noisy bool)
+	AnnounceSkippedSpec(spec *types.SpecSummary, succinct bool, fullTrace bool)
+
+	AnnounceSpecTimedOut(spec *types.SpecSummary, succinct bool, fullTrace bool)
+	AnnounceSpecPanicked(spec *types.SpecSummary, succinct bool, fullTrace bool)
+	AnnounceSpecFailed(spec *types.SpecSummary, succinct bool, fullTrace bool)
+
+	SummarizeFailures(summaries []*types.SpecSummary)
+}
+
+func New(color bool, enableFlakes bool, writer io.Writer) Stenographer {
+	denoter := "•"
+	if runtime.GOOS == "windows" {
+		denoter = "+"
+	}
+	return &consoleStenographer{
+		color:        color,
+		denoter:      denoter,
+		cursorState:  cursorStateTop,
+		enableFlakes: enableFlakes,
+		w:            writer,
+	}
+}
+
+type consoleStenographer struct {
+	color        bool
+	denoter      string
+	cursorState  cursorStateType
+	enableFlakes bool
+	w            io.Writer
+}
+
+var alternatingColors = []string{defaultStyle, grayColor}
+
+func (s *consoleStenographer) AnnounceSuite(description string, randomSeed int64, randomizingAll bool, succinct bool) {
+	if succinct {
+		s.print(0, "[%d] %s ", randomSeed, s.colorize(boldStyle, description))
+		return
+	}
+	s.printBanner(fmt.Sprintf("Running Suite: %s", description), "=")
+	s.print(0, "Random Seed: %s", s.colorize(boldStyle, "%d", randomSeed))
+	if randomizingAll {
+		s.print(0, " - Will randomize all specs")
+	}
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceParallelRun(node int, nodes int, succinct bool) {
+	if succinct {
+		s.print(0, "- node #%d ", node)
+		return
+	}
+	s.println(0,
+		"Parallel test node %s/%s.",
+		s.colorize(boldStyle, "%d", node),
+		s.colorize(boldStyle, "%d", nodes),
+	)
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceAggregatedParallelRun(nodes int, succinct bool) {
+	if succinct {
+		s.print(0, "- %d nodes ", nodes)
+		return
+	}
+	s.println(0,
+		"Running in parallel across %s nodes",
+		s.colorize(boldStyle, "%d", nodes),
+	)
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceNumberOfSpecs(specsToRun int, total int, succinct bool) {
+	if succinct {
+		s.print(0, "- %d/%d specs ", specsToRun, total)
+		s.stream()
+		return
+	}
+	s.println(0,
+		"Will run %s of %s specs",
+		s.colorize(boldStyle, "%d", specsToRun),
+		s.colorize(boldStyle, "%d", total),
+	)
+
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceTotalNumberOfSpecs(total int, succinct bool) {
+	if succinct {
+		s.print(0, "- %d specs ", total)
+		s.stream()
+		return
+	}
+	s.println(0,
+		"Will run %s specs",
+		s.colorize(boldStyle, "%d", total),
+	)
+
+	s.printNewLine()
+}
+
+func (s *consoleStenographer) AnnounceSpecRunCompletion(summary *types.SuiteSummary, succinct bool) {
+	if succinct && summary.SuiteSucceeded {
+		s.print(0, " %s %s ", s.colorize(greenColor, "SUCCESS!"), summary.RunTime)
+		return
+	}
+	s.printNewLine()
+	color := greenColor
+	if !summary.SuiteSucceeded {
+		color = redColor
+	}
+	s.println(0, s.colorize(boldStyle+color, "Ran %d of %d Specs in %.3f seconds", summary.NumberOfSpecsThatWillBeRun, summary.NumberOfTotalSpecs, summary.RunTime.Seconds()))
+
+	status := ""
+	if summary.SuiteSucceeded {
+		status = s.colorize(boldStyle+greenColor, "SUCCESS!")
+	} else {
+		status = s.colorize(boldStyle+redColor, "FAIL!")
+	}
+
+	flakes := ""
+	if s.enableFlakes {
+		flakes = " | " + s.colorize(yellowColor+boldStyle, "%d Flaked", summary.NumberOfFlakedSpecs)
+	}
+
+	s.print(0,
+		"%s -- %s | %s | %s | %s\n",
+		status,
+		s.colorize(greenColor+boldStyle, "%d Passed", summary.NumberOfPassedSpecs),
+		s.colorize(redColor+boldStyle, "%d Failed", summary.NumberOfFailedSpecs)+flakes,
+		s.colorize(yellowColor+boldStyle, "%d Pending", summary.NumberOfPendingSpecs),
+		s.colorize(cyanColor+boldStyle, "%d Skipped", summary.NumberOfSkippedSpecs),
+	)
+}
+
+func (s *consoleStenographer) AnnounceSpecWillRun(spec *types.SpecSummary) {
+	s.startBlock()
+	for i, text := range spec.ComponentTexts[1 : len(spec.ComponentTexts)-1] {
+		s.print(0, s.colorize(alternatingColors[i%2], text)+" ")
+	}
+
+	indentation := 0
+	if len(spec.ComponentTexts) > 2 {
+		indentation = 1
+		s.printNewLine()
+	}
+	index := len(spec.ComponentTexts) - 1
+	s.print(indentation, s.colorize(boldStyle, spec.ComponentTexts[index]))
+	s.printNewLine()
+	s.print(indentation, s.colorize(lightGrayColor, spec.ComponentCodeLocations[index].String()))
+	s.printNewLine()
+	s.midBlock()
+}
+
+func (s *consoleStenographer) AnnounceBeforeSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	s.announceSetupFailure("BeforeSuite", summary, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) AnnounceAfterSuiteFailure(summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	s.announceSetupFailure("AfterSuite", summary, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) announceSetupFailure(name string, summary *types.SetupSummary, succinct bool, fullTrace bool) {
+	s.startBlock()
+	var message string
+	switch summary.State {
+	case types.SpecStateFailed:
+		message = "Failure"
+	case types.SpecStatePanicked:
+		message = "Panic"
+	case types.SpecStateTimedOut:
+		message = "Timeout"
+	}
+
+	s.println(0, s.colorize(redColor+boldStyle, "%s [%.3f seconds]", message, summary.RunTime.Seconds()))
+
+	indentation := s.printCodeLocationBlock([]string{name}, []types.CodeLocation{summary.CodeLocation}, summary.ComponentType, 0, summary.State, true)
+
+	s.printNewLine()
+	s.printFailure(indentation, summary.State, summary.Failure, fullTrace)
+
+	s.endBlock()
+}
+
+func (s *consoleStenographer) AnnounceCapturedOutput(output string) {
+	if output == "" {
+		return
+	}
+
+	s.startBlock()
+	s.println(0, output)
+	s.midBlock()
+}
+
+func (s *consoleStenographer) AnnounceSuccesfulSpec(spec *types.SpecSummary) {
+	s.print(0, s.colorize(greenColor, s.denoter))
+	s.stream()
+}
+
+func (s *consoleStenographer) AnnounceSuccesfulSlowSpec(spec *types.SpecSummary, succinct bool) {
+	s.printBlockWithMessage(
+		s.colorize(greenColor, "%s [SLOW TEST:%.3f seconds]", s.denoter, spec.RunTime.Seconds()),
+		"",
+		spec,
+		succinct,
+	)
+}
+
+func (s *consoleStenographer) AnnounceSuccesfulMeasurement(spec *types.SpecSummary, succinct bool) {
+	s.printBlockWithMessage(
+		s.colorize(greenColor, "%s [MEASUREMENT]", s.denoter),
+		s.measurementReport(spec, succinct),
+		spec,
+		succinct,
+	)
+}
+
+func (s *consoleStenographer) AnnouncePendingSpec(spec *types.SpecSummary, noisy bool) {
+	if noisy {
+		s.printBlockWithMessage(
+			s.colorize(yellowColor, "P [PENDING]"),
+			"",
+			spec,
+			false,
+		)
+	} else {
+		s.print(0, s.colorize(yellowColor, "P"))
+		s.stream()
+	}
+}
+
+func (s *consoleStenographer) AnnounceSkippedSpec(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	// Skips at runtime will have a non-empty spec.Failure. All others should be succinct.
+	if succinct || spec.Failure == (types.SpecFailure{}) {
+		s.print(0, s.colorize(cyanColor, "S"))
+		s.stream()
+	} else {
+		s.startBlock()
+		s.println(0, s.colorize(cyanColor+boldStyle, "S [SKIPPING]%s [%.3f seconds]", s.failureContext(spec.Failure.ComponentType), spec.RunTime.Seconds()))
+
+		indentation := s.printCodeLocationBlock(spec.ComponentTexts, spec.ComponentCodeLocations, spec.Failure.ComponentType, spec.Failure.ComponentIndex, spec.State, succinct)
+
+		s.printNewLine()
+		s.printSkip(indentation, spec.Failure)
+		s.endBlock()
+	}
+}
+
+func (s *consoleStenographer) AnnounceSpecTimedOut(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	s.printSpecFailure(fmt.Sprintf("%s... Timeout", s.denoter), spec, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) AnnounceSpecPanicked(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	s.printSpecFailure(fmt.Sprintf("%s! Panic", s.denoter), spec, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) AnnounceSpecFailed(spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	s.printSpecFailure(fmt.Sprintf("%s Failure", s.denoter), spec, succinct, fullTrace)
+}
+
+func (s *consoleStenographer) SummarizeFailures(summaries []*types.SpecSummary) {
+	failingSpecs := []*types.SpecSummary{}
+
+	for _, summary := range summaries {
+		if summary.HasFailureState() {
+			failingSpecs = append(failingSpecs, summary)
+		}
+	}
+
+	if len(failingSpecs) == 0 {
+		return
+	}
+
+	s.printNewLine()
+	s.printNewLine()
+	plural := "s"
+	if len(failingSpecs) == 1 {
+		plural = ""
+	}
+	s.println(0, s.colorize(redColor+boldStyle, "Summarizing %d Failure%s:", len(failingSpecs), plural))
+	for _, summary := range failingSpecs {
+		s.printNewLine()
+		if summary.HasFailureState() {
+			if summary.TimedOut() {
+				s.print(0, s.colorize(redColor+boldStyle, "[Timeout...] "))
+			} else if summary.Panicked() {
+				s.print(0, s.colorize(redColor+boldStyle, "[Panic!] "))
+			} else if summary.Failed() {
+				s.print(0, s.colorize(redColor+boldStyle, "[Fail] "))
+			}
+			s.printSpecContext(summary.ComponentTexts, summary.ComponentCodeLocations, summary.Failure.ComponentType, summary.Failure.ComponentIndex, summary.State, true)
+			s.printNewLine()
+			s.println(0, s.colorize(lightGrayColor, summary.Failure.Location.String()))
+		}
+	}
+}
+
+func (s *consoleStenographer) startBlock() {
+	if s.cursorState == cursorStateStreaming {
+		s.printNewLine()
+		s.printDelimiter()
+	} else if s.cursorState == cursorStateMidBlock {
+		s.printNewLine()
+	}
+}
+
+func (s *consoleStenographer) midBlock() {
+	s.cursorState = cursorStateMidBlock
+}
+
+func (s *consoleStenographer) endBlock() {
+	s.printDelimiter()
+	s.cursorState = cursorStateEndBlock
+}
+
+func (s *consoleStenographer) stream() {
+	s.cursorState = cursorStateStreaming
+}
+
+func (s *consoleStenographer) printBlockWithMessage(header string, message string, spec *types.SpecSummary, succinct bool) {
+	s.startBlock()
+	s.println(0, header)
+
+	indentation := s.printCodeLocationBlock(spec.ComponentTexts, spec.ComponentCodeLocations, types.SpecComponentTypeInvalid, 0, spec.State, succinct)
+
+	if message != "" {
+		s.printNewLine()
+		s.println(indentation, message)
+	}
+
+	s.endBlock()
+}
+
+func (s *consoleStenographer) printSpecFailure(message string, spec *types.SpecSummary, succinct bool, fullTrace bool) {
+	s.startBlock()
+	s.println(0, s.colorize(redColor+boldStyle, "%s%s [%.3f seconds]", message, s.failureContext(spec.Failure.ComponentType), spec.RunTime.Seconds()))
+
+	indentation := s.printCodeLocationBlock(spec.ComponentTexts, spec.ComponentCodeLocations, spec.Failure.ComponentType, spec.Failure.ComponentIndex, spec.State, succinct)
+
+	s.printNewLine()
+	s.printFailure(indentation, spec.State, spec.Failure, fullTrace)
+	s.endBlock()
+}
+
+func (s *consoleStenographer) failureContext(failedComponentType types.SpecComponentType) string {
+	switch failedComponentType {
+	case types.SpecComponentTypeBeforeSuite:
+		return " in Suite Setup (BeforeSuite)"
+	case types.SpecComponentTypeAfterSuite:
+		return " in Suite Teardown (AfterSuite)"
+	case types.SpecComponentTypeBeforeEach:
+		return " in Spec Setup (BeforeEach)"
+	case types.SpecComponentTypeJustBeforeEach:
+		return " in Spec Setup (JustBeforeEach)"
+	case types.SpecComponentTypeAfterEach:
+		return " in Spec Teardown (AfterEach)"
+	}
+
+	return ""
+}
+
+func (s *consoleStenographer) printSkip(indentation int, spec types.SpecFailure) {
+	s.println(indentation, s.colorize(cyanColor, spec.Message))
+	s.printNewLine()
+	s.println(indentation, spec.Location.String())
+}
+
+func (s *consoleStenographer) printFailure(indentation int, state types.SpecState, failure types.SpecFailure, fullTrace bool) {
+	if state == types.SpecStatePanicked {
+		s.println(indentation, s.colorize(redColor+boldStyle, failure.Message))
+		s.println(indentation, s.colorize(redColor, failure.ForwardedPanic))
+		s.println(indentation, failure.Location.String())
+		s.printNewLine()
+		s.println(indentation, s.colorize(redColor, "Full Stack Trace"))
+		s.println(indentation, failure.Location.FullStackTrace)
+	} else {
+		s.println(indentation, s.colorize(redColor, failure.Message))
+		s.printNewLine()
+		s.println(indentation, failure.Location.String())
+		if fullTrace {
+			s.printNewLine()
+			s.println(indentation, s.colorize(redColor, "Full Stack Trace"))
+			s.println(indentation, failure.Location.FullStackTrace)
+		}
+	}
+}
+
+func (s *consoleStenographer) printSpecContext(componentTexts []string, componentCodeLocations []types.CodeLocation, failedComponentType types.SpecComponentType, failedComponentIndex int, state types.SpecState, succinct bool) int {
+	startIndex := 1
+	indentation := 0
+
+	if len(componentTexts) == 1 {
+		startIndex = 0
+	}
+
+	for i := startIndex; i < len(componentTexts); i++ {
+		if (state.IsFailure() || state == types.SpecStateSkipped) && i == failedComponentIndex {
+			color := redColor
+			if state == types.SpecStateSkipped {
+				color = cyanColor
+			}
+			blockType := ""
+			switch failedComponentType {
+			case types.SpecComponentTypeBeforeSuite:
+				blockType = "BeforeSuite"
+			case types.SpecComponentTypeAfterSuite:
+				blockType = "AfterSuite"
+			case types.SpecComponentTypeBeforeEach:
+				blockType = "BeforeEach"
+			case types.SpecComponentTypeJustBeforeEach:
+				blockType = "JustBeforeEach"
+			case types.SpecComponentTypeAfterEach:
+				blockType = "AfterEach"
+			case types.SpecComponentTypeIt:
+				blockType = "It"
+			case types.SpecComponentTypeMeasure:
+				blockType = "Measurement"
+			}
+			if succinct {
+				s.print(0, s.colorize(color+boldStyle, "[%s] %s ", blockType, componentTexts[i]))
+			} else {
+				s.println(indentation, s.colorize(color+boldStyle, "%s [%s]", componentTexts[i], blockType))
+				s.println(indentation, s.colorize(grayColor, "%s", componentCodeLocations[i]))
+			}
+		} else {
+			if succinct {
+				s.print(0, s.colorize(alternatingColors[i%2], "%s ", componentTexts[i]))
+			} else {
+				s.println(indentation, componentTexts[i])
+				s.println(indentation, s.colorize(grayColor, "%s", componentCodeLocations[i]))
+			}
+		}
+		indentation++
+	}
+
+	return indentation
+}
+
+func (s *consoleStenographer) printCodeLocationBlock(componentTexts []string, componentCodeLocations []types.CodeLocation, failedComponentType types.SpecComponentType, failedComponentIndex int, state types.SpecState, succinct bool) int {
+	indentation := s.printSpecContext(componentTexts, componentCodeLocations, failedComponentType, failedComponentIndex, state, succinct)
+
+	if succinct {
+		if len(componentTexts) > 0 {
+			s.printNewLine()
+			s.print(0, s.colorize(lightGrayColor, "%s", componentCodeLocations[len(componentCodeLocations)-1]))
+		}
+		s.printNewLine()
+		indentation = 1
+	} else {
+		indentation--
+	}
+
+	return indentation
+}
+
+func (s *consoleStenographer) orderedMeasurementKeys(measurements map[string]*types.SpecMeasurement) []string {
+	orderedKeys := make([]string, len(measurements))
+	for key, measurement := range measurements {
+		orderedKeys[measurement.Order] = key
+	}
+	return orderedKeys
+}
+
+func (s *consoleStenographer) measurementReport(spec *types.SpecSummary, succinct bool) string {
+	if len(spec.Measurements) == 0 {
+		return "Found no measurements"
+	}
+
+	message := []string{}
+	orderedKeys := s.orderedMeasurementKeys(spec.Measurements)
+
+	if succinct {
+		message = append(message, fmt.Sprintf("%s samples:", s.colorize(boldStyle, "%d", spec.NumberOfSamples)))
+		for _, key := range orderedKeys {
+			measurement := spec.Measurements[key]
+			message = append(message, fmt.Sprintf("  %s - %s: %s%s, %s: %s%s ± %s%s, %s: %s%s",
+				s.colorize(boldStyle, "%s", measurement.Name),
+				measurement.SmallestLabel,
+				s.colorize(greenColor, measurement.PrecisionFmt(), measurement.Smallest),
+				measurement.Units,
+				measurement.AverageLabel,
+				s.colorize(cyanColor, measurement.PrecisionFmt(), measurement.Average),
+				measurement.Units,
+				s.colorize(cyanColor, measurement.PrecisionFmt(), measurement.StdDeviation),
+				measurement.Units,
+				measurement.LargestLabel,
+				s.colorize(redColor, measurement.PrecisionFmt(), measurement.Largest),
+				measurement.Units,
+			))
+		}
+	} else {
+		message = append(message, fmt.Sprintf("Ran %s samples:", s.colorize(boldStyle, "%d", spec.NumberOfSamples)))
+		for _, key := range orderedKeys {
+			measurement := spec.Measurements[key]
+			info := ""
+			if measurement.Info != nil {
+				message = append(message, fmt.Sprintf("%v", measurement.Info))
+			}
+
+			message = append(message, fmt.Sprintf("%s:\n%s  %s: %s%s\n  %s: %s%s\n  %s: %s%s ± %s%s",
+				s.colorize(boldStyle, "%s", measurement.Name),
+				info,
+				measurement.SmallestLabel,
+				s.colorize(greenColor, measurement.PrecisionFmt(), measurement.Smallest),
+				measurement.Units,
+				measurement.LargestLabel,
+				s.colorize(redColor, measurement.PrecisionFmt(), measurement.Largest),
+				measurement.Units,
+				measurement.AverageLabel,
+				s.colorize(cyanColor, measurement.PrecisionFmt(), measurement.Average),
+				measurement.Units,
+				s.colorize(cyanColor, measurement.PrecisionFmt(), measurement.StdDeviation),
+				measurement.Units,
+			))
+		}
+	}
+
+	return strings.Join(message, "\n")
+}

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable/LICENSE
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty/LICENSE
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/api/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
+++ b/api/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
@@ -1,0 +1,93 @@
+/*
+
+TeamCity Reporter for Ginkgo
+
+Makes use of TeamCity's support for Service Messages
+http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
+*/
+
+package reporters
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+const (
+	messageId = "##teamcity"
+)
+
+type TeamCityReporter struct {
+	writer        io.Writer
+	testSuiteName string
+}
+
+func NewTeamCityReporter(writer io.Writer) *TeamCityReporter {
+	return &TeamCityReporter{
+		writer: writer,
+	}
+}
+
+func (reporter *TeamCityReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	reporter.testSuiteName = escape(summary.SuiteDescription)
+	fmt.Fprintf(reporter.writer, "%s[testSuiteStarted name='%s']", messageId, reporter.testSuiteName)
+}
+
+func (reporter *TeamCityReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("BeforeSuite", setupSummary)
+}
+
+func (reporter *TeamCityReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("AfterSuite", setupSummary)
+}
+
+func (reporter *TeamCityReporter) handleSetupSummary(name string, setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		testName := escape(name)
+		fmt.Fprintf(reporter.writer, "%s[testStarted name='%s']", messageId, testName)
+		message := escape(setupSummary.Failure.ComponentCodeLocation.String())
+		details := escape(setupSummary.Failure.Message)
+		fmt.Fprintf(reporter.writer, "%s[testFailed name='%s' message='%s' details='%s']", messageId, testName, message, details)
+		durationInMilliseconds := setupSummary.RunTime.Seconds() * 1000
+		fmt.Fprintf(reporter.writer, "%s[testFinished name='%s' duration='%v']", messageId, testName, durationInMilliseconds)
+	}
+}
+
+func (reporter *TeamCityReporter) SpecWillRun(specSummary *types.SpecSummary) {
+	testName := escape(strings.Join(specSummary.ComponentTexts[1:], " "))
+	fmt.Fprintf(reporter.writer, "%s[testStarted name='%s']", messageId, testName)
+}
+
+func (reporter *TeamCityReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	testName := escape(strings.Join(specSummary.ComponentTexts[1:], " "))
+
+	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
+		message := escape(specSummary.Failure.ComponentCodeLocation.String())
+		details := escape(specSummary.Failure.Message)
+		fmt.Fprintf(reporter.writer, "%s[testFailed name='%s' message='%s' details='%s']", messageId, testName, message, details)
+	}
+	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {
+		fmt.Fprintf(reporter.writer, "%s[testIgnored name='%s']", messageId, testName)
+	}
+
+	durationInMilliseconds := specSummary.RunTime.Seconds() * 1000
+	fmt.Fprintf(reporter.writer, "%s[testFinished name='%s' duration='%v']", messageId, testName, durationInMilliseconds)
+}
+
+func (reporter *TeamCityReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	fmt.Fprintf(reporter.writer, "%s[testSuiteFinished name='%s']", messageId, reporter.testSuiteName)
+}
+
+func escape(output string) string {
+	output = strings.Replace(output, "|", "||", -1)
+	output = strings.Replace(output, "'", "|'", -1)
+	output = strings.Replace(output, "\n", "|n", -1)
+	output = strings.Replace(output, "\r", "|r", -1)
+	output = strings.Replace(output, "[", "|[", -1)
+	output = strings.Replace(output, "]", "|]", -1)
+	return output
+}

--- a/api/vendor/github.com/onsi/ginkgo/types/code_location.go
+++ b/api/vendor/github.com/onsi/ginkgo/types/code_location.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"fmt"
+)
+
+type CodeLocation struct {
+	FileName       string
+	LineNumber     int
+	FullStackTrace string
+}
+
+func (codeLocation CodeLocation) String() string {
+	return fmt.Sprintf("%s:%d", codeLocation.FileName, codeLocation.LineNumber)
+}

--- a/api/vendor/github.com/onsi/ginkgo/types/synchronization.go
+++ b/api/vendor/github.com/onsi/ginkgo/types/synchronization.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"encoding/json"
+)
+
+type RemoteBeforeSuiteState int
+
+const (
+	RemoteBeforeSuiteStateInvalid RemoteBeforeSuiteState = iota
+
+	RemoteBeforeSuiteStatePending
+	RemoteBeforeSuiteStatePassed
+	RemoteBeforeSuiteStateFailed
+	RemoteBeforeSuiteStateDisappeared
+)
+
+type RemoteBeforeSuiteData struct {
+	Data  []byte
+	State RemoteBeforeSuiteState
+}
+
+func (r RemoteBeforeSuiteData) ToJSON() []byte {
+	data, _ := json.Marshal(r)
+	return data
+}
+
+type RemoteAfterSuiteData struct {
+	CanRun bool
+}

--- a/api/vendor/github.com/onsi/ginkgo/types/types.go
+++ b/api/vendor/github.com/onsi/ginkgo/types/types.go
@@ -1,0 +1,174 @@
+package types
+
+import (
+	"strconv"
+	"time"
+)
+
+const GINKGO_FOCUS_EXIT_CODE = 197
+
+/*
+SuiteSummary represents the a summary of the test suite and is passed to both
+Reporter.SpecSuiteWillBegin
+Reporter.SpecSuiteDidEnd
+
+this is unfortunate as these two methods should receive different objects.  When running in parallel
+each node does not deterministically know how many specs it will end up running.
+
+Unfortunately making such a change would break backward compatibility.
+
+Until Ginkgo 2.0 comes out we will continue to reuse this struct but populate unkown fields
+with -1.
+*/
+type SuiteSummary struct {
+	SuiteDescription string
+	SuiteSucceeded   bool
+	SuiteID          string
+
+	NumberOfSpecsBeforeParallelization int
+	NumberOfTotalSpecs                 int
+	NumberOfSpecsThatWillBeRun         int
+	NumberOfPendingSpecs               int
+	NumberOfSkippedSpecs               int
+	NumberOfPassedSpecs                int
+	NumberOfFailedSpecs                int
+	// Flaked specs are those that failed initially, but then passed on a
+	// subsequent try.
+	NumberOfFlakedSpecs int
+	RunTime             time.Duration
+}
+
+type SpecSummary struct {
+	ComponentTexts         []string
+	ComponentCodeLocations []CodeLocation
+
+	State           SpecState
+	RunTime         time.Duration
+	Failure         SpecFailure
+	IsMeasurement   bool
+	NumberOfSamples int
+	Measurements    map[string]*SpecMeasurement
+
+	CapturedOutput string
+	SuiteID        string
+}
+
+func (s SpecSummary) HasFailureState() bool {
+	return s.State.IsFailure()
+}
+
+func (s SpecSummary) TimedOut() bool {
+	return s.State == SpecStateTimedOut
+}
+
+func (s SpecSummary) Panicked() bool {
+	return s.State == SpecStatePanicked
+}
+
+func (s SpecSummary) Failed() bool {
+	return s.State == SpecStateFailed
+}
+
+func (s SpecSummary) Passed() bool {
+	return s.State == SpecStatePassed
+}
+
+func (s SpecSummary) Skipped() bool {
+	return s.State == SpecStateSkipped
+}
+
+func (s SpecSummary) Pending() bool {
+	return s.State == SpecStatePending
+}
+
+type SetupSummary struct {
+	ComponentType SpecComponentType
+	CodeLocation  CodeLocation
+
+	State   SpecState
+	RunTime time.Duration
+	Failure SpecFailure
+
+	CapturedOutput string
+	SuiteID        string
+}
+
+type SpecFailure struct {
+	Message        string
+	Location       CodeLocation
+	ForwardedPanic string
+
+	ComponentIndex        int
+	ComponentType         SpecComponentType
+	ComponentCodeLocation CodeLocation
+}
+
+type SpecMeasurement struct {
+	Name  string
+	Info  interface{}
+	Order int
+
+	Results []float64
+
+	Smallest     float64
+	Largest      float64
+	Average      float64
+	StdDeviation float64
+
+	SmallestLabel string
+	LargestLabel  string
+	AverageLabel  string
+	Units         string
+	Precision     int
+}
+
+func (s SpecMeasurement) PrecisionFmt() string {
+	if s.Precision == 0 {
+		return "%f"
+	}
+
+	str := strconv.Itoa(s.Precision)
+
+	return "%." + str + "f"
+}
+
+type SpecState uint
+
+const (
+	SpecStateInvalid SpecState = iota
+
+	SpecStatePending
+	SpecStateSkipped
+	SpecStatePassed
+	SpecStateFailed
+	SpecStatePanicked
+	SpecStateTimedOut
+)
+
+func (state SpecState) IsFailure() bool {
+	return state == SpecStateTimedOut || state == SpecStatePanicked || state == SpecStateFailed
+}
+
+type SpecComponentType uint
+
+const (
+	SpecComponentTypeInvalid SpecComponentType = iota
+
+	SpecComponentTypeContainer
+	SpecComponentTypeBeforeSuite
+	SpecComponentTypeAfterSuite
+	SpecComponentTypeBeforeEach
+	SpecComponentTypeJustBeforeEach
+	SpecComponentTypeJustAfterEach
+	SpecComponentTypeAfterEach
+	SpecComponentTypeIt
+	SpecComponentTypeMeasure
+)
+
+type FlagType uint
+
+const (
+	FlagTypeNone FlagType = iota
+	FlagTypeFocused
+	FlagTypePending
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport conformance tests to v2.8. 
I basically copied over the required files from master to avoid a cherry-pick mess.
I had to change our code at some places, but that has been done in a dedicated commit https://github.com/kubermatic/kubermatic/commit/78fc081088fe155b1a1821064004378054d3f043

**Release note**:
```release-note
NONE
```
