### PR TITLE
Cleanup e2e tests on timeout

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"os/signal"
 	"os/user"
 	"path"
 	"strings"
@@ -124,6 +125,13 @@ var (
 func main() {
 	mainLog := logrus.New()
 	mainLog.SetLevel(logrus.InfoLevel)
+
+	chanSigInt := make(chan os.Signal, 1)
+	signal.Notify(chanSigInt, os.Interrupt)
+	go func() {
+		<-chanSigInt
+		logrus.Fatalf("Received SIGINT, terminating")
+	}()
 
 	opts := Opts{
 		providers:  sets.NewString(),

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -69,7 +69,7 @@ docker ps &>/dev/null || start-docker.sh
 
 echodate "Unlocking secrets repo"
 cd $(go env GOPATH)/src/github.com/kubermatic/secrets
-echodate $KUBERMATIC_SECRETS_GPG_KEY_BASE64 | base64 -d > /tmp/git-crypt-key
+echo $KUBERMATIC_SECRETS_GPG_KEY_BASE64 | base64 -d > /tmp/git-crypt-key
 git-crypt unlock /tmp/git-crypt-key
 cd -
 echodate "Successfully unlocked secrets repo"

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -14,8 +14,6 @@ export NAMESPACE="prow-kubermatic-${BUILD_ID}"
 echodate "Testing versions: ${VERSIONS}"
 cd $(dirname $0)/../..
 
-exit 1
-
 function cleanup {
   set +e
 

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -28,7 +28,7 @@ function cleanup {
 
   # Kill all sub-processes to make sure they don't create
   # any new resources and dont block termination of the job
-  jobs -p|xargs -r -I ^ kill -9 ^ &>dev/null
+  jobs -p|xargs -r kill -9
 
   # Delete addons from all clusters that have our worker-name label
   kubectl get cluster -l worker-name=$BUILD_ID \
@@ -192,8 +192,6 @@ echodate "Starting conformance tests"
   -providers=aws \
   -exclude-distributions="ubuntu,centos"
 
-# Test if cleanup on timeout works
-sleep 1d
 ) &
 
 # Bash can not forward signals and doesn't react to signals

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -3,14 +3,15 @@
 set -euo pipefail
 
 export BUILD_ID=${BUILD_ID:-BUILD_ID_UNDEF}
-echo "Build ID is $BUILD_ID"
+echodate() { echo "$(date) $@"; }
+echodate "Build ID is $BUILD_ID"
 export VERSIONS=${VERSIONS_TO_TEST:-"v1.12.4"}
 export NAMESPACE="prow-kubermatic-${BUILD_ID}"
-echo "Testing versions: ${VERSIONS}"
+echodate "Testing versions: ${VERSIONS}"
 cd $(dirname $0)/../..
 
 function cleanup {
-  echo "Starting cleanup"
+  echodate "Starting cleanup"
   set +e
   # Delete addons from all clusters that have our worker-name label
   kubectl get cluster -l worker-name=$BUILD_ID \
@@ -33,20 +34,20 @@ function cleanup {
   # Delete the Helm installation
   kubectl delete clusterrolebinding -l prowjob=$BUILD_ID
   kubectl delete namespace $NAMESPACE
-  echo "Finished cleanup"
+  echodate "Finished cleanup"
 }
-trap cleanup EXIT
+trap cleanup EXIT SIGINT SIGTERM
 
 docker ps &>/dev/null || start-docker.sh
 
-echo "Unlocking secrets repo"
+echodate "Unlocking secrets repo"
 cd $(go env GOPATH)/src/github.com/kubermatic/secrets
-echo $KUBERMATIC_SECRETS_GPG_KEY_BASE64 | base64 -d > /tmp/git-crypt-key
+echodate $KUBERMATIC_SECRETS_GPG_KEY_BASE64 | base64 -d > /tmp/git-crypt-key
 git-crypt unlock /tmp/git-crypt-key
 cd -
-echo "Successfully unlocked secrets repo"
+echodate "Successfully unlocked secrets repo"
 
-echo "Getting secrets from Vault"
+echodate "Getting secrets from Vault"
 export VAULT_ADDR=https://vault.loodse.com/
 export VAULT_TOKEN=$(vault write \
   --format=json auth/approle/login \
@@ -58,26 +59,26 @@ vault kv get -field=values.yaml \
   dev/seed-clusters/dev.kubermatic.io > /tmp/values.yaml
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-echo "Successfully got secrets from Vault"
+echodate "Successfully got secrets from Vault"
 
 
 if [[ ! -f $HOME/.docker/config.json ]]; then
-  echo "Logging into quay.io"
+  echodate "Logging into quay.io"
   docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io
-  echo "Logging into dockerhub"
+  echodate "Logging into dockerhub"
   docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
-  echo "Successfully logged into all registries"
+  echodate "Successfully logged into all registries"
 fi
 
-echo "Building conformance-tests cli"
+echodate "Building conformance-tests cli"
 time go build -v github.com/kubermatic/kubermatic/api/cmd/conformance-tests
-echo "Building kubermatic-controller-manager"
+echodate "Building kubermatic-controller-manager"
 time make -C api build
-echo "Finished building conformance-tests and kubermatic-controller-manager"
+echodate "Finished building conformance-tests and kubermatic-controller-manager"
 
-echo "Building docker image"
+echodate "Building docker image"
 ./api/hack/push_image.sh ${PULL_PULL_SHA}
-echo "Finished building and pushing docker images"
+echodate "Finished building and pushing docker images"
 
 INITIAL_MANIFESTS=$(cat <<EOF
 apiVersion: v1
@@ -124,13 +125,13 @@ roleRef:
   name: cluster-admin
 EOF
 )
-echo "Creating namespace $NAMESPACE to deploy kubermatic in"
+echodate "Creating namespace $NAMESPACE to deploy kubermatic in"
 echo "$INITIAL_MANIFESTS"|kubectl apply -f -
 
-echo "Deploying tiller"
+echodate "Deploying tiller"
 helm init --wait --service-account=tiller --tiller-namespace=$NAMESPACE
 
-echo "Installing Kubermatic via Helm"
+echodate "Installing Kubermatic via Helm"
 rm -f config/kubermatic/templates/cluster-role-binding.yaml
 helm upgrade --install --wait --timeout 300 \
   --tiller-namespace=$NAMESPACE \
@@ -144,9 +145,9 @@ helm upgrade --install --wait --timeout 300 \
   --values ${VALUES_FILE} \
   --namespace $NAMESPACE \
   kubermatic-$BUILD_ID ./config/kubermatic/
-echo "Finished installing Kubermatic"
+echodate "Finished installing Kubermatic"
 
-echo "Starting conformance tests"
+echodate "Starting conformance tests"
 ./conformance-tests \
   -debug \
   -worker-name=$BUILD_ID \

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -14,6 +14,8 @@ export NAMESPACE="prow-kubermatic-${BUILD_ID}"
 echodate "Testing versions: ${VERSIONS}"
 cd $(dirname $0)/../..
 
+exit 1
+
 function cleanup {
   set +e
 
@@ -27,8 +29,8 @@ function cleanup {
   echodate "Starting cleanup"
 
   # Kill all sub-processes to make sure they don't create
-  # any new resources
-  kill -9 $(jobs -p) &>/dev/null
+  # any new resources and dont block termination of the job
+  jobs -p|xargs -r -I ^ kill -9 ^ &>dev/null
 
   # Delete addons from all clusters that have our worker-name label
   kubectl get cluster -l worker-name=$BUILD_ID \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes sure that the cleanup in the e2e tests gets called, even when they timeout and hence [get a SIGINT from Prow](https://github.com/kubernetes/test-infra/blob/c23317e88f679ccadf6922e1cb51dfd58f35a3e6/prow/entrypoint/run.go#L228)

This requires wrapping everything in a subshell as Bash does not forward signals and can not react to signals via traps as long as a child is running. By wrapping in a subshell that is forked we circumvent this by just running short sleeps and waiting for the cleanup to be done which implies that either the subshell finished (successfully or not) or we got a SIGINT

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @thz 
/cc @mrIncompetent @nikhita 
