### PR TITLE
allow kube-state-metrics to scrape PDB's

### DIFF
--- a/api/pkg/resources/kubestatemetrics/clusterrole.go
+++ b/api/pkg/resources/kubestatemetrics/clusterrole.go
@@ -66,6 +66,13 @@ func ClusterRole(_ resources.ClusterRoleDataProvider, existing *rbacv1.ClusterRo
 			},
 			Verbs: []string{"list", "watch"},
 		},
+		{
+			APIGroups: []string{"policy"},
+			Resources: []string{
+				"poddisruptionbudgets",
+			},
+			Verbs: []string{"list", "watch"},
+		},
 	}
 	return r, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Release note**:
```release-note
NONE
```
