### PR TITLE
implements GetMachineClientForCustomerCluster method

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -32,6 +32,7 @@ import (
 	prometheusapi "github.com/prometheus/client_golang/api"
 
 	"github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
 	"github.com/kubermatic/kubermatic/api/pkg/handler"
@@ -118,6 +119,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 				client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
 				kubermaticSeedInformerFactory.Kubermatic().V1().Clusters().Lister(),
 				options.workerName,
+				rbac.ExtractGroupPrefix,
 			)
 
 			kubeInformerFactory.Start(wait.NeverStop)

--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -58,10 +58,8 @@ func deleteNodeForClusterLegacy(projectProvider provider.ProjectProvider) endpoi
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		// TODO:
-		// normally we have project, user and sshkey providers
-		// but here we decided to use machineClient and kubeClient directly to access the user cluster.
-		//
+		// TODO: change to
+		// machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a machine client: %v", err)

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -14,6 +14,7 @@ import (
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	kubermaticfakeclentset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
 	kubermaticclientv1 "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/typed/kubermatic/v1"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
@@ -119,6 +120,7 @@ func CreateTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.Dat
 		fUserClusterConnection,
 		kubermaticInformerFactory.Kubermatic().V1().Clusters().Lister(),
 		"",
+		rbac.ExtractGroupPrefix,
 	)
 	clusterProviders := map[string]provider.ClusterProvider{"us-central1": clusterProvider}
 

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -107,6 +107,7 @@ type ClusterProvider interface {
 	// GetAdminKubeconfigForCustomerCluster returns the admin kubeconfig for the given cluster
 	GetAdminKubeconfigForCustomerCluster(cluster *kubermaticv1.Cluster) (*clientcmdapi.Config, error)
 
+	// Deprecated use GetMachineClientForCustomerCluster instead
 	// GetAdminMachineClientForCustomerCluster returns a client to interact with machine resources in the given cluster
 	//
 	// Note that the client you will get has admin privileges
@@ -116,6 +117,11 @@ type ClusterProvider interface {
 	//
 	// Note that the client you will get has admin privileges
 	GetAdminKubernetesClientForCustomerCluster(cluster *kubermaticv1.Cluster) (kubernetes.Interface, error)
+
+	// GetMachineClientForCustomerCluster returns a client to interact with machine resources in the given cluster
+	//
+	// Note that the client doesn't use admin account instead it authn/authz as userInfo(email, group)
+	GetMachineClientForCustomerCluster(userInfo *UserInfo, c *kubermaticv1.Cluster) (clusterv1alpha1clientset.Interface, error)
 }
 
 // SSHKeyListOptions allows to set filters that will be applied to filter the result.


### PR DESCRIPTION
**What this PR does / why we need it**: adds `ImpersonationConfig` to` restclient.Config`, user information will be taken from `provider.UserInfo` struct. `GetMachineClientForCustomerCluster` is not used because there is no controller in the cluster that would generate proper permissions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 2680


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
