### PR TITLE
extends user cluster provider component

### DIFF
--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -41,8 +41,11 @@ func (p *Provider) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
 	return d, nil
 }
 
+// ClientConfigOptions defines a function that applies additional configuration to restclient.Config in a generic way.
+type ClientConfigOption func(*restclient.Config) *restclient.Config
+
 // GetClientConfig returns the client config used for initiating a connection for the given cluster
-func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster) (*restclient.Config, error) {
+func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster, options ...ClientConfigOption) (*restclient.Config, error) {
 	b, err := p.GetAdminKubeconfig(c)
 	if err != nil {
 		return nil, err
@@ -69,12 +72,17 @@ func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster) (*restclient.Config,
 	clientConfig.QPS = 20
 	clientConfig.Burst = 50
 
+	// apply all options
+	for _, opt := range options {
+		clientConfig = opt(clientConfig)
+	}
+
 	return clientConfig, err
 }
 
 // GetClient returns a kubernetes client to interact with the given cluster
-func (p *Provider) GetClient(c *kubermaticv1.Cluster) (kubernetes.Interface, error) {
-	config, err := p.GetClientConfig(c)
+func (p *Provider) GetClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (kubernetes.Interface, error) {
+	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +96,8 @@ func (p *Provider) GetClient(c *kubermaticv1.Cluster) (kubernetes.Interface, err
 }
 
 // GetMachineClient returns a client to interact with machine resources for the given cluster
-func (p *Provider) GetMachineClient(c *kubermaticv1.Cluster) (clusterv1alpha1clientset.Interface, error) {
-	config, err := p.GetClientConfig(c)
+func (p *Provider) GetMachineClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (clusterv1alpha1clientset.Interface, error) {
+	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +110,8 @@ func (p *Provider) GetMachineClient(c *kubermaticv1.Cluster) (clusterv1alpha1cli
 }
 
 // GetApiextensionsClient returns a client to interact with apiextension resources for the given cluster
-func (p *Provider) GetApiextensionsClient(c *kubermaticv1.Cluster) (apiextensionsclientset.Interface, error) {
-	config, err := p.GetClientConfig(c)
+func (p *Provider) GetApiextensionsClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (apiextensionsclientset.Interface, error) {
+	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -111,8 +119,8 @@ func (p *Provider) GetApiextensionsClient(c *kubermaticv1.Cluster) (apiextension
 }
 
 // GetAdmissionRegistrationClient returns a client to interact with admissionregistration resources
-func (p *Provider) GetAdmissionRegistrationClient(c *kubermaticv1.Cluster) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error) {
-	config, err := p.GetClientConfig(c)
+func (p *Provider) GetAdmissionRegistrationClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error) {
+	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -120,8 +128,8 @@ func (p *Provider) GetAdmissionRegistrationClient(c *kubermaticv1.Cluster) (admi
 }
 
 // GetKubeAggregatorClient returns a client to interact with the aggregation API for the given cluster
-func (p *Provider) GetKubeAggregatorClient(c *kubermaticv1.Cluster) (aggregationclientset.Interface, error) {
-	config, err := p.GetClientConfig(c)
+func (p *Provider) GetKubeAggregatorClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (aggregationclientset.Interface, error) {
+	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -41,7 +41,7 @@ func (p *Provider) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
 	return d, nil
 }
 
-// ClientConfigOptions defines a function that applies additional configuration to restclient.Config in a generic way.
+// ConfigOption defines a function that applies additional configuration to restclient.Config in a generic way.
 type ConfigOption func(*restclient.Config) *restclient.Config
 
 // GetClientConfig returns the client config used for initiating a connection for the given cluster

--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -42,10 +42,10 @@ func (p *Provider) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
 }
 
 // ClientConfigOptions defines a function that applies additional configuration to restclient.Config in a generic way.
-type ClientConfigOption func(*restclient.Config) *restclient.Config
+type ConfigOption func(*restclient.Config) *restclient.Config
 
 // GetClientConfig returns the client config used for initiating a connection for the given cluster
-func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster, options ...ClientConfigOption) (*restclient.Config, error) {
+func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster, options ...ConfigOption) (*restclient.Config, error) {
 	b, err := p.GetAdminKubeconfig(c)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster, options ...ClientCon
 }
 
 // GetClient returns a kubernetes client to interact with the given cluster
-func (p *Provider) GetClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (kubernetes.Interface, error) {
+func (p *Provider) GetClient(c *kubermaticv1.Cluster, options ...ConfigOption) (kubernetes.Interface, error) {
 	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (p *Provider) GetClient(c *kubermaticv1.Cluster, options ...ClientConfigOpt
 }
 
 // GetMachineClient returns a client to interact with machine resources for the given cluster
-func (p *Provider) GetMachineClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (clusterv1alpha1clientset.Interface, error) {
+func (p *Provider) GetMachineClient(c *kubermaticv1.Cluster, options ...ConfigOption) (clusterv1alpha1clientset.Interface, error) {
 	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func (p *Provider) GetMachineClient(c *kubermaticv1.Cluster, options ...ClientCo
 }
 
 // GetApiextensionsClient returns a client to interact with apiextension resources for the given cluster
-func (p *Provider) GetApiextensionsClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (apiextensionsclientset.Interface, error) {
+func (p *Provider) GetApiextensionsClient(c *kubermaticv1.Cluster, options ...ConfigOption) (apiextensionsclientset.Interface, error) {
 	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (p *Provider) GetApiextensionsClient(c *kubermaticv1.Cluster, options ...Cl
 }
 
 // GetAdmissionRegistrationClient returns a client to interact with admissionregistration resources
-func (p *Provider) GetAdmissionRegistrationClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error) {
+func (p *Provider) GetAdmissionRegistrationClient(c *kubermaticv1.Cluster, options ...ConfigOption) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error) {
 	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func (p *Provider) GetAdmissionRegistrationClient(c *kubermaticv1.Cluster, optio
 }
 
 // GetKubeAggregatorClient returns a client to interact with the aggregation API for the given cluster
-func (p *Provider) GetKubeAggregatorClient(c *kubermaticv1.Cluster, options ...ClientConfigOption) (aggregationclientset.Interface, error) {
+func (p *Provider) GetKubeAggregatorClient(c *kubermaticv1.Cluster, options ...ConfigOption) (aggregationclientset.Interface, error) {
 	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -51,11 +51,11 @@ import (
 
 // userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
 type userClusterConnectionProvider interface {
-	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (kubernetes.Interface, error)
-	GetMachineClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (clusterv1alpha1clientset.Interface, error)
-	GetApiextensionsClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (apiextensionsclientset.Interface, error)
-	GetAdmissionRegistrationClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error)
-	GetKubeAggregatorClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (aggregationclientset.Interface, error)
+	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (kubernetes.Interface, error)
+	GetMachineClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (clusterv1alpha1clientset.Interface, error)
+	GetApiextensionsClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (apiextensionsclientset.Interface, error)
+	GetAdmissionRegistrationClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error)
+	GetKubeAggregatorClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (aggregationclientset.Interface, error)
 }
 
 // Controller is a controller which is responsible for managing clusters

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/glog"
 
+	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticscheme "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/scheme"
 	kubermaticv1informers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions/kubermatic/v1"
@@ -50,11 +51,11 @@ import (
 
 // userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
 type userClusterConnectionProvider interface {
-	GetClient(*kubermaticv1.Cluster) (kubernetes.Interface, error)
-	GetMachineClient(*kubermaticv1.Cluster) (clusterv1alpha1clientset.Interface, error)
-	GetApiextensionsClient(*kubermaticv1.Cluster) (apiextensionsclientset.Interface, error)
-	GetAdmissionRegistrationClient(*kubermaticv1.Cluster) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error)
-	GetKubeAggregatorClient(*kubermaticv1.Cluster) (aggregationclientset.Interface, error)
+	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (kubernetes.Interface, error)
+	GetMachineClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (clusterv1alpha1clientset.Interface, error)
+	GetApiextensionsClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (apiextensionsclientset.Interface, error)
+	GetAdmissionRegistrationClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error)
+	GetKubeAggregatorClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (aggregationclientset.Interface, error)
 }
 
 // Controller is a controller which is responsible for managing clusters

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -40,7 +40,7 @@ const (
 
 // userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
 type userClusterConnectionProvider interface {
-	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (kubernetes.Interface, error)
+	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (kubernetes.Interface, error)
 }
 
 // Controller stores all components required for monitoring

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/glog"
 
+	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	kubermaticv1informers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions/kubermatic/v1"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -39,7 +40,7 @@ const (
 
 // userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
 type userClusterConnectionProvider interface {
-	GetClient(*kubermaticv1.Cluster) (kubernetes.Interface, error)
+	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (kubernetes.Interface, error)
 }
 
 // Controller stores all components required for monitoring

--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -62,12 +62,12 @@ func deleteNodeForClusterLegacy(projectProvider provider.ProjectProvider) endpoi
 		// normally we have project, user and sshkey providers
 		// but here we decided to use machineClient and kubeClient directly to access the user cluster.
 		//
-		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a machine client: %v", err)
 		}
 
-		kubeClient, err := clusterProvider.GetKubernetesClientForCustomerCluster(cluster)
+		kubeClient, err := clusterProvider.GetAdminKubernetesClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a kubernetes client: %v", err)
 		}
@@ -110,7 +110,7 @@ func listNodesForClusterLegacy(projectProvider provider.ProjectProvider) endpoin
 		// but here we decided to use machineClient and kubeClient directly to access the user cluster.
 		//
 		// how about moving machineClient and kubeClient to their own provider ?
-		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -160,7 +160,7 @@ func listNodesForClusterLegacy(projectProvider provider.ProjectProvider) endpoin
 }
 
 func getNodeList(cluster *v1.Cluster, clusterProvider provider.ClusterProvider) (*corev1.NodeList, error) {
-	kubeClient, err := clusterProvider.GetKubernetesClientForCustomerCluster(cluster)
+	kubeClient, err := clusterProvider.GetAdminKubernetesClientForCustomerCluster(cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -184,7 +184,7 @@ func getNodeForClusterLegacy(projectProvider provider.ProjectProvider) endpoint.
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -194,7 +194,7 @@ func getNodeForClusterLegacy(projectProvider provider.ProjectProvider) endpoint.
 		// but here we decided to use machineClient and kubeClient directly to access the user cluster.
 		//
 		// how about moving machineClient and kubeClient to their own provider ?
-		kubeClient, err := clusterProvider.GetKubernetesClientForCustomerCluster(cluster)
+		kubeClient, err := clusterProvider.GetAdminKubernetesClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -582,7 +582,7 @@ func createNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvide
 		// but here we decided to use machineClient and kubeClient directly to access the user cluster.
 		//
 		// how about moving machineClient and kubeClient to their own provider ?
-		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -717,7 +717,7 @@ func listNodeDeployments(projectProvider provider.ProjectProvider) endpoint.Endp
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -799,7 +799,7 @@ func getNodeDeployment(projectProvider provider.ProjectProvider) endpoint.Endpoi
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -850,7 +850,7 @@ func decodeListNodeDeploymentNodes(c context.Context, r *http.Request) (interfac
 
 func getMachinesForNodeDeployment(clusterProvider provider.ClusterProvider, cluster *v1.Cluster, nodeDeploymentID string) (*clusterv1alpha1.MachineList, error) {
 
-	machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+	machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -963,7 +963,7 @@ func patchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -1084,7 +1084,7 @@ func deleteNodeDeployment(projectProvider provider.ProjectProvider) endpoint.End
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a machine client: %v", err)
 		}
@@ -1155,7 +1155,7 @@ func listNodeDeploymentNodesEvents() endpoint.Endpoint {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		customerClusterClient, err := clusterProvider.GetKubernetesClientForCustomerCluster(cluster)
+		customerClusterClient, err := clusterProvider.GetAdminKubernetesClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -13,6 +13,7 @@ import (
 	prometheusapi "github.com/prometheus/client_golang/api"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	kubermaticfakeclentset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
 	kubermaticclientv1 "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/typed/kubermatic/v1"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
@@ -199,11 +200,11 @@ func (f *fakeUserClusterConnection) GetAdminKubeconfig(c *kubermaticapiv1.Cluste
 	return []byte(generateTestKubeconfig(ClusterID, IDToken)), nil
 }
 
-func (f *fakeUserClusterConnection) GetMachineClient(c *kubermaticapiv1.Cluster) (clusterclientset.Interface, error) {
+func (f *fakeUserClusterConnection) GetMachineClient(c *kubermaticapiv1.Cluster, options ...k8cuserclusterclient.ClientConfigOption) (clusterclientset.Interface, error) {
 	return f.fakeMachineClient, nil
 }
 
-func (f *fakeUserClusterConnection) GetClient(c *kubermaticapiv1.Cluster) (kubernetesclient.Interface, error) {
+func (f *fakeUserClusterConnection) GetClient(c *kubermaticapiv1.Cluster, options ...k8cuserclusterclient.ClientConfigOption) (kubernetesclient.Interface, error) {
 	return f.fakeKubernetesClient, nil
 }
 

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -200,11 +200,11 @@ func (f *fakeUserClusterConnection) GetAdminKubeconfig(c *kubermaticapiv1.Cluste
 	return []byte(generateTestKubeconfig(ClusterID, IDToken)), nil
 }
 
-func (f *fakeUserClusterConnection) GetMachineClient(c *kubermaticapiv1.Cluster, options ...k8cuserclusterclient.ClientConfigOption) (clusterclientset.Interface, error) {
+func (f *fakeUserClusterConnection) GetMachineClient(c *kubermaticapiv1.Cluster, options ...k8cuserclusterclient.ConfigOption) (clusterclientset.Interface, error) {
 	return f.fakeMachineClient, nil
 }
 
-func (f *fakeUserClusterConnection) GetClient(c *kubermaticapiv1.Cluster, options ...k8cuserclusterclient.ClientConfigOption) (kubernetesclient.Interface, error) {
+func (f *fakeUserClusterConnection) GetClient(c *kubermaticapiv1.Cluster, options ...k8cuserclusterclient.ConfigOption) (kubernetesclient.Interface, error) {
 	return f.fakeKubernetesClient, nil
 }
 

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -21,9 +22,9 @@ import (
 
 // UserClusterConnectionProvider offers functions to interact with a user cluster
 type UserClusterConnectionProvider interface {
-	GetClient(*kubermaticapiv1.Cluster) (kubernetes.Interface, error)
-	GetMachineClient(*kubermaticapiv1.Cluster) (clusterv1alpha1clientset.Interface, error)
-	GetAdminKubeconfig(c *kubermaticapiv1.Cluster) ([]byte, error)
+	GetClient(*kubermaticapiv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (kubernetes.Interface, error)
+	GetMachineClient(*kubermaticapiv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (clusterv1alpha1clientset.Interface, error)
+	GetAdminKubeconfig(*kubermaticapiv1.Cluster) ([]byte, error)
 }
 
 // NewClusterProvider returns a new cluster provider that respects RBAC policies
@@ -194,16 +195,16 @@ func (p *ClusterProvider) GetAdminKubeconfigForCustomerCluster(c *kubermaticapiv
 	return clientcmd.Load(b)
 }
 
-// GetMachineClientForCustomerCluster returns a client to interact with machine resources in the given cluster
+// GetAdminMachineClientForCustomerCluster returns a client to interact with machine resources in the given cluster
 //
 // Note that the client you will get has admin privileges
-func (p *ClusterProvider) GetMachineClientForCustomerCluster(c *kubermaticapiv1.Cluster) (clusterv1alpha1clientset.Interface, error) {
+func (p *ClusterProvider) GetAdminMachineClientForCustomerCluster(c *kubermaticapiv1.Cluster) (clusterv1alpha1clientset.Interface, error) {
 	return p.userClusterConnProvider.GetMachineClient(c)
 }
 
-// GetKubernetesClientForCustomerCluster returns a client to interact with the given cluster
+// GetAdminKubernetesClientForCustomerCluster returns a client to interact with the given cluster
 //
 // Note that the client you will get has admin privileges
-func (p *ClusterProvider) GetKubernetesClientForCustomerCluster(c *kubermaticapiv1.Cluster) (kubernetes.Interface, error) {
+func (p *ClusterProvider) GetAdminKubernetesClientForCustomerCluster(c *kubermaticapiv1.Cluster) (kubernetes.Interface, error) {
 	return p.userClusterConnProvider.GetClient(c)
 }

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -22,8 +22,8 @@ import (
 
 // UserClusterConnectionProvider offers functions to interact with a user cluster
 type UserClusterConnectionProvider interface {
-	GetClient(*kubermaticapiv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (kubernetes.Interface, error)
-	GetMachineClient(*kubermaticapiv1.Cluster, ...k8cuserclusterclient.ClientConfigOption) (clusterv1alpha1clientset.Interface, error)
+	GetClient(*kubermaticapiv1.Cluster, ...k8cuserclusterclient.ConfigOption) (kubernetes.Interface, error)
+	GetMachineClient(*kubermaticapiv1.Cluster, ...k8cuserclusterclient.ConfigOption) (clusterv1alpha1clientset.Interface, error)
 	GetAdminKubeconfig(*kubermaticapiv1.Cluster) ([]byte, error)
 }
 

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -107,15 +107,15 @@ type ClusterProvider interface {
 	// GetAdminKubeconfigForCustomerCluster returns the admin kubeconfig for the given cluster
 	GetAdminKubeconfigForCustomerCluster(cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
 
-	// GetMachineClientForCustomerCluster returns a client to interact with machine resources in the given cluster
+	// GetAdminMachineClientForCustomerCluster returns a client to interact with machine resources in the given cluster
 	//
 	// Note that the client you will get has admin privileges
-	GetMachineClientForCustomerCluster(cluster *kubermaticv1.Cluster) (clusterv1alpha1clientset.Interface, error)
+	GetAdminMachineClientForCustomerCluster(cluster *kubermaticv1.Cluster) (clusterv1alpha1clientset.Interface, error)
 
 	// GetClientForCustomerCluster returns a client to interact with the given cluster
 	//
 	// Note that the client you will get has admin privileges
-	GetKubernetesClientForCustomerCluster(cluster *kubermaticv1.Cluster) (kubernetes.Interface, error)
+	GetAdminKubernetesClientForCustomerCluster(cluster *kubermaticv1.Cluster) (kubernetes.Interface, error)
 }
 
 // SSHKeyListOptions allows to set filters that will be applied to filter the result.

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -112,7 +112,7 @@ type ClusterProvider interface {
 	// Note that the client you will get has admin privileges
 	GetAdminMachineClientForCustomerCluster(cluster *kubermaticv1.Cluster) (clusterv1alpha1clientset.Interface, error)
 
-	// GetClientForCustomerCluster returns a client to interact with the given cluster
+	// GetAdminKubernetesClientForCustomerCluster returns a client to interact with the given cluster
 	//
 	// Note that the client you will get has admin privileges
 	GetAdminKubernetesClientForCustomerCluster(cluster *kubermaticv1.Cluster) (kubernetes.Interface, error)


### PR DESCRIPTION
**What this PR does / why we need it**: simply extends user cluster provider component so that  additional options to the rest config can be added in a generic way.
 
**Special notes for your reviewer**: see #2680 for more info

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
