### PR TITLE
Update kube-state-metrics to 1.5.0

### DIFF
--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -28,7 +28,7 @@ var (
 
 const (
 	name    = "kube-state-metrics"
-	version = "v1.5.0-beta.0"
+	version = "v1.5.0"
 )
 
 // Deployment returns the kube-state-metrics Deployment

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -27,9 +27,8 @@ var (
 )
 
 const (
-	name = "kube-state-metrics"
-
-	version = "v1.3.1"
+	name    = "kube-state-metrics"
+	version = "v1.5.0-beta.0"
 )
 
 // Deployment returns the kube-state-metrics Deployment

--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -324,16 +324,4 @@ groups:
     for: 30m
     labels:
       severity: warning
-
-- name: kube-state-metrics
-  rules:
-  - alert: KubeStateMetricsHighErrorRate
-    annotations:
-      message: >
-        kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-        when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-    expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-    for: 15m
-    labels:
-      severity: warning
 `

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -531,18 +531,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -527,18 +527,6 @@ data:
         for: 30m
         labels:
           severity: warning
-
-    - name: kube-state-metrics
-      rules:
-      - alert: KubeStateMetricsHighErrorRate
-        annotations:
-          message: >
-            kube-state-metrics is experiencing {{ printf "%0.0f" $value }} errors / 5min
-            when scraping {{ $labels.resource }} resources on {{ $labels.instance }}.
-        expr: sum(rate(ksm_scrape_error_total[5m])) by (instance, resource) > 0.1
-        for: 15m
-        labels:
-          severity: warning
 metadata:
   creationTimestamp: null
   labels:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -34,7 +34,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.5.0-beta.0
+    tag: v1.5.0
   resizer:
     image:
       repository: k8s.gcr.io/addon-resizer

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.3.1
+    tag: v1.5.0-beta.0
   resizer:
     image:
       repository: k8s.gcr.io/addon-resizer


### PR DESCRIPTION
**What this PR does / why we need it**:
This update enables us to build proper alerts for OOMKilled pods (see #2259).

**Release note**:
```release-note monitoring
Updated kube-state-metrics to 1.5.0
```
