### PR TITLE
add owners file for the folder containing the supported kubernetes versions

### DIFF
--- a/config/kubermatic/static/master/OWNERS
+++ b/config/kubermatic/static/master/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - team-lifecycle
+
+reviewers:
+  - team-lifecycle
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Add owners file for the folder containing the supported kubernetes versions.
The cluster-lifecycle teams manages the versions & supported updates, thus it should be responsible for reviewing changes in those files.

**Release note**:
```release-note
NONE
```
