### PR TITLE
Update Ark to 0.10

### DIFF
--- a/config/backup/ark-config/Chart.yaml
+++ b/config/backup/ark-config/Chart.yaml
@@ -1,3 +1,3 @@
 description: A Helm chart for configuring Ark
 name: ark-config
-version: 1.0.0
+version: 1.1.0

--- a/config/backup/ark-config/templates/config.yaml
+++ b/config/backup/ark-config/templates/config.yaml
@@ -1,5 +1,8 @@
+{{ range $name, $config := .Values.ark.backupStorageLocations }}
 apiVersion: ark.heptio.com/v1
-kind: Config
+kind: BackupStorageLocation
 metadata:
-  name: default
-{{ .Values.ark.configuration | toYaml }}
+  name: {{ $name }}
+spec:
+{{ $config | toYaml | indent 2 }}
+{{ end }}

--- a/config/backup/ark-config/values.yaml
+++ b/config/backup/ark-config/values.yaml
@@ -1,42 +1,27 @@
 ark:
-  # see https://heptio.github.io/ark/v0.9.0/config-definition
-  configuration:
-    # If you are using volumes backed by cloud provider
-    # storages, you can enable this option to use the provider's
-    # native API to perform snapshots for you.
-    #persistentVolumeProvider:
-    #  name:
-    #  config:
-    #    region:
-    #    apiTimeout:
+  # define one of your backupStorageLocations as the default
+  defaultBackupStorageLocation: aws
 
-    # In all cases, you need to specify where backups should be
-    # placed. This can either be a cloud-native storage (like
-    # AWS S3) or your own S3-compatible storage (like Minio,
-    # configure "aws" in that case).
-    backupStorageProvider:
-      name: aws|gcp|azure
-      bucket: myclusterbackups
+  # see https://heptio.github.io/ark/v0.10.0/api-types/backupstoragelocation.html
+  #backupStorageLocations:
+  #  aws:
+  #    provider: aws
+  #    objectStorage:
+  #      bucket: myclusterbackups
+  #    config:
+  #      region: eu-west-1
 
-      # provider specific configuration, for example for AWS S3
+  # optionally define some of your volumeSnapshotLocations as the default;
+  # each element in the list must be a string of the form "provider:location"
+  defaultVolumeSnapshotLocations:
+    - aws:aws
+
+  # see https://heptio.github.io/ark/v0.10.0/api-types/volumesnapshotlocation.html
+  volumeSnapshotLocations:
+    aws:
+      provider: aws
       config:
         region: eu-west-1
