### PR TITLE
Improve seed-level alerts

### DIFF
--- a/config/monitoring/prometheus/rules/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic.yaml
@@ -14,7 +14,7 @@ groups:
     annotations:
       message: Cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticclusterdeletiontakestoolong
-    expr: (time() - kubermatic_cluster_deleted) > 30*60
+    expr: (time() - max by (cluster) (kubermatic_cluster_deleted)) > 30*60
     for: 0m
     labels:
       severity: warning

--- a/config/monitoring/prometheus/rules/kubernetes-system.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes-system.yaml
@@ -19,16 +19,30 @@ groups:
     labels:
       severity: warning
 
+  # a dedicated rule for pods to include more helpful labels in the message like the instance and job name
   - alert: KubeClientErrors
     annotations:
       message: >
-        Kubernetes API server client {{ $labels.job }}/{{ $labels.instance }} is experiencing
-        {{ printf "%0.0f" $value }}% errors.
+        The pod {{ $labels.namespace }}/{{ $labels.pod }} is experiencing {{ printf "%0.0f" $value }}% errors.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclienterrors
     expr: |
-      (sum(rate(rest_client_requests_total{code!~"2..|404"}[5m])) by (instance, job)
+      (sum(rate(rest_client_requests_total{code=~"5..",job="pods"}[5m])) by (namespace, pod)
         /
-      sum(rate(rest_client_requests_total[5m])) by (instance, job))
+      sum(rate(rest_client_requests_total{job="pods"}[5m])) by (namespace, pod))
+      * 100 > 1
+    for: 15m
+    labels:
+      severity: warning
+
+  - alert: KubeClientErrors
+    annotations:
+      message: >
+        The kubelet on {{ $labels.instance }} is experiencing {{ printf "%0.0f" $value }}% errors.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclienterrors
+    expr: |
+      (sum(rate(rest_client_requests_total{code=~"5..",job="kubelet"}[5m])) by (instance)
+        /
+      sum(rate(rest_client_requests_total{job="kubelet"}[5m])) by (instance))
       * 100 > 1
     for: 15m
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
We run two replicas for the controller manager in each user cluster. This means that Prometheus will scrape both and all of its metrics are duplicated, like so:

```
kubermatic_cluster_deleted{cluster="g7dh92t8hm",instance="10.12.12.39:8085",job="pods",namespace="kubermatic",pod="controller-manager-v1-67f89ff78f-dtw4f",pod_template_hash="2394599349",role="controller-manager",version="v1"}
kubermatic_cluster_deleted{cluster="g7dh92t8hm",instance="10.12.13.40:8085",job="pods",namespace="kubermatic",pod="controller-manager-v1-67f89ff78f-n5zcm",pod_template_hash="2394599349",role="controller-manager",version="v1"}
```

This will lead to duplicated alerts. This PR groups the cluster deletion metric by cluster and thereby de-duplicates the alerts.

---

This PR also improves the error messages for apiserver client error rates. In the old implementation, when a pod has a high error rate, we would get this alert:

> Kubernetes API server client pods/10.44.189.12:8085 is experiencing 7% errors.

This is somewhere between useless and actively hostile. The change in this PR acknowledge the difference between pods and kubelets and creates two distinct alerts with customized formatting. This has the further advantage that if a pod is rescheduled to a different node, the alert stays the same because we do not group pod alerts by instance anymore.

Based on feedback by @alvaroaleman we also do not alert on 404 errors anymore and consider 3XX errors anymore (not sure if the apiserver would ever respond with a 3XX), but only consider 5XX as errors.

**Release note**:
```release-note
NONE
```
