### PR TITLE
update Grafana to 5.4.3

### DIFF
--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -3,7 +3,7 @@ grafana:
   password: bG9vZHNlMTIz # loodse123
   image:
     repository: grafana/grafana
-    tag: 5.2.1
+    tag: 5.4.3
 
   # Control where the provisioning files are located.
   # If you want to *not* use the predefined ones, this


### PR DESCRIPTION
**What this PR does / why we need it**:
It's high time we update Grafana. No breaking changes are documented in the changelog, but there have been one or two security fixes.

**Release note**:
```release-note monitoring
Update Grafana to `v5.4.3`
```
