### PR TITLE
Version skew check for MachineDeployments

### DIFF
--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -600,7 +600,6 @@ func createNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvide
 			return nil, k8cerrors.NewBadRequest("cannot create node deployment without cloud provider")
 		}
 
-		//TODO: We need to make the kubelet version configurable but restrict it to versions supported by the control plane
 		if nd.Spec.Template.Versions.Kubelet != "" {
 			kversion, err := semver.NewVersion(nd.Spec.Template.Versions.Kubelet)
 			if err != nil {

--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -22,7 +22,6 @@ import (
 	machineconversions "github.com/kubermatic/kubermatic/api/pkg/machine"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	machineresource "github.com/kubermatic/kubermatic/api/pkg/resources/machine"
-	apierrors "github.com/kubermatic/kubermatic/api/pkg/util/errors"
 	k8cerrors "github.com/kubermatic/kubermatic/api/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -203,7 +202,7 @@ func getNodeForCluster(projectProvider provider.ProjectProvider) endpoint.Endpoi
 			return nil, err
 		}
 		if machine == nil && node == nil {
-			return nil, apierrors.NewNotFound("Node", req.NodeID)
+			return nil, k8cerrors.NewNotFound("Node", req.NodeID)
 		}
 
 		if machine == nil {

--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -985,6 +985,15 @@ func patchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 			return nil, fmt.Errorf("cannot decode patched cluster: %v", err)
 		}
 
+		//TODO: We need to make the kubelet version configurable but restrict it to versions supported by the control plane
+		kversion, err := semver.NewVersion(patchedNodeDeployment.Spec.Template.Versions.Kubelet)
+		if err != nil {
+			return nil, k8cerrors.NewBadRequest("failed to parse kubelet version: %v", err)
+		}
+		if err = ensureVersionCompatible(cluster.Spec.Version.Semver(), kversion); err != nil {
+			return nil, k8cerrors.NewBadRequest(err.Error())
+		}
+
 		dc, found := dcs[cluster.Spec.Cloud.DatacenterName]
 		if !found {
 			return nil, fmt.Errorf("unknown cluster datacenter %s", cluster.Spec.Cloud.DatacenterName)

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -508,7 +508,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 
 		// scenario 4
 		{
-			Name:                   "scenario 4: kubelet version is too old",
+			Name:                   "scenario 4: kubelet version is too new",
 			Body:                   `{"spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.10.0"}}}}`,
 			ExpectedResponse:       `{"error":{"code":400,"message":"kubelet version 9.10.0 is not compatible with control plane version 9.9.9"}}`,
 			HTTPStatus:             http.StatusBadRequest,
@@ -972,7 +972,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil)},
 			ExistingKubermaticObjs:     test.GenDefaultKubermaticObjects(genTestCluster(true)),
 		},
-		// Scenario 4: Downgrade to too old kubelet version
+		// Scenario 5: Upgrade kubelet to a too new version
 		{
 			Name:                       "Scenario 5: Upgrade kubelet to too new",
 			Body:                       fmt.Sprintf(`{"spec":{"template":{"versions":{"kubelet":"9.10.0"}}}}`),

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -474,7 +474,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 		{
 			Name:                   "scenario 1: create a node deployment that match the given spec",
 			Body:                   `{"spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
-			ExpectedResponse:       `{"id":"%s","name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":""}},"paused":false},"status":{}}`,
+			ExpectedResponse:       `{"id":"%s","name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"}},"paused":false},"status":{}}`,
 			HTTPStatus:             http.StatusCreated,
 			ProjectID:              test.GenDefaultProject().Name,
 			ClusterID:              test.GenDefaultCluster().Name,
@@ -1160,10 +1160,8 @@ func genTestCluster(isControllerReady bool) *kubermaticv1.Cluster {
 			},
 		},
 	}
-	cluster.Spec = kubermaticv1.ClusterSpec{
-		Cloud: kubermaticv1.CloudSpec{
-			DatacenterName: "us-central1",
-		},
+	cluster.Spec.Cloud = kubermaticv1.CloudSpec{
+		DatacenterName: "us-central1",
 	}
 	return cluster
 }

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -178,7 +178,7 @@ func TestListNodesForCluster(t *testing.T) {
 							},
 						},
 						Versions: apiv1.NodeVersionInfo{
-							Kubelet: "v1.9.9",
+							Kubelet: "v9.9.9",
 						},
 					},
 					Status: apiv1.NodeStatus{
@@ -211,7 +211,7 @@ func TestListNodesForCluster(t *testing.T) {
 							},
 						},
 						Versions: apiv1.NodeVersionInfo{
-							Kubelet: "v1.9.9",
+							Kubelet: "v9.9.9",
 						},
 					},
 					Status: apiv1.NodeStatus{
@@ -263,7 +263,7 @@ func TestListNodesForCluster(t *testing.T) {
 							},
 						},
 						Versions: apiv1.NodeVersionInfo{
-							Kubelet: "v1.9.9",
+							Kubelet: "v9.9.9",
 						},
 					},
 					Status: apiv1.NodeStatus{
@@ -335,7 +335,7 @@ func TestGetNodeForCluster(t *testing.T) {
 		// scenario 1
 		{
 			Name:                   "scenario 1: get a node that belongs to the given cluster",
-			ExpectedResponse:       `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":null}},"operatingSystem":{},"versions":{"kubelet":"v1.9.9"}},"status":{"machineName":"venus","capacity":{"cpu":"0","memory":"0"},"allocatable":{"cpu":"0","memory":"0"},"nodeInfo":{"kernelVersion":"","containerRuntime":"","containerRuntimeVersion":"","kubeletVersion":"","operatingSystem":"","architecture":""}}}`,
+			ExpectedResponse:       `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":null}},"operatingSystem":{},"versions":{"kubelet":"v9.9.9"}},"status":{"machineName":"venus","capacity":{"cpu":"0","memory":"0"},"allocatable":{"cpu":"0","memory":"0"},"nodeInfo":{"kernelVersion":"","containerRuntime":"","containerRuntimeVersion":"","kubeletVersion":"","operatingSystem":"","architecture":""}}}`,
 			HTTPStatus:             http.StatusOK,
 			NodeIDToSync:           "venus",
 			ClusterIDToSync:        test.GenDefaultCluster().Name,
