### PR TITLE
move conformance test image to docker

### DIFF
--- a/containers/conformance-tests/release.sh
+++ b/containers/conformance-tests/release.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-ver=v0.2
+TAG=v0.3
 
 set -euox pipefail
 
-docker build --no-cache --pull -t quay.io/kubermatic/conformance-tests:${ver} .
-docker push quay.io/kubermatic/conformance-tests:${ver}
+docker build --no-cache --pull -t kubermatic/kubernetes-test-binaries:${TAG} .
+docker push kubermatic/kubernetes-test-binaries:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:
move conformance test image to docker

**Release note**:
```release-note
NONE
```
