### PR TITLE
Update Prometheus

### DIFF
--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -14,11 +14,10 @@ import (
 
 const (
 	name = "prometheus"
+	tag  = "v2.6.0"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"
-
-	tag = "v2.3.2"
 )
 
 var (

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -1,5 +1,5 @@
 alertmanager:
-  version: v0.15.0
+  version: v0.15.3
   host: ""
   config:
     global:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         {{- if .Values.prometheus.backups }}
         - --web.enable-admin-api
         {{- end }}
-        image: quay.io/prometheus/prometheus:v2.3.2
+        image: 'quay.io/prometheus/prometheus:{{ .Values.prometheus.version }}'
         livenessProbe:
           failureThreshold: 6
           httpGet:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,7 +1,7 @@
 prometheus:
   # admin:loodse123
   auth: 'YWRtaW46JGFwcjEkUFR0Y3lQc0MkWVZFTk9nZmpiVE52RWtSeVk1ZjJULgo='
-  version: 'v2.2.1'
+  version: 'v2.6.0'
   host: ""
   storageSize: 100Gi
   backups: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Prometheus to the latest stable version. According to the changelog since 2.3, no breaking changes happened, *but* the TSDB for 2.4 is incompatible with 2.3, so *we cannot downgrade/rollback after deploying this* without also wiping the volume.

Alertmanager was also updated with no significant changes mentioned in its changelog.

**Release note**:
```release-note
Updated Prometheus to `v2.6.0` and Alertmanager to `v0.15.3`
```
