### PR TITLE
better slack templates for alerts

### DIFF
--- a/config/monitoring/alertmanager/kubermatic.tmpl
+++ b/config/monitoring/alertmanager/kubermatic.tmpl
@@ -1,21 +1,39 @@
-{{ define "slack.kubermatic.title.range" }}
-{{range .Alerts }}
-{{ if eq .Status "firing" }}:fire:{{ else }}:white_check_mark:{{ end }}{{ .Labels.alertname }}{{ if eq .Status "firing" }}:fire:{{ else }}:white_check_mark:{{ end }}
-{{ end }}
-{{ end }}
+{* regular Slack alerts *}
 
-{{ define "slack.kubermatic.text.range" }}
-{{range .Alerts }}
-{{ .Annotations.message }}
-{{ if .Annotations.runbook_url }}{{ .Annotations.runbook_url }}{{ end }}
-{{ end }}
-{{ end }}
+{{ define "slack.kubermatic.pretty.runbook" }}{{ with .Annotations.runbook_url }}<{{ .}}|:notebook:>{{ end }}{{ end }}
+{{ define "slack.kubermatic.titlelink" }}{{ end }}
+{{ define "slack.kubermatic.pretty.icon" }}{{ end }}
+{{ define "slack.kubermatic.color" }}{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}{{ end }}
 
-{{ define "slack.kubermatic.title" }}{{ template "slack.kubermatic.title.range" . }}{{ end }}
-{{ define "slack.kubermatic.text" }}
-{{ template "slack.kubermatic.text.range" . }}
-{{ range $k, $v := .GroupLabels }}
-{{- if ne $k "alertname" }}• *{{ $k }}*: {{ $v }}{{ end }}
-{{ end }}
-{{ end }}
-{{ define "slack.kubermatic.fallback" }}{{ template "slack.kubermatic.fallback.range" . }}{{ end }}
+{{ define "slack.kubermatic.pretty.labels" -}}
+{{- with .Labels.seed_cluster -}}
+{{- if      (match "^(eu|europe)-" .) }}:flag-eu:
+{{- else if (match "^usa?-" .) }}:flag-us:
+{{- else if (match "^asia-" .) }}:flag-cn:
+{{- else }}[{{ . }}]{{ end -}}
+{{- end -}} {{ with .Labels.cluster }} [{{ . }}]{{ end }}
+{{- end }}
+
+{{ define "slack.kubermatic.title" -}}
+{{- with (index .Alerts 0) -}}
+{{- template "slack.kubermatic.pretty.icon" . }} {{ template "slack.kubermatic.pretty.labels" . }} <{{ $.ExternalURL }}/#/alerts?receiver={{ $.Receiver }}|{{ .Labels.alertname }}>
+{{- end -}}
+{{- end }}
+
+{{ define "slack.kubermatic.text" -}}
+{{- with (index .Alerts 0) -}}
+{{ .Annotations.message }} {{ template "slack.kubermatic.pretty.runbook" . }}
+{{- end -}}
+{{- end }}
+
+{* slack fallback for constraint environments like Android notifications *}
+
+{{ define "slack.kubermatic.fallback.icon" }}{{ if eq .Status "firing" }}✗{{ else }}✓{{ end }}{{ end }}
+{{ define "slack.kubermatic.fallback.labels" }}[{{ .Labels.seed_cluster | toUpper }}]{{ end }} {* do not include user cluster IDs in fallbacks *}
+{{ define "slack.kubermatic.fallback.runbook" }}{{ with .Annotations.runbook_url }}<{{ .}}|:notebook:>{{ end }}{{ end }}
+
+{{ define "slack.kubermatic.fallback" -}}
+{{- with (index .Alerts 0) -}}
+{{- template "slack.kubermatic.fallback.icon" . }} {{ template "slack.kubermatic.fallback.labels" . }} {{ .Labels.alertname }} {{ .Annotations.message }}
+{{- end -}}
+{{- end }}

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -1,14 +1,11 @@
 alertmanager:
-  version: v0.15.3
+  version: v0.16.0-beta.0
   host: ""
   config:
     global:
       slack_api_url: https://
     route:
       receiver: 'default'
-      group_by: ['alertname', 'cluster', 'seed_cluster']
-      group_wait: 10s
-      group_interval: 5m
       repeat_interval: 1h
     receivers:
     - name: 'default'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the Slack notifications for alerts.

* Alerts are not grouped anymore, because that made creating good-looking Slack messages extremely hard.
* We have a proper fallback text for mobile notifications.
* Each single alert takes up less space in Slack.

Old:

![screenshot_2019-01-18_10-38-47](https://user-images.githubusercontent.com/127499/51378390-73a18200-1b0d-11e9-82fc-26225c8a79d0.png)

New:

![screenshot_2019-01-18_10-38-26](https://user-images.githubusercontent.com/127499/51378378-6e443780-1b0d-11e9-815b-be0024a240b4.png)

Customers not using our templates and instead use the defaults will not notice any changes, hence the empty changelog entry.

We require the current beta version from Alertmanager because they added the `match` template function, which makes it possible to match on the seed cluster name and display fancy flags without hardcoding the seed cluster names into the template. A stable 0.16.0 is supposed to be released next week (prometheus/alertmanager#1714).

**Release note**:
```release-note
NONE
```
