### PR TITLE
move cluster and node test to _test package

### DIFF
--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -1,4 +1,4 @@
-package handler
+package handler_test
 
 import (
 	"encoding/json"
@@ -12,6 +12,8 @@ import (
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
 	"github.com/kubermatic/kubermatic/api/pkg/validation"
 
@@ -42,13 +44,13 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 			Body:             ``,
 			ExpectedResponse: `{}`,
 			HTTPStatus:       http.StatusOK,
-			ProjectToSync:    genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				genCluster("clusterAbcID", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			),
 			ClusterToSync:      "clusterAbcID",
-			ExistingAPIUser:    genDefaultAPIUser(),
+			ExistingAPIUser:    test.GenDefaultAPIUser(),
 			HeaderParams:       map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "true"},
 			ExpectedUpdates:    1,
 			ExpectedFinalizers: []string{"kubermatic.io/cleanup-in-cluster-pv", "kubermatic.io/cleanup-in-cluster-lb"},
@@ -58,13 +60,13 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 			Body:             ``,
 			ExpectedResponse: `{}`,
 			HTTPStatus:       http.StatusOK,
-			ProjectToSync:    genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				genCluster("clusterAbcID", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			),
 			ClusterToSync:      "clusterAbcID",
-			ExistingAPIUser:    genDefaultAPIUser(),
+			ExistingAPIUser:    test.GenDefaultAPIUser(),
 			HeaderParams:       map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "false"},
 			ExpectedUpdates:    1,
 			ExpectedFinalizers: []string{"kubermatic.io/cleanup-in-cluster-pv"},
@@ -74,13 +76,13 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 			Body:             ``,
 			ExpectedResponse: `{}`,
 			HTTPStatus:       http.StatusOK,
-			ProjectToSync:    genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				genCluster("clusterAbcID", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			),
 			ClusterToSync:   "clusterAbcID",
-			ExistingAPIUser: genDefaultAPIUser(),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
 			HeaderParams:    map[string]string{},
 			ExpectedUpdates: 0,
 		},
@@ -97,19 +99,19 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, clientsSets, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
 
-			kubermaticClient := clientsSets.fakeKubermaticClient
+			kubermaticClient := clientsSets.FakeKubermaticClient
 
 			ep.ServeHTTP(res, req)
 
 			if res.Code != tc.HTTPStatus {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
-			compareWithResult(t, res, tc.ExpectedResponse)
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
 
 			validatedActions := 0
 			for _, action := range kubermaticClient.Actions() {
@@ -159,10 +161,10 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 		Body:             ``,
 		ExpectedResponse: `{}`,
 		HTTPStatus:       http.StatusOK,
-		ProjectToSync:    genDefaultProject().Name,
-		ExistingKubermaticObjs: genDefaultKubermaticObjects(
+		ProjectToSync:    test.GenDefaultProject().Name,
+		ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 			// add a cluster
-			genCluster("clusterAbcID", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+			test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			// add ssh keys
 			&kubermaticv1.UserSSHKey{
 				ObjectMeta: metav1.ObjectMeta{
@@ -172,7 +174,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 							APIVersion: "kubermatic.k8s.io/v1",
 							Kind:       "Project",
 							UID:        "",
-							Name:       genDefaultProject().Name,
+							Name:       test.GenDefaultProject().Name,
 						},
 					},
 				},
@@ -188,7 +190,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 							APIVersion: "kubermatic.k8s.io/v1",
 							Kind:       "Project",
 							UID:        "",
-							Name:       genDefaultProject().Name,
+							Name:       test.GenDefaultProject().Name,
 						},
 					},
 				},
@@ -198,7 +200,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 			},
 		),
 		ClusterToSync:   "clusterAbcID",
-		ExistingAPIUser: genDefaultAPIUser(),
+		ExistingAPIUser: test.GenDefaultAPIUser(),
 		ExpectedSSHKeys: []*kubermaticv1.UserSSHKey{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -208,7 +210,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 							APIVersion: "kubermatic.k8s.io/v1",
 							Kind:       "Project",
 							UID:        "",
-							Name:       genDefaultProject().Name,
+							Name:       test.GenDefaultProject().Name,
 						},
 					},
 				},
@@ -224,7 +226,7 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 							APIVersion: "kubermatic.k8s.io/v1",
 							Kind:       "Project",
 							UID:        "",
-							Name:       genDefaultProject().Name,
+							Name:       test.GenDefaultProject().Name,
 						},
 					},
 				},
@@ -241,19 +243,19 @@ func TestDeleteClusterEndpoint(t *testing.T) {
 	res := httptest.NewRecorder()
 	kubermaticObj := []runtime.Object{}
 	kubermaticObj = append(kubermaticObj, testcase.ExistingKubermaticObjs...)
-	ep, clientsSets, err := createTestEndpointAndGetClients(*testcase.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil)
+	ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*testcase.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 	if err != nil {
 		t.Fatalf("failed to create test endpoint due to %v", err)
 	}
 
-	kubermaticClient := clientsSets.fakeKubermaticClient
+	kubermaticClient := clientsSets.FakeKubermaticClient
 
 	ep.ServeHTTP(res, req)
 
 	if res.Code != testcase.HTTPStatus {
 		t.Fatalf("Expected HTTP status code %d, got %d: %s", testcase.HTTPStatus, res.Code, res.Body.String())
 	}
-	compareWithResult(t, res, testcase.ExpectedResponse)
+	test.CompareWithResult(t, res, testcase.ExpectedResponse)
 
 	validatedActions := 0
 	for _, action := range kubermaticClient.Actions() {
@@ -311,11 +313,11 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 			ExpectedDeleteHTTPStatus:        http.StatusOK,
 			ExpectedGetHTTPStatus:           http.StatusOK,
 			ExpectedResponseOnGetAfterDelte: `[{"id":"key-abc-yafn","name":"key-display-name","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"fingerprint":"","publicKey":""}}]`,
-			ProjectToSync:                   genDefaultProject().Name,
-			ExistingAPIUser:                 genDefaultAPIUser(),
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ProjectToSync:                   test.GenDefaultProject().Name,
+			ExistingAPIUser:                 test.GenDefaultAPIUser(),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				genCluster("clusterAbcID", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 				// add ssh keys
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
@@ -325,7 +327,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 								APIVersion: "kubermatic.k8s.io/v1",
 								Kind:       "Project",
 								UID:        "",
-								Name:       genDefaultProject().Name,
+								Name:       test.GenDefaultProject().Name,
 							},
 						},
 					},
@@ -341,7 +343,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 								APIVersion: "kubermatic.k8s.io/v1",
 								Kind:       "Project",
 								UID:        "",
