### PR TITLE
pull UI image from quay.io

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -54,7 +54,7 @@ kubermatic:
   ui:
     replicas: 2
     image:
-      repository: "kubermatic/ui-v2"
+      repository: "quay.io/kubermatic/ui-v2"
       tag: "v1.0.2"
       pullPolicy: "IfNotPresent"
     config: |


### PR DESCRIPTION
**What this PR does / why we need it**:
All our images are now on `quay.io`.

**Release note**:
```release-note
Credentials for Docker Hub are no longer necessary.
```
