### PR TITLE
Use encrypted weave on Hetzner

### DIFF
--- a/addons/canal/configmap.yaml
+++ b/addons/canal/configmap.yaml
@@ -1,3 +1,4 @@
+{{ if not .Cluster.Spec.Cloud.Hetzner }}
 # This ConfigMap can be used to configure a self-hosted Canal installation.
 kind: ConfigMap
 apiVersion: v1
@@ -58,3 +59,4 @@ data:
         "Type": "vxlan"
       }
     }
+{{ end }}

--- a/addons/canal/crd-globalbgpconfigs.yaml.yaml
+++ b/addons/canal/crd-globalbgpconfigs.yaml.yaml
@@ -1,3 +1,4 @@
+{{ if not .Cluster.Spec.Cloud.Hetzner }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,3 +15,4 @@ spec:
     kind: GlobalBGPConfig
     plural: globalbgpconfigs
     singular: globalbgpconfig
+{{ end }}

--- a/addons/canal/crd-globalfelixconfigs.yaml.yaml
+++ b/addons/canal/crd-globalfelixconfigs.yaml.yaml
@@ -1,3 +1,4 @@
+{{ if not .Cluster.Spec.Cloud.Hetzner }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,3 +15,4 @@ spec:
     kind: GlobalFelixConfig
     plural: globalfelixconfigs
     singular: globalfelixconfig
+{{ end }}

--- a/addons/canal/crd-globalnetworkpolicies.yaml.yaml
+++ b/addons/canal/crd-globalnetworkpolicies.yaml.yaml
@@ -1,3 +1,4 @@
+{{ if not .Cluster.Spec.Cloud.Hetzner }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,3 +15,4 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+{{ end }}

--- a/addons/canal/crd-ippools.yaml.yaml
+++ b/addons/canal/crd-ippools.yaml.yaml
@@ -1,3 +1,4 @@
+{{ if not .Cluster.Spec.Cloud.Hetzner }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,3 +15,4 @@ spec:
     kind: IPPool
     plural: ippools
     singular: ippool
+{{ end }}

--- a/addons/canal/daemonset.yaml
+++ b/addons/canal/daemonset.yaml
@@ -1,3 +1,4 @@
+{{ if not .Cluster.Spec.Cloud.Hetzner }}
 # This manifest installs the calico/node container, as well
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
@@ -175,3 +176,4 @@ spec:
         - name: flannel-cfg
           configMap:
             name: canal-config
+{{ end }}

--- a/addons/canal/rbac.yaml
+++ b/addons/canal/rbac.yaml
@@ -1,3 +1,4 @@
+{{ if not .Cluster.Spec.Cloud.Hetzner }}
 # Calico Roles
 # Pulled from https://docs.projectcalico.org/v2.5/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
 kind: ClusterRole
@@ -124,3 +125,4 @@ subjects:
 - kind: ServiceAccount
   name: canal
   namespace: kube-system
+{{ end }}

--- a/addons/canal/serviceaccount.yaml
+++ b/addons/canal/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if not .Cluster.Spec.Cloud.Hetzner }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,4 @@ metadata:
     k8s-app: canal
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+{{ end }}

--- a/addons/canal/weave.yaml
+++ b/addons/canal/weave.yaml
@@ -1,0 +1,220 @@
+{{ if .Cluster.Spec.Cloud.Hetzner }}
+{{/* We use weave on Hetzner because it Hetner has no VPC functionality and weave is the only CNI that encrypts the pod networking traffic */}}
+{{/* Note however that this encryption results in a _hefty_ performance penalty: https://itnext.io/benchmark-results-of-kubernetes-network-plugins-cni-over-10gbit-s-network-36475925a560 */}}
+{{/* We should get rid of it ASAP when Hetzner has VPCs */}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: weave-passwd
+  namespace: kube-system
+data:
+{{/* We need something that is deterministic, unlikely to change and hard to guess - just use the clusters UID */}}
+  weave-passwd: {{ .Cluster.UID | toString | b64enc}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: weave-net
+  annotations:
+  labels:
+    name: weave-net
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+roleRef:
+  kind: ClusterRole
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - weave-net
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: weave-net
+  labels:
+    name: weave-net
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: weave-net
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: weave-net
+    namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  annotations:
+  labels:
+    name: weave-net
+  namespace: kube-system
+spec:
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        name: weave-net
+    spec:
+      containers:
+        - name: weave
+          command:
+            - /home/weave/launch.sh
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: IPALLOC_RANGE
+              value: "{{first .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks}}"
+            - name: WEAVE_METRICS_ADDR
+              value: '127.0.0.1:6782'
+            - name: WEAVE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: weave-passwd
+                  key: weave-passwd
+          image: 'docker.io/weaveworks/weave-kube:2.5.0'
+          readinessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 6784
+          resources:
+            requests:
+              cpu: 10m
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: weavedb
+              mountPath: /weavedb
+            - name: cni-bin
+              mountPath: /host/opt
+            - name: cni-bin2
+              mountPath: /host/home
+            - name: cni-conf
+              mountPath: /host/etc
+            - name: dbus
+              mountPath: /host/var/lib/dbus
+            - name: lib-modules
+              mountPath: /lib/modules
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+        - name: weave-npc
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          image: 'docker.io/weaveworks/weave-npc:2.5.0'
+          resources:
+            requests:
+              cpu: 10m
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+      hostNetwork: true
+      hostPID: true
+      restartPolicy: Always
+      securityContext:
+        seLinuxOptions: {}
+      serviceAccountName: weave-net
+      tolerations:
+        - operator: Exists
+      volumes:
+        - name: weavedb
+          hostPath:
+            path: /var/lib/weave
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-bin2
+          hostPath:
+            path: /home
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: dbus
+          hostPath:
+            path: /var/lib/dbus
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+  updateStrategy:
+    type: RollingUpdate
+{{ end }}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.1.15
+export TAG=v0.1.17-dev
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -33,7 +33,7 @@ kubermatic:
     addons:
       image:
         repository: "quay.io/kubermatic/addons"
-        tag: "v0.1.15"
+        tag: "v0.1.17-dev"
         pullPolicy: "IfNotPresent"
       # list of Addons to install into every user-cluster. All need to exist in the addons image
       defaultAddons:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I'd love to rename the `canal` addon to something more generic like `networking` but I think this will cause issues for existing clusters, because they already have a `canal` addon which we can't remove because that will create service disruptions - And allowing both the `canal` and a new `networking` addon would mean we can never change anything in that new addon because that would mean the two fight each other in older clusters

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Clusters created on Hetzner will now by default use encrypted Weave as CNI
```

/hold

Addon image tag has to get bumped

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubermatic/kubermatic/2614)
<!-- Reviewable:end -->
