### PR TITLE
define typical resource usage for elasticsearch/kibana

### DIFF
--- a/config/logging/elasticsearch/templates/es-data-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-data-stateful.yaml
@@ -84,6 +84,10 @@ spec:
             initialDelaySeconds: 120
             timeoutSeconds: 10
             periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1500Mi
           volumeMounts:
             - name: storage
               mountPath: /usr/share/elasticsearch/data

--- a/config/logging/elasticsearch/templates/es-master-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-master-stateful.yaml
@@ -86,6 +86,10 @@ spec:
             initialDelaySeconds: 120
             timeoutSeconds: 10
             periodSeconds: 10
+          resources:
+            requests:
+              cpu: 75m
+              memory: 350Mi
           volumeMounts:
             - name: storage
               mountPath: /usr/share/elasticsearch/data

--- a/config/logging/kibana/templates/kibana-deployment.yaml
+++ b/config/logging/kibana/templates/kibana-deployment.yaml
@@ -28,6 +28,7 @@ spec:
             cpu: 1000m
           requests:
             cpu: 100m
+            memory: 300Mi
         env:
           - name: ELASTICSEARCH_URL
             value: http://es-data:9200


### PR DESCRIPTION
**What this PR does / why we need it**:
To aid in auto scaling clusters, this defines the resource usages for Elasticsearch/Kibana based on our 4 running clusters.

**Release note**:
```release-note
NONE
```