-								Name:       genDefaultProject().Name,
+								Name:       test.GenDefaultProject().Name,
 							},
 						},
 					},
@@ -364,7 +366,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				res := httptest.NewRecorder()
 				kubermaticObj := []runtime.Object{}
 				kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-				ep, err = createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil)
+				ep, err = test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 				if err != nil {
 					t.Fatalf("failed to create test endpoint due to %v", err)
 				}
@@ -374,7 +376,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				if res.Code != tc.ExpectedDeleteHTTPStatus {
 					t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedDeleteHTTPStatus, res.Code, res.Body.String())
 				}
-				compareWithResult(t, res, tc.ExpectedDeleteResponse)
+				test.CompareWithResult(t, res, tc.ExpectedDeleteResponse)
 			}
 
 			// GET request list the keys from the cache, thus we wait 1 s before firing the request . . . I know :)
@@ -388,7 +390,7 @@ func TestDetachSSHKeyFromClusterEndpoint(t *testing.T) {
 				if res.Code != tc.ExpectedGetHTTPStatus {
 					t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedGetHTTPStatus, res.Code, res.Body.String())
 				}
-				compareWithResult(t, res, tc.ExpectedResponseOnGetAfterDelte)
+				test.CompareWithResult(t, res, tc.ExpectedResponseOnGetAfterDelte)
 			}
 		})
 	}
@@ -437,10 +439,10 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 				},
 			},
 			HTTPStatus:    http.StatusOK,
-			ProjectToSync: genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ProjectToSync: test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				genDefaultCluster(),
+				test.GenDefaultCluster(),
 				// add ssh keys
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
@@ -450,14 +452,14 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 								APIVersion: "kubermatic.k8s.io/v1",
 								Kind:       "Project",
 								UID:        "",
-								Name:       genDefaultProject().Name,
+								Name:       test.GenDefaultProject().Name,
 							},
 						},
 						CreationTimestamp: metav1.NewTime(creationTime),
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "yafn",
-						Clusters: []string{genDefaultCluster().Name},
+						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
 				&kubermaticv1.UserSSHKey{
@@ -468,19 +470,19 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 								APIVersion: "kubermatic.k8s.io/v1",
 								Kind:       "Project",
 								UID:        "",
-								Name:       genDefaultProject().Name,
+								Name:       test.GenDefaultProject().Name,
 							},
 						},
 						CreationTimestamp: metav1.NewTime(creationTime.Add(time.Minute)),
 					},
 					Spec: kubermaticv1.SSHKeySpec{
 						Name:     "abcd",
-						Clusters: []string{genDefaultCluster().Name},
+						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
 			),
-			ExistingAPIUser: genDefaultAPIUser(),
-			ClusterToSync:   genDefaultCluster().Name,
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			ClusterToSync:   test.GenDefaultCluster().Name,
 		},
 	}
 
@@ -490,7 +492,7 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, err := createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -501,10 +503,10 @@ func TestListSSHKeysAssignedToClusterEndpoint(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			actualKeys := newSSHKeyV1SliceWrapper{}
+			actualKeys := test.NewSSHKeyV1SliceWrapper{}
 			actualKeys.DecodeOrDie(res.Body, t).Sort()
 
-			wrappedExpectedKeys := newSSHKeyV1SliceWrapper(tc.ExpectedKeys)
+			wrappedExpectedKeys := test.NewSSHKeyV1SliceWrapper(tc.ExpectedKeys)
 			wrappedExpectedKeys.Sort()
 
 			actualKeys.EqualOrDie(wrappedExpectedKeys, t)
@@ -531,11 +533,11 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 			SSHKeyID:         "key-c08aa5c7abf34504f18552846485267d-yafn",
 			ExpectedResponse: `{}`,
 			HTTPStatus:       http.StatusCreated,
-			ProjectToSync:    genDefaultProject().Name,
-			ExistingAPIUser:  genDefaultAPIUser(),
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				genDefaultCluster(),
+				test.GenDefaultCluster(),
 				// add a ssh key
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
@@ -545,16 +547,16 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 								APIVersion: "kubermatic.k8s.io/v1",
 								Kind:       "Project",
 								UID:        "",
-								Name:       genDefaultProject().Name,
+								Name:       test.GenDefaultProject().Name,
 							},
 						},
 					},
 					Spec: kubermaticv1.SSHKeySpec{
-						Clusters: []string{genDefaultCluster().Name},
+						Clusters: []string{test.GenDefaultCluster().Name},
 					},
 				},
 			),
-			ClusterToSync: genDefaultCluster().Name,
+			ClusterToSync: test.GenDefaultCluster().Name,
 		},
 		// scenario 2
 		{
@@ -562,12 +564,12 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 			SSHKeyID:         "key-c08aa5c7abf34504f18552846485267d-yafn",
 			ExpectedResponse: `{"error":{"code":500,"message":"the given ssh key key-c08aa5c7abf34504f18552846485267d-yafn does not belong to the given project my-first-project (my-first-project-ID)"}}`,
 			HTTPStatus:       http.StatusInternalServerError,
-			ProjectToSync:    genDefaultProject().Name,
-			ExistingAPIUser:  genDefaultAPIUser(),
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
 			ExpectedSSHKeys:  []*kubermaticv1.UserSSHKey{},
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				genDefaultCluster(),
+				test.GenDefaultCluster(),
 				// add an ssh key
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
@@ -583,7 +585,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 					},
 				},
 			),
-			ClusterToSync: genDefaultCluster().Name,
+			ClusterToSync: test.GenDefaultCluster().Name,
 		},
 	}
 
@@ -593,7 +595,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, clientsSets, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -604,9 +606,9 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			compareWithResult(t, res, tc.ExpectedResponse)
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
 
