### PR TITLE
Temporarily fix machine deployment defaulting

### DIFF
--- a/api/pkg/resources/machine/machinedeployment.go
+++ b/api/pkg/resources/machine/machinedeployment.go
@@ -34,6 +34,9 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc provider.D
 	md.Spec.Replicas = &nd.Spec.Replicas
 	md.Spec.Template.Spec.Versions.Kubelet = nd.Spec.Template.Versions.Kubelet
 
+	// TODO: Remove after machine-controller will be updated to v0.10.7 or later as it contains fix for defaulting.
+	md.Spec.Strategy = &clusterv1alpha1.MachineDeploymentStrategy{}
+
 	if nd.Spec.Paused != nil {
 		md.Spec.Paused = *nd.Spec.Paused
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: It is needed to create Machine Deployments without any errors coming from webhook. It can be reverted after https://github.com/kubermatic/machine-controller/pull/434 will be used (part of v10.0.7 that is not used yet - https://github.com/kubermatic/kubermatic/pull/2528).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
