### PR TITLE
Deploy CSI driver on Hetzner

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -55,3 +55,246 @@ metadata:
 provisioner: kubernetes.io/cinder
 {{ end }}
 
+{{ if .Cluster.Spec.Cloud.Hetzner }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hcloud-csi
+  namespace: kube-system
+data:
+  token: {{ .Cluster.Spec.Cloud.Hetzner.Token|b64enc }}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: hcloud-volumes
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.hetzner.cloud
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hcloud-csi
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hcloud-csi
+rules:
+  # attacher
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  # provisioner
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  # cluster registrar
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "list", "watch", "delete"]
+  # node
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hcloud-csi
+subjects:
+  - kind: ServiceAccount
+    name: hcloud-csi
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: hcloud-csi
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: hcloud-csi-controller
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: hcloud-csi-controller
+  serviceName: hcloud-csi-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hcloud-csi-controller
+    spec:
+      serviceAccount: hcloud-csi
+      containers:
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v1.0.1
+          args:
+            - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+            - --v=5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.0.1
+          args:
+            - --provisioner=csi.hetzner.cloud
+            - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+            - --v=5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+        - name: csi-cluster-driver-registrar
+          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          args:
+            - --pod-info-mount-version="v1"
+            - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+            - --v=5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: hcloud-csi-driver
+          image: hetznercloud/hcloud-csi-driver:1.0.0
+          imagePullPolicy: Always
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-csi
+                  key: token
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: hcloud-csi-node
+  namespace: kube-system
+  labels:
+    app: hcloud-csi
+spec:
+  selector:
+    matchLabels:
+      app: hcloud-csi
+  template:
+    metadata:
+      labels:
+        app: hcloud-csi
+    spec:
+      serviceAccount: hcloud-csi
+      hostNetwork: true
+      containers:
+        - name: csi-node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          securityContext:
+            privileged: true
+        - name: hcloud-csi-driver
+          image: hetznercloud/hcloud-csi-driver:1.0.0
+          imagePullPolicy: Always
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-csi
+                  key: token
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: device-dir
+              mountPath: /dev
+          securityContext:
+            privileged: true
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.hetzner.cloud/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+{{ end }}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.1.15
+export TAG=v0.1.16
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -783,7 +783,8 @@ func supportsStorage(cluster *kubermaticv1.Cluster) bool {
 	return cluster.Spec.Cloud.Openstack != nil ||
 		cluster.Spec.Cloud.Azure != nil ||
 		cluster.Spec.Cloud.AWS != nil ||
-		cluster.Spec.Cloud.VSphere != nil
+		cluster.Spec.Cloud.VSphere != nil ||
+		cluster.Spec.Cloud.Hetzner != nil
 }
 
 func supportsLBs(cluster *kubermaticv1.Cluster) bool {

--- a/api/pkg/crd/kubermatic/v1/addon.go
+++ b/api/pkg/crd/kubermatic/v1/addon.go
@@ -32,7 +32,7 @@ type AddonSpec struct {
 	// Cluster is the reference to the cluster the addon should be installed in
 	Cluster corev1.ObjectReference `json:"cluster"`
 	// Variables is free form data to use for parsing the manifest templates
-	Variables runtime.RawExtension `json:"variables"`
+	Variables runtime.RawExtension `json:"variables,omitempty"`
 }
 
 // AddonList is a list of addons

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -33,7 +33,7 @@ kubermatic:
     addons:
       image:
         repository: "quay.io/kubermatic/addons"
-        tag: "v0.1.15"
+        tag: "v0.1.16"
         pullPolicy: "IfNotPresent"
       # list of Addons to install into every user-cluster. All need to exist in the addons image
       defaultAddons:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Proof this works:

```
$ k get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS    CLAIM                       STORAGECLASS     REASON    AGE
pvc-1d415e4e-1690-11e9-98b8-bae3b722bbb7   20Gi       RWO            Delete           Bound     kube-system/redis-datadir   hcloud-volumes             3s


$ k get pod
NAME                                   READY     STATUS    RESTARTS   AGE
redis-master-7b66d8bf5d-pcd6p          1/1       Running   0          54s

$ k exec -it redis-master-7b66d8bf5d-pcd6p sh
# ls /data
lost+found
# touch /data/newfile
#

root@machinedeployment-kubermatic-p8lh5nnrsw-svvrs-5fd5f75f9d-nmv27:~# mount|grep pvc
/dev/sdb on /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-1d415e4e-1690-11e9-98b8-bae3b722bbb7/globalmount type ext4 (rw,relatime,data=ordered)
/dev/sdb on /var/lib/kubelet/pods/1d4d6d09-1690-11e9-98b8-bae3b722bbb7/volumes/kubernetes.io~csi/pvc-1d415e4e-1690-11e9-98b8-bae3b722bbb7/mount type ext4 (rw,relatime,data=ordered
```

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note cloud provider
Added support for PersistentVolumes on **Hetzner Cloud**
```
