### PR TITLE
Remove redundant enable_node_deployments flag

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -67,7 +67,6 @@ kubermatic:
       pullPolicy: "IfNotPresent"
     config: |
       {
-        "enable_node_deployments": false,
         "share_kubeconfig": false,
         "show_demo_info": false,
         "show_terms_of_service": false,


### PR DESCRIPTION
**What this PR does / why we need it**: Removes redundant enable_node_deployments flag. Follow up of https://github.com/kubermatic/secrets/pull/222 and https://github.com/kubermatic/dashboard-v2/pull/986.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: n/a

**Special notes for your reviewer**: n/a

**Documentation**: n/a
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
