### PR TITLE
add load balancers and volumes finilizers for delete cluster

### DIFF
--- a/api/pkg/controller/cluster/deleting.go
+++ b/api/pkg/controller/cluster/deleting.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	inClusterPVCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-pv"
-	inClusterLBCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-lb"
+	InClusterPVCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-pv"
+	InClusterLBCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-lb"
 )
 
 // cleanupCluster is the function which handles clusters in the deleting phase.
@@ -42,7 +42,7 @@ func (cc *Controller) cleanupCluster(c *kubermaticv1.Cluster) (*kubermaticv1.Clu
 
 	// Do not run the cloud provider cleanup until we finished the PV & LB cleanup.
 	// Otherwise we risk deleting those resources as well
-	if kuberneteshelper.HasFinalizer(c, inClusterLBCleanupFinalizer) || kuberneteshelper.HasFinalizer(c, inClusterPVCleanupFinalizer) {
+	if kuberneteshelper.HasFinalizer(c, InClusterLBCleanupFinalizer) || kuberneteshelper.HasFinalizer(c, InClusterPVCleanupFinalizer) {
 		return c, nil
 	}
 
@@ -54,8 +54,8 @@ func (cc *Controller) cleanupCluster(c *kubermaticv1.Cluster) (*kubermaticv1.Clu
 }
 
 func (cc *Controller) cleanupInClusterResources(c *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
-	shouldDeleteLBs := kuberneteshelper.HasFinalizer(c, inClusterLBCleanupFinalizer)
-	shouldDeletePVs := kuberneteshelper.HasFinalizer(c, inClusterPVCleanupFinalizer)
+	shouldDeleteLBs := kuberneteshelper.HasFinalizer(c, InClusterLBCleanupFinalizer)
+	shouldDeletePVs := kuberneteshelper.HasFinalizer(c, InClusterPVCleanupFinalizer)
 
 	// If no relevant finalizer exists, directly return
 	if !shouldDeleteLBs && !shouldDeletePVs {
@@ -144,8 +144,8 @@ func (cc *Controller) cleanupInClusterResources(c *kubermaticv1.Cluster) (*kuber
 			c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, azure.FinalizerResourceGroup)
 		}
 
-		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, inClusterLBCleanupFinalizer)
-		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, inClusterPVCleanupFinalizer)
+		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, InClusterLBCleanupFinalizer)
+		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, InClusterPVCleanupFinalizer)
 	})
 	if err != nil {
 		return nil, err

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -694,9 +694,7 @@ func revokeClusterAdminToken(projectProvider provider.ProjectProvider) endpoint.
 }
 
 type DeleteClusterReq struct {
-	common.DCReq
-	// in: path
-	ClusterID string `json:"cluster_id"`
+	common.GetClusterReq
 	// DeleteVolumes if true all cluster PV's and PVC's will be deleted from cluster
 	DeleteVolumes bool
 	// DeleteLoadBalancers if true all load balancers will be deleted from cluster
@@ -711,8 +709,7 @@ func DecodeDeleteClusterReq(c context.Context, r *http.Request) (interface{}, er
 		return nil, err
 	}
 	clusterReq := clusterReqRaw.(common.GetClusterReq)
-	req.DCReq = clusterReq.DCReq
-	req.ClusterID = clusterReq.ClusterID
+	req.GetClusterReq = clusterReq
 
 	headerValue := r.Header.Get("DeleteVolumes")
 	if len(headerValue) > 0 {

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -16,10 +16,12 @@ import (
 	"github.com/prometheus/common/model"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	finalizer "github.com/kubermatic/kubermatic/api/pkg/controller/cluster"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/kubernetes"
+	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/cluster"
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
@@ -146,7 +148,7 @@ func listClusters(projectProvider provider.ProjectProvider) endpoint.Endpoint {
 
 func deleteCluster(sshKeyProvider provider.SSHKeyProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(common.GetClusterReq)
+		req := request.(common.DeleteClusterReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
 		project, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
@@ -162,6 +164,24 @@ func deleteCluster(sshKeyProvider provider.SSHKeyProvider, projectProvider provi
 		for _, clusterSSHKey := range clusterSSHKeys {
 			clusterSSHKey.RemoveFromCluster(req.ClusterID)
 			if _, err = sshKeyProvider.Update(userInfo, clusterSSHKey); err != nil {
+				return nil, common.KubernetesErrorToHTTPError(err)
+			}
+		}
+
+		if req.DeleteVolumes || req.DeleteLoadBalancers {
+			existingCluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
+			if err != nil {
+				return nil, common.KubernetesErrorToHTTPError(err)
+			}
+			if req.DeleteLoadBalancers {
+				existingCluster.Finalizers = kuberneteshelper.AddFinalizer(existingCluster.Finalizers, finalizer.InClusterLBCleanupFinalizer)
+			}
+			if req.DeleteVolumes {
+				existingCluster.Finalizers = kuberneteshelper.AddFinalizer(existingCluster.Finalizers, finalizer.InClusterPVCleanupFinalizer)
+			}
+
+			_, err = clusterProvider.Update(userInfo, existingCluster)
+			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 		}

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -181,8 +181,7 @@ func deleteCluster(sshKeyProvider provider.SSHKeyProvider, projectProvider provi
 				existingCluster.Finalizers = kuberneteshelper.AddFinalizer(existingCluster.Finalizers, finalizer.InClusterPVCleanupFinalizer)
 			}
 
-			_, err = clusterProvider.Update(userInfo, existingCluster)
-			if err != nil {
+			if _, err = clusterProvider.Update(userInfo, existingCluster); err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 		}

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -699,7 +699,7 @@ type DeleteClusterReq struct {
 	ClusterID string `json:"cluster_id"`
 	// DeleteVolumes if true all cluster PV's and PVC's will be deleted from cluster
 	DeleteVolumes bool
-	// DeleteVolumes if true all load balancers will be deleted from cluster
+	// DeleteLoadBalancers if true all load balancers will be deleted from cluster
 	DeleteLoadBalancers bool
 }
 

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -128,7 +127,7 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 
 					sort.Strings(finalizers)
 					sort.Strings(tc.ExpectedFinalizers)
-					if !reflect.DeepEqual(finalizers, tc.ExpectedFinalizers) {
+					if !equality.Semantic.DeepEqual(finalizers, tc.ExpectedFinalizers) {
 						t.Fatalf("finalizer list %v is not the same as expected %v", finalizers, tc.ExpectedFinalizers)
 					}
 

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -863,7 +863,7 @@ func (r Routing) deleteCluster() http.Handler {
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			r.userInfoMiddleware(),
 		)(deleteCluster(r.sshKeyProvider, r.projectProvider)),
-		common.DecodeGetClusterReq,
+		common.DecodeDeleteClusterReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -863,7 +863,7 @@ func (r Routing) deleteCluster() http.Handler {
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			r.userInfoMiddleware(),
 		)(deleteCluster(r.sshKeyProvider, r.projectProvider)),
-		common.DecodeDeleteClusterReq,
+		DecodeDeleteClusterReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/v1/common/request.go
+++ b/api/pkg/handler/v1/common/request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gorilla/mux"
 )
@@ -61,48 +60,6 @@ type GetClusterReq struct {
 	DCReq
 	// in: path
 	ClusterID string `json:"cluster_id"`
-}
-
-type DeleteClusterReq struct {
-	DCReq
-	// in: path
-	ClusterID string `json:"cluster_id"`
-	// DeleteVolumes if true all cluster PV's and PVC's will be deleted from cluster
-	DeleteVolumes bool
-	// DeleteVolumes if true all load balancers will be deleted from cluster
-	DeleteLoadBalancers bool
-}
-
-func DecodeDeleteClusterReq(c context.Context, r *http.Request) (interface{}, error) {
-	var req DeleteClusterReq
-
-	clusterReqRaw, err := DecodeGetClusterReq(c, r)
-	if err != nil {
-		return nil, err
-	}
-	clusterReq := clusterReqRaw.(GetClusterReq)
-	req.DCReq = clusterReq.DCReq
-	req.ClusterID = clusterReq.ClusterID
-
-	headerValue := r.Header.Get("DeleteVolumes")
-	if len(headerValue) > 0 {
-		deleteVolumes, err := strconv.ParseBool(headerValue)
-		if err != nil {
-			return nil, err
-		}
-		req.DeleteVolumes = deleteVolumes
-	}
-
-	headerValue = r.Header.Get("DeleteLoadBalancers")
-	if len(headerValue) > 0 {
-		deleteLB, err := strconv.ParseBool(headerValue)
-		if err != nil {
-			return nil, err
-		}
-		req.DeleteLoadBalancers = deleteLB
-	}
-
-	return req, nil
 }
 
 func DecodeGetClusterReq(c context.Context, r *http.Request) (interface{}, error) {


### PR DESCRIPTION
**What this PR does / why we need it**: it is possible for a user to select if PVC's/PV's and/or LB's should be cleaned up when deleting the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2602

**Release note**:
```release-note
It is now possible for a user to select whether PVCs/PVs and/or LBs should be cleaned up when deleting the cluster.
```
