### PR TITLE
Remove static users from dex config

### DIFF
--- a/config/oauth/templates/dex-config.yaml
+++ b/config/oauth/templates/dex-config.yaml
@@ -18,6 +18,7 @@ data:
     web:
       http: 0.0.0.0:5556
 {{ if .Values.dex.grpc }}
+    enablePasswordDB: true
     grpc:
 {{ toYaml .Values.dex.grpc.api | indent 7 }}
 {{- end }}
@@ -28,9 +29,4 @@ data:
 {{ if .Values.dex.clients }}
     staticClients:
 {{ toYaml .Values.dex.clients | indent 7 }}
-{{- end }}
-{{ if .Values.dex.staticPasswordLogins }}
-    enablePasswordDB: true
-    staticPasswords:
-{{ toYaml .Values.dex.staticPasswordLogins | indent 7 }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes static clients configuration from dex. We can add user manually using dex client now. No need to hardcode them.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
