### PR TITLE
filter out VM size types for valid only

### DIFF
--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -139,12 +139,12 @@ type AzureSizeList []AzureSize
 // AzureSize is the object representing Azure VM sizes.
 // swagger:model AzureSize
 type AzureSize struct {
-	Name                 *string `json:"name"`
-	NumberOfCores        *int32  `json:"numberOfCores"`
-	OsDiskSizeInMB       *int32  `json:"osDiskSizeInMB"`
-	ResourceDiskSizeInMB *int32  `json:"resourceDiskSizeInMB"`
-	MemoryInMB           *int32  `json:"memoryInMB"`
-	MaxDataDiskCount     *int32  `json:"maxDataDiskCount"`
+	Name                 string `json:"name"`
+	NumberOfCores        int32  `json:"numberOfCores"`
+	OsDiskSizeInMB       int32  `json:"osDiskSizeInMB"`
+	ResourceDiskSizeInMB int32  `json:"resourceDiskSizeInMB"`
+	MemoryInMB           int32  `json:"memoryInMB"`
+	MaxDataDiskCount     int32  `json:"maxDataDiskCount"`
 }
 
 // SSHKey represents a ssh key

--- a/api/pkg/handler/v1/provider/azure.go
+++ b/api/pkg/handler/v1/provider/azure.go
@@ -106,17 +106,19 @@ func azureSize(ctx context.Context, subscriptionID, clientID, clientSecret, tena
 	var sizeList apiv1.AzureSizeList
 	for _, v := range *sizesResult.Value {
 		// add only valid VM size types
-		if _, ok := validVMSizeSet[*v.Name]; ok {
-			s := apiv1.AzureSize{
-				Name:                 v.Name,
-				NumberOfCores:        v.NumberOfCores,
-				OsDiskSizeInMB:       v.OsDiskSizeInMB,
-				ResourceDiskSizeInMB: v.ResourceDiskSizeInMB,
-				MemoryInMB:           v.MemoryInMB,
-				MaxDataDiskCount:     v.MaxDataDiskCount,
-			}
+		if v.Name != nil {
+			if _, ok := validVMSizeSet[*v.Name]; ok {
+				s := apiv1.AzureSize{
+					Name:                 *v.Name,
+					NumberOfCores:        *v.NumberOfCores,
+					OsDiskSizeInMB:       *v.OsDiskSizeInMB,
+					ResourceDiskSizeInMB: *v.ResourceDiskSizeInMB,
+					MemoryInMB:           *v.MemoryInMB,
+					MaxDataDiskCount:     *v.MaxDataDiskCount,
+				}
 
-			sizeList = append(sizeList, s)
+				sizeList = append(sizeList, s)
+			}
 		}
 	}
 

--- a/api/pkg/handler/v1/provider/azure.go
+++ b/api/pkg/handler/v1/provider/azure.go
@@ -17,6 +17,30 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
+var NewSizeClient = func(subscriptionID, clientID, clientSecret, tenantID string) (SizeClient, error) {
+	var err error
+	sizesClient := compute.NewVirtualMachineSizesClient(subscriptionID)
+	sizesClient.Authorizer, err = auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID).Authorizer()
+	if err != nil {
+		return nil, err
+	}
+	return &sizeClientImpl{
+		vmSizeClient: sizesClient,
+	}, nil
+}
+
+type sizeClientImpl struct {
+	vmSizeClient compute.VirtualMachineSizesClient
+}
+
+type SizeClient interface {
+	List(ctx context.Context, location string) (compute.VirtualMachineSizeListResult, error)
+}
+
+func (s *sizeClientImpl) List(ctx context.Context, location string) (compute.VirtualMachineSizeListResult, error) {
+	return s.vmSizeClient.List(ctx, location)
+}
+
 func AzureSizeNoCredentialsEndpoint(projectProvider provider.ProjectProvider, dcs map[string]provider.DatacenterMeta) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AzureSizeNoCredentialsReq)
@@ -57,13 +81,12 @@ func AzureSizeEndpoint() endpoint.Endpoint {
 }
 
 func azureSize(ctx context.Context, subscriptionID, clientID, clientSecret, tenantID, location string) (apiv1.AzureSizeList, error) {
-	var err error
-	sizesClient := compute.NewVirtualMachineSizesClient(subscriptionID)
-	sizesClient.Authorizer, err = auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID).Authorizer()
+	sizesClient, err := NewSizeClient(subscriptionID, clientID, clientSecret, tenantID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create authorizer: %v", err)
+		return nil, fmt.Errorf("failed to create authorizer for size client: %v", err)
 	}
 
