### PR TITLE
update node-exporter to 0.17

### DIFF
--- a/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
@@ -825,7 +825,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(node_filesystem_size{fstype=~\"ext[24]\"} - node_filesystem_avail{fstype=~\"ext[24]\"}) by (device,pod,namespace)) by (pod,namespace) / scalar(sum(max(node_filesystem_size{fstype=~\"ext[24]\"}) by (device,pod,namespace))) * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{node=~\"$node\"}",
+          "expr": "sum(max(node_filesystem_size_bytes{fstype=~\"ext[24]\"} - node_filesystem_avail_bytes{fstype=~\"ext[24]\"}) by (device,pod,namespace)) by (pod,namespace) / scalar(sum(max(node_filesystem_size_bytes{fstype=~\"ext[24]\"}) by (device,pod,namespace))) * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{node=~\"$node\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
@@ -146,7 +146,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (instance) (irate(node_cpu{app=\"node-exporter\", mode!=\"idle\", instance=~\"$instance\"}[5m]) * 100)",
+          "expr": "sum by (instance) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=~\"$instance\"}[5m]) * 100)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ instance }}",
@@ -240,7 +240,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (\n  node_memory_MemTotal{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_MemFree{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_Buffers{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_Cached{app=\"node-exporter\", instance=~\"$instance\"}\n)\n",
+          "expr": "max by (instance) (\n  node_memory_MemTotal_bytes{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_MemFree_bytes{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_Buffers_bytes{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_Cached_bytes{app=\"node-exporter\", instance=~\"$instance\"}\n)\n",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -328,7 +328,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (rate(node_disk_io_time_ms{app=\"node-exporter\",  instance=~\"$instance\"}[2m]))",
+          "expr": "max by (instance) (rate(node_disk_io_time_seconds_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -355,7 +355,7 @@
       },
       "yaxes": [
         {
-          "format": "ms",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -363,7 +363,7 @@
           "show": true
         },
         {
-          "format": "ms",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -426,7 +426,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (rate(node_disk_bytes_read{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
+          "expr": "max by (instance) (rate(node_disk_read_bytes_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -523,7 +523,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (rate(node_disk_bytes_written{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
+          "expr": "max by (instance) (rate(node_disk_written_bytes_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -612,7 +612,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (rate(node_network_receive_bytes{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
+          "expr": "max by (instance) (rate(node_network_receive_bytes_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -700,7 +700,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (rate(node_network_transmit_bytes{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
+          "expr": "max by (instance) (rate(node_network_transmit_bytes_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -782,7 +782,7 @@
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(node_boot_time{app=\"node-exporter\"}, instance)",
+        "query": "label_values(node_boot_time_seconds{app=\"node-exporter\"}, instance)",
         "refresh": 2,
         "regex": "",
         "sort": 0,

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes.json
@@ -161,7 +161,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (cpu) (irate(node_cpu{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]) * 100)",
+          "expr": "sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]) * 100)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ cpu }}",
@@ -255,28 +255,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(\n  node_memory_MemTotal{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_MemFree{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Buffers{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Cached{app=\"node-exporter\", instance=\"$instance\"}\n)\n",
+          "expr": "max(\n  node_memory_MemTotal_bytes{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_MemFree_bytes{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Buffers_bytes{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Cached_bytes{app=\"node-exporter\", instance=\"$instance\"}\n)\n",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "memory used",
           "refId": "A"
         },
         {
-          "expr": "max(node_memory_Buffers{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_memory_Buffers_bytes{app=\"node-exporter\", instance=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "memory buffers",
           "refId": "B"
         },
         {
-          "expr": "max(node_memory_Cached{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_memory_Cached_bytes{app=\"node-exporter\", instance=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "memory cached",
           "refId": "C"
         },
         {
-          "expr": "max(node_memory_MemFree{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_memory_MemFree_bytes{app=\"node-exporter\", instance=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "memory free",
@@ -370,14 +370,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(node_network_receive_bytes{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
+          "expr": "max(rate(node_network_receive_bytes_total{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "received",
           "refId": "A"
         },
         {
-          "expr": "max(rate(node_network_transmit_bytes{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
+          "expr": "max(rate(node_network_transmit_bytes_total{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "sent",
@@ -475,14 +475,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(node_disk_bytes_read{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
+          "expr": "max(rate(node_disk_read_bytes_total{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "read",
           "refId": "A"
         },
         {
-          "expr": "max(rate(node_disk_bytes_written{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
+          "expr": "max(rate(node_disk_written_bytes_total{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "written",
@@ -570,7 +570,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(node_disk_io_time_ms{app=\"node-exporter\",  instance=\"$instance\"}[2m]))",
+          "expr": "max(rate(node_disk_io_time_seconds_total{app=\"node-exporter\",  instance=\"$instance\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "io time",
@@ -597,7 +597,7 @@
       },
       "yaxes": [
         {
-          "format": "ms",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -605,7 +605,7 @@
           "show": true
         },
         {
-          "format": "ms",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -652,7 +652,7 @@
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(node_boot_time{app=\"node-exporter\"}, instance)",
+        "query": "label_values(node_boot_time_seconds{app=\"node-exporter\"}, instance)",
         "refresh": 2,
         "regex": "",
         "sort": 0,

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
@@ -664,7 +664,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes) / sum(node_memory_MemTotal)",
+          "expr": "sum(kube_pod_container_resource_requests_memory_bytes) / sum(node_memory_MemTotal_bytes)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -803,7 +803,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes) / sum(node_memory_MemTotal)",
+          "expr": "sum(kube_pod_container_resource_limits_memory_bytes) / sum(node_memory_MemTotal_bytes)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,

--- a/config/monitoring/node-exporter/values.yaml
+++ b/config/monitoring/node-exporter/values.yaml
@@ -1,4 +1,4 @@
 nodeExporter:
   image:
     repository: quay.io/prometheus/node-exporter
-    tag: v0.15.2
+    tag: v0.17.0

--- a/config/monitoring/prometheus/rules/kubernetes-resources.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes-resources.yaml
@@ -22,7 +22,7 @@ groups:
     expr: |
       sum(namespace_name:kube_pod_container_resource_requests_memory_bytes:sum)
         /
-      sum(node_memory_MemTotal)
+      sum(node_memory_MemTotal_bytes)
         >
       (count(node:node_num_cpu:sum)-1)
         /
@@ -51,7 +51,7 @@ groups:
     expr: |
       sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="requests.memory"})
         /
-      sum(node_memory_MemTotal{app="node-exporter"})
+      sum(node_memory_MemTotal_bytes{app="node-exporter"})
         > 1.5
     for: 5m
     labels:

--- a/config/monitoring/prometheus/rules/node-exporter.rules.yaml
+++ b/config/monitoring/prometheus/rules/node-exporter.rules.yaml
@@ -5,14 +5,14 @@ groups:
     expr: |
       count by (instance) (
         sum by (instance, cpu) (
-          node_cpu{app="node-exporter"}
+          node_cpu_seconds_total{app="node-exporter"}
         )
       )
 
   - record: instance:node_cpu_utilisation:avg1m
     expr: |
       1 - avg by (instance) (
-        rate(node_cpu{app="node-exporter",mode="idle"}[1m])
+        rate(node_cpu_seconds_total{app="node-exporter",mode="idle"}[1m])
       )
 
   - record: 'instance:node_cpu_saturation_load1:'
@@ -24,15 +24,15 @@ groups:
   - record: instance:node_memory_bytes_total:sum
     expr: |
       sum by (instance) (
-        node_memory_MemTotal{app="node-exporter"}
+        node_memory_MemTotal_bytes{app="node-exporter"}
       )
 
   - record: instance:node_memory_utilisation:ratio
     expr: |
       1 - (
-          node_memory_MemAvailable{app="node-exporter"}
+          node_memory_MemAvailable_bytes{app="node-exporter"}
         /
-          node_memory_MemTotal{app="node-exporter"}
+          node_memory_MemTotal_bytes{app="node-exporter"}
       )
 
   - record: instance:node_memory_swap_io_bytes:sum_rate
@@ -45,25 +45,25 @@ groups:
   - record: instance:node_disk_utilisation:sum_irate
     expr: |
       sum by (instance) (
-        irate(node_disk_io_time_ms{app="node-exporter",device=~"(sd|xvd).+"}[1m]) / 1e3
+        irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd).+"}[1m])
       )
 
   - record: instance:node_disk_saturation:sum_irate
     expr: |
       sum by (instance) (
-        irate(node_disk_io_time_weighted{app="node-exporter",device=~"(sd|xvd).+"}[1m]) / 1e3
+        irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd).+"}[1m])
       )
 
   - record: instance:node_net_utilisation:sum_irate
     expr: |
       sum by (instance) (
-        (irate(node_network_receive_bytes{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
-          irate(node_network_transmit_bytes{app="node-exporter",device=~"eth[0-9]+"}[1m]))
+        (irate(node_network_receive_bytes_total{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
+          irate(node_network_transmit_bytes_total{app="node-exporter",device=~"eth[0-9]+"}[1m]))
       )
 
   - record: instance:node_net_saturation:sum_irate
     expr: |
       sum by (instance) (
-        (irate(node_network_receive_drop{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
-          irate(node_network_transmit_drop{app="node-exporter",device=~"eth[0-9]+"}[1m]))
+        (irate(node_network_receive_drop_total{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
+          irate(node_network_transmit_drop_total{app="node-exporter",device=~"eth[0-9]+"}[1m]))
       )

--- a/config/monitoring/prometheus/rules/node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/node-exporter.yaml
@@ -7,11 +7,11 @@ groups:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of space within the next 24 hours.
     expr: |
-      predict_linear(node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"}[6h], 24*60*60) < 0
+      predict_linear(node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"}[6h], 24*60*60) < 0
       and
-      node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_size{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} < 0.4
+      node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} < 0.4
       and
-      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+      node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: warning
@@ -22,11 +22,11 @@ groups:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of space within the next 4 hours.
     expr: |
-      predict_linear(node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"}[6h], 4*60*60) < 0
+      predict_linear(node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"}[6h], 4*60*60) < 0
       and
-      node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_size{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} < 0.2
+      node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} < 0.2
       and
-      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+      node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: critical
@@ -37,9 +37,9 @@ groups:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
     expr: |
-      node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_size{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} * 100 < 5
+      node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
       and
-      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+      node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: warning
@@ -50,9 +50,9 @@ groups:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
     expr: |
-      node_filesystem_avail{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_size{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} * 100 < 3
+      node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
       and
-      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+      node_filesystem_readonly_bytes{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: critical
@@ -63,11 +63,11 @@ groups:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of files within the next 24 hours.
     expr: |
-      predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"}[6h], 24*60*60) < 0
+      predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"}[6h], 24*60*60) < 0
       and
-      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} < 0.4
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} < 0.4
       and
-      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: warning
@@ -78,11 +78,11 @@ groups:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of files within the next 4 hours.
     expr: |
-      predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"}[6h], 4*60*60) < 0
+      predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"}[6h], 4*60*60) < 0
       and
-      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} < 0.2
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} < 0.2
       and
-      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: warning
@@ -93,9 +93,9 @@ groups:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available inodes left.
     expr: |
-      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} * 100 < 5
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
       and
-      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: warning
@@ -106,9 +106,9 @@ groups:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
     expr: |
-      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} * 100 < 3
+      node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
       and
-      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs",mountpoint!="/var/lib/docker/aufs"} == 0
+      node_filesystem_readonly{app="node-exporter",fstype=~"ext.|xfs"} == 0
     for: 1h
     labels:
       severity: critical
@@ -118,7 +118,7 @@ groups:
       message: >
         {{ $labels.instance }} interface {{ $labels.device }} shows errors
         while receiving packets ({{ $value }} errors in two minutes).
-    expr: increase(node_network_receive_errs[2m]) > 10
+    expr: increase(node_network_receive_errs_total[2m]) > 10
     for: 1h
     labels:
       severity: critical
@@ -128,7 +128,7 @@ groups:
       message: >
         {{ $labels.instance }} interface {{ $labels.device }} shows errors
         while transmitting packets ({{ $value }} errors in two minutes).
-    expr: increase(node_network_transmit_errs[2m]) > 10
+    expr: increase(node_network_transmit_errs_total[2m]) > 10
     for: 1h
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/node.rules.yaml
+++ b/config/monitoring/prometheus/rules/node.rules.yaml
@@ -12,19 +12,19 @@ groups:
   - record: node:node_num_cpu:sum
     expr: |
       count by (node) (sum by (node, cpu) (
-        node_cpu{app="node-exporter"}
+        node_cpu_seconds_total{app="node-exporter"}
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       ))
 
   - record: :node_cpu_utilisation:avg1m
     expr: |
-      1 - avg(rate(node_cpu{app="node-exporter",mode="idle"}[1m]))
+      1 - avg(rate(node_cpu_seconds_total{app="node-exporter",mode="idle"}[1m]))
 
   - record: node:node_cpu_utilisation:avg1m
     expr: |
       1 - avg by (node) (
-        rate(node_cpu{app="node-exporter",mode="idle"}[1m])
+        rate(node_cpu_seconds_total{app="node-exporter",mode="idle"}[1m])
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:)
 
@@ -47,22 +47,22 @@ groups:
   - record: ':node_memory_utilisation:'
     expr: |
       1 -
-      sum(node_memory_MemFree{app="node-exporter"} + node_memory_Cached{app="node-exporter"} + node_memory_Buffers{app="node-exporter"})
+      sum(node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
       /
-      sum(node_memory_MemTotal{app="node-exporter"})
+      sum(node_memory_MemTotal_bytes{app="node-exporter"})
 
   - record: :node_memory_MemFreeCachedBuffers:sum
     expr: |
-      sum(node_memory_MemFree{app="node-exporter"} + node_memory_Cached{app="node-exporter"} + node_memory_Buffers{app="node-exporter"})
+      sum(node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
 
   - record: :node_memory_MemTotal:sum
     expr: |
-      sum(node_memory_MemTotal{app="node-exporter"})
+      sum(node_memory_MemTotal_bytes{app="node-exporter"})
 
   - record: node:node_memory_bytes_available:sum
     expr: |
       sum by (node) (
-        (node_memory_MemFree{app="node-exporter"} + node_memory_Cached{app="node-exporter"} + node_memory_Buffers{app="node-exporter"})
+        (node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
       )
@@ -70,7 +70,7 @@ groups:
   - record: node:node_memory_bytes_total:sum
     expr: |
       sum by (node) (
-        node_memory_MemTotal{app="node-exporter"}
+        node_memory_MemTotal_bytes{app="node-exporter"}
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
       )
@@ -92,13 +92,13 @@ groups:
     expr: |
       1 -
       sum by (node) (
-        (node_memory_MemFree{app="node-exporter"} + node_memory_Cached{app="node-exporter"} + node_memory_Buffers{app="node-exporter"})
+        (node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
       /
       sum by (node) (
-        node_memory_MemTotal{app="node-exporter"}
+        node_memory_MemTotal_bytes{app="node-exporter"}
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
@@ -118,62 +118,66 @@ groups:
 
   - record: :node_disk_utilisation:avg_irate
     expr: |
-      avg(irate(node_disk_io_time_ms{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3)
+      avg(irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]))
 
   - record: node:node_disk_utilisation:avg_irate
     expr: |
       avg by (node) (
-        irate(node_disk_io_time_ms{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3
+        irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m])
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
 
   - record: :node_disk_saturation:avg_irate
     expr: |
-      avg(irate(node_disk_io_time_weighted{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3)
+      avg(irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]))
 
   - record: node:node_disk_saturation:avg_irate
     expr: |
       avg by (node) (
-        irate(node_disk_io_time_weighted{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3
+        irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m])
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
 
   - record: 'node:node_filesystem_usage:'
     expr: |
-      max by (namespace, pod, device) ((node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"}
-      - node_filesystem_avail{fstype=~"ext[234]|btrfs|xfs|zfs"})
-      / node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"})
+      max by (namespace, pod, device) (
+        (node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+        /
+        node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+      )
 
   - record: 'node:node_filesystem_avail:'
     expr: |
-      max by (namespace, pod, device) (node_filesystem_avail{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"})
+      max by (namespace, pod, device) (
+        node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+      )
 
   - record: :node_net_utilisation:sum_irate
     expr: |
-      sum(irate(node_network_receive_bytes{app="node-exporter",device="eth0"}[1m])) +
-      sum(irate(node_network_transmit_bytes{app="node-exporter",device="eth0"}[1m]))
+      sum(irate(node_network_receive_bytes_total{app="node-exporter",device="eth0"}[1m])) +
+      sum(irate(node_network_transmit_bytes_total{app="node-exporter",device="eth0"}[1m]))
 
   - record: node:node_net_utilisation:sum_irate
     expr: |
       sum by (node) (
-        (irate(node_network_receive_bytes{app="node-exporter",device="eth0"}[1m]) +
-        irate(node_network_transmit_bytes{app="node-exporter",device="eth0"}[1m]))
+        (irate(node_network_receive_bytes_total{app="node-exporter",device="eth0"}[1m]) +
+        irate(node_network_transmit_bytes_total{app="node-exporter",device="eth0"}[1m]))
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
 
   - record: :node_net_saturation:sum_irate
     expr: |
-      sum(irate(node_network_receive_drop{app="node-exporter",device="eth0"}[1m])) +
-      sum(irate(node_network_transmit_drop{app="node-exporter",device="eth0"}[1m]))
+      sum(irate(node_network_receive_drop_total{app="node-exporter",device="eth0"}[1m])) +
+      sum(irate(node_network_transmit_drop_total{app="node-exporter",device="eth0"}[1m]))
 
   - record: node:node_net_saturation:sum_irate
     expr: |
       sum by (node) (
-        (irate(node_network_receive_drop{app="node-exporter",device="eth0"}[1m]) +
-        irate(node_network_transmit_drop{app="node-exporter",device="eth0"}[1m]))
+        (irate(node_network_receive_drop_total{app="node-exporter",device="eth0"}[1m]) +
+        irate(node_network_transmit_drop_total{app="node-exporter",device="eth0"}[1m]))
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )


### PR DESCRIPTION
**What this PR does / why we need it**:
Unfortunately NE 0.16 has changed the naming of a ton of metrics, so this PR is kind of bloated.

**Release note**:
```release-note monitoring
Updated node-exporter to `v0.17` (**note: breaking changes to metric names might require updates to customized dashboards**)
```