-			kubermaticClient := clientsSets.fakeKubermaticClient
+			kubermaticClient := clientsSets.FakeKubermaticClient
 			validatedActions := 0
 			if tc.HTTPStatus == http.StatusCreated {
 				for _, action := range kubermaticClient.Actions() {
@@ -653,9 +655,9 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			Body:                   `{"name":"keen-snyder","spec":{"cloud":{"digitalocean":{"token":"dummy_token"},"dc":"us-central1"}, "version":""}}`,
 			ExpectedResponse:       `{"error":{"code":400,"message":"invalid cluster: invalid cloud spec \"Version\" is required but was not specified"}}`,
 			HTTPStatus:             http.StatusBadRequest,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(),
-			ProjectToSync:          genDefaultProject().Name,
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
+			ProjectToSync:          test.GenDefaultProject().Name,
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 2
 		{
@@ -664,8 +666,8 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			ExpectedResponse: `{"id":"%s","name":"keen-snyder","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"cloud":{"dc":"us-central1","fake":{}},"version":"1.9.7"},"status":{"version":"1.9.7","url":""}}`,
 			RewriteClusterID: true,
 			HTTPStatus:       http.StatusCreated,
-			ProjectToSync:    genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add an ssh key
 				&kubermaticv1.UserSSHKey{
 					ObjectMeta: metav1.ObjectMeta{
@@ -675,13 +677,13 @@ func TestCreateClusterEndpoint(t *testing.T) {
 								APIVersion: "kubermatic.k8s.io/v1",
 								Kind:       "Project",
 								UID:        "",
-								Name:       genDefaultProject().Name,
+								Name:       test.GenDefaultProject().Name,
 							},
 						},
 					},
 				},
 			),
-			ExistingAPIUser: genDefaultAPIUser(),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
 		// scenario 3
 		{
@@ -689,10 +691,10 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			Body:                   `{"cluster":{"humanReadableName":"keen-snyder","version":"1.9.7","pause":false,"cloud":{"digitalocean":{},"dc":"do-fra1"}},"sshKeys":["key-c08aa5c7abf34504f18552846485267d-yafn"]}`,
 			ExpectedResponse:       `{"error":{"code":403,"message":"forbidden: The user \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
 			HTTPStatus:             http.StatusForbidden,
-			ProjectToSync:          genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(),
+			ProjectToSync:          test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
 			ExistingAPIUser: func() *apiv1.User {
-				defaultUser := genDefaultAPIUser()
+				defaultUser := test.GenDefaultAPIUser()
 				defaultUser.Email = "john@acme.com"
 				return defaultUser
 			}(),
@@ -704,16 +706,16 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			ExpectedResponse: `{"error":{"code":503,"message":"Project is not initialized yet"}}`,
 			HTTPStatus:       http.StatusServiceUnavailable,
 			ExistingProject: func() *kubermaticv1.Project {
-				project := genDefaultProject()
+				project := test.GenDefaultProject()
 				project.Status.Phase = kubermaticv1.ProjectInactive
 				return project
 			}(),
-			ProjectToSync: genDefaultProject().Name,
+			ProjectToSync: test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: []runtime.Object{
-				genDefaultUser(),
-				genDefaultOwnerBinding(),
+				test.GenDefaultUser(),
+				test.GenDefaultOwnerBinding(),
 			},
-			ExistingAPIUser: genDefaultAPIUser(),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
 	}
 
@@ -726,7 +728,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 				kubermaticObj = append(kubermaticObj, tc.ExistingProject)
 			}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, err := createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -748,7 +750,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 				expectedResponse = fmt.Sprintf(tc.ExpectedResponse, actualCluster.ID)
 			}
 
-			compareWithResult(t, res, expectedResponse)
+			test.CompareWithResult(t, res, expectedResponse)
 		})
 	}
 }
@@ -772,13 +774,13 @@ func TestGetClusterHealth(t *testing.T) {
 			ExpectedResponse: `{"apiserver":true,"scheduler":false,"controller":true,"machineController":false,"etcd":true}`,
 			HTTPStatus:       http.StatusOK,
 			ClusterToGet:     "keen-snyder",
-			ProjectToSync:    genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				genCluster("clusterDefID", "clusterDef", genDefaultProject().Name, time.Date(2013, 02, 04, 01, 54, 0, 0, time.UTC)),
+				test.GenCluster("clusterDefID", "clusterDef", test.GenDefaultProject().Name, time.Date(2013, 02, 04, 01, 54, 0, 0, time.UTC)),
 				// add another cluster
 				func() *kubermaticv1.Cluster {
-					cluster := genCluster("keen-snyder", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+					cluster := test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 					cluster.Status.Health = kubermaticv1.ClusterHealth{
 						ClusterHealthStatus: kubermaticv1.ClusterHealthStatus{
 							Apiserver:         true,
@@ -791,7 +793,7 @@ func TestGetClusterHealth(t *testing.T) {
 					return cluster
 				}(),
 			),
-			ExistingAPIUser: genDefaultAPIUser(),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
 	}
 
@@ -801,7 +803,7 @@ func TestGetClusterHealth(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, err := createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -812,7 +814,7 @@ func TestGetClusterHealth(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			compareWithResult(t, res, tc.ExpectedResponse)
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
 		})
 	}
 }
@@ -822,7 +824,7 @@ func TestPatchCluster(t *testing.T) {
 
 	// Mock timezone to keep creation timestamp always the same.
 	time.Local = time.UTC
-	cluster := genCluster("keen-snyder", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+	cluster := test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 	cluster.Spec.Cloud.DatacenterName = "us-central1"
 
 	testcases := []struct {
@@ -842,11 +844,11 @@ func TestPatchCluster(t *testing.T) {
 			ExpectedResponse: `{"id":"keen-snyder","name":"clusterAbc","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"us-central1","fake":{}},"version":"1.2.3"},"status":{"version":"1.2.3","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
 			cluster:          "keen-snyder",
 			HTTPStatus:       http.StatusOK,
-			project:          genDefaultProject().Name,
-			ExistingAPIUser:  genDefaultAPIUser(),
-			ExistingKubermaticObjects: genDefaultKubermaticObjects(
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
 				func() *kubermaticv1.Cluster {
-					cluster := genCluster("keen-snyder", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+					cluster := test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 					cluster.Spec.Cloud.DatacenterName = "us-central1"
 					return cluster
 				}()),
@@ -858,9 +860,9 @@ func TestPatchCluster(t *testing.T) {
 			ExpectedResponse:          `{"error":{"code":400,"message":"cannot patch cluster: Invalid JSON Patch"}}`,
 			cluster:                   "keen-snyder",
 			HTTPStatus:                http.StatusBadRequest,
-			project:                   genDefaultProject().Name,
-			ExistingAPIUser:           genDefaultAPIUser(),
-			ExistingKubermaticObjects: genDefaultKubermaticObjects(genCluster("keen-snyder", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))),
+			project:                   test.GenDefaultProject().Name,
+			ExistingAPIUser:           test.GenDefaultAPIUser(),
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))),
 		},
 	}
 
@@ -869,7 +871,7 @@ func TestPatchCluster(t *testing.T) {
 			// test data
 			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", tc.project, tc.cluster), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
-			ep, err := createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, tc.ExistingKubermaticObjects, nil, nil)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, tc.ExistingKubermaticObjects, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -882,7 +884,7 @@ func TestPatchCluster(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			compareWithResult(t, res, tc.ExpectedResponse)
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
 		})
 	}
 }
