### PR TITLE
Use internal API server service (Without ClusterIP) + Do custom endpoint reconciling to avoid handling the NodePort

### DIFF
--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -418,11 +418,11 @@ func (d *secretData) GetFrontProxyCA() (*triple.KeyPair, error) {
 }
 
 func (d *secretData) InClusterApiserverURL() (*url.URL, error) {
-	return resources.GetClusterApiserverURL(d.cluster, d.serviceLister)
+	return resources.GetClusterApiserverURL(d.cluster)
 }
 
 func (d *secretData) InClusterApiserverAddress() (string, error) {
-	return resources.GetClusterApiserverAddress(d.cluster, d.serviceLister)
+	return resources.GetClusterApiserverAddress(d.cluster)
 }
 
 func (c *Controller) getEtcdSecretName(cluster *kubermaticv1.Cluster) string {

--- a/api/pkg/controller/cluster/address_test.go
+++ b/api/pkg/controller/cluster/address_test.go
@@ -17,11 +17,16 @@ import (
 // - 192.168.1.2
 // - 2001:16B8:6844:D700:A1B9:D94B:FDC3:1C33
 func TestGetExternalIPv4(t *testing.T) {
-	ip, err := getExternalIPv4("dns-test.kubermatic.io")
+	ipSet, err := getExternalIPv4Set("dns-test.kubermatic.io")
 	if err != nil {
 		t.Fatal(err)
 	}
+	ips := ipSet.List()
+	if len(ips) != 2 {
+		t.Fatalf("expected to get exactly 2 IPs. But got %d: %v", len(ips), ips)
+	}
 
+	ip := ips[0]
 	if ip != "192.168.1.1" {
 		t.Fatalf("expected to get 192.168.1.1. Got: %s", ip)
 	}

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -16,6 +16,12 @@ const (
 
 func (cc *Controller) reconcileCluster(cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
 	var err error
+
+	if err = cc.reconcileAPIServerEndpoints(cluster); err != nil {
+		// Accept it and proceed
+		glog.Errorf("failed to reconcile the APIServer endpoints: %v", err)
+		cc.enqueueAfter(cluster, 1*time.Second)
+	}
 	// Create the namespace
 	if cluster, err = cc.ensureNamespaceExists(cluster); err != nil {
 		return nil, err

--- a/api/pkg/resources/apiserver/service.go
+++ b/api/pkg/resources/apiserver/service.go
@@ -20,15 +20,16 @@ func Service(data resources.ServiceDataProvider, existing *corev1.Service) (*cor
 	se.Labels = resources.BaseAppLabel(name, nil)
 
 	se.Spec.Type = corev1.ServiceTypeClusterIP
+	se.Spec.ClusterIP = corev1.ClusterIPNone
 	se.Spec.Selector = map[string]string{
 		resources.AppLabelKey: name,
 	}
 	se.Spec.Ports = []corev1.ServicePort{
 		{
 			Name:       "insecure",
-			Port:       8080,
+			Port:       6443,
 			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt(8080),
+			TargetPort: intstr.FromString("https"),
 		},
 	}
 
@@ -60,7 +61,7 @@ func ExternalService(data resources.ServiceDataProvider, existing *corev1.Servic
 				Name:       "secure",
 				Port:       443,
 				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(443),
+				TargetPort: intstr.FromString("https"),
 			},
 		}
 
@@ -69,7 +70,7 @@ func ExternalService(data resources.ServiceDataProvider, existing *corev1.Servic
 
 	se.Spec.Ports[0].Name = "secure"
 	se.Spec.Ports[0].Port = se.Spec.Ports[0].NodePort
-	se.Spec.Ports[0].TargetPort = intstr.FromInt(int(se.Spec.Ports[0].NodePort))
+	se.Spec.Ports[0].TargetPort = intstr.FromString("https")
 	se.Spec.Ports[0].Protocol = corev1.ProtocolTCP
 
 	return se, nil

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -332,14 +332,14 @@ func (d *TemplateData) GetApiserverExternalNodePort() (int32, error) {
 // and returns them joined by a `:`.
 // Service lookup happens within `Cluster.Status.NamespaceName`.
 func (d *TemplateData) InClusterApiserverAddress() (string, error) {
-	return GetClusterApiserverAddress(d.cluster, d.serviceLister)
+	return GetClusterApiserverAddress(d.cluster)
 }
 
 // InClusterApiserverURL takes the ClusterIP and node-port of the external/secure apiserver service
 // and returns them joined by a `:` and the used protocol.
 // Service lookup happens within `Cluster.Status.NamespaceName`.
 func (d *TemplateData) InClusterApiserverURL() (*url.URL, error) {
-	return GetClusterApiserverURL(d.cluster, d.serviceLister)
+	return GetClusterApiserverURL(d.cluster)
 }
 
 // ImageRegistry returns the image registry to use or the passed in default if no override is specified

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -104,10 +104,12 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 				"--authorization-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 				"--kubelet-port", "10250",
 				"--kubelet-insecure-tls",
+				"--enable-swagger-ui",
 				// We use the same as the API server as we use the same dnat-controller
 				"--kubelet-preferred-address-types", "ExternalIP,InternalIP",
-				"--v", "1",
+				"--metric-resolution", "10s",
 				"--logtostderr",
+				"--secure-port", "443",
 			},
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
@@ -117,6 +119,13 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 					Name:      resources.MetricsServerKubeconfigSecretName,
 					MountPath: "/etc/kubernetes/kubeconfig",
 					ReadOnly:  true,
+				},
+			},
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          "https",
+					ContainerPort: 443,
+					Protocol:      corev1.ProtocolTCP,
 				},
 			},
 		},

--- a/api/pkg/resources/metrics-server/service.go
+++ b/api/pkg/resources/metrics-server/service.go
@@ -25,7 +25,7 @@ func Service(data resources.ServiceDataProvider, existing *corev1.Service) (*cor
 		{
 			Port:       443,
 			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt(443),
+			TargetPort: intstr.FromString("https"),
 		},
 	}
 

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -411,23 +411,14 @@ type ObjectCreator = func(existing runtime.Object) (runtime.Object, error)
 type ObjectModifier func(create ObjectCreator) ObjectCreator
 
 // GetClusterApiserverAddress returns the apiserver address for the given Cluster
-func GetClusterApiserverAddress(cluster *kubermaticv1.Cluster, lister corev1lister.ServiceLister) (string, error) {
-	service, err := lister.Services(cluster.Status.NamespaceName).Get(ApiserverExternalServiceName)
-	if err != nil {
-		return "", fmt.Errorf("could not get service %s from lister for cluster %s: %v", ApiserverExternalServiceName, cluster.Name, err)
-	}
-
-	if len(service.Spec.Ports) != 1 {
-		return "", errors.New("apiserver service does not have exactly one port")
-	}
-
-	dnsName := GetAbsoluteServiceDNSName(ApiserverExternalServiceName, cluster.Status.NamespaceName)
-	return fmt.Sprintf("%s:%d", dnsName, service.Spec.Ports[0].NodePort), nil
+func GetClusterApiserverAddress(cluster *kubermaticv1.Cluster) (string, error) {
+	dnsName := GetAbsoluteServiceDNSName(ApiserverInternalServiceName, cluster.Status.NamespaceName)
+	return fmt.Sprintf("%s:%d", dnsName, 6443), nil
 }
 
 // GetClusterApiserverURL returns the apiserver url for the given Cluster
-func GetClusterApiserverURL(cluster *kubermaticv1.Cluster, lister corev1lister.ServiceLister) (*url.URL, error) {
-	addr, err := GetClusterApiserverAddress(cluster, lister)
+func GetClusterApiserverURL(cluster *kubermaticv1.Cluster) (*url.URL, error) {
+	addr, err := GetClusterApiserverAddress(cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ data:
 
       kubernetes_sd_configs:
       - role: node
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -48,7 +48,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_node_name]
         regex: (.+)
         target_label: __metrics_path__
@@ -100,7 +100,7 @@ data:
         key_file: /etc/kubernetes/prometheus-client.key
       kubernetes_sd_configs:
       - role: pod
-        api_server: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        api_server: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
         tls_config:
           ca_file: /etc/kubernetes/ca.crt
           cert_file: /etc/kubernetes/prometheus-client.crt
@@ -119,7 +119,7 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
       - target_label: __address__
-        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        replacement: 'apiserver.cluster-de-test-01.svc.cluster.local.:6443'
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -235,7 +235,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -243,13 +243,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -235,7 +235,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -243,13 +243,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -235,7 +235,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -243,13 +243,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -235,7 +235,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -243,13 +243,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -200,7 +200,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -235,7 +235,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -243,13 +243,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -203,7 +203,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -161,7 +161,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -235,7 +235,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -243,13 +243,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -206,7 +206,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -194,7 +194,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -161,7 +161,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -190,7 +190,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -161,7 +161,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -83,7 +83,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -190,7 +190,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -161,7 +161,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -222,7 +222,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -230,13 +230,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -94,7 +94,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -94,7 +94,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -94,7 +94,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -94,7 +94,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -194,7 +194,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -94,7 +94,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -161,7 +161,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -197,7 +197,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -94,7 +94,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -87,7 +87,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -195,7 +195,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -159,7 +159,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -198,7 +198,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -161,7 +161,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "30000"
+        prometheus.io/port: "6443"
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
@@ -145,9 +145,7 @@ spec:
         - --advertise-address
         - 35.198.93.90
         - --secure-port
-        - "30000"
-        - --kubernetes-service-node-port
-        - "30000"
+        - "6443"
         - --etcd-servers
         - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
         - --etcd-cafile
@@ -209,6 +207,8 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --endpoint-reconciler-type
+        - none
         - --runtime-config
         - admissionregistration.k8s.io/v1alpha1
         - --feature-gates
@@ -226,7 +226,7 @@ spec:
           failureThreshold: 8
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -234,13 +234,14 @@ spec:
           timeoutSeconds: 15
         name: apiserver
         ports:
-        - containerPort: 30000
+        - containerPort: 6443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 30000
+            port: https
             scheme: HTTPS
           periodSeconds: 5
           successThreshold: 1

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -201,7 +201,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -51,16 +51,23 @@ spec:
         - --kubelet-port
         - "10250"
         - --kubelet-insecure-tls
+        - --enable-swagger-ui
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
-        - --v
-        - "1"
+        - --metric-resolution
+        - 10s
         - --logtostderr
+        - --secure-port
+        - "443"
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         name: metrics-server
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
         resources:
           limits:
             cpu: 150m
@@ -166,7 +173,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
       initContainers:
       - args:
         - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - https://apiserver.cluster-de-test-01.svc.cluster.local.:6443/healthz
         - -insecure
         - -retries
         - "100"

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.6-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.6-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.6-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.6-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.1-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.1-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.1-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.1-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.12.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.12.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.12.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.12.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.13.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.13.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.13.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.13.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.6-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.6-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.6-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.6-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.1-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.1-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.1-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.1-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.12.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.12.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.12.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.12.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.13.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.13.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.13.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.13.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.13.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.13.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.13.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.13.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.13.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.13.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.13.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.13.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.6-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.6-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.6-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.6-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.1-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.1-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.1-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.1-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.12.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.12.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.12.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.12.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.13.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.13.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.13.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.13.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.13.0-apiserver-external.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.13.0-apiserver-external.yaml
@@ -15,7 +15,7 @@ spec:
   - name: secure
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: apiserver
   type: NodePort

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.13.0-apiserver.yaml
@@ -11,11 +11,12 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
+  clusterIP: None
   ports:
   - name: insecure
-    port: 8080
+    port: 6443
     protocol: TCP
-    targetPort: 8080
+    targetPort: https
   selector:
     app: apiserver
   type: ClusterIP

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.13.0-metrics-server.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: https
   selector:
     app: metrics-server
 status:

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash


### PR DESCRIPTION
**What this PR does / why we need it**:

**Release note**:
```release-note
NONE
```