-        #s3Url: ...
-        #s3ForcePathStyle: "true" or "false" # must be a string
-        #kmsKeyId: ...
-
-      # If you are making use of restic to perform file-based
-      # snapshots of your volumes, configure the bucket name
-      # inside your backupStorageProvider where restic should
-      # create its repository. If you leave this empty, no
-      # restic daemonset will be created.
-      #resticLocation: resticbackups
-
-    backupSyncPeriod: 60m
-    gcSyncPeriod: 60m
-    scheduleSyncPeriod: 1m
-    resourcePriorities: []
-    restoreOnlyMode: false
 
   # glob expressions to find schedule defitions
   schedulesPath: schedules/*

--- a/config/backup/ark-config/values.yaml
+++ b/config/backup/ark-config/values.yaml
@@ -1,6 +1,6 @@
 ark:
   # define one of your backupStorageLocations as the default
-  defaultBackupStorageLocation: aws
+  #defaultBackupStorageLocation: aws
 
   # see https://heptio.github.io/ark/v0.10.0/api-types/backupstoragelocation.html
   #backupStorageLocations:
@@ -13,15 +13,15 @@ ark:
 
   # optionally define some of your volumeSnapshotLocations as the default;
   # each element in the list must be a string of the form "provider:location"
-  defaultVolumeSnapshotLocations:
-    - aws:aws
+  #defaultVolumeSnapshotLocations:
+  #  - aws:aws
 
   # see https://heptio.github.io/ark/v0.10.0/api-types/volumesnapshotlocation.html
-  volumeSnapshotLocations:
-    aws:
-      provider: aws
-      config:
-        region: eu-west-1
+  #volumeSnapshotLocations:
+  #  aws:
+  #    provider: aws
+  #    config:
+  #      region: eu-west-1
 
   # glob expressions to find schedule defitions
   schedulesPath: schedules/*

--- a/config/backup/ark/Chart.yaml
+++ b/config/backup/ark/Chart.yaml
@@ -1,13 +1,3 @@
-apiVersion: v1
-appVersion: 0.9.1
 description: A Helm chart for ark
 name: ark
-version: 1.2.0
-home: https://heptio.com/products/#heptio-ark
-sources:
-- https://github.com/heptio/ark
-maintainers:
-  - name: domcar
-    email: d-caruso@hotmail.it
-  - name: unguiculus
-    email: unguiculus@gmail.com
+version: 1.3.0

--- a/config/backup/ark/templates/customresourcedefinitions.yaml
+++ b/config/backup/ark/templates/customresourcedefinitions.yaml
@@ -14,14 +14,31 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: configs.ark.heptio.com
+  name: backupstoragelocations.ark.heptio.com
+  labels:
+    component: ark
 spec:
   group: ark.heptio.com
   version: v1
   scope: Namespaced
   names:
-    plural: configs
-    kind: Config
+    plural: backupstoragelocations
+    kind: BackupStorageLocation
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotlocations.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: volumesnapshotlocations
+    kind: VolumeSnapshotLocation
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/config/backup/ark/templates/daemonset.yaml
+++ b/config/backup/ark/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.ark.configuration.backupStorageProvider.resticLocation }}
+{{ if .Values.ark.restic }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/config/backup/ark/templates/deployment.yaml
+++ b/config/backup/ark/templates/deployment.yaml
@@ -27,6 +27,15 @@ spec:
             - /ark
           args:
             - server
+            {{- range .Values.ark.serverFlags }}
+            - '{{ . }}'
+            {{- end }}
+            {{- with .Values.ark.defaultBackupStorageLocation }}
+            - '--default-backup-storage-location={{ . }}'
+            {{- end }}
+            {{- with .Values.ark.defaultVolumeSnapshotLocations }}
+            - '--default-volume-snapshot-locations={{ . | join "," }}'
+            {{- end }}
           {{- if .Values.ark.credentials.azure }}
           envFrom:
             - secretRef:

--- a/config/backup/ark/values.yaml
+++ b/config/backup/ark/values.yaml
@@ -4,22 +4,25 @@ ark:
   # that also contains the restic binary
   image:
     repository: gcr.io/heptio-images/ark
-    tag: v0.9.1
+    tag: v0.10.0
     pullPolicy: IfNotPresent
 
-  # The value itself is not important for this chart, but it needs
-  # to know whether or not to enable the restic daemonset. Make sure
-  # to use a single values.yaml shared with the ark-config chart to
-  # not let this drift apart.
-  #configuration:
-  #  backupStorageProvider:
-  #    resticLocation: resticbackups
+  # CLI flags to pass to ark server; note that the two flags
+  # `default-backup-storage-location` and `default-volume-snapshot-locations`
+  # are automatically set via the ark-config Helm chart's
+  # values.
+  serverFlags:
+    - --metrics-address=:8085
+    - --backup-sync-period=1m
+
+  # whether or not to create a restic daemonset
+  # restic: true
 
   # configure the credentials used to make snapshots (when using
   # persistentVolumeProvider) and to store backups; you can enable
   # multiple credentials, if for some reason you run on GCP and
   # still want to make restic snapshots to be stored in AWS S3.
-  credentials:
+  credentials: {}
     #aws:
     #  accessKey: ...
     #  secretKey: ...


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Ark to 0.10. This version has an important bugfix for its metrics which are now initialized with 0 after Ark starts. This makes it much, much easier to define proper alerting rules in Prometheus.

**Release note**:
```release-note
Updated Ark to 0.10 [requires manual configuration update]
```