@@ -903,36 +905,36 @@ func TestGetCluster(t *testing.T) {
 			Name:             "scenario 1: gets cluster with the given name that belongs to the given project",
 			Body:             ``,
 			ExpectedResponse: `{"id":"defClusterID","name":"defClusterName","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"FakeDatacenter","fake":{}},"version":"9.9.9"},"status":{"version":"9.9.9","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
-			ClusterToGet:     genDefaultCluster().Name,
+			ClusterToGet:     test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusOK,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
-				genDefaultCluster(),
-				genCluster("clusterAbcID", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenDefaultCluster(),
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			),
-			ExistingAPIUser: genDefaultAPIUser(),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
 		// scenario 2
 		{
 			Name:             "scenario 2: gets cluster for Openstack and no sensitive data (credentials) are returned",
 			Body:             ``,
 			ExpectedResponse: `{"id":"defClusterID","name":"defClusterName","creationTimestamp":"2013-02-03T19:54:00Z","spec":{"cloud":{"dc":"OpenstackDatacenter","openstack":{"floatingIpPool":"floatingIPPool"}},"version":"9.9.9"},"status":{"version":"9.9.9","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
-			ClusterToGet:     genDefaultCluster().Name,
+			ClusterToGet:     test.GenDefaultCluster().Name,
 			HTTPStatus:       http.StatusOK,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
-				genClusterWithOpenstack(genDefaultCluster()),
-				genCluster("clusterAbcID", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				genClusterWithOpenstack(test.GenDefaultCluster()),
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			),
-			ExistingAPIUser: genDefaultAPIUser(),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", testingProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", test.ProjectName, tc.ClusterToGet), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, err := createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -943,7 +945,7 @@ func TestGetCluster(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			compareWithResult(t, res, tc.ExpectedResponse)
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
 		})
 	}
 }
