### PR TITLE
decrease openvpn memory limit

### DIFF
--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -16,11 +16,11 @@ import (
 var (
 	defaultResourceRequirements = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("16Mi"),
+			corev1.ResourceMemory: resource.MustParse("5Mi"),
 			corev1.ResourceCPU:    resource.MustParse("5m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceMemory: resource.MustParse("20Mi"),
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 	}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -99,10 +99,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -92,10 +92,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -86,10 +86,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -109,10 +109,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log
@@ -174,10 +174,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 128Mi
+            memory: 20Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           capabilities:
             add:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 32Mi
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 5Mi
         securityContext:
           privileged: true
         terminationMessagePath: /dev/termination-log

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -10,11 +10,11 @@ import (
 var (
 	vpnClientResourceRequirements = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("16Mi"),
+			corev1.ResourceMemory: resource.MustParse("5Mi"),
 			corev1.ResourceCPU:    resource.MustParse("5m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Decrease openvpn memory limit as it need ~4MI on average.

**Release note**:
```release-note
NONE
```