+	// get all available VM size types for given location
 	sizesResult, err := sizesClient.List(ctx, location)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sizes: %v", err)
@@ -73,18 +96,28 @@ func azureSize(ctx context.Context, subscriptionID, clientID, clientSecret, tena
 		return nil, fmt.Errorf("failed to list sizes: Azure return a nil result")
 	}
 
+	// prepare set of valid VM size types
+	validVMSizeList := compute.PossibleContainerServiceVMSizeTypesValues()
+	validVMSizeSet := make(map[string]struct{}, len(validVMSizeList))
+	for _, s := range validVMSizeList {
+		validVMSizeSet[string(s)] = struct{}{}
+	}
+
 	var sizeList apiv1.AzureSizeList
 	for _, v := range *sizesResult.Value {
-		s := apiv1.AzureSize{
-			Name:                 v.Name,
-			NumberOfCores:        v.NumberOfCores,
-			OsDiskSizeInMB:       v.OsDiskSizeInMB,
-			ResourceDiskSizeInMB: v.ResourceDiskSizeInMB,
-			MemoryInMB:           v.MemoryInMB,
-			MaxDataDiskCount:     v.MaxDataDiskCount,
-		}
+		// add only valid VM size types
+		if _, ok := validVMSizeSet[*v.Name]; ok {
+			s := apiv1.AzureSize{
+				Name:                 v.Name,
+				NumberOfCores:        v.NumberOfCores,
+				OsDiskSizeInMB:       v.OsDiskSizeInMB,
+				ResourceDiskSizeInMB: v.ResourceDiskSizeInMB,
+				MemoryInMB:           v.MemoryInMB,
+				MaxDataDiskCount:     v.MaxDataDiskCount,
+			}
 
-		sizeList = append(sizeList, s)
+			sizeList = append(sizeList, s)
+		}
 	}
 
 	return sizeList, nil

