### PR TITLE
do not scrape pods in prow-kubermatic-* namespaces

### DIFF
--- a/config/monitoring/prometheus/config/scraping/pods.yaml
+++ b/config/monitoring/prometheus/config/scraping/pods.yaml
@@ -2,6 +2,11 @@ job_name: 'pods'
 kubernetes_sd_configs:
 - role: pod
 relabel_configs:
+# drop everything within test clusters
+- source_labels: [__meta_kubernetes_namespace]
+  separator: ;
+  regex: prow-kubermatic-.*
+  action: drop
 - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape]
   action: keep
   regex: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reduces alerts for ephemeral pods in test clusters.

**Release note**:
```release-note
NONE
```
