### PR TITLE
Cherry pick/release v2.8/fix etcd operator migration

### DIFF
--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -311,9 +311,10 @@ else
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"
     fi
 
+    export ETCD_CERT_ARGS="--cacert /etc/etcd/pki/ca/ca.crt --cert /etc/etcd/pki/client/apiserver-etcd-client.crt --key /etc/etcd/pki/client/apiserver-etcd-client.key"
     if [ "${POD_NAME}" = "etcd-1" ]; then
         echo "i'm etcd-1. I join as new member as soon as etcd-0 comes up"
-        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380
+        etcdctl ${ETCD_CERT_ARGS} --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380
         echo "added etcd-1 to members"
         export INITIAL_STATE="existing"
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"
@@ -321,8 +322,8 @@ else
 
     if [ "${POD_NAME}" = "etcd-2" ]; then
         echo "i'm etcd-2. I join as new member as soon as we have 2 existing & healthy members"
-        until etcdctl --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
-        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-2 --peer-urls=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380
+        until etcdctl ${ETCD_CERT_ARGS} --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
+        etcdctl ${ETCD_CERT_ARGS} --endpoints ${MASTER_ENDPOINT} member add etcd-2 --peer-urls=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380
         echo "added etcd-2 to members"
         export INITIAL_STATE="existing"
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-2=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -106,9 +106,10 @@ else
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
     fi
 
+    export ETCD_CERT_ARGS="--cacert /etc/etcd/pki/ca/ca.crt --cert /etc/etcd/pki/client/apiserver-etcd-client.crt --key /etc/etcd/pki/client/apiserver-etcd-client.key"
     if [ "${POD_NAME}" = "etcd-1" ]; then
         echo "i'm etcd-1. I join as new member as soon as etcd-0 comes up"
-        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
+        etcdctl ${ETCD_CERT_ARGS} --endpoints ${MASTER_ENDPOINT} member add etcd-1 --peer-urls=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
         echo "added etcd-1 to members"
         export INITIAL_STATE="existing"
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"
@@ -116,8 +117,8 @@ else
 
     if [ "${POD_NAME}" = "etcd-2" ]; then
         echo "i'm etcd-2. I join as new member as soon as we have 2 existing & healthy members"
-        until etcdctl --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
-        etcdctl --endpoints ${MASTER_ENDPOINT} member add etcd-2 --peer-urls=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
+        until etcdctl ${ETCD_CERT_ARGS} --endpoints ${MASTER_ENDPOINT} member list | grep -q etcd-1; do sleep 1; echo "Waiting for etcd-1"; done
+        etcdctl ${ETCD_CERT_ARGS} --endpoints ${MASTER_ENDPOINT} member add etcd-2 --peer-urls=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380
         echo "added etcd-2 to members"
         export INITIAL_STATE="existing"
         export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-62m9k9tqlm.svc.cluster.local:2380"


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry picks the fix for the etcd operator migration.

**Release note**:
```release-note
NONE
```