@@ -1019,22 +1021,22 @@ func TestListClusters(t *testing.T) {
 				},
 			},
 			HTTPStatus: http.StatusOK,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(
-				genCluster("clusterAbcID", "clusterAbc", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
-				genCluster("clusterDefID", "clusterDef", genDefaultProject().Name, time.Date(2013, 02, 04, 01, 54, 0, 0, time.UTC)),
-				genClusterWithOpenstack(genCluster("clusterOpenstackID", "clusterOpenstack", genDefaultProject().Name, time.Date(2013, 02, 04, 03, 54, 0, 0, time.UTC))),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+				test.GenCluster("clusterDefID", "clusterDef", test.GenDefaultProject().Name, time.Date(2013, 02, 04, 01, 54, 0, 0, time.UTC)),
+				genClusterWithOpenstack(test.GenCluster("clusterOpenstackID", "clusterOpenstack", test.GenDefaultProject().Name, time.Date(2013, 02, 04, 03, 54, 0, 0, time.UTC))),
 			),
-			ExistingAPIUser: genDefaultAPIUser(),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters", testingProjectName), strings.NewReader(""))
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters", test.ProjectName), strings.NewReader(""))
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, err := createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -1045,10 +1047,10 @@ func TestListClusters(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			actualClusters := newClusterV1SliceWrapper{}
+			actualClusters := test.NewClusterV1SliceWrapper{}
 			actualClusters.DecodeOrDie(res.Body, t).Sort()
 
-			wrappedExpectedClusters := newClusterV1SliceWrapper(tc.ExpectedClusters)
+			wrappedExpectedClusters := test.NewClusterV1SliceWrapper(tc.ExpectedClusters)
 			wrappedExpectedClusters.Sort()
 
 			actualClusters.EqualOrDie(wrappedExpectedClusters, t)
@@ -1060,12 +1062,12 @@ func TestRevokeClusterAdminTokenEndpoint(t *testing.T) {
 	t.Parallel()
 	// setup world view
 	expectedResponse := "{}"
-	kubermaticObjs := genDefaultKubermaticObjects()
-	tester := genDefaultAPIUser()
-	projectToSync := genDefaultProject().Name
-	cluster := genDefaultCluster()
+	kubermaticObjs := test.GenDefaultKubermaticObjects()
+	tester := test.GenDefaultAPIUser()
+	projectToSync := test.GenDefaultProject().Name
+	cluster := test.GenDefaultCluster()
 	kubermaticObjs = append(kubermaticObjs, cluster)
-	ep, clientsSets, err := createTestEndpointAndGetClients(*tester, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObjs, nil, nil)
+	ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tester, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObjs, nil, nil, hack.NewTestRouting)
 	if err != nil {
 		t.Fatalf("failed to create test endpoint due to %v", err)
 	}
@@ -1076,10 +1078,10 @@ func TestRevokeClusterAdminTokenEndpoint(t *testing.T) {
 	ep.ServeHTTP(res, req)
 
 	// check assertions
-	checkStatusCode(http.StatusOK, res, t)
-	compareWithResult(t, res, expectedResponse)
+	test.CheckStatusCode(http.StatusOK, res, t)
+	test.CompareWithResult(t, res, expectedResponse)
 	wasUpdateActionValidated := false
-	for _, action := range clientsSets.fakeKubermaticClient.Actions() {
+	for _, action := range clientsSets.FakeKubermaticClient.Actions() {
 		if action.Matches("update", "clusters") {
 			updateAction, ok := action.(clienttesting.CreateAction)
 			if !ok {
@@ -1103,47 +1105,6 @@ func TestRevokeClusterAdminTokenEndpoint(t *testing.T) {
 	if !wasUpdateActionValidated {
 		t.Error("updated admin token in cluster resource was not persisted")
 	}
-}
-
-func genCluster(id string, name string, projectID string, creationTime time.Time) *kubermaticv1.Cluster {
-	return &kubermaticv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   id,
-			Labels: map[string]string{"project-id": projectID},
-			CreationTimestamp: func() metav1.Time {
-				return metav1.NewTime(creationTime)
-			}(),
-		},
-		Spec: kubermaticv1.ClusterSpec{
-			Cloud: kubermaticv1.CloudSpec{
-				DatacenterName: "FakeDatacenter",
-				Fake:           &kubermaticv1.FakeCloudSpec{Token: "SecretToken"},
-			},
-			Version:           *semver.NewSemverOrDie("9.9.9"),
-			HumanReadableName: name,
-		},
-		Address: kubermaticv1.ClusterAddress{
-			AdminToken:   "drphc2.g4kq82pnlfqjqt65",
-			ExternalName: "w225mx4z66.asia-east1-a-1.cloud.kubermatic.io",
-			IP:           "35.194.142.199",
-			URL:          "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
-		},
-		Status: kubermaticv1.ClusterStatus{
-			Health: kubermaticv1.ClusterHealth{
-				ClusterHealthStatus: kubermaticv1.ClusterHealthStatus{
-					Apiserver:         true,
-					Scheduler:         true,
-					Controller:        true,
-					MachineController: true,
-					Etcd:              true,
-				},
-			},
-		},
-	}
-}
-
-func genDefaultCluster() *kubermaticv1.Cluster {
-	return genCluster("defClusterID", "defClusterName", genDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 }
 
 func genClusterWithOpenstack(cluster *kubermaticv1.Cluster) *kubermaticv1.Cluster {

--- a/api/pkg/handler/kubeconfig_test.go
+++ b/api/pkg/handler/kubeconfig_test.go
@@ -215,7 +215,7 @@ func genTestKubeconfigKubermaticObjects() []runtime.Object {
 		// make John the owner of the first project and the editor of the second
 		genBinding(testingProjectName, testUserEmail, "owners"),
 		// add a cluster
-		genCluster(test.ClusterID, testClusterName, genDefaultProject().Name, defaultCreationTimestamp()),
+		test.GenCluster(test.ClusterID, testClusterName, genDefaultProject().Name, defaultCreationTimestamp()),
 	}
 }
 

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -1,4 +1,4 @@
-package handler
+package handler_test
 
 import (
 	"encoding/json"
@@ -12,8 +12,11 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,10 +47,10 @@ func TestDeleteNodeForCluster(t *testing.T) {
 			Name:                   "scenario 1: delete the node that belong to the given cluster",
 			HTTPStatus:             http.StatusOK,
 			NodeIDToDelete:         "venus",
-			ClusterIDToSync:        genDefaultCluster().Name,
-			ProjectIDToSync:        genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genDefaultCluster()),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingNodes: []*corev1.Node{
 				{ObjectMeta: metav1.ObjectMeta{Name: "venus"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "mars"}},
@@ -79,7 +82,7 @@ func TestDeleteNodeForCluster(t *testing.T) {
 			for _, existingMachine := range tc.ExistingMachines {
 				machineObj = append(machineObj, existingMachine)
 			}
-			ep, clientsSets, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil)
+			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -90,7 +93,7 @@ func TestDeleteNodeForCluster(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			fakeMachineClient := clientsSets.fakeMachineClient
+			fakeMachineClient := clientsSets.FakeMachineClient
 			if len(fakeMachineClient.Actions()) != tc.ExpectedActions {
 				t.Fatalf("expected to get %d but got %d actions = %v", tc.ExpectedActions, len(fakeMachineClient.Actions()), fakeMachineClient.Actions())
 			}
@@ -119,7 +122,7 @@ func TestDeleteNodeForCluster(t *testing.T) {
 			if res.Code != tc.ExpectedHTTPStatusOnGet {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedHTTPStatusOnGet, res.Code, res.Body.String())
 			}
-			compareWithResult(t, res, tc.ExpectedResponseOnGet)
+			test.CompareWithResult(t, res, tc.ExpectedResponseOnGet)
 
 		})
 	}
@@ -145,10 +148,10 @@ func TestListNodesForCluster(t *testing.T) {
 		{
 			Name:                   "scenario 1: list nodes that belong to the given cluster",
 			HTTPStatus:             http.StatusOK,
-			ClusterIDToSync:        genDefaultCluster().Name,
-			ProjectIDToSync:        genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genDefaultCluster()),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingNodes: []*corev1.Node{
 				{ObjectMeta: metav1.ObjectMeta{Name: "venus"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "mars"}},
@@ -229,10 +232,10 @@ func TestListNodesForCluster(t *testing.T) {
 		{
 			Name:                   "scenario 2: list nodes that belong to the given cluster should skip controlled machines",
 			HTTPStatus:             http.StatusOK,
-			ClusterIDToSync:        genDefaultCluster().Name,
-			ProjectIDToSync:        genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genDefaultCluster()),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingNodes: []*corev1.Node{
 				{ObjectMeta: metav1.ObjectMeta{Name: "venus"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "mars"}},
@@ -293,7 +296,7 @@ func TestListNodesForCluster(t *testing.T) {
 			for _, existingMachine := range tc.ExistingMachines {
 				machineObj = append(machineObj, existingMachine)
 			}
-			ep, _, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil)
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -304,10 +307,10 @@ func TestListNodesForCluster(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			actualNodes := nodeV1SliceWrapper{}
+			actualNodes := test.NodeV1SliceWrapper{}
 			actualNodes.DecodeOrDie(res.Body, t).Sort()
 
-			wrappedExpectedNodes := nodeV1SliceWrapper(tc.ExpectedResponse)
+			wrappedExpectedNodes := test.NodeV1SliceWrapper(tc.ExpectedResponse)
 			wrappedExpectedNodes.Sort()
 
 			actualNodes.EqualOrDie(wrappedExpectedNodes, t)
@@ -335,10 +338,10 @@ func TestGetNodeForCluster(t *testing.T) {
 			ExpectedResponse:       `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":null}},"operatingSystem":{},"versions":{"kubelet":"v1.9.9"}},"status":{"machineName":"venus","capacity":{"cpu":"0","memory":"0"},"allocatable":{"cpu":"0","memory":"0"},"nodeInfo":{"kernelVersion":"","containerRuntime":"","containerRuntimeVersion":"","kubeletVersion":"","operatingSystem":"","architecture":""}}}`,
 			HTTPStatus:             http.StatusOK,
 			NodeIDToSync:           "venus",
-			ClusterIDToSync:        genDefaultCluster().Name,
-			ProjectIDToSync:        genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genDefaultCluster()),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingNodes:          []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "venus"}}},
 			ExistingMachines:       []*clusterv1alpha1.Machine{genTestMachine("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}}`, map[string]string{"md-id": "123", "xyz": "abc"}, nil)},
 		},
@@ -358,7 +361,7 @@ func TestGetNodeForCluster(t *testing.T) {
 			for _, existingMachine := range tc.ExistingMachines {
 				machineObj = append(machineObj, existingMachine)
 			}
-			ep, _, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil)
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -368,7 +371,7 @@ func TestGetNodeForCluster(t *testing.T) {
 			if res.Code != tc.HTTPStatus {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
-			compareWithResult(t, res, tc.ExpectedResponse)
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
 		})
 	}
 }
@@ -396,10 +399,10 @@ func TestCreateNodeForCluster(t *testing.T) {
 			ExpectedResponse:                   `{"id":"%s","name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":""}},"status":{"machineName":"%s","capacity":{"cpu":"","memory":""},"allocatable":{"cpu":"","memory":""},"nodeInfo":{"kernelVersion":"","containerRuntime":"","containerRuntimeVersion":"","kubeletVersion":"","operatingSystem":"","architecture":""}}}`,
 			HTTPStatus:                         http.StatusCreated,
 			RewriteClusterNameAndNamespaceName: true,
-			ProjectIDToSync:                    genDefaultProject().Name,
-			ClusterIDToSync:                    genDefaultCluster().Name,
-			ExistingKubermaticObjs:             genDefaultKubermaticObjects(genTestCluster(true)),
-			ExistingAPIUser:                    genDefaultAPIUser(),
+			ProjectIDToSync:                    test.GenDefaultProject().Name,
+			ClusterIDToSync:                    test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs:             test.GenDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingAPIUser:                    test.GenDefaultAPIUser(),
 		},
 
 		// scenario 2
@@ -409,10 +412,10 @@ func TestCreateNodeForCluster(t *testing.T) {
 			ExpectedResponse:                   `{"error":{"code":503,"message":"Cluster components are not ready yet"}}`,
 			HTTPStatus:                         http.StatusServiceUnavailable,
 			RewriteClusterNameAndNamespaceName: true,
-			ProjectIDToSync:                    genDefaultProject().Name,
-			ClusterIDToSync:                    genDefaultCluster().Name,
-			ExistingKubermaticObjs:             genDefaultKubermaticObjects(genTestCluster(false)),
-			ExistingAPIUser:                    genDefaultAPIUser(),
+			ProjectIDToSync:                    test.GenDefaultProject().Name,
+			ClusterIDToSync:                    test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs:             test.GenDefaultKubermaticObjects(genTestCluster(false)),
+			ExistingAPIUser:                    test.GenDefaultAPIUser(),
 		},
 	}
 
@@ -422,7 +425,7 @@ func TestCreateNodeForCluster(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, err := createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -447,7 +450,7 @@ func TestCreateNodeForCluster(t *testing.T) {
 					expectedResponse = fmt.Sprintf(tc.ExpectedResponse, actualNode.ID, actualNode.Name, actualNode.Status.MachineName)
 				}
 			}
-			compareWithResult(t, res, expectedResponse)
+			test.CompareWithResult(t, res, expectedResponse)
 		})
 	}
 }
@@ -473,10 +476,10 @@ func TestCreateNodeDeployment(t *testing.T) {
 			Body:                   `{"spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
 			ExpectedResponse:       `{"id":"%s","name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":""}},"paused":false},"status":{}}`,
 			HTTPStatus:             http.StatusCreated,
-			ProjectID:              genDefaultProject().Name,
-			ClusterID:              genDefaultCluster().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genTestCluster(true)),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ProjectID:              test.GenDefaultProject().Name,
+			ClusterID:              test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
 
 		// scenario 2
@@ -485,10 +488,10 @@ func TestCreateNodeDeployment(t *testing.T) {
 			Body:                   `{"spec":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}`,
 			ExpectedResponse:       `{"error":{"code":503,"message":"Cluster components are not ready yet"}}`,
 			HTTPStatus:             http.StatusServiceUnavailable,
-			ProjectID:              genDefaultProject().Name,
-			ClusterID:              genDefaultCluster().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genTestCluster(false)),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ProjectID:              test.GenDefaultProject().Name,
+			ClusterID:              test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(false)),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
 	}
 
@@ -498,7 +501,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, err := createTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -522,7 +525,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 				expectedResponse = fmt.Sprintf(tc.ExpectedResponse, nd.ID, nd.Name)
 			}
 
-			compareWithResult(t, res, expectedResponse)
+			test.CompareWithResult(t, res, expectedResponse)
 		})
 	}
 }
@@ -548,10 +551,10 @@ func TestListNodeDeployments(t *testing.T) {
 		{
 			Name:                   "scenario 1: list node deployments that belong to the given cluster",
 			HTTPStatus:             http.StatusOK,
-			ClusterIDToSync:        genDefaultCluster().Name,
-			ProjectIDToSync:        genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genDefaultCluster()),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
 				genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil),
 				genTestMachineDeployment("mars", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
@@ -626,7 +629,7 @@ func TestListNodeDeployments(t *testing.T) {
 			for _, existingMachineDeployment := range tc.ExistingMachineDeployments {
 				machineObj = append(machineObj, existingMachineDeployment)
 			}
-			ep, _, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil)
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -669,10 +672,10 @@ func TestGetNodeDeployment(t *testing.T) {
 		{
 			Name:                   "scenario 1: get node deployment that belong to the given cluster",
 			HTTPStatus:             http.StatusOK,
-			ClusterIDToSync:        genDefaultCluster().Name,
-			ProjectIDToSync:        genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genDefaultCluster()),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
 				genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil),
 			},
@@ -717,7 +720,7 @@ func TestGetNodeDeployment(t *testing.T) {
 			for _, existingMachineDeployment := range tc.ExistingMachineDeployments {
 				machineObj = append(machineObj, existingMachineDeployment)
 			}
-			ep, _, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil)
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -733,7 +736,7 @@ func TestGetNodeDeployment(t *testing.T) {
 				t.Fatalf("failed to marshall expected response %v", err)
 			}
 
-			compareWithResult(t, res, string(bytes))
+			test.CompareWithResult(t, res, string(bytes))
 		})
 	}
 }
@@ -760,10 +763,10 @@ func TestListNodeDeploymentNodes(t *testing.T) {
 		{
 			Name:                   "scenario 1: list nodes that belong to the given node deployment",
 			HTTPStatus:             http.StatusOK,
-			ClusterIDToSync:        genDefaultCluster().Name,
-			ProjectIDToSync:        genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genDefaultCluster()),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
 				genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123"}),
 				genTestMachineDeployment("mars", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil),
@@ -849,7 +852,7 @@ func TestListNodeDeploymentNodes(t *testing.T) {
 				machineObj = append(machineObj, existingMachine)
 			}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, _, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil)
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -860,10 +863,10 @@ func TestListNodeDeploymentNodes(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			actualNodes := nodeV1SliceWrapper{}
+			actualNodes := test.NodeV1SliceWrapper{}
 			actualNodes.DecodeOrDie(res.Body, t).Sort()
 
-			wrappedExpectedNodes := nodeV1SliceWrapper(tc.ExpectedResponse)
+			wrappedExpectedNodes := test.NodeV1SliceWrapper(tc.ExpectedResponse)
 			wrappedExpectedNodes.Sort()
 
 			actualNodes.EqualOrDie(wrappedExpectedNodes, t)
@@ -900,11 +903,11 @@ func TestPatchNodeDeployment(t *testing.T) {
 			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v1.9.9"}},"paused":false},"status":{}}`, replicasUpdated),
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusOK,
-			project:                    genDefaultProject().Name,
-			ExistingAPIUser:            genDefaultAPIUser(),
+			project:                    test.GenDefaultProject().Name,
+			ExistingAPIUser:            test.GenDefaultAPIUser(),
 			NodeDeploymentID:           "venus",
 			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil)},
