### PR TITLE
README: fix markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This covers the existing, developer focusing, documentation:
   - [Releasing kubermatic](docs/release-process.md) 
   - [datacenters.yaml](docs/datacenters.md)
 - Development guidelines
-  - [Code style] (docs/code-style)
-  - [Logging guideline] (docs/logging.md)
-  - [Events guideline] (docs/events.md)
+  - [Code style](docs/code-style)
+  - [Logging guideline](docs/logging.md)
+  - [Events guideline](docs/events.md)
 - [Proposals](docs/proposals)
 
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -2,7 +2,7 @@
 
 ## Guidelines
 
-We're following the [guidelines from Kubernetes](https://github.com/kubernetes/community/blob/b3349d5b1354df814b67bbdee6890477f3c250cb/contributors/devel/event-style-guide.md)
+We're following the [guidelines from Kubernetes](https://github.com/kubernetes/community/blob/b3349d5b1354df814b67bbdee6890477f3c250cb/contributors/devel/event-style-guide.md).
 
 ## Handling old code
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -8,7 +8,7 @@ As klog follows the same interface as [glog](https://github.com/golang/glog), th
 
 ## Guidelines
 
-We're following the [guidelines from Kubernetes](https://github.com/kubernetes/community/blob/b3349d5b1354df814b67bbdee6890477f3c250cb/contributors/devel/logging.md)
+We're following the [guidelines from Kubernetes](https://github.com/kubernetes/community/blob/b3349d5b1354df814b67bbdee6890477f3c250cb/contributors/devel/logging.md).
 
 
 ## Handling old code


### PR DESCRIPTION
Fixes a small issue with markdown formatting in the README.

/assign @mrIncompetent 
/shrug


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
