### PR TITLE
Conformance tester: fail testcase if conformance tests failed

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -353,6 +353,7 @@ func (r *testRunner) testCluster(
 		return nil
 	})
 	if err != nil {
+		report.Errors++
 		log.Errorf("Failed to successfully run kubernetes e2e tests: %v", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the conformance-tester happily returns with a RC0 if the conformance tests failed: https://prow.loodse.com/log?job=pull-kubermatic-e2e-aws-coreos-1.13&id=1076120506983256065

This PR fixes that

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
