### PR TITLE
Force IAP pods to restart on config change

### DIFF
--- a/config/iap/templates/deployments.yaml
+++ b/config/iap/templates/deployments.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: iap
         target: {{ .name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       containers:
       - name: keycloak-proxy


### PR DESCRIPTION
**What this PR does / why we need it**:
Force IAP pods to restart on config change, otherwise a config change will not trigger a restart of the pod and the new config will not be applied.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
