### PR TITLE
update alertmanager to 0.16

### DIFF
--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -1,5 +1,5 @@
 alertmanager:
-  version: v0.16.0-beta.0
+  version: v0.16.0
   host: ""
   config:
     global:


### PR DESCRIPTION
**What this PR does / why we need it**:
After deploying the beta last week, the announced final release is here. Time to update.

**Release note**:
```release-note monitoring
Updated alertmanager to `v0.16`
```
