### PR TITLE
drop the AllowedNodeVersions field

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3501,13 +3501,6 @@
       "description": "MasterVersion describes a version of the master components",
       "type": "object",
       "properties": {
-        "allowedNodeVersions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "AllowedNodeVersions"
-        },
         "default": {
           "type": "boolean",
           "x-go-name": "Default"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+
 	"github.com/Masterminds/semver"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -260,9 +261,8 @@ type VSphereNetwork struct {
 // MasterVersion describes a version of the master components
 // swagger:model MasterVersion
 type MasterVersion struct {
-	Version             *semver.Version `json:"version"`
-	AllowedNodeVersions []string        `json:"allowedNodeVersions"`
-	Default             bool            `json:"default,omitempty"`
+	Version *semver.Version `json:"version"`
+	Default bool            `json:"default,omitempty"`
 }
 
 // Cluster defines the cluster resource

--- a/api/pkg/handler/upgrade.go
+++ b/api/pkg/handler/upgrade.go
@@ -39,8 +39,7 @@ func getClusterUpgrades(updateManager UpdateManager, projectProvider provider.Pr
 		var upgrades []*apiv1.MasterVersion
 		for _, v := range versions {
 			upgrades = append(upgrades, &apiv1.MasterVersion{
-				Version:             v.Version,
-				AllowedNodeVersions: v.AllowedNodeVersions,
+				Version: v.Version,
 			})
 		}
 
@@ -58,9 +57,8 @@ func getMasterVersions(updateManager UpdateManager) endpoint.Endpoint {
 		sv := make([]*apiv1.MasterVersion, len(versions))
 		for v := range versions {
 			sv[v] = &apiv1.MasterVersion{
-				Version:             versions[v].Version,
-				AllowedNodeVersions: versions[v].AllowedNodeVersions,
-				Default:             versions[v].Default,
+				Version: versions[v].Version,
+				Default: versions[v].Default,
 			}
 		}
 

--- a/api/pkg/version/manager.go
+++ b/api/pkg/version/manager.go
@@ -21,9 +21,8 @@ type Manager struct {
 
 // MasterVersion is the object representing a Kubernetes Master version.
 type MasterVersion struct {
-	Version             *semver.Version `json:"version"`
-	Default             bool            `json:"default"`
-	AllowedNodeVersions []string        `json:"allowedNodeVersions"`
+	Version *semver.Version `json:"version"`
+	Default bool            `json:"default"`
 }
 
 // MasterUpdate represents an update option for K8s master components

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,33 +1,19 @@
-# We support 1.10,1.11,1.12 & kubernetes is able to handle the whole matrix of those versions
-allowed-node-versions: &node-versions
-- "1.10.*"
-- "1.11.*"
-- "1.12.*"
-- "1.13.*"
-
 versions:
 # Kubernetes 1.10
 - version: "1.10.11"
   default: false
-  allowedNodeVersions: *node-versions
 # Kubernetes 1.11
 - version: "1.11.5"
   default: false
-  allowedNodeVersions: *node-versions
 - version: "1.11.6"
   default: true
-  allowedNodeVersions: *node-versions
 # Kubernetes 1.12
 - version: "1.12.3"
   default: false
-  allowedNodeVersions: *node-versions
 - version: "1.12.4"
   default: false
-  allowedNodeVersions: *node-versions
 # Kubernetes 1.13
 - version: "1.13.0"
   default: false
-  allowedNodeVersions: *node-versions
 - version: "1.13.1"
   default: false
-  allowedNodeVersions: *node-versions


### PR DESCRIPTION
**What this PR does / why we need it**: the AllowedNodeVersions was never really used except for passing it to the Dashboard that did not use it either. With the new controlplane-kubelet version checking, the field is being deprecated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2543 

**Release note**:
```release-note
NONE
```
