### PR TITLE
Machine-Controller: Use readyness endpoint to determine liveness

### DIFF
--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -107,7 +107,7 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 			TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 			Resources:                controllerResourceRequirements,
-			ReadinessProbe: &corev1.Probe{
+			LivenessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path:   "/ready",
@@ -115,20 +115,7 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 						Scheme: corev1.URISchemeHTTP,
 					},
 				},
-				FailureThreshold: 3,
-				PeriodSeconds:    10,
-				SuccessThreshold: 1,
-				TimeoutSeconds:   15,
-			},
-			LivenessProbe: &corev1.Probe{
-				FailureThreshold: 8,
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path:   "/live",
-						Port:   intstr.FromInt(8085),
-						Scheme: corev1.URISchemeHTTP,
-					},
-				},
+				FailureThreshold:    3,
 				InitialDelaySeconds: 15,
 				PeriodSeconds:       10,
 				SuccessThreshold:    1,

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -48,9 +48,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -58,15 +58,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -51,9 +51,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -61,15 +61,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -51,9 +51,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -61,15 +61,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -51,9 +51,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -61,15 +61,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -51,9 +51,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -61,15 +61,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -51,9 +51,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -61,15 +61,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -51,9 +51,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -61,15 +61,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -59,9 +59,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -69,15 +69,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -59,9 +59,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -69,15 +69,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -59,9 +59,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -69,15 +69,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -59,9 +59,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -69,15 +69,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -59,9 +59,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -69,15 +69,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -59,9 +59,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -69,15 +69,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -53,9 +53,9 @@ spec:
         image: docker.io/kubermatic/machine-controller:v1.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
-            path: /live
+            path: /ready
             port: 8085
             scheme: HTTP
           initialDelaySeconds: 15
@@ -63,15 +63,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 15
         name: machine-controller
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8085
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 15
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
We've had multiple occasions were the machine-controller just hung, in
those cases the liveness endpoint.

Since the liveness endpoint on the machine-controller is only an empty
http handler, we instead use the readyness endpoint that has some actual
checking to force a restart when there is an issue

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 