-			ExistingKubermaticObjs:     genDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingKubermaticObjs:     test.GenDefaultKubermaticObjects(genTestCluster(true)),
 		},
 		// Scenario 2: Update kubelet version.
 		{
@@ -913,11 +916,11 @@ func TestPatchNodeDeployment(t *testing.T) {
 			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"%v"}},"paused":false},"status":{}}`, replicas, kubeletVerUpdated),
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusOK,
-			project:                    genDefaultProject().Name,
-			ExistingAPIUser:            genDefaultAPIUser(),
+			project:                    test.GenDefaultProject().Name,
+			ExistingAPIUser:            test.GenDefaultAPIUser(),
 			NodeDeploymentID:           "venus",
 			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil)},
-			ExistingKubermaticObjs:     genDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingKubermaticObjs:     test.GenDefaultKubermaticObjects(genTestCluster(true)),
 		},
 		// Scenario 3: Change to paused.
 		{
@@ -926,18 +929,18 @@ func TestPatchNodeDeployment(t *testing.T) {
 			ExpectedResponse:           `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v1.9.9"}},"paused":true},"status":{}}`,
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusOK,
-			project:                    genDefaultProject().Name,
-			ExistingAPIUser:            genDefaultAPIUser(),
+			project:                    test.GenDefaultProject().Name,
+			ExistingAPIUser:            test.GenDefaultAPIUser(),
 			NodeDeploymentID:           "venus",
 			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil)},