@@ -602,7 +602,7 @@ func TestListNodeDeployments(t *testing.T) {
 								},
 							},
 							Versions: apiv1.NodeVersionInfo{
-								Kubelet: "v1.9.9",
+								Kubelet: "v9.9.9",
 							},
 						},
 						Replicas: replicas,
@@ -629,7 +629,7 @@ func TestListNodeDeployments(t *testing.T) {
 								},
 							},
 							Versions: apiv1.NodeVersionInfo{
-								Kubelet: "v1.9.9",
+								Kubelet: "v9.9.9",
 							},
 						},
 						Replicas: replicas,
@@ -721,7 +721,7 @@ func TestGetNodeDeployment(t *testing.T) {
 							},
 						},
 						Versions: apiv1.NodeVersionInfo{
-							Kubelet: "v1.9.9",
+							Kubelet: "v9.9.9",
 						},
 					},
 					Replicas: replicas,
@@ -820,7 +820,7 @@ func TestListNodeDeploymentNodes(t *testing.T) {
 							},
 						},
 						Versions: apiv1.NodeVersionInfo{
-							Kubelet: "v1.9.9",
+							Kubelet: "v9.9.9",
 						},
 					},
 					Status: apiv1.NodeStatus{
@@ -846,7 +846,7 @@ func TestListNodeDeploymentNodes(t *testing.T) {
 							},
 						},
 						Versions: apiv1.NodeVersionInfo{
-							Kubelet: "v1.9.9",
+							Kubelet: "v9.9.9",
 						},
 					},
 					Status: apiv1.NodeStatus{
@@ -903,7 +903,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 
 	var replicas int32 = 1
 	var replicasUpdated int32 = 3
-	var kubeletVerUpdated = "v1.2.3"
+	var kubeletVerUpdated = "v9.8.0"
 
 	// Mock timezone to keep creation timestamp always the same.
 	time.Local = time.UTC
@@ -924,7 +924,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 		{
 			Name:                       "Scenario 1: Update replicas count",
 			Body:                       fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
-			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v1.9.9"}},"paused":false},"status":{}}`, replicasUpdated),
+			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"}},"paused":false},"status":{}}`, replicasUpdated),
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusOK,
 			project:                    test.GenDefaultProject().Name,
@@ -950,9 +950,35 @@ func TestPatchNodeDeployment(t *testing.T) {
 		{
 			Name:                       "Scenario 3: Change to paused",
 			Body:                       `{"spec":{"paused":true}}`,
-			ExpectedResponse:           `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v1.9.9"}},"paused":true},"status":{}}`,
+			ExpectedResponse:           `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubermatic","kubermatic-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"}},"paused":true},"status":{}}`,
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusOK,
+			project:                    test.GenDefaultProject().Name,
+			ExistingAPIUser:            test.GenDefaultAPIUser(),
+			NodeDeploymentID:           "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil)},
+			ExistingKubermaticObjs:     test.GenDefaultKubermaticObjects(genTestCluster(true)),
+		},
+		// Scenario 4: Downgrade to too old kubelet version
+		{
+			Name:                       "Scenario 4: Downgrade kubelet to too old",
+			Body:                       fmt.Sprintf(`{"spec":{"template":{"versions":{"kubelet":"9.6.0"}}}}`),
+			ExpectedResponse:           fmt.Sprintf(`{"error":{"code":400,"message":"kubelet version 9.6.0 is not compatible with control plane version 9.9.9"}}`),
+			cluster:                    "keen-snyder",
+			HTTPStatus:                 http.StatusBadRequest,
+			project:                    test.GenDefaultProject().Name,
+			ExistingAPIUser:            test.GenDefaultAPIUser(),
+			NodeDeploymentID:           "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil)},
+			ExistingKubermaticObjs:     test.GenDefaultKubermaticObjects(genTestCluster(true)),
+		},
+		// Scenario 4: Downgrade to too old kubelet version
+		{
+			Name:                       "Scenario 5: Upgrade kubelet to too new",
+			Body:                       fmt.Sprintf(`{"spec":{"template":{"versions":{"kubelet":"9.10.0"}}}}`),
+			ExpectedResponse:           fmt.Sprintf(`{"error":{"code":400,"message":"kubelet version 9.10.0 is not compatible with control plane version 9.9.9"}}`),
+			cluster:                    "keen-snyder",
+			HTTPStatus:                 http.StatusBadRequest,
 			project:                    test.GenDefaultProject().Name,
 			ExistingAPIUser:            test.GenDefaultAPIUser(),
 			NodeDeploymentID:           "venus",
@@ -1137,7 +1163,7 @@ func genTestMachine(name, rawProviderConfig string, labels map[string]string, ow
 				},
 			},
 			Versions: clusterv1alpha1.MachineVersionInfo{
-				Kubelet: "v1.9.9",
+				Kubelet: "v9.9.9",
 			},
 		},
 	}
@@ -1163,7 +1189,7 @@ func genTestMachineDeployment(name, rawProviderConfig string, selector map[strin
 						},
 					},
 					Versions: clusterv1alpha1.MachineVersionInfo{
-						Kubelet: "v1.9.9",
+						Kubelet: "v9.9.9",
 					},
 				},
 			},

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -493,6 +493,30 @@ func TestCreateNodeDeployment(t *testing.T) {
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(false)),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
+
+		// scenario 3
+		{
+			Name:                   "scenario 3: kubelet version is too old",
+			Body:                   `{"spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.6.0"}}}}`,
+			ExpectedResponse:       `{"error":{"code":400,"message":"kubelet version 9.6.0 is not compatible with control plane version 9.9.9"}}`,
+			HTTPStatus:             http.StatusBadRequest,
+			ProjectID:              test.GenDefaultProject().Name,
+			ClusterID:              test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+		},
+
+		// scenario 4
+		{
+			Name:                   "scenario 4: kubelet version is too old",
+			Body:                   `{"spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.10.0"}}}}`,
+			ExpectedResponse:       `{"error":{"code":400,"message":"kubelet version 9.10.0 is not compatible with control plane version 9.9.9"}}`,
+			HTTPStatus:             http.StatusBadRequest,
+			ProjectID:              test.GenDefaultProject().Name,
+			ClusterID:              test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+		},
 	}
 
 	for _, tc := range testcases {

--- a/api/pkg/handler/version_skew.go
+++ b/api/pkg/handler/version_skew.go
@@ -7,18 +7,18 @@ import (
 	"github.com/Masterminds/semver"
 )
 
-// ErrVersionSkew denotes an error condition where a given kubelet/controlplane version pair is not supported
-type ErrVersionSkew struct {
+// errVersionSkew denotes an error condition where a given kubelet/controlplane version pair is not supported
+type errVersionSkew struct {
 	ControlPlane *semver.Version
 	Kubelet      *semver.Version
 }
 
 // Error returns a string representation of the error
-func (e ErrVersionSkew) Error() string {
+func (e errVersionSkew) Error() string {
 	return fmt.Sprintf("kubelet version %s is not compatible with control plane version %s", e.Kubelet, e.ControlPlane)
 }
 
-var _ error = ErrVersionSkew{}
+var _ error = errVersionSkew{}
 
 // ensureVersionCompatible checks whether the given kubelet version
 // is deemed compatible with the given version of the control plane.
@@ -37,7 +37,7 @@ func ensureVersionCompatible(controlPlane *semver.Version, kubelet *semver.Versi
 	compatible := kubelet.Major() == controlPlane.Major() && kubelet.Minor() >= (controlPlane.Minor()-2) && kubelet.Minor() <= controlPlane.Minor()
 
 	if !compatible {
-		return ErrVersionSkew{
+		return errVersionSkew{
 			ControlPlane: controlPlane,
 			Kubelet:      kubelet,
 		}

--- a/api/pkg/handler/version_skew.go
+++ b/api/pkg/handler/version_skew.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Masterminds/semver"
+)
+
+// ErrVersionSkew denotes an error condition where a given kubelet/controlplane version pair is not supported
+type ErrVersionSkew struct {
+	ControlPlane *semver.Version
+	Kubelet      *semver.Version
+}
+
+// Error returns a string representation of the error
+func (e ErrVersionSkew) Error() string {
+	return fmt.Sprintf("kubelet version %s is not compatible with control plane version %s", e.Kubelet, e.ControlPlane)
+}
+
+var _ error = ErrVersionSkew{}
+
+// ensureVersionCompatible checks whether the given kubelet version
+// is deemed compatible with the given version of the control plane.
+func ensureVersionCompatible(controlPlane *semver.Version, kubelet *semver.Version) error {
+	if controlPlane == nil {
+		return errors.New("ensureVersionCompatible: controlPlane is nil")
+	}
+
+	if kubelet == nil {
+		return errors.New("ensureVersionCompatible: kubelet is nil")
+	}
+
+	// Kubelet must be the same major version and no more than 2 minor versions behind the control plane.
+	// https://kubernetes.io/docs/setup/version-skew-policy/
+	// https://github.com/kubernetes/website/blob/076efdf364651859553681a75f60c957de729023/content/en/docs/setup/version-skew-policy.md
+	compatible := kubelet.Major() == controlPlane.Major() && kubelet.Minor() >= (controlPlane.Minor()-2) && kubelet.Minor() <= controlPlane.Minor()
+
+	if !compatible {
+		return ErrVersionSkew{
+			ControlPlane: controlPlane,
+			Kubelet:      kubelet,
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #2539
Fixes #2540 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note bugfix
NodeDeployments can no longer be configured to provision kubelets at versions incompatible with the control plane.
```

/assign @p0lyn0mial 