### PR TITLE
Analyze the JUnit report in case ginkgo fails, to accept flakey tests

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -149,7 +149,7 @@ func main() {
 	flag.DurationVar(&opts.controlPlaneReadyWaitTimeout, "kubermatic-cluster-timeout", defaultTimeout, "cluster creation timeout")
 	flag.DurationVar(&opts.nodeReadyWaitTimeout, "kubermatic-nodes-timeout", defaultTimeout, "nodes creation timeout")
 	flag.BoolVar(&opts.deleteClusterAfterTests, "kubermatic-delete-cluster", true, "delete test cluster at the exit")
-	flag.BoolVar(&debug, "debug", true, "Enable debug logs")
+	flag.BoolVar(&debug, "debug", false, "Enable debug logs")
 	flag.StringVar(&pubKeyPath, "node-ssh-pub-key", pubkeyPath, "path to a public key which gets deployed onto every node")
 	flag.StringVar(&opts.workerName, "worker-name", "", "name of the worker, if set the 'worker-name' label will be set on all clusters")
 	flag.BoolVar(&opts.runKubermaticControllerManager, "run-kubermatic-controller-manager", true, "should the runner run the controller-manager")

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -282,6 +282,14 @@ func (r *testRunner) testCluster(
 	const maxTestAttempts = 3
 	var err error
 	totalStart := time.Now()
+	log.Info("Starting to test cluster...")
+	defer log.Infof("Finished testing cluster after %s", time.Since(totalStart))
+
+	// We'll store the report there and all kinds of logs
+	scenarioFolder := path.Join(r.reportsRoot, scenarioName)
+	if err := os.MkdirAll(scenarioFolder, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("failed to create the scenario folder '%s': %v", scenarioFolder, err)
+	}
 
 	report := &reporters.JUnitTestSuite{
 		Name: scenarioName,
@@ -322,54 +330,56 @@ func (r *testRunner) testCluster(
 		report.Tests++
 	}
 
-	var reportsDir string
-	var ginkgoReport *reporters.JUnitTestSuite
-	err = retryNAttempts(maxTestAttempts, func(attempt int) error {
-		startedE2E := time.Now()
-
-		reportsDir = path.Join(r.reportsRoot, scenarioName, fmt.Sprintf("attempt-%d", attempt))
-		if err := os.MkdirAll(reportsDir, 0755); err != nil {
-			return fmt.Errorf("failed to create reports dir: %v", err)
-		}
-
-		log.Infof("[Attempt: %d/%d] Starting E2E tests...", attempt, maxTestAttempts)
-		if err := r.runE2E(log, cluster, kubeconfigFilename, cloudConfigFilename, reportsDir, apiNodes, dc); err != nil {
-			log.Warnf("[Attempt: %d/%d] failed to run E2E tests: %v", attempt, maxTestAttempts, err)
-			return err
-		}
-		log.Infof("[Attempt: %d/%d] E2E tests finished after %.2f seconds", attempt, maxTestAttempts, time.Since(startedE2E).Seconds())
-
-		ginkgoReport, err = collectReports(scenarioName, reportsDir, time.Since(startedE2E))
-		if err != nil {
-			log.Warnf("[Attempt: %d/%d] failed to combine reports: %v. Restarting...", attempt, maxTestAttempts, err)
-			return err
-		}
-
-		if ginkgoReport.Errors > 0 || ginkgoReport.Failures > 0 {
-			log.Warnf("[Attempt: %d/%d] e2e tests had some failures (See %s for details). Restarting...", attempt, maxTestAttempts, reportsDir)
-			return errors.New("encountered partial errors during ginkgo run")
-		}
-
-		return nil
-	})
+	ginkgoRuns, err := r.getGinkgoRuns(log, scenarioName, kubeconfigFilename, cloudConfigFilename, cluster, apiNodes, dc)
 	if err != nil {
-		log.Errorf("Failed to successfully run kubernetes e2e tests: %v", err)
+		return nil, fmt.Errorf("failed to get Ginkgo runs: %v", err)
 	}
+	for _, run := range ginkgoRuns {
+		var ginkgoRes *ginkgoResult
+		var runErr error
 
-	if ginkgoReport != nil {
-		report.Time = time.Since(totalStart).Seconds()
-		report.Tests += ginkgoReport.Tests
-		report.Errors += ginkgoReport.Errors
-		report.Failures += ginkgoReport.Failures
-		report.TestCases = append(report.TestCases, ginkgoReport.TestCases...)
+		for attempt := 1; attempt <= maxTestAttempts; attempt++ {
+
+			ginkgoRes, runErr = executeGinkgoRun(log, run)
+			if runErr != nil {
+				// Something critical happened and we don't have a valid result
+				log.Errorf("failed to execute the Ginkgo run '%s': %v", run.name, runErr)
+				continue
+			}
+
+			if ginkgoRes.report.Errors > 0 || ginkgoRes.report.Failures > 0 {
+				msg := fmt.Sprintf("Ginkgo run '%s' had failed tests.", run.name)
+				if attempt < maxTestAttempts {
+					msg = fmt.Sprintf("%s. Retrying...", msg)
+				}
+				log.Info(msg)
+				continue
+			}
+
+			report = combineReports("Kubernetes Conformance tests", report, ginkgoRes.report)
+			break
+		}
+
+		if ginkgoRes != nil {
+			// We executed all 3 runs but failed all of them. We'll just append to the existing report
+			report = combineReports("Kubernetes Conformance tests", report, ginkgoRes.report)
+		} else {
+			// In case we have no valid ginkgo result, add a failed test case
+			report.TestCases = append(report.TestCases, reporters.JUnitTestCase{
+				Name:           "[Ginkgo] Run ginkgo tests",
+				ClassName:      "Ginkgo",
+				FailureMessage: &reporters.JUnitFailureMessage{Message: fmt.Sprintf("%v", runErr)},
+			})
+		}
 	}
+	report.Time = time.Since(totalStart).Seconds()
 
 	b, err := xml.Marshal(report)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal combined report file: %v", err)
 	}
 
-	if err := ioutil.WriteFile(path.Join(reportsDir, "junit.xml"), b, 0644); err != nil {
+	if err := ioutil.WriteFile(path.Join(scenarioFolder, "junit.xml"), b, 0644); err != nil {
 		return nil, fmt.Errorf("failed to wrte combined report file: %v", err)
 	}
 
@@ -621,28 +631,35 @@ func (r *testRunner) waitUntilAllPodsAreReady(log *logrus.Entry, client kubernet
 	return nil
 }
 
-func (r *testRunner) runE2E(
+type ginkgoResult struct {
+	logfile  string
+	report   *reporters.JUnitTestSuite
+	duration time.Duration
+}
+
+const (
+	argSeparator = ` \
+    `
+)
+
+type ginkgoRun struct {
+	name       string
+	cmd        *exec.Cmd
+	reportsDir string
+}
+
+func (r *testRunner) getGinkgoRuns(
 	log *logrus.Entry,
-	cluster *kubermaticv1.Cluster,
+	scenarioName,
 	kubeconfigFilename,
-	cloudConfigFilename,
-	reportsDir string,
+	cloudConfigFilename string,
+	cluster *kubermaticv1.Cluster,
 	nodes []*kubermaticapiv1.Node,
 	dc provider.DatacenterMeta,
-) error {
+) ([]*ginkgoRun, error) {
 	kubeconfigFilename = path.Clean(kubeconfigFilename)
 	repoRoot := path.Clean(r.repoRoot)
 	MajorMinor := fmt.Sprintf("%d.%d", cluster.Spec.Version.Major(), cluster.Spec.Version.Minor())
-
-	// TODO: Figure out why they fail & potentially fix. Otherwise, explain why they are deactivated
-	//brokenTests := []string{
-	//	"should set TCP CLOSE_WAIT timeout",                // AWS
-	//	"should support exec through an HTTP proxy",        // AWS
-	//	"should proxy to cadvisor",                         // AWS
-	//	"should handle in-cluster config",                  // AWS
-	//	"should proxy to cadvisor using proxy subresource", // AWS
-	//	"should support exec through kubectl proxy",        // AWS
-	//}
 
 	runs := []struct {
 		name          string
@@ -654,31 +671,21 @@ func (r *testRunner) runE2E(
 			name:          "parallel",
 			ginkgoFocus:   `\[Conformance\]`,
 			ginkgoSkip:    `\[Serial\]`,
-			parallelTests: 25,
+			parallelTests: len(nodes) * 10,
 		},
 		{
 			name:          "serial",
 			ginkgoFocus:   `\[Serial\].*\[Conformance\]`,
-			ginkgoSkip:    ``,
+			ginkgoSkip:    `should not cause race condition when used for configmap`,
 			parallelTests: 1,
 		},
-		// TODO: Enable more e2e tests
-		//{
-		//	name:          "parallel",
-		//	ginkgoFocus:   `.*`,
-		//	ginkgoSkip:    `\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|` + strings.Join(brokenTests, "|"),
-		//	parallelTests: 25,
-		//},
-		//{
-		//	name:          "serial",
-		//	ginkgoFocus:   `\[Serial\].*`,
-		//	ginkgoSkip:    `\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort` + strings.Join(brokenTests, "|"),
-		//	parallelTests: 1,
-		//},
 	}
 	versionRoot := path.Join(repoRoot, MajorMinor)
 	binRoot := path.Join(versionRoot, "/platforms/linux/amd64")
+	var ginkgoRuns []*ginkgoRun
 	for _, run := range runs {
+
+		reportsDir := path.Join("/tmp", scenarioName, run.name)
 		env := []string{
 			fmt.Sprintf("HOME=%s", r.homeDir),
 			fmt.Sprintf("AWS_SSH_KEY=%s", path.Join(r.homeDir, ".ssh", "google_compute_engine")),
@@ -732,51 +739,90 @@ func (r *testRunner) runE2E(
 		cmd := exec.Command(path.Join(binRoot, "ginkgo"), args...)
 		cmd.Env = env
 
-		run := func() error {
-			logFile := path.Join(reportsDir, "e2e.log")
-			f, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE, 0644)
-			if err != nil {
-				return fmt.Errorf("failed to open logfile: %v", err)
-			}
-			defer func() {
-				if err := f.Close(); err != nil {
-					log.Errorf("failed to close file handle on '%s': %v", logFile, err)
-				}
-			}()
+		ginkgoRuns = append(ginkgoRuns, &ginkgoRun{
+			name:       run.name,
+			cmd:        cmd,
+			reportsDir: reportsDir,
+		})
+	}
 
-			writer := bufio.NewWriter(f)
-			defer func() {
-				if err := writer.Flush(); err != nil {
-					log.Errorf("failed to flush log file buffer: %v", err)
-				}
-			}()
+	return ginkgoRuns, nil
+}
 
-			err = ioutil.WriteFile(
-				path.Join(reportsDir, fmt.Sprintf("script-%s.sh", run.name)),
-				[]byte(strings.Join(cmd.Args, ` \
-    `)),
-				0644,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to write script: %v", err)
-			}
+func executeGinkgoRun(parentLog *logrus.Entry, run *ginkgoRun) (*ginkgoResult, error) {
+	started := time.Now()
+	log := parentLog.WithField("reports-dir", run.reportsDir)
 
-			log.Debugf("Starting ginkgo run '%s'...", run.name)
+	// Make sure we write to a file instead of a byte buffer as the logs are pretty big
+	file, err := ioutil.TempFile("/tmp", run.name+"-log")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open logfile: %v", err)
+	}
+	defer file.Close()
+	log = log.WithField("ginkgo-log", file.Name())
 
-			cmd.Stdout = writer
-			cmd.Stderr = writer
-			if err := cmd.Run(); err != nil {
-				return fmt.Errorf("failed to execute ginkgo run '%s': %v. Output can be found at %s", run.name, err, logFile)
-			}
-			return nil
-		}
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
 
-		if err := run(); err != nil {
-			return err
+	// Copy the command as we cannot execute a command twice
+	cmd := &exec.Cmd{
+		Path:       run.cmd.Path,
+		Args:       run.cmd.Args,
+		Env:        run.cmd.Env,
+		Dir:        run.cmd.Dir,
+		ExtraFiles: run.cmd.ExtraFiles,
+	}
+	if _, err := writer.Write([]byte(strings.Join(cmd.Args, argSeparator))); err != nil {
+		return nil, fmt.Errorf("failed to write command to log: %v", err)
+	}
+
+	// We're clearing up the temp dir on every run
+	if err := os.RemoveAll(run.reportsDir); err != nil {
+		return nil, fmt.Errorf("failed to clean temporary reports directory: %v", err)
+	}
+	if err := os.MkdirAll(run.reportsDir, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("failed to create temporary reports directory: %v", err)
+	}
+
+	log.Debugf("Starting Ginkgo run '%s'...", run.name)
+
+	// Flush to disk so we can actually watch logs
+	stopCh := make(chan struct{}, 1)
+	defer close(stopCh)
+	go wait.Until(func() {
+		writer.Flush()
+		file.Sync()
+	}, 1*time.Second, stopCh)
+
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			log.Debugf("Ginkgo exited with a non 0 return code: %v", exitErr)
+		} else {
+			return nil, fmt.Errorf("ginkgo failed to start: %T %v", err, err)
 		}
 	}
 
-	return nil
+	// When running ginkgo in parallel, each ginkgo worker creates a own report, thus we must combine them
+	combinedReport, err := collectReports(run.name, run.reportsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we have no junit files, we cannot return a valid report
+	if len(combinedReport.TestCases) == 0 {
+		return nil, errors.New("ginkgo report is empty. It seems no tests where executed")
+	}
+
+	combinedReport.Time = time.Since(started).Seconds()
+
+	log.Debugf("Ginkgo run '%s' took %s", run.name, time.Since(started))
+	return &ginkgoResult{
+		logfile:  file.Name(),
+		report:   combinedReport,
+		duration: time.Since(started),
+	}, nil
 }
 
 func supportsStorage(cluster *kubermaticv1.Cluster) bool {

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -790,8 +790,12 @@ func executeGinkgoRun(parentLog *logrus.Entry, run *ginkgoRun) (*ginkgoResult, e
 	stopCh := make(chan struct{}, 1)
 	defer close(stopCh)
 	go wait.Until(func() {
-		writer.Flush()
-		file.Sync()
+		if err := writer.Flush(); err != nil {
+			log.Warnf("failed to flush log writer: %v", err)
+		}
+		if err := file.Sync(); err != nil {
+			log.Warnf("failed to sync log file: %v", err)
+		}
 	}, 1*time.Second, stopCh)
 
 	cmd.Stdout = writer

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -685,12 +685,12 @@ func (r *testRunner) getGinkgoRuns(
 			ginkgoSkip:    `\[Serial\]`,
 			parallelTests: len(nodes) * 10,
 		},
-		//{
-		//	name:          "serial",
-		//	ginkgoFocus:   `\[Serial\].*\[Conformance\]`,
-		//	ginkgoSkip:    `should not cause race condition when used for configmap`,
-		//	parallelTests: 1,
-		//},
+		{
+			name:          "serial",
+			ginkgoFocus:   `\[Serial\].*\[Conformance\]`,
+			ginkgoSkip:    `should not cause race condition when used for configmap`,
+			parallelTests: 1,
+		},
 	}
 	versionRoot := path.Join(repoRoot, MajorMinor)
 	binRoot := path.Join(versionRoot, "/platforms/linux/amd64")

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -765,15 +765,13 @@ func executeGinkgoRun(parentLog *logrus.Entry, run *ginkgoRun) (*ginkgoResult, e
 	started := time.Now()
 	log := parentLog.WithField("reports-dir", run.reportsDir)
 
+	// We're clearing up the temp dir on every run
+	if err := os.RemoveAll(run.reportsDir); err != nil {
+		log.Errorf("failed to remove temporary reports directory: %v", err)
+	}
 	if err := os.MkdirAll(run.reportsDir, os.ModePerm); err != nil {
 		return nil, fmt.Errorf("failed to create temporary reports directory: %v", err)
 	}
-	defer func() {
-		// We're clearing up the temp dir on every run
-		if err := os.RemoveAll(run.reportsDir); err != nil {
-			log.Errorf("failed to remove temporary reports directory: %v", err)
-		}
-	}()
 
 	// Make sure we write to a file instead of a byte buffer as the logs are pretty big
 	file, err := ioutil.TempFile("/tmp", run.name+"-log")

--- a/containers/conformance-tests/release.sh
+++ b/containers/conformance-tests/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=v0.5
+TAG=v0.6
 
 set -euox pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This will make our conformance test command analyze the reports in case ginkgo returns with a non-0 status code.
This is required as ginkgo returns with status code 1 in case it encounters flakey tests.
Tests a being marked as flakey if ginkgo had to retry a tests. In case the test still did not succeed after several retries, it will be marked as failure - So tests which are only marked as flakey succeeded after some retries.

**Release note**:
```release-note
NONE
```