--- a/api/pkg/handler/v1/provider/azure_test.go
+++ b/api/pkg/handler/v1/provider/azure_test.go
@@ -1,0 +1,162 @@
+package provider_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+	azure "github.com/kubermatic/kubermatic/api/pkg/handler/v1/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+)
+
+const (
+	testID     = "test"
+	locationUS = "US"
+	locationEU = "EU"
+)
+
+type mockSizeClientImpl struct {
+	machineSizeList compute.VirtualMachineSizeListResult
+}
+
+func TestAzureSizeEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name             string
+		secret           string
+		location         string
+		httpStatus       int
+		expectedResponse string
+	}{
+		{
+			name:             "test when user unauthorized",
+			httpStatus:       http.StatusInternalServerError,
+			expectedResponse: "",
+		},
+		{
+			name:       "test US location when two VM size types are valid",
+			httpStatus: http.StatusOK,
+			location:   locationUS,
+			secret:     "secret",
+			expectedResponse: `[
+				{"name":"Standard_GS3", "maxDataDiskCount": 3, "memoryInMB": 254, "numberOfCores": 8, "osDiskSizeInMB": 1024, "resourceDiskSizeInMB":1024},
+				{"name":"Standard_A5", "maxDataDiskCount": 3, "memoryInMB": 254, "numberOfCores": 8, "osDiskSizeInMB": 1024, "resourceDiskSizeInMB":1024}
+			]`,
+		},
+		{
+			name:       "test EU location when only one VM size type is valid",
+			httpStatus: http.StatusOK,
+			location:   locationEU,
+			secret:     "secret",
+			expectedResponse: `[
+				{"name":"Standard_GS3", "maxDataDiskCount": 3, "memoryInMB": 254, "numberOfCores": 8, "osDiskSizeInMB": 1024, "resourceDiskSizeInMB":1024}
+			]`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := httptest.NewRequest("GET", "/api/v1/providers/azure/sizes", strings.NewReader(""))
+
+			req.Header.Add("SubscriptionID", testID)
+			req.Header.Add("ClientID", testID)
+			req.Header.Add("ClientSecret", tc.secret)
+			req.Header.Add("TenantID", testID)
+			req.Header.Add("Location", tc.location)
+
+			azure.NewSizeClient = MockNewSizeClient
+
+			apiUser := test.GetUser(test.UserEmail, test.UserID, test.UserName, false)
+
+			res := httptest.NewRecorder()
+			router, _, err := test.CreateTestEndpointAndGetClients(apiUser, buildAzureDatacenterMeta(), []runtime.Object{}, []runtime.Object{}, []runtime.Object{test.APIUserToKubermaticUser(apiUser)}, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v\n", err)
+			}
+
+			router.ServeHTTP(res, req)
+
+			// validate
+			assert.Equal(t, tc.httpStatus, res.Code)
+
+			if res.Code == http.StatusOK {
+				compareJSON(t, res, tc.expectedResponse)
+			}
+
+		})
+	}
+}
+
+func buildAzureDatacenterMeta() map[string]provider.DatacenterMeta {
+	return map[string]provider.DatacenterMeta{
+		datacenterName: {
+			Location: "ap-northeast",
+			Country:  "JP",
+			Private:  false,
+			IsSeed:   true,
+			Spec: provider.DatacenterSpec{
+				Azure: &provider.AzureSpec{
+					Location: "ap-northeast",
+				},
+			},
+		},
+	}
+}
+
+func MockNewSizeClient(subscriptionID, clientID, clientSecret, tenantID string) (azure.SizeClient, error) {
+
+	if len(clientSecret) == 0 || len(subscriptionID) == 0 || len(clientID) == 0 || len(tenantID) == 0 {
+		return nil, fmt.Errorf("")
+	}
+
+	return &mockSizeClientImpl{}, nil
+}
+
+func (s *mockSizeClientImpl) List(ctx context.Context, location string) (compute.VirtualMachineSizeListResult, error) {
+
+	standardFake := "Fake"
+	standardGS3 := "Standard_GS3"
+	standardA5 := "Standard_A5"
+	maxDataDiskCount := int32(3)
+	memoryInMB := int32(254)
+	numberOfCores := int32(8)
+	diskSizeInMB := int32(1024)
+
+	s.machineSizeList = compute.VirtualMachineSizeListResult{Value: &[]compute.VirtualMachineSize{}}
+
+	if location == locationEU {
+		// one valid VM size type, two in total
+		s.machineSizeList.Value = &[]compute.VirtualMachineSize{{Name: &standardGS3,
+			MaxDataDiskCount: &maxDataDiskCount, MemoryInMB: &memoryInMB, NumberOfCores: &numberOfCores,
+			OsDiskSizeInMB: &diskSizeInMB, ResourceDiskSizeInMB: &diskSizeInMB},
+			{Name: &standardFake,
+				MaxDataDiskCount: &maxDataDiskCount, MemoryInMB: &memoryInMB, NumberOfCores: &numberOfCores,
+				OsDiskSizeInMB: &diskSizeInMB, ResourceDiskSizeInMB: &diskSizeInMB},
+		}
+	}
+	if location == locationUS {
+		// two valid VM size types, three in total
+		s.machineSizeList.Value = &[]compute.VirtualMachineSize{
+			{Name: &standardGS3, MaxDataDiskCount: &maxDataDiskCount, MemoryInMB: &memoryInMB, NumberOfCores: &numberOfCores,
+				OsDiskSizeInMB: &diskSizeInMB, ResourceDiskSizeInMB: &diskSizeInMB},
+			{Name: &standardFake,
+				MaxDataDiskCount: &maxDataDiskCount, MemoryInMB: &memoryInMB, NumberOfCores: &numberOfCores,
+				OsDiskSizeInMB: &diskSizeInMB, ResourceDiskSizeInMB: &diskSizeInMB},
+			{Name: &standardA5,
+				MaxDataDiskCount: &maxDataDiskCount, MemoryInMB: &memoryInMB, NumberOfCores: &numberOfCores,
+				OsDiskSizeInMB: &diskSizeInMB, ResourceDiskSizeInMB: &diskSizeInMB},
+		}
+	}
+
+	return s.machineSizeList, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**: the kubermatic returns all available VM size types for a given location for the azure provider. A major part of them are invalid and cannot be used for cluster orchestration. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2511

**Release note**:
```release-note
NONE
```
