### PR TITLE
Update cert-manager to 0.5.2

### DIFF
--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -1,5 +1,5 @@
 certManager:
   image:
     repository: quay.io/jetstack/cert-manager-controller
-    tag: v0.4.1
+    tag: v0.5.2
     pullPolicy: Always


### PR DESCRIPTION
Fixes an issue where a not properly cleaned up Ingress causes the next
certificate order to fail https://github.com/jetstack/cert-manager/pull/831

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note bugfix
Updated cert-manager to fix an issue which caused re-issuing of a certficate via the http01 challenge to fail
```
