### PR TITLE
move VPA into kube-system namespace as its hard coded in the upstream VPA code

### DIFF
--- a/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
+++ b/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: vpa-admission-controller
+  namespace: kube-system
 spec:
   replicas: 1
   template:
@@ -37,6 +38,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: vpa-webhook
+  namespace: kube-system
 spec:
   ports:
     - port: 443

--- a/config/kubermatic/templates/vpa-rbac.yaml
+++ b/config/kubermatic/templates/vpa-rbac.yaml
@@ -117,7 +117,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vpa-recommender
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -130,10 +130,10 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vpa-recommender
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 - kind: ServiceAccount
   name: vpa-updater
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -146,7 +146,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vpa-recommender
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -182,7 +182,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vpa-updater
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -195,13 +195,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vpa-updater
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vpa-admission-controller
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -255,4 +255,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vpa-admission-controller
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system

--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vpa-recommender
+  namespace: kube-system
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: vpa-recommender
+  namespace: kube-system
 spec:
   replicas: 1
   template:

--- a/config/kubermatic/templates/vpa-tls.yaml
+++ b/config/kubermatic/templates/vpa-tls.yaml
@@ -1,12 +1,13 @@
 {{- $ca := genCA "deployment-admission-controller" 3650 -}}
-{{- $cn := .Chart.Name -}}
-{{- $altName1 := printf "%s.%s" .Chart.Name .Release.Namespace -}}
-{{- $altName2 := printf "%s.%s.svc" .Chart.Name .Release.Namespace -}}
+{{- $cn := "vpa-webhook" -}}
+{{- $altName1 := "vpa-webhook.kube-system" -}}
+{{- $altName2 := "vpa-webhook.kube-system.svc" -}}
 {{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: vpa-tls-certs
+  namespace: kube-system
 type: Opaque
 data:
   caCert.pem: {{ b64enc $ca.Cert }}

--- a/config/kubermatic/templates/vpa-updater-deployment.yaml
+++ b/config/kubermatic/templates/vpa-updater-deployment.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vpa-updater
+  namespace: kube-system
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: vpa-updater
+  namespace: kube-system
 spec:
   replicas: 1
   template:


### PR DESCRIPTION
**What this PR does / why we need it**:
The VPA must be deployed into the kube-system namespace as the VPA creates the MutatingWebhook Config which has the kube-system namespace hardcoded... https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/admission-controller/config.go#L120

**Release note**:
```release-note
NONE
```
