### PR TITLE
define alert for containers that have been OOMKilled

### DIFF
--- a/config/monitoring/prometheus/rules/kubernetes-resources.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes-resources.yaml
@@ -84,3 +84,16 @@ groups:
   #   for: 15m
   #   labels:
   #     severity: warning
+
+  - alert: KubePodOOMKilled
+    annotations:
+      message:
+        Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }}
+        has been OOMKilled {{ $value }} times in the last 30 minutes.
+    expr: |
+      (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 30m >= 2)
+      and
+      ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[30m]) == 1
+    for: 0m
+    labels:
+      severity: warning


### PR DESCRIPTION
**What this PR does / why we need it**:
Alert on containers that have been OOMKilled at least twice in the last 30 minutes. The implementation is based on https://github.com/kubernetes/kube-state-metrics/pull/535#issuecomment-446682139.

**Which issue(s) this PR fixes**:
Fixes #2259

**Release note**:
```release-note
NONE
```
