### PR TITLE
fix handling missing dry_run value for projects-migrator

### DIFF
--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -139,7 +139,6 @@ helm upgrade --install --wait --timeout 300 \
   --set=kubermatic.api.image.tag=$PULL_PULL_SHA \
   --set=kubermatic.rbac.image.tag=$PULL_PULL_SHA \
   --set-string=kubermatic.worker_name=$BUILD_ID \
-  --set=kubermatic.project_migrator.dry_run=true \
   --set=kubermatic.deployVPA=false \
   --values ${VALUES_FILE} \
   --namespace $NAMESPACE \

--- a/config/kubermatic/templates/rbac-generator-dep.yaml
+++ b/config/kubermatic/templates/rbac-generator-dep.yaml
@@ -25,7 +25,9 @@ spec:
         - -v=3
         - -logtostderr
         - -kubeconfig=/opt/.kube/kubeconfig
-        - -dry-run={{default "false" .Values.kubermatic.project_migrator.dry_run}}
+        {{- with .Values.kubermatic.projects_migrator }}
+        - -dry-run={{ .dry_run }}
+        {{- end }}
         volumeMounts:
           - name: kubeconfig
             mountPath: "/opt/.kube/"


### PR DESCRIPTION
**What this PR does / why we need it**:
In #2554, we introduced a custom value for the `dry-run` flag of the projects-migrator. Unfortunately a tiny hiccup happened and we created a Helm template that relied on `kubermatic.project_migrator.dry_run` to always be set.

This PR makes it so that

* We only overwrite the CLI flag if `projects_migrator` (NB the `projectS` instead of `project` to align it with the actual program's name) is set. We cannot sensible use the `default` function because it would consider `false` to be an empty/unset value and then default to the.. default (`true`). Likewise, `with` thinks `false` is empty, so we cannot write `{{ with .kubermatic.projects_migrator.dry_run }}`.
* As the projects-migrator defaults the flag to `true`, the Helm chart was adjusted accordingly and the overwritten flag in the conformence test script was removed.

For other deployments (cloud.kubermatic.io), we will specify `false` in the respective `values.yaml`.

cc @alvaroaleman 

**Which issue(s) this PR fixes**:
Fixes #2591 

**Release note**:
```release-note
NONE
```
