### PR TITLE
let the conformance tests cleanup test namespaces on start

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -765,11 +765,9 @@ func executeGinkgoRun(parentLog *logrus.Entry, run *ginkgoRun, kubeClient kubern
 	started := time.Now()
 	log := parentLog.WithField("reports-dir", run.reportsDir)
 
-	defer func() {
-		if err := deleteAllNonDefaultNamespaces(log, kubeClient); err != nil {
-			log.Errorf("Failed to cleanup namespaces after the Ginkgo run test: %v", err)
-		}
-	}()
+	if err := deleteAllNonDefaultNamespaces(log, kubeClient); err != nil {
+		return nil, fmt.Errorf("failed to cleanup namespaces before the Ginkgo run: %v", err)
+	}
 
 	// We're clearing up the temp dir on every run
 	if err := os.RemoveAll(run.reportsDir); err != nil {

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -715,6 +715,7 @@ func (r *testRunner) getGinkgoRuns(
 			path.Join(binRoot, "e2e.test"),
 			"--",
 			"--disable-log-dump",
+			"--clean-start",
 			fmt.Sprintf("--repo-root=%s", versionRoot),
 			fmt.Sprintf("--report-dir=%s", reportsDir),
 			fmt.Sprintf("--report-prefix=%s", run.name),


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will instruct the kubernetes conformance test suite to cleanup unrelated namespaces on start.
As we create the cluster within the command it's safe to do so.

This prevents retries to fail because a previous test run orphaned a namespace.
We had such a case in https://prow.loodse.com/build/prow-data/pr-logs/pull/kubermatic_kubermatic/2628/pull-kubermatic-e2e-aws-coreos-1.11/1086240249178230785

**Release note**:
```release-note
NONE
```