-			ExistingKubermaticObjs:     genDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingKubermaticObjs:     test.GenDefaultKubermaticObjects(genTestCluster(true)),
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s",
-				genDefaultProject().Name, genDefaultCluster().Name, tc.NodeDeploymentID), strings.NewReader(tc.Body))
+				test.GenDefaultProject().Name, test.GenDefaultCluster().Name, tc.NodeDeploymentID), strings.NewReader(tc.Body))
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			machineDeploymentObjets := []runtime.Object{}
@@ -946,7 +949,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 			for _, existingMachineDeployment := range tc.ExistingMachineDeployments {
 				machineDeploymentObjets = append(machineDeploymentObjets, existingMachineDeployment)
 			}
-			ep, _, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineDeploymentObjets, kubermaticObj, nil, nil)
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineDeploymentObjets, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -957,7 +960,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			compareWithResult(t, res, tc.ExpectedResponse)
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
 		})
 	}
 }
@@ -983,10 +986,10 @@ func TestDeleteNodeDeployment(t *testing.T) {
 			Name:                   "scenario 1: delete the node that belong to the given cluster",
 			HTTPStatus:             http.StatusOK,
 			NodeIDToDelete:         "venus",
-			ClusterIDToSync:        genDefaultCluster().Name,
-			ProjectIDToSync:        genDefaultProject().Name,
-			ExistingKubermaticObjs: genDefaultKubermaticObjects(genDefaultCluster()),
-			ExistingAPIUser:        genDefaultAPIUser(),
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExistingNodes: []*corev1.Node{
 				{ObjectMeta: metav1.ObjectMeta{Name: "venus"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "mars"}},
@@ -1020,7 +1023,7 @@ func TestDeleteNodeDeployment(t *testing.T) {
 			for _, existingMachineDeployment := range tc.ExistingMachineDeployments {
 				machineDeploymentObjets = append(machineDeploymentObjets, existingMachineDeployment)
 			}
-			ep, clientsSets, err := createTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineDeploymentObjets, kubermaticObj, nil, nil)
+			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineDeploymentObjets, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -1031,7 +1034,7 @@ func TestDeleteNodeDeployment(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}
 
-			fakeMachineClient := clientsSets.fakeMachineClient
+			fakeMachineClient := clientsSets.FakeMachineClient
 			if len(fakeMachineClient.Actions()) != tc.ExpectedActions {
 				t.Fatalf("expected to get %d but got %d actions = %v", tc.ExpectedActions, len(fakeMachineClient.Actions()), fakeMachineClient.Actions())
 			}
@@ -1060,7 +1063,7 @@ func TestDeleteNodeDeployment(t *testing.T) {
 			if res.Code != tc.ExpectedHTTPStatusOnGet {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedHTTPStatusOnGet, res.Code, res.Body.String())
 			}
-			compareWithResult(t, res, tc.ExpectedResponseOnGet)
+			test.CompareWithResult(t, res, tc.ExpectedResponseOnGet)
 		})
 	}
 }
