### PR TITLE
Make alerts less noisy

### DIFF
--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -145,7 +145,7 @@ groups:
       message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
     expr: |
       sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-    for: 10m
+    for: 20m
     labels:
       severity: warning
 
@@ -179,7 +179,7 @@ groups:
       message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
     expr: |
       sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-    for: 3m
+    for: 15m
     labels:
       severity: critical
 
@@ -188,7 +188,7 @@ groups:
       message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
     expr: |
       etcd_server_has_leader{job="etcd"} == 0
-    for: 1m
+    for: 15m
     labels:
       severity: critical
 
@@ -279,7 +279,7 @@ groups:
     annotations:
       message: Kubernetes apiserver has disappeared from Prometheus target discovery.
     expr: absent(up{job="apiserver"} == 1)
-    for: 3m
+    for: 15m
     labels:
       severity: critical
 
@@ -287,7 +287,7 @@ groups:
     annotations:
       message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
     expr: absent(up{job="controller-manager"} == 1)
-    for: 3m
+    for: 15m
     labels:
       severity: critical
 
@@ -295,7 +295,7 @@ groups:
     annotations:
       message: Kubernetes scheduler has disappeared from Prometheus target discovery.
     expr: absent(up{job="scheduler"} == 1)
-    for: 3m
+    for: 15m
     labels:
       severity: critical
 
@@ -303,7 +303,7 @@ groups:
     annotations:
       message: Machine controller has disappeared from Prometheus target discovery.
     expr: absent(up{job="machine-controller"} == 1)
-    for: 3m
+    for: 15m
     labels:
       severity: critical
 
@@ -311,7 +311,7 @@ groups:
     annotations:
       message: Etcd has disappeared from Prometheus target discovery.
     expr: absent(up{job="etcd"} == 1)
-    for: 3m
+    for: 15m
     labels:
       severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -352,7 +352,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -386,7 +386,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -395,7 +395,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -486,7 +486,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -494,7 +494,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -502,7 +502,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -510,7 +510,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -518,7 +518,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -348,7 +348,7 @@ data:
           message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
         expr: |
           sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
-        for: 10m
+        for: 20m
         labels:
           severity: warning
 
@@ -382,7 +382,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
         expr: |
           sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -391,7 +391,7 @@ data:
           message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
         expr: |
           etcd_server_has_leader{job="etcd"} == 0
-        for: 1m
+        for: 15m
         labels:
           severity: critical
 
@@ -482,7 +482,7 @@ data:
         annotations:
           message: Kubernetes apiserver has disappeared from Prometheus target discovery.
         expr: absent(up{job="apiserver"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -490,7 +490,7 @@ data:
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
         expr: absent(up{job="controller-manager"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -498,7 +498,7 @@ data:
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
         expr: absent(up{job="scheduler"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -506,7 +506,7 @@ data:
         annotations:
           message: Machine controller has disappeared from Prometheus target discovery.
         expr: absent(up{job="machine-controller"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 
@@ -514,7 +514,7 @@ data:
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.
         expr: absent(up{job="etcd"} == 1)
-        for: 3m
+        for: 15m
         labels:
           severity: critical
 


### PR DESCRIPTION
**What this PR does / why we need it**:
During CPU/memory pressure on clusters, a lot of pods are shuffled around, triggering tons of alerts that we cannot do anything about. This PR increases the threshold so we trigger fewer alerts and hopefully only when there's an actual issue.

In the future we're thinking about getting rid of these alerts alltogether, but for now this should at least help against alerting fatigue.

**Release note**:
```release-note
NONE
```
