### PR TITLE
Cherry-pick enforce IP forwarding

### DIFF
--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -23,6 +23,17 @@ var (
 	defaultCPURequest    = resource.MustParse("25m")
 	defaultMemoryLimit   = resource.MustParse("256Mi")
 	defaultCPULimit      = resource.MustParse("250m")
+
+	ipForwardRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("16Mi"),
+			corev1.ResourceCPU:    resource.MustParse("5m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+		},
+	}
 )
 
 const (
@@ -106,10 +117,7 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"/bin/bash"},
 			Args: []string{
-				"-c", `# Always set IP forwarding
-sysctl -w net.ipv4.ip_forward=1
-
-# do not give a 10.20.0.0/24 route to clients (nodes) but
+				"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but
 # masquerade to openvpn-server's IP instead:
 iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
 
@@ -264,6 +272,23 @@ iptables -A INPUT -i tun0 -j DROP
 					ReadOnly:  true,
 				},
 			},
+		},
+		{
+			Name:            "ip-forward",
+			Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/openvpn:v0.4",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/bin/bash"},
+			Args: []string{
+				"-c",
+				// Always set IP forwarding as a CNI plugin might reset this to 0 (Like Calico 3).
+				"while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done",
+			},
+			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: resources.Bool(true),
+			},
+			Resources: ipForwardRequirements,
 		},
 	}
 

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.8.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.9.10-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.8.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.9.10-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.8.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.9.10-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.8.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.9.10-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.8.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.9.10-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.8.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.0-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.9.10-openvpn-server.yaml
@@ -130,13 +130,29 @@ spec:
         - mountPath: /etc/openvpn/clients
           name: openvpn-client-configs
           readOnly: true
+      - args:
+        - -c
+        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        command:
+        - /bin/bash
+        image: docker.io/kubermatic/openvpn:v0.4
+        imagePullPolicy: IfNotPresent
+        name: ip-forward
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       initContainers:
       - args:
         - -c
         - |
-          # Always set IP forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # do not give a 10.20.0.0/24 route to clients (nodes) but
           # masquerade to openvpn-server's IP instead:
           iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE


### PR DESCRIPTION
**What this PR does / why we need it**:
Enforce IP forwarding

**Release note**:
```release-note bugfix
Fixed an issue with kubelets being unreachable by the apiserver on some OS configurations.
```
