### PR TITLE
Fix Node Deployments update method

### DIFF
--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -1081,9 +1081,11 @@ func patchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 			return nil, fmt.Errorf("failed to create machine deployment from template: %v", err)
 		}
 
-		// Only spec will be updated by a patch.
+		// Only the fields from NodeDeploymentSpec will be updated by a patch.
 		// It ensures that the name and resource version are set and the selector stays the same.
-		machineDeployment.Spec = patchedMachineDeployment.Spec
+		machineDeployment.Spec.Template.Spec = patchedMachineDeployment.Spec.Template.Spec
+		machineDeployment.Spec.Replicas = patchedMachineDeployment.Spec.Replicas
+		machineDeployment.Spec.Paused = patchedMachineDeployment.Spec.Paused
 
 		machineDeployment, err = machineClient.ClusterV1alpha1().MachineDeployments(machineDeployment.Namespace).Update(machineDeployment)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes Node Deployments update method. Previously it `spec.selector` was changed and MachineDeployment was losing old MachineSet, now the field remain untouched.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes #2632

**Special notes for your reviewer**: n/a

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
