### PR TITLE
Fix tide batch testing

### DIFF
--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -135,9 +135,9 @@ rm -f config/kubermatic/templates/cluster-role-binding.yaml
 helm upgrade --install --wait --timeout 300 \
   --tiller-namespace=$NAMESPACE \
   --set=kubermatic.isMaster=true \
-  --set=kubermatic.controller.image.tag=$BUILD_ID \
-  --set=kubermatic.api.image.tag=$BUILD_ID \
-  --set=kubermatic.rbac.image.tag=$BUILD_ID \
+  --set-string=kubermatic.controller.image.tag=$BUILD_ID \
+  --set-string=kubermatic.api.image.tag=$BUILD_ID \
+  --set-string=kubermatic.rbac.image.tag=$BUILD_ID \
   --set-string=kubermatic.worker_name=$BUILD_ID \
   --set=kubermatic.deployVPA=false \
   --set=kubermatic.ingressClass=non-existent \

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -76,7 +76,7 @@ time make -C api build
 echo "Finished building conformance-tests and kubermatic-controller-manager"
 
 echo "Building docker image"
-./api/hack/push_image.sh ${PULL_PULL_SHA}
+./api/hack/push_image.sh ${BUILD_ID}
 echo "Finished building and pushing docker images"
 
 INITIAL_MANIFESTS=$(cat <<EOF
@@ -135,9 +135,9 @@ rm -f config/kubermatic/templates/cluster-role-binding.yaml
 helm upgrade --install --wait --timeout 300 \
   --tiller-namespace=$NAMESPACE \
   --set=kubermatic.isMaster=true \
-  --set=kubermatic.controller.image.tag=$PULL_PULL_SHA \
-  --set=kubermatic.api.image.tag=$PULL_PULL_SHA \
-  --set=kubermatic.rbac.image.tag=$PULL_PULL_SHA \
+  --set=kubermatic.controller.image.tag=$BUILD_ID \
+  --set=kubermatic.api.image.tag=$BUILD_ID \
+  --set=kubermatic.rbac.image.tag=$BUILD_ID \
   --set-string=kubermatic.worker_name=$BUILD_ID \
   --set=kubermatic.deployVPA=false \
   --set=kubermatic.ingressClass=non-existent \


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes tide batch testing, there is no `PULL_PULL_SHA` env var avaiable, seen e.G. here: https://prow.loodse.com/view/gcs/prow-data/pr-logs/pull/kubermatic_kubermatic/2683/pull-kubermatic-e2e-aws-coreos-1.10/1088461822350069760

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 

CC @nikhita 