### PR TITLE
ignore prow-related metrics

### DIFF
--- a/config/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
@@ -57,5 +57,5 @@ relabel_configs:
   action: replace
 metric_relabel_configs:
 - source_labels: [namespace]
-  regex: prow-kubermatic-.*
+  regex: .*prow-(e2e|kubermatic)-.*
   action: drop

--- a/config/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
@@ -55,3 +55,7 @@ relabel_configs:
   target_label: endpoint
   replacement: http-metrics
   action: replace
+metric_relabel_configs:
+- source_labels: [namespace]
+  regex: prow-kubermatic-.*
+  action: drop


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that even when scraping kube-state-metrics, we still ignore and not ingest any metric related to prow stuff.

**Release note**:
```release-note
NONE
```
