### PR TITLE
Only log error while listing nodes in conformance test

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -531,7 +531,8 @@ func (r *testRunner) waitForReadyNodes(log *logrus.Entry, client kubernetes.Inte
 	err := wait.Poll(nodesReadyPollPeriod, r.nodesReadyWaitTimeout, func() (done bool, err error) {
 		nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to list nodes: %v", err)
+			log.Debugf("failed to list nodes while waiting for them to be ready. %v. Will retry", err)
+			return false, nil
 		}
 
 		if len(nodeList.Items) != num {


### PR DESCRIPTION
**What this PR does / why we need it**:
Only log error while listing nodes in conformance test.
This ensures that the tests continue even if the apiserver was down for a moment.

**Release note**:
```release-note
NONE
```
