### PR TITLE
marks the remaining node HTTP endpoints as deprecated

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1062,14 +1062,15 @@
     },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes": {
       "get": {
-        "description": "Lists nodes that belong to the given cluster",
+        "description": "This endpoint is deprecated, please create a Node Deployment instead.",
         "produces": [
           "application/json"
         ],
         "tags": [
           "project"
         ],
-        "operationId": "listNodesForCluster",
+        "summary": "Deprecated:\nLists nodes that belong to the given cluster",
+        "operationId": "listNodesForClusterLegacy",
         "parameters": [
           {
             "type": "string",
@@ -1184,6 +1185,7 @@
     },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/{node_id}": {
       "get": {
+        "description": "This endpoint is deprecated, please create a Node Deployment instead.",
         "consumes": [
           "application/json"
         ],
@@ -1193,8 +1195,8 @@
         "tags": [
           "project"
         ],
-        "summary": "Gets a node that is assigned to the given cluster.",
-        "operationId": "getNodeForCluster",
+        "summary": "Deprecated:\nGets a node that is assigned to the given cluster.",
+        "operationId": "getNodeForClusterLegacy",
         "parameters": [
           {
             "type": "string",
@@ -1250,14 +1252,15 @@
         }
       },
       "delete": {
+        "description": "This endpoint is deprecated, please create a Node Deployment instead.",
         "produces": [
           "application/json"
         ],
         "tags": [
           "project"
         ],
-        "summary": "Deletes the given node that belongs to the cluster.",
-        "operationId": "deleteNodeForCluster",
+        "summary": "Deprecated:\nDeletes the given node that belongs to the cluster.",
+        "operationId": "deleteNodeForClusterLegacy",
         "parameters": [
           {
             "type": "string",

--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -44,7 +44,7 @@ const (
 	initialConditionParsingDelay = 5
 )
 
-func deleteNodeForCluster(projectProvider provider.ProjectProvider) endpoint.Endpoint {
+func deleteNodeForClusterLegacy(projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(DeleteNodeForClusterReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
@@ -91,7 +91,7 @@ func deleteNodeForCluster(projectProvider provider.ProjectProvider) endpoint.End
 	}
 }
 
-func listNodesForCluster(projectProvider provider.ProjectProvider) endpoint.Endpoint {
+func listNodesForClusterLegacy(projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(ListNodesForClusterReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
@@ -170,7 +170,7 @@ func getNodeList(cluster *v1.Cluster, clusterProvider provider.ClusterProvider) 
 	return kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
 }
 
-func getNodeForCluster(projectProvider provider.ProjectProvider) endpoint.Endpoint {
+func getNodeForClusterLegacy(projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(NodeReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
@@ -403,15 +403,15 @@ func findMachineAndNode(name string, machineClient clusterv1alpha1clientset.Inte
 	return machine, node, nil
 }
 
-// DeleteNodeForClusterReq defines HTTP request for deleteNodeForCluster
-// swagger:parameters deleteNodeForCluster
+// DeleteNodeForClusterReq defines HTTP request for deleteNodeForClusterLegacy
+// swagger:parameters deleteNodeForClusterLegacy
 type DeleteNodeForClusterReq struct {
 	common.GetClusterReq
 	// in: path
 	NodeID string `json:"node_id"`
 }
 
-func decodeDeleteNodeForCluster(c context.Context, r *http.Request) (interface{}, error) {
+func decodeDeleteNodeForClusterLegacy(c context.Context, r *http.Request) (interface{}, error) {
 	var req DeleteNodeForClusterReq
 
 	nodeID := mux.Vars(r)["node_id"]
@@ -436,15 +436,15 @@ func decodeDeleteNodeForCluster(c context.Context, r *http.Request) (interface{}
 	return req, nil
 }
 
-// ListNodesForClusterReq defines HTTP request for listNodesForCluster
-// swagger:parameters listNodesForCluster
+// ListNodesForClusterReq defines HTTP request for listNodesForClusterLegacy
+// swagger:parameters listNodesForClusterLegacy
 type ListNodesForClusterReq struct {
 	common.GetClusterReq
 	// in: query
 	HideInitialConditions bool `json:"hideInitialConditions"`
 }
 
-func decodeListNodesForCluster(c context.Context, r *http.Request) (interface{}, error) {
+func decodeListNodesForClusterLegacy(c context.Context, r *http.Request) (interface{}, error) {
 	var req ListNodesForClusterReq
 
 	clusterID, err := common.DecodeClusterID(c, r)
@@ -472,7 +472,7 @@ type CreateNodeReqLegacy struct {
 	Body apiv1.Node
 }
 
-func decodeCreateNodeForCluster(c context.Context, r *http.Request) (interface{}, error) {
+func decodeCreateNodeForClusterLegacy(c context.Context, r *http.Request) (interface{}, error) {
 	var req CreateNodeReqLegacy
 
 	clusterID, err := common.DecodeClusterID(c, r)
@@ -494,8 +494,8 @@ func decodeCreateNodeForCluster(c context.Context, r *http.Request) (interface{}
 	return req, nil
 }
 
-// NodeReq defines HTTP request for getNodeForCluster
-// swagger:parameters getNodeForCluster
+// NodeReq defines HTTP request for getNodeForClusterLegacy
+// swagger:parameters getNodeForClusterLegacy
 type NodeReq struct {
 	common.GetClusterReq
 	// in: path
@@ -504,7 +504,7 @@ type NodeReq struct {
 	HideInitialConditions bool `json:"hideInitialConditions"`
 }
 
-func decodeGetNodeForCluster(c context.Context, r *http.Request) (interface{}, error) {
+func decodeGetNodeForClusterLegacy(c context.Context, r *http.Request) (interface{}, error) {
 	var req NodeReq
 
 	clusterID, err := common.DecodeClusterID(c, r)

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -159,7 +159,7 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 	// Defines a set of HTTP endpoints for nodes that belong to a cluster
 	mux.Methods(http.MethodGet).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/{node_id}").
-		Handler(r.getNodeForCluster())
+		Handler(r.getNodeForClusterLegacy())
 
 	mux.Methods(http.MethodPost).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes").
@@ -167,11 +167,11 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 
 	mux.Methods(http.MethodGet).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes").
-		Handler(r.listNodesForCluster())
+		Handler(r.listNodesForClusterLegacy())
 
 	mux.Methods(http.MethodDelete).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/{node_id}").
-		Handler(r.deleteNodeForCluster())
+		Handler(r.deleteNodeForClusterLegacy())
 
 	mux.Methods(http.MethodPut).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/token").
@@ -1019,9 +1019,12 @@ func (r Routing) revokeClusterAdminToken() http.Handler {
 	)
 }
 
-// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/{node_id} project getNodeForCluster
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/{node_id} project getNodeForClusterLegacy
 //
+//     Deprecated:
 //     Gets a node that is assigned to the given cluster.
+//
+//     This endpoint is deprecated, please create a Node Deployment instead.
 //
 //     Consumes:
 //     - application/json
@@ -1034,15 +1037,15 @@ func (r Routing) revokeClusterAdminToken() http.Handler {
 //       200: Node
 //       401: empty
 //       403: empty
-func (r Routing) getNodeForCluster() http.Handler {
+func (r Routing) getNodeForClusterLegacy() http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(
 			r.oidcAuthenticator.Verifier(),
 			r.userSaverMiddleware(),
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			r.userInfoMiddleware(),
-		)(getNodeForCluster(r.projectProvider)),
-		decodeGetNodeForCluster,
+		)(getNodeForClusterLegacy(r.projectProvider)),
+		decodeGetNodeForClusterLegacy,
 		EncodeJSON,
 		r.defaultServerOptions()...,
 	)
@@ -1075,16 +1078,18 @@ func (r Routing) createNodeForClusterLegacy() http.Handler {
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			r.userInfoMiddleware(),
 		)(createNodeForClusterLegacy(r.sshKeyProvider, r.projectProvider, r.datacenters)),
-		decodeCreateNodeForCluster,
+		decodeCreateNodeForClusterLegacy,
 		setStatusCreatedHeader(EncodeJSON),
 		r.defaultServerOptions()...,
 	)
 }
 
-// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes project listNodesForCluster
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes project listNodesForClusterLegacy
 //
-//
+//     Deprecated:
 //     Lists nodes that belong to the given cluster
+//
+//     This endpoint is deprecated, please create a Node Deployment instead.
 //
 //     Produces:
 //     - application/json
@@ -1094,23 +1099,26 @@ func (r Routing) createNodeForClusterLegacy() http.Handler {
 //       200: []Node
 //       401: empty
 //       403: empty
-func (r Routing) listNodesForCluster() http.Handler {
+func (r Routing) listNodesForClusterLegacy() http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(
 			r.oidcAuthenticator.Verifier(),
 			r.userSaverMiddleware(),
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			r.userInfoMiddleware(),
-		)(listNodesForCluster(r.projectProvider)),
-		decodeListNodesForCluster,
+		)(listNodesForClusterLegacy(r.projectProvider)),
+		decodeListNodesForClusterLegacy,
 		EncodeJSON,
 		r.defaultServerOptions()...,
 	)
 }
 
-// swagger:route DELETE /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/{node_id} project deleteNodeForCluster
+// swagger:route DELETE /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/{node_id} project deleteNodeForClusterLegacy
 //
+//    Deprecated:
 //    Deletes the given node that belongs to the cluster.
+//
+//     This endpoint is deprecated, please create a Node Deployment instead.
 //
 //     Produces:
 //     - application/json
@@ -1120,15 +1128,15 @@ func (r Routing) listNodesForCluster() http.Handler {
 //       200: empty
 //       401: empty
 //       403: empty
-func (r Routing) deleteNodeForCluster() http.Handler {
+func (r Routing) deleteNodeForClusterLegacy() http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(
 			r.oidcAuthenticator.Verifier(),
 			r.userSaverMiddleware(),
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			r.userInfoMiddleware(),
-		)(deleteNodeForCluster(r.projectProvider)),
-		decodeDeleteNodeForCluster,
+		)(deleteNodeForClusterLegacy(r.projectProvider)),
+		decodeDeleteNodeForClusterLegacy,
 		EncodeJSON,
 		r.defaultServerOptions()...,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**: marks the remaining node HTTP endpoints as deprecated


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
