### PR TITLE
add missing drone build step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,12 @@ pipeline:
     pull: true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+  build:
+    commands:
+    - cd api
+    - make build
+    group: build
+    image: golang:1.11.4
   docker:
     commands:
     - export VAULT_ADDR=https://vault.loodse.com/


### PR DESCRIPTION
**What this PR does / why we need it**:
We removed the `build` step from drone, which causes the `docker` step to fail as the `docker` step depends on the binaries produced during the `build` step.

**Release note**:
```release-note
NONE
```
