### PR TITLE
Add additionalPrinterColumns to cluster crd

### DIFF
--- a/config/kubermatic/crd/crd-clusters.yaml
+++ b/config/kubermatic/crd/crd-clusters.yaml
@@ -11,3 +11,17 @@ spec:
     singular: cluster
   scope: Cluster
   version: v1
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
+  - JSONPath: .spec.humanReadableName
+    name: HumanReadableName
+    type: string
+  - JSONPath: .status.userEmail
+    name: Owner
+    type: string


### PR DESCRIPTION
**What this PR does / why we need it**:

As requested by Arvato, this adds some additionalPrinterColumns to the Kubermatic CRD. You can already check it out on the dev.kubermatic.io seed via `kubectl get cluster`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Running `kubectl get cluster` in a seed now shows some more details
```

/assign @mrIncompetent 