@@ -1145,7 +1148,7 @@ func genTestMachineDeployment(name, rawProviderConfig string, selector map[strin
 }
 
 func genTestCluster(isControllerReady bool) *kubermaticv1.Cluster {
-	cluster := genDefaultCluster()
+	cluster := test.GenDefaultCluster()
 	cluster.Status = kubermaticv1.ClusterStatus{
 		Health: kubermaticv1.ClusterHealth{
 			ClusterHealthStatus: kubermaticv1.ClusterHealthStatus{

--- a/api/pkg/handler/routing_test.go
+++ b/api/pkg/handler/routing_test.go
@@ -101,15 +101,6 @@ func apiUserToKubermaticUser(user apiv1.User) *kubermaticapiv1.User {
 	return test.APIUserToKubermaticUser(user)
 }
 
-func checkStatusCode(wantStatusCode int, recorder *httptest.ResponseRecorder, t *testing.T) {
-	t.Helper()
-	if recorder.Code != wantStatusCode {
-		t.Errorf("Expected status code to be %d, got: %d", wantStatusCode, recorder.Code)
-		t.Error(recorder.Body.String())
-		return
-	}
-}
-
 func TestUpRoute(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest("GET", "/api/v1/healthz", nil)
@@ -119,7 +110,7 @@ func TestUpRoute(t *testing.T) {
 		t.Fatalf("failed to create test endpoint due to %v", err)
 	}
 	ep.ServeHTTP(res, req)
-	checkStatusCode(http.StatusOK, res, t)
+	test.CheckStatusCode(http.StatusOK, res, t)
 }
 
 type clientsSets struct {
@@ -151,66 +142,6 @@ func (k *newSSHKeyV1SliceWrapper) DecodeOrDie(r io.Reader, t *testing.T) *newSSH
 
 // EqualOrDie compares whether expected collection is equal to the actual one
 func (k newSSHKeyV1SliceWrapper) EqualOrDie(expected newSSHKeyV1SliceWrapper, t *testing.T) {
-	t.Helper()
-	if diff := deep.Equal(k, expected); diff != nil {
-		t.Errorf("actual slice is different that the expected one. Diff: %v", diff)
-	}
-}
-
-// newClusterV1SliceWrapper wraps []apiv1.Cluster
-// to provide convenient methods for tests
-type newClusterV1SliceWrapper []apiv1.Cluster
-
-// Sort sorts the collection by CreationTimestamp
-func (k newClusterV1SliceWrapper) Sort() {
-	sort.Slice(k, func(i, j int) bool {
-		return k[i].CreationTimestamp.Before(k[j].CreationTimestamp)
-	})
-}
-
-// DecodeOrDie reads and decodes json data from the reader
-func (k *newClusterV1SliceWrapper) DecodeOrDie(r io.Reader, t *testing.T) *newClusterV1SliceWrapper {
-	t.Helper()
-	dec := json.NewDecoder(r)
-	err := dec.Decode(k)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return k
-}
-
-// EqualOrDie compares whether expected collection is equal to the actual one
-func (k newClusterV1SliceWrapper) EqualOrDie(expected newClusterV1SliceWrapper, t *testing.T) {
-	t.Helper()
-	if diff := deep.Equal(k, expected); diff != nil {
-		t.Errorf("actual slice is different that the expected one. Diff: %v", diff)
-	}
-}
-
-// nodeV1SliceWrapper wraps []apiv1.Node
-// to provide convenient methods for tests
-type nodeV1SliceWrapper []apiv1.Node
-
-// Sort sorts the collection by CreationTimestamp
-func (k nodeV1SliceWrapper) Sort() {
-	sort.Slice(k, func(i, j int) bool {
-		return k[i].CreationTimestamp.Before(k[j].CreationTimestamp)
-	})
-}
-
-// DecodeOrDie reads and decodes json data from the reader
-func (k *nodeV1SliceWrapper) DecodeOrDie(r io.Reader, t *testing.T) *nodeV1SliceWrapper {
-	t.Helper()
-	dec := json.NewDecoder(r)
-	err := dec.Decode(k)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return k
-}
-
-// EqualOrDie compares whether expected collection is equal to the actual one
-func (k nodeV1SliceWrapper) EqualOrDie(expected nodeV1SliceWrapper, t *testing.T) {
 	t.Helper()
 	if diff := deep.Equal(k, expected); diff != nil {
 		t.Errorf("actual slice is different that the expected one. Diff: %v", diff)

--- a/api/pkg/handler/ssh_test.go
+++ b/api/pkg/handler/ssh_test.go
@@ -15,6 +15,7 @@ import (
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
 )
 
 func TestDeleteSSHKey(t *testing.T) {
@@ -40,9 +41,9 @@ func TestDeleteSSHKey(t *testing.T) {
 				/*add users*/
 				genUser("", "john", "john@acme.com"),
 				/*add cluster*/
-				genDefaultCluster(),
+				test.GenDefaultCluster(),
 				/*add ssh keys*/
-				genSSHKey(defaultCreationTimestamp(), "c08aa5c7abf34504f18552846485267d", "first-key", "my-first-project-ID", genDefaultCluster().Name),
+				genSSHKey(defaultCreationTimestamp(), "c08aa5c7abf34504f18552846485267d", "first-key", "my-first-project-ID", test.GenDefaultCluster().Name),
 				genSSHKey(defaultCreationTimestamp(), "abc", "second-key", "my-first-project-ID", "abcd-ID"),
 			},
 			ExistingAPIUser: genAPIUser("john", "john@acme.com"),
@@ -139,9 +140,9 @@ func TestListSSHKeys(t *testing.T) {
 				/*add users*/
 				genUser("", "john", "john@acme.com"),
 				/*add cluster*/
-				genDefaultCluster(),
+				test.GenDefaultCluster(),
 				/*add ssh keys*/
-				genSSHKey(creationTime, "c08aa5c7abf34504f18552846485267d", "first-key", "my-first-project-ID", genDefaultCluster().Name),
+				genSSHKey(creationTime, "c08aa5c7abf34504f18552846485267d", "first-key", "my-first-project-ID", test.GenDefaultCluster().Name),
 				genSSHKey(creationTime.Add(time.Minute), "abc", "second-key", "my-first-project-ID", "abcd-ID"),
 			},
 			ExistingAPIUser: genAPIUser("john", "john@acme.com"),
@@ -204,7 +205,7 @@ func TestCreateSSHKeysEndpoint(t *testing.T) {
 				/*add users*/
 				genUser("", "john", "john@acme.com"),
 				/*add cluster*/
-				genDefaultCluster(),
+				test.GenDefaultCluster(),
 			},
 			ExistingAPIUser: genAPIUser("john", "john@acme.com"),
 		},
@@ -223,9 +224,9 @@ func TestCreateSSHKeysEndpoint(t *testing.T) {
 				/*add users*/
 				genUser("", "john", "john@acme.com"),
 				/*add cluster*/
-				genDefaultCluster(),
+				test.GenDefaultCluster(),
 				/*add sshkeys*/
-				genSSHKey(defaultCreationTimestamp(), "d08aa5d7bce34504f18552846485267c", "my-second-ssh-key", "my-first-project-ID", genDefaultCluster().Name),
+				genSSHKey(defaultCreationTimestamp(), "d08aa5d7bce34504f18552846485267c", "my-second-ssh-key", "my-first-project-ID", test.GenDefaultCluster().Name),
 			},
 			ExistingAPIUser: genAPIUser("john", "john@acme.com"),
 		},

--- a/api/pkg/handler/user_test.go
+++ b/api/pkg/handler/user_test.go
@@ -916,7 +916,3 @@ func genDefaultAPIUser() *apiv1.User {
 func genBinding(projectID, email, group string) *kubermaticapiv1.UserProjectBinding {
 	return test.GenBinding(projectID, email, group)
 }
-
-func genDefaultOwnerBinding() *kubermaticapiv1.UserProjectBinding {
-	return test.GenBinding(genDefaultProject().Name, genDefaultUser().Spec.Email, "owners")
-}


### PR DESCRIPTION
**What this PR does / why we need it**:  this is the fourth step to moving unit tests from handler package to handler_test package

**Special notes for your reviewer**:
The issue for this task: #2359 

**Release note**:
```release-note
NONE
```
