### PR TITLE
new endpoint for node deployment events

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -994,14 +994,14 @@
     },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodedeployments/{nodedeployment_id}/nodes/events": {
       "get": {
-        "description": "If the value is false then normal events are returned. If the query parameter is missing method returns all events.",
+        "description": "If the value is 'normal' then normal events are returned. If the query parameter is missing method returns all events.",
         "produces": [
           "application/json"
         ],
         "tags": [
           "project"
         ],
-        "summary": "Lists node deployment events. If query parameter `warning` is set to true then only warning events are retrieved.",
+        "summary": "Lists node deployment events. If query parameter `type` is set to `warning` then only warning events are retrieved.",
         "operationId": "listNodeDeploymentNodesEvents",
         "parameters": [
           {
@@ -1027,7 +1027,7 @@
           },
           {
             "type": "string",
-            "name": "Warning",
+            "name": "Type",
             "in": "query"
           },
           {
@@ -3440,7 +3440,7 @@
           "x-go-name": "Source"
         },
         "type": {
-          "description": "Type of this event (Normal, Warning), new types could be added in the future",
+          "description": "Type of this event (normal, warning), new types could be added in the future",
           "type": "string",
           "x-go-name": "Type"
         }

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3404,11 +3404,6 @@
           "type": "string",
           "x-go-name": "Message"
         },
-        "reason": {
-          "description": "This should be a short, machine understandable string that gives the reason\nfor the transition into the object's current status.",
-          "type": "string",
-          "x-go-name": "Reason"
-        },
         "type": {
           "description": "Type of this event (normal, warning), new types could be added in the future",
           "type": "string",
@@ -3421,6 +3416,10 @@
       "type": "object",
       "title": "EventList is an events response structure.",
       "properties": {
+        "Name": {
+          "description": "The object name that those events are about.",
+          "type": "string"
+        },
         "events": {
           "description": "List of events",
           "type": "array",
@@ -3428,11 +3427,6 @@
             "$ref": "#/definitions/Event"
           },
           "x-go-name": "Events"
-        },
-        "involvedObjectName": {
-          "description": "The object that those events are about.",
-          "type": "string",
-          "x-go-name": "InvolvedObjectName"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3416,10 +3416,6 @@
       "type": "object",
       "title": "EventList is an events response structure.",
       "properties": {
-        "Name": {
-          "description": "The object name that those events are about.",
-          "type": "string"
-        },
         "events": {
           "description": "List of events",
           "type": "array",
@@ -3427,6 +3423,11 @@
             "$ref": "#/definitions/Event"
           },
           "x-go-name": "Events"
+        },
+        "name": {
+          "description": "The object name that those events are about.",
+          "type": "string",
+          "x-go-name": "Name"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3399,50 +3399,40 @@
       "type": "object",
       "title": "Event is a report of an event somewhere in the cluster.",
       "properties": {
-        "count": {
-          "description": "The number of times this event has occurred.",
-          "type": "integer",
-          "format": "int32",
-          "x-go-name": "Count"
-        },
-        "firstTimestamp": {
-          "$ref": "#/definitions/Time"
-        },
-        "involvedObject": {
-          "$ref": "#/definitions/ObjectReference"
-        },
-        "lastTimestamp": {
-          "$ref": "#/definitions/Time"
-        },
         "message": {
           "description": "A human-readable description of the status of this operation.",
           "type": "string",
           "x-go-name": "Message"
-        },
-        "name": {
-          "description": "Name of the event.",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "namespace": {
-          "description": "Namespace of the event.",
-          "type": "string",
-          "x-go-name": "Namespace"
         },
         "reason": {
           "description": "This should be a short, machine understandable string that gives the reason\nfor the transition into the object's current status.",
           "type": "string",
           "x-go-name": "Reason"
         },
-        "source": {
-          "description": "The component reporting this event. Should be a short machine understandable string.",
-          "type": "string",
-          "x-go-name": "Source"
-        },
         "type": {
           "description": "Type of this event (normal, warning), new types could be added in the future",
           "type": "string",
           "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "EventList": {
+      "type": "object",
+      "title": "EventList is an events response structure.",
+      "properties": {
+        "events": {
+          "description": "List of events",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Event"
+          },
+          "x-go-name": "Events"
+        },
+        "involvedObjectName": {
+          "description": "The object that those events are about.",
+          "type": "string",
+          "x-go-name": "InvolvedObjectName"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
@@ -4063,28 +4053,6 @@
           "description": "Name represents human readable name for the resource",
           "type": "string",
           "x-go-name": "Name"
-        }
-      },
-      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-    },
-    "ObjectReference": {
-      "type": "object",
-      "title": "ObjectReference contains enough information to let you inspect or modify the referred object.",
-      "properties": {
-        "kind": {
-          "description": "Kind of the referent.",
-          "type": "string",
-          "x-go-name": "Kind"
-        },
-        "name": {
-          "description": "Name of the referent.",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "namespace": {
-          "description": "Namespace of the referent.",
-          "type": "string",
-          "x-go-name": "Namespace"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -992,6 +992,74 @@
         }
       }
     },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodedeployments/{nodedeployment_id}/nodes/events": {
+      "get": {
+        "description": "If the value is false then normal events are returned. If the query parameter is missing method returns all events.",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "project"
+        ],
+        "summary": "Lists node deployment events. If query parameter `warning` is set to true then only warning events are retrieved.",
+        "operationId": "listNodeDeploymentNodesEvents",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Warning",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "NodeDeploymentID",
+            "name": "nodedeployment_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Event",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Event"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes": {
       "get": {
         "description": "Lists nodes that belong to the given cluster",
@@ -3327,6 +3395,58 @@
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/handler"
     },
+    "Event": {
+      "type": "object",
+      "title": "Event is a report of an event somewhere in the cluster.",
+      "properties": {
+        "count": {
+          "description": "The number of times this event has occurred.",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "Count"
+        },
+        "firstTimestamp": {
+          "$ref": "#/definitions/Time"
+        },
+        "involvedObject": {
+          "$ref": "#/definitions/ObjectReference"
+        },
+        "lastTimestamp": {
+          "$ref": "#/definitions/Time"
+        },
+        "message": {
+          "description": "A human-readable description of the status of this operation.",
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "name": {
+          "description": "Name of the event.",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "namespace": {
+          "description": "Namespace of the event.",
+          "type": "string",
+          "x-go-name": "Namespace"
+        },
+        "reason": {
+          "description": "This should be a short, machine understandable string that gives the reason\nfor the transition into the object's current status.",
+          "type": "string",
+          "x-go-name": "Reason"
+        },
+        "source": {
+          "description": "The component reporting this event. Should be a short machine understandable string.",
+          "type": "string",
+          "x-go-name": "Source"
+        },
+        "type": {
+          "description": "Type of this event (Normal, Warning), new types could be added in the future",
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
     "ExecConfig": {
       "description": "See the client.authentiction.k8s.io API group for specifications of the exact input\nand output format",
       "type": "object",
@@ -3943,6 +4063,28 @@
           "description": "Name represents human readable name for the resource",
           "type": "string",
           "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "ObjectReference": {
+      "type": "object",
+      "title": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+      "properties": {
+        "kind": {
+          "description": "Kind of the referent.",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "name": {
+          "description": "Name of the referent.",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "namespace": {
+          "description": "Namespace of the referent.",
+          "type": "string",
+          "x-go-name": "Namespace"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -667,8 +667,8 @@ type NodeDeploymentSpec struct {
 
 // EventList is an events response structure.
 type EventList struct {
-	// The object that those events are about.
-	InvolvedObjectName string `json:"involvedObjectName"`
+	// The object name that those events are about.
+	Name string `json:"Name"`
 
 	// List of events
 	Events []Event `json:"events"`
@@ -676,10 +676,6 @@ type EventList struct {
 
 // Event is a report of an event somewhere in the cluster.
 type Event struct {
-	// This should be a short, machine understandable string that gives the reason
-	// for the transition into the object's current status.
-	Reason string `json:"reason,omitempty"`
-
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty"`
 

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -701,7 +701,7 @@ type Event struct {
 	// The number of times this event has occurred.
 	Count int32 `json:"count,omitempty"`
 
-	// Type of this event (Normal, Warning), new types could be added in the future
+	// Type of this event (normal, warning), new types could be added in the future
 	Type string `json:"type,omitempty"`
 
 	// The time at which the event was first recorded.

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -665,29 +665,17 @@ type NodeDeploymentSpec struct {
 	Paused *bool `json:"paused,omitempty"`
 }
 
-// ObjectReference contains enough information to let you inspect or modify the referred object.
-type ObjectReference struct {
-	// Kind of the referent.
-	Kind string `json:"kind,omitempty"`
+// EventList is an events response structure.
+type EventList struct {
+	// The object that those events are about.
+	InvolvedObjectName string `json:"involvedObjectName"`
 
-	// Namespace of the referent.
-	Namespace string `json:"namespace,omitempty"`
-
-	// Name of the referent.
-	Name string `json:"name,omitempty"`
+	// List of events
+	Events []Event `json:"events"`
 }
 
 // Event is a report of an event somewhere in the cluster.
 type Event struct {
-	// Namespace of the event.
-	Namespace string `json:"namespace,omitempty"`
-
-	// Name of the event.
-	Name string `json:"name,omitempty"`
-
-	// The object that this event is about.
-	InvolvedObject ObjectReference `json:"involvedObject"`
-
 	// This should be a short, machine understandable string that gives the reason
 	// for the transition into the object's current status.
 	Reason string `json:"reason,omitempty"`
@@ -695,18 +683,6 @@ type Event struct {
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty"`
 
-	// The component reporting this event. Should be a short machine understandable string.
-	Source string `json:"source,omitempty"`
-
-	// The number of times this event has occurred.
-	Count int32 `json:"count,omitempty"`
-
 	// Type of this event (normal, warning), new types could be added in the future
 	Type string `json:"type,omitempty"`
-
-	// The time at which the event was first recorded.
-	FirstTimestamp Time `json:"firstTimestamp,omitempty"`
-
-	// The time at which the most recent occurrence of this event was recorded.
-	LastTimestamp Time `json:"lastTimestamp,omitempty"`
 }

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"encoding/json"
-
 	"github.com/Masterminds/semver"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -664,4 +663,50 @@ type NodeDeploymentSpec struct {
 	Template NodeSpec `json:"template"`
 
 	Paused *bool `json:"paused,omitempty"`
+}
+
+// ObjectReference contains enough information to let you inspect or modify the referred object.
+type ObjectReference struct {
+	// Kind of the referent.
+	Kind string `json:"kind,omitempty"`
+
+	// Namespace of the referent.
+	Namespace string `json:"namespace,omitempty"`
+
+	// Name of the referent.
+	Name string `json:"name,omitempty"`
+}
+
+// Event is a report of an event somewhere in the cluster.
+type Event struct {
+	// Namespace of the event.
+	Namespace string `json:"namespace,omitempty"`
+
+	// Name of the event.
+	Name string `json:"name,omitempty"`
+
+	// The object that this event is about.
+	InvolvedObject ObjectReference `json:"involvedObject"`
+
+	// This should be a short, machine understandable string that gives the reason
+	// for the transition into the object's current status.
+	Reason string `json:"reason,omitempty"`
+
+	// A human-readable description of the status of this operation.
+	Message string `json:"message,omitempty"`
+
+	// The component reporting this event. Should be a short machine understandable string.
+	Source string `json:"source,omitempty"`
+
+	// The number of times this event has occurred.
+	Count int32 `json:"count,omitempty"`
+
+	// Type of this event (Normal, Warning), new types could be added in the future
+	Type string `json:"type,omitempty"`
+
+	// The time at which the event was first recorded.
+	FirstTimestamp Time `json:"firstTimestamp,omitempty"`
+
+	// The time at which the most recent occurrence of this event was recorded.
+	LastTimestamp Time `json:"lastTimestamp,omitempty"`
 }

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -668,7 +668,7 @@ type NodeDeploymentSpec struct {
 // EventList is an events response structure.
 type EventList struct {
 	// The object name that those events are about.
-	Name string `json:"Name"`
+	Name string `json:"name"`
 
 	// List of events
 	Events []Event `json:"events"`

--- a/api/pkg/handler/event.go
+++ b/api/pkg/handler/event.go
@@ -19,7 +19,7 @@ func GetMachineEvents(client kubernetes.Interface, machine clusterv1alpha1.Machi
 		return nil, err
 	}
 
-	return CreateEventList(events.Items), nil
+	return createEventList(events.Items), nil
 }
 
 // FilterEventsByType filters kubernetes API event objects based on event type.
@@ -39,19 +39,19 @@ func FilterEventsByType(events []v1.Event, eventType string) []v1.Event {
 	return result
 }
 
-// CreateEventList converts array of api events to kubermatic array events
-func CreateEventList(events []corev1.Event) []v1.Event {
+// createEventList converts array of api events to kubermatic array events
+func createEventList(events []corev1.Event) []v1.Event {
 	kubermaticEvents := make([]v1.Event, 0)
 
 	for _, event := range events {
-		kubermaticEvent := ToEvent(event)
+		kubermaticEvent := toEvent(event)
 		kubermaticEvents = append(kubermaticEvents, kubermaticEvent)
 	}
 	return kubermaticEvents
 }
 
-// ToEvent converts event api Event to Event model object.
-func ToEvent(event corev1.Event) v1.Event {
+// toEvent converts event api Event to Event model object.
+func toEvent(event corev1.Event) v1.Event {
 	result := v1.Event{
 		Name:           event.ObjectMeta.Name,
 		Namespace:      event.ObjectMeta.Namespace,

--- a/api/pkg/handler/event.go
+++ b/api/pkg/handler/event.go
@@ -3,24 +3,8 @@ package handler
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/api/v1"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-
-	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
-
-// GetMachineEvents returns kubernetes API event objects assigned to the machine.
-func GetMachineEvents(client kubernetes.Interface, machine clusterv1alpha1.Machine) (v1.EventList, error) {
-	events, err := client.CoreV1().Events(metav1.NamespaceSystem).Search(runtime.NewScheme(), &machine)
-	if err != nil {
-		return v1.EventList{}, err
-	}
-
-	return createMachineEventList(events.Items, machine), nil
-}
 
 // FilterEventsByType filters kubernetes API event objects based on event type.
 // Empty string will return all events.
@@ -38,21 +22,6 @@ func FilterEventsByType(eventList v1.EventList, eventType string) v1.EventList {
 	return v1.EventList{
 		Name:   eventList.Name,
 		Events: resultEvents,
-	}
-}
-
-// createMachineEventList converts array of api events to kubermatic EventList
-func createMachineEventList(events []corev1.Event, machine clusterv1alpha1.Machine) v1.EventList {
-	kubermaticEvents := make([]v1.Event, 0)
-
-	for _, event := range events {
-		kubermaticEvent := toEvent(event)
-		kubermaticEvents = append(kubermaticEvents, kubermaticEvent)
-	}
-
-	return v1.EventList{
-		Name:   machine.Name,
-		Events: kubermaticEvents,
 	}
 }
 

--- a/api/pkg/handler/event.go
+++ b/api/pkg/handler/event.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/api/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// GetMachineEvents returns kubernetes API event objects assigned to the machine.
+func GetMachineEvents(client kubernetes.Interface, machine clusterv1alpha1.Machine) ([]v1.Event, error) {
+	events, err := client.CoreV1().Events(metav1.NamespaceSystem).Search(runtime.NewScheme(), &machine)
+	if err != nil {
+		return nil, err
+	}
+
+	return CreateEventList(events.Items), nil
+}
+
+// FilterEventsByType filters kubernetes API event objects based on event type.
+// Empty string will return all events.
+func FilterEventsByType(events []v1.Event, eventType string) []v1.Event {
+	if len(eventType) == 0 || len(events) == 0 {
+		return events
+	}
+
+	result := make([]v1.Event, 0)
+	for _, event := range events {
+		if event.Type == eventType {
+			result = append(result, event)
+		}
+	}
+
+	return result
+}
+
+// CreateEventList converts array of api events to kubermatic array events
+func CreateEventList(events []corev1.Event) []v1.Event {
+	kubermaticEvents := make([]v1.Event, 0)
+
+	for _, event := range events {
+		kubermaticEvent := ToEvent(event)
+		kubermaticEvents = append(kubermaticEvents, kubermaticEvent)
+	}
+	return kubermaticEvents
+}
+
+// ToEvent converts event api Event to Event model object.
+func ToEvent(event corev1.Event) v1.Event {
+	result := v1.Event{
+		Name:           event.ObjectMeta.Name,
+		Namespace:      event.ObjectMeta.Namespace,
+		FirstTimestamp: v1.NewTime(event.FirstTimestamp.Time),
+		LastTimestamp:  v1.NewTime(event.LastTimestamp.Time),
+		InvolvedObject: v1.ObjectReference{
+			Name:      event.InvolvedObject.Name,
+			Namespace: event.InvolvedObject.Namespace,
+			Kind:      event.InvolvedObject.Kind,
+		},
+		Source:  event.Source.Component,
+		Message: event.Message,
+		Count:   event.Count,
+		Reason:  event.Reason,
+		Type:    event.Type,
+	}
+
+	return result
+}

--- a/api/pkg/handler/event.go
+++ b/api/pkg/handler/event.go
@@ -36,8 +36,8 @@ func FilterEventsByType(eventList v1.EventList, eventType string) v1.EventList {
 		}
 	}
 	return v1.EventList{
-		InvolvedObjectName: eventList.InvolvedObjectName,
-		Events:             resultEvents,
+		Name:   eventList.Name,
+		Events: resultEvents,
 	}
 }
 
@@ -51,8 +51,8 @@ func createMachineEventList(events []corev1.Event, machine clusterv1alpha1.Machi
 	}
 
 	return v1.EventList{
-		InvolvedObjectName: machine.Name,
-		Events:             kubermaticEvents,
+		Name:   machine.Name,
+		Events: kubermaticEvents,
 	}
 }
 
@@ -60,7 +60,6 @@ func createMachineEventList(events []corev1.Event, machine clusterv1alpha1.Machi
 func toEvent(event corev1.Event) v1.Event {
 	result := v1.Event{
 		Message: event.Message,
-		Reason:  event.Reason,
 		Type:    event.Type,
 	}
 	return result

--- a/api/pkg/handler/event_test.go
+++ b/api/pkg/handler/event_test.go
@@ -3,13 +3,10 @@ package handler_test
 import (
 	"testing"
 
-	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
-
 	"github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestFilterEventsByType(t *testing.T) {
@@ -18,7 +15,7 @@ func TestFilterEventsByType(t *testing.T) {
 		Name           string
 		Filter         string
 		ExpectedEvents []v1.Event
-		InputEvents    []v1.Event
+		InputEvents    v1.EventList
 	}{
 		{
 			Name:   "scenario 1, filter out warning event types",
@@ -27,11 +24,14 @@ func TestFilterEventsByType(t *testing.T) {
 				genEvent("test1", corev1.EventTypeWarning),
 				genEvent("test2", corev1.EventTypeWarning),
 			},
-			InputEvents: []v1.Event{
-				genEvent("test1", corev1.EventTypeWarning),
-				genEvent("test2", corev1.EventTypeWarning),
-				genEvent("test3", corev1.EventTypeNormal),
-				genEvent("test4", corev1.EventTypeNormal),
+			InputEvents: v1.EventList{
+				InvolvedObjectName: "machine",
+				Events: []v1.Event{
+					genEvent("test1", corev1.EventTypeWarning),
+					genEvent("test2", corev1.EventTypeWarning),
+					genEvent("test3", corev1.EventTypeNormal),
+					genEvent("test4", corev1.EventTypeNormal),
+				},
 			},
 		},
 		{
@@ -41,11 +41,14 @@ func TestFilterEventsByType(t *testing.T) {
 				genEvent("test3", corev1.EventTypeNormal),
 				genEvent("test4", corev1.EventTypeNormal),
 			},
-			InputEvents: []v1.Event{
-				genEvent("test1", corev1.EventTypeWarning),
-				genEvent("test2", corev1.EventTypeWarning),
-				genEvent("test3", corev1.EventTypeNormal),
-				genEvent("test4", corev1.EventTypeNormal),
+			InputEvents: v1.EventList{
+				InvolvedObjectName: "machine",
+				Events: []v1.Event{
+					genEvent("test1", corev1.EventTypeWarning),
+					genEvent("test2", corev1.EventTypeWarning),
+					genEvent("test3", corev1.EventTypeNormal),
+					genEvent("test4", corev1.EventTypeNormal),
+				},
 			},
 		},
 	}
@@ -53,7 +56,7 @@ func TestFilterEventsByType(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 
 			result := handler.FilterEventsByType(tc.InputEvents, tc.Filter)
-			if !equal(result, tc.ExpectedEvents) {
+			if !equal(result.Events, tc.ExpectedEvents) {
 				t.Fatalf("event list %v is not the same as expected %v", result, tc.ExpectedEvents)
 			}
 
@@ -76,13 +79,9 @@ func equal(a, b []v1.Event) bool {
 	return true
 }
 
-func genEvent(eventName, eventType string) v1.Event {
+func genEvent(message, eventType string) v1.Event {
 	return v1.Event{
-		Namespace:      metav1.NamespaceSystem,
-		Name:           eventName,
-		Type:           eventType,
-		LastTimestamp:  v1.NewTime(test.DefaultCreationTimestamp()),
-		FirstTimestamp: v1.NewTime(test.DefaultCreationTimestamp()),
-		InvolvedObject: v1.ObjectReference{},
+		Type:    eventType,
+		Message: message,
 	}
 }

--- a/api/pkg/handler/event_test.go
+++ b/api/pkg/handler/event_test.go
@@ -3,6 +3,8 @@ package handler_test
 import (
 	"testing"
 
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+
 	"github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler"
 
@@ -76,8 +78,11 @@ func equal(a, b []v1.Event) bool {
 
 func genEvent(eventName, eventType string) v1.Event {
 	return v1.Event{
-		Namespace: metav1.NamespaceSystem,
-		Name:      eventName,
-		Type:      eventType,
+		Namespace:      metav1.NamespaceSystem,
+		Name:           eventName,
+		Type:           eventType,
+		LastTimestamp:  v1.NewTime(test.DefaultCreationTimestamp()),
+		FirstTimestamp: v1.NewTime(test.DefaultCreationTimestamp()),
+		InvolvedObject: v1.ObjectReference{},
 	}
 }

--- a/api/pkg/handler/event_test.go
+++ b/api/pkg/handler/event_test.go
@@ -1,0 +1,83 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFilterEventsByType(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		Name           string
+		Filter         string
+		ExpectedEvents []v1.Event
+		InputEvents    []v1.Event
+	}{
+		{
+			Name:   "scenario 1, filter out warning event types",
+			Filter: corev1.EventTypeWarning,
+			ExpectedEvents: []v1.Event{
+				genEvent("test1", corev1.EventTypeWarning),
+				genEvent("test2", corev1.EventTypeWarning),
+			},
+			InputEvents: []v1.Event{
+				genEvent("test1", corev1.EventTypeWarning),
+				genEvent("test2", corev1.EventTypeWarning),
+				genEvent("test3", corev1.EventTypeNormal),
+				genEvent("test4", corev1.EventTypeNormal),
+			},
+		},
+		{
+			Name:   "scenario 1, filter out normal event types",
+			Filter: corev1.EventTypeNormal,
+			ExpectedEvents: []v1.Event{
+				genEvent("test3", corev1.EventTypeNormal),
+				genEvent("test4", corev1.EventTypeNormal),
+			},
+			InputEvents: []v1.Event{
+				genEvent("test1", corev1.EventTypeWarning),
+				genEvent("test2", corev1.EventTypeWarning),
+				genEvent("test3", corev1.EventTypeNormal),
+				genEvent("test4", corev1.EventTypeNormal),
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+
+			result := handler.FilterEventsByType(tc.InputEvents, tc.Filter)
+			if !equal(result, tc.ExpectedEvents) {
+				t.Fatalf("event list %v is not the same as expected %v", result, tc.ExpectedEvents)
+			}
+
+		})
+	}
+
+}
+
+// equal tells whether a and b contain the same elements.
+// A nil argument is equivalent to an empty slice.
+func equal(a, b []v1.Event) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func genEvent(eventName, eventType string) v1.Event {
+	return v1.Event{
+		Namespace: metav1.NamespaceSystem,
+		Name:      eventName,
+		Type:      eventType,
+	}
+}

--- a/api/pkg/handler/event_test.go
+++ b/api/pkg/handler/event_test.go
@@ -35,7 +35,7 @@ func TestFilterEventsByType(t *testing.T) {
 			},
 		},
 		{
-			Name:   "scenario 1, filter out normal event types",
+			Name:   "scenario 2, filter out normal event types",
 			Filter: corev1.EventTypeNormal,
 			ExpectedEvents: []v1.Event{
 				genEvent("test3", corev1.EventTypeNormal),

--- a/api/pkg/handler/event_test.go
+++ b/api/pkg/handler/event_test.go
@@ -25,7 +25,7 @@ func TestFilterEventsByType(t *testing.T) {
 				genEvent("test2", corev1.EventTypeWarning),
 			},
 			InputEvents: v1.EventList{
-				InvolvedObjectName: "machine",
+				Name: "machine",
 				Events: []v1.Event{
 					genEvent("test1", corev1.EventTypeWarning),
 					genEvent("test2", corev1.EventTypeWarning),
@@ -42,7 +42,7 @@ func TestFilterEventsByType(t *testing.T) {
 				genEvent("test4", corev1.EventTypeNormal),
 			},
 			InputEvents: v1.EventList{
-				InvolvedObjectName: "machine",
+				Name: "machine",
 				Events: []v1.Event{
 					genEvent("test1", corev1.EventTypeWarning),
 					genEvent("test2", corev1.EventTypeWarning),

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -913,7 +913,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"Name":"venus-1","events":[{"message":"message started","type":"Normal"},{"message":"message killed","type":"Warning"}]}]`,
+			ExpectedResult: `[{"name":"venus-1","events":[{"message":"message started","type":"Normal"},{"message":"message killed","type":"Warning"}]}]`,
 		},
 		// scenario 2
 		{
@@ -935,7 +935,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"Name":"venus-1","events":[{"message":"message killed","type":"Warning"}]}]`,
+			ExpectedResult: `[{"name":"venus-1","events":[{"message":"message killed","type":"Warning"}]}]`,
 		},
 		// scenario 3
 		{
@@ -957,7 +957,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"Name":"venus-1","events":[{"message":"message started","type":"Normal"}]}]`,
+			ExpectedResult: `[{"name":"venus-1","events":[{"message":"message started","type":"Normal"}]}]`,
 		},
 	}
 

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -913,7 +913,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"involvedObjectName":"venus-1","events":[{"reason":"Started","message":"message started","type":"Normal"},{"reason":"Killed","message":"message killed","type":"Warning"}]}]`,
+			ExpectedResult: `[{"Name":"venus-1","events":[{"message":"message started","type":"Normal"},{"message":"message killed","type":"Warning"}]}]`,
 		},
 		// scenario 2
 		{
@@ -935,7 +935,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"involvedObjectName":"venus-1","events":[{"reason":"Killed","message":"message killed","type":"Warning"}]}]`,
+			ExpectedResult: `[{"Name":"venus-1","events":[{"message":"message killed","type":"Warning"}]}]`,
 		},
 		// scenario 3
 		{
@@ -957,7 +957,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"involvedObjectName":"venus-1","events":[{"reason":"Started","message":"message started","type":"Normal"}]}]`,
+			ExpectedResult: `[{"Name":"venus-1","events":[{"message":"message started","type":"Normal"}]}]`,
 		},
 	}
 

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -913,7 +913,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"namespace":"kube-system","name":"event-1","involvedObject":{"namespace":"kube-system"},"reason":"Started","message":"message started","source":"eventTest","count":1,"type":"Normal","firstTimestamp":"0001-01-01T00:00:00Z","lastTimestamp":"0001-01-01T00:00:00Z"},{"namespace":"kube-system","name":"event-2","involvedObject":{"namespace":"kube-system"},"reason":"Killed","message":"message killed","source":"eventTest","count":1,"type":"Warning","firstTimestamp":"0001-01-01T00:00:00Z","lastTimestamp":"0001-01-01T00:00:00Z"}]`,
+			ExpectedResult: `[{"involvedObjectName":"venus-1","events":[{"reason":"Started","message":"message started","type":"Normal"},{"reason":"Killed","message":"message killed","type":"Warning"}]}]`,
 		},
 		// scenario 2
 		{
@@ -935,7 +935,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"namespace":"kube-system","name":"event-2","involvedObject":{"namespace":"kube-system"},"reason":"Killed","message":"message killed","source":"eventTest","count":1,"type":"Warning","firstTimestamp":"0001-01-01T00:00:00Z","lastTimestamp":"0001-01-01T00:00:00Z"}]`,
+			ExpectedResult: `[{"involvedObjectName":"venus-1","events":[{"reason":"Killed","message":"message killed","type":"Warning"}]}]`,
 		},
 		// scenario 3
 		{
@@ -957,7 +957,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"namespace":"kube-system","name":"event-1","involvedObject":{"namespace":"kube-system"},"reason":"Started","message":"message started","source":"eventTest","count":1,"type":"Normal","firstTimestamp":"0001-01-01T00:00:00Z","lastTimestamp":"0001-01-01T00:00:00Z"}]`,
+			ExpectedResult: `[{"involvedObjectName":"venus-1","events":[{"reason":"Started","message":"message started","type":"Normal"}]}]`,
 		},
 	}
 

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -918,7 +918,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 		// scenario 2
 		{
 			Name:                   "scenario 2: list all warning events",
-			QueryParams:            "?warning=true",
+			QueryParams:            "?type=warning",
 			HTTPStatus:             http.StatusOK,
 			ClusterIDToSync:        test.GenDefaultCluster().Name,
 			ProjectIDToSync:        test.GenDefaultProject().Name,
@@ -940,7 +940,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 		// scenario 3
 		{
 			Name:                   "scenario 3: list all normal events",
-			QueryParams:            "?warning=false",
+			QueryParams:            "?type=normal",
 			HTTPStatus:             http.StatusOK,
 			ClusterIDToSync:        test.GenDefaultCluster().Name,
 			ProjectIDToSync:        test.GenDefaultProject().Name,

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -874,6 +874,130 @@ func TestListNodeDeploymentNodes(t *testing.T) {
 	}
 }
 
+func TestListNodeDeploymentNodesEvents(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		Name                       string
+		HTTPStatus                 int
+		ExpectedResult             string
+		ProjectIDToSync            string
+		ClusterIDToSync            string
+		ExistingProject            *kubermaticv1.Project
+		ExistingKubermaticUser     *kubermaticv1.User
+		ExistingAPIUser            *apiv1.User
+		ExistingCluster            *kubermaticv1.Cluster
+		ExistingNodes              []*corev1.Node
+		ExistingMachineDeployments []*clusterv1alpha1.MachineDeployment
+		ExistingMachines           []*clusterv1alpha1.Machine
+		ExistingKubermaticObjs     []runtime.Object
+		ExistingEvents             []*corev1.Event
+		NodeDeploymentID           string
+		QueryParams                string
+	}{
+		// scenario 1
+		{
+			Name:                   "scenario 1: list all events",
+			HTTPStatus:             http.StatusOK,
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123"}),
+			},
+			NodeDeploymentID: "venus",
+			ExistingMachines: []*clusterv1alpha1.Machine{
+				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","containerRuntimeInfo":{"name":"docker","version":"1.13"},"operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
+			},
+			ExistingEvents: []*corev1.Event{
+				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
+				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
+			},
+			ExpectedResult: `[{"namespace":"kube-system","name":"event-1","involvedObject":{"namespace":"kube-system"},"reason":"Started","message":"message started","source":"eventTest","count":1,"type":"Normal","firstTimestamp":"0001-01-01T00:00:00Z","lastTimestamp":"0001-01-01T00:00:00Z"},{"namespace":"kube-system","name":"event-2","involvedObject":{"namespace":"kube-system"},"reason":"Killed","message":"message killed","source":"eventTest","count":1,"type":"Warning","firstTimestamp":"0001-01-01T00:00:00Z","lastTimestamp":"0001-01-01T00:00:00Z"}]`,
+		},
+		// scenario 2
+		{
+			Name:                   "scenario 2: list all warning events",
+			QueryParams:            "?warning=true",
+			HTTPStatus:             http.StatusOK,
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123"}),
+			},
+			NodeDeploymentID: "venus",
+			ExistingMachines: []*clusterv1alpha1.Machine{
+				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","containerRuntimeInfo":{"name":"docker","version":"1.13"},"operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
+			},
+			ExistingEvents: []*corev1.Event{
+				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
+				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
+			},
+			ExpectedResult: `[{"namespace":"kube-system","name":"event-2","involvedObject":{"namespace":"kube-system"},"reason":"Killed","message":"message killed","source":"eventTest","count":1,"type":"Warning","firstTimestamp":"0001-01-01T00:00:00Z","lastTimestamp":"0001-01-01T00:00:00Z"}]`,
+		},
+		// scenario 3
+		{
+			Name:                   "scenario 3: list all normal events",
+			QueryParams:            "?warning=false",
+			HTTPStatus:             http.StatusOK,
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123"}),
+			},
+			NodeDeploymentID: "venus",
+			ExistingMachines: []*clusterv1alpha1.Machine{
+				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","containerRuntimeInfo":{"name":"docker","version":"1.13"},"operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
+			},
+			ExistingEvents: []*corev1.Event{
+				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
+				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
+			},
+			ExpectedResult: `[{"namespace":"kube-system","name":"event-1","involvedObject":{"namespace":"kube-system"},"reason":"Started","message":"message started","source":"eventTest","count":1,"type":"Normal","firstTimestamp":"0001-01-01T00:00:00Z","lastTimestamp":"0001-01-01T00:00:00Z"}]`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/nodedeployments/%s/nodes/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.NodeDeploymentID, tc.QueryParams), strings.NewReader(""))
+			res := httptest.NewRecorder()
+			kubermaticObj := []runtime.Object{}
+			machineObj := []runtime.Object{}
+			kubernetesObj := []runtime.Object{}
+			for _, existingNode := range tc.ExistingNodes {
+				kubernetesObj = append(kubernetesObj, existingNode)
+			}
+			for _, existingEvents := range tc.ExistingEvents {
+				kubernetesObj = append(kubernetesObj, existingEvents)
+			}
+			for _, existingMachineDeployment := range tc.ExistingMachineDeployments {
+				machineObj = append(machineObj, existingMachineDeployment)
+			}
+			for _, existingMachine := range tc.ExistingMachines {
+				machineObj = append(machineObj, existingMachine)
+			}
+			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
+
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.HTTPStatus {
+				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
+			}
+
+			test.CompareWithResult(t, res, tc.ExpectedResult)
+		})
+	}
+}
+
 func TestPatchNodeDeployment(t *testing.T) {
 	t.Parallel()
 
@@ -1166,4 +1290,21 @@ func genTestCluster(isControllerReady bool) *kubermaticv1.Cluster {
 		},
 	}
 	return cluster
+}
+
+func genTestEvent(eventName, eventType, eventReason, eventMessage string) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      eventName,
+			Namespace: metav1.NamespaceSystem,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Namespace: metav1.NamespaceSystem,
+		},
+		Reason:  eventReason,
+		Message: eventMessage,
+		Source:  corev1.EventSource{Component: "eventTest"},
+		Count:   1,
+		Type:    eventType,
+	}
 }

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1596,8 +1596,8 @@ func (r Routing) listNodeDeploymentNodes() http.Handler {
 
 // swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodedeployments/{nodedeployment_id}/nodes/events project listNodeDeploymentNodesEvents
 //
-//     Lists node deployment events. If query parameter `warning` is set to true then only warning events are retrieved.
-//     If the value is false then normal events are returned. If the query parameter is missing method returns all events.
+//     Lists node deployment events. If query parameter `type` is set to `warning` then only warning events are retrieved.
+//     If the value is 'normal' then normal events are returned. If the query parameter is missing method returns all events.
 //
 //     Produces:
 //     - application/json


### PR DESCRIPTION
**What this PR does / why we need it* added new endpoint for node deployment events: `/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodedeployments/{nodedeployment_id}/nodes/events`
Lists node deployment events. If the query parameter `type` is set to `warning` then only warning events are retrieved. If the value `normal`  then normal events are returned. If the query parameter is missing method returns all events.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2635 

**Special notes for your reviewer**:


**Release note**:
```release-note
Added new edpoint: `/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodedeployments/{nodedeployment_id}/nodes/events` with query parameter `type`. When `?type=warning` then endpoint returns only warning type events. When `?type=normal` then endpoint returns only normal type events. Without query parameters the endpoint returns all events.
```
