### PR TITLE
Improve e2e tests

### DIFF
--- a/api/cmd/conformance-tests/custom_tests.go
+++ b/api/cmd/conformance-tests/custom_tests.go
@@ -18,11 +18,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func (r *testRunner) testPVC(log *logrus.Entry, kubeClient kubernetes.Interface) error {
+func (r *testRunner) testPVC(log *logrus.Entry, kubeClient kubernetes.Interface, attempt int) error {
 	log.Info("Testing support for PVC's...")
 
-	// We're creating a own namespace, so the cleanup routine will take care as fallback
-	const nsName = "pvc-test"
+	nsName := fmt.Sprintf("pvc-test-%d", attempt)
 	ns, err := kubeClient.CoreV1().Namespaces().Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
@@ -31,12 +30,6 @@ func (r *testRunner) testPVC(log *logrus.Entry, kubeClient kubernetes.Interface)
 	if err != nil {
 		return fmt.Errorf("failed to create namespace: %v", err)
 	}
-
-	defer func() {
-		if err := deleteAllNonDefaultNamespaces(log, kubeClient); err != nil {
-			log.Errorf("Failed to cleanup namespaces after the PVC test: %v", err)
-		}
-	}()
 
 	log.Info("Creating a StatefulSet with PVC...")
 	labels := map[string]string{"app": "data-writer"}
@@ -127,11 +120,10 @@ func (r *testRunner) testPVC(log *logrus.Entry, kubeClient kubernetes.Interface)
 	return nil
 }
 
-func (r *testRunner) testLB(log *logrus.Entry, kubeClient kubernetes.Interface) error {
+func (r *testRunner) testLB(log *logrus.Entry, kubeClient kubernetes.Interface, attempt int) error {
 	log.Info("Testing support for LB's...")
 
-	// We're creating a own namespace, so the cleanup routine will take care as fallback
-	const nsName = "lb-test"
+	nsName := fmt.Sprintf("lb-test-%d", attempt)
 	ns, err := kubeClient.CoreV1().Namespaces().Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
@@ -140,12 +132,6 @@ func (r *testRunner) testLB(log *logrus.Entry, kubeClient kubernetes.Interface) 
 	if err != nil {
 		return fmt.Errorf("failed to create namespace: %v", err)
 	}
-
-	defer func() {
-		if err := deleteAllNonDefaultNamespaces(log, kubeClient); err != nil {
-			log.Errorf("Failed to cleanup namespaces after the LB test: %v", err)
-		}
-	}()
 
 	log.Info("Creating a Service of type LoadBalancer...")
 	labels := map[string]string{"app": "hello"}

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -364,8 +364,8 @@ func (r *testRunner) testCluster(
 		return nil, fmt.Errorf("failed to marshal combined report file: %v", err)
 	}
 
-	if err := ioutil.WriteFile(path.Join(scenarioFolder, "junit.xml"), b, 0644); err != nil {
-		return nil, fmt.Errorf("failed to wrte combined report file: %v", err)
+	if err := ioutil.WriteFile(path.Join(r.reportsRoot, fmt.Sprintf("junit.%s.xml", scenarioName)), b, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write combined report file: %v", err)
 	}
 
 	return report, nil

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -160,7 +160,9 @@ helm init --wait --service-account=tiller --tiller-namespace=$NAMESPACE
 
 echodate "Installing Kubermatic via Helm"
 rm -f config/kubermatic/templates/cluster-role-binding.yaml
-helm upgrade --install --wait --timeout 900 \
+# --force is needed in case the first attempt at installing didn't succeed
+# see https://github.com/helm/helm/pull/3597
+retry 3 helm upgrade --install --force --wait --timeout 300 \
   --tiller-namespace=$NAMESPACE \
   --set=kubermatic.isMaster=true \
   --set-string=kubermatic.controller.image.tag=$GIT_HEAD_HASH \

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -165,8 +165,11 @@ rm -f config/kubermatic/templates/cluster-role-binding.yaml
 retry 3 helm upgrade --install --force --wait --timeout 300 \
   --tiller-namespace=$NAMESPACE \
   --set=kubermatic.isMaster=true \
+  --set-string=kubermatic.controller.image.repository=docker.io/kubermatic/api \
   --set-string=kubermatic.controller.image.tag=$GIT_HEAD_HASH \
+  --set-string=kubermatic.api.image.repository=docker.io/kubermatic/api \
   --set-string=kubermatic.api.image.tag=$GIT_HEAD_HASH \
+  --set-string=kubermatic.rbac.image.repository=docker.io/kubermatic/api \
   --set-string=kubermatic.rbac.image.tag=$GIT_HEAD_HASH \
   --set-string=kubermatic.worker_name=$BUILD_ID \
   --set=kubermatic.deployVPA=false \

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -88,6 +88,7 @@ time go build -v github.com/kubermatic/kubermatic/api/cmd/conformance-tests
 echodate "Finished building conformance-tests cli"
 
 if [[ ! -f $HOME/.docker/config.json ]]; then
+  docker ps &>/dev/null || start-docker.sh
   mkdir  -p $HOME/.docker
   echo '{"experimental": "enabled"}' > ~/.docker/config.json
   echodate "Logging into dockerhub"
@@ -99,7 +100,6 @@ fi
 # We use dockerhub because docker manifest inspect doesn't seem to work on quay
 if ! docker manifest inspect docker.io/kubermatic/api:$GIT_HEAD_HASH &>/dev/null; then
   echodate "Building binaries"
-  docker ps &>/dev/null || start-docker.sh
   time make -C api build
   cd api
   echodate "Building docker image"

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -33,6 +33,9 @@ function cleanup {
   # Delete the Helm installation
   kubectl delete clusterrolebinding -l prowjob=$BUILD_ID
   kubectl delete namespace $NAMESPACE
+
+  # Upload the JUNIT files
+  mv /reports/* ${ARTIFACTS}/
   echo "Finished cleanup"
 }
 trap cleanup EXIT


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull adds several improvements to the e2e tests:

* The PVC and LB test are run at the end of the suite and each attempt has a distinct namespace, this way we don't have to explicitly clean up the namespaces which saves us some time
* All `echo` outputs in the `ci-run-minimal-conformance-tests.sh` scripts now have a date prefix
* The Junit artifacts are now uploaded to GCS which makes the visible in Deck, e.G. here: https://prow.loodse.com/view/gcs/prow-data/pr-logs/pull/kubermatic_kubermatic/2702/pull-kubermatic-e2e-aws-coreos-1.11/1088869637627580417
* We now use the git HEADs sha as image tag and check if an image with that tag already exists prior to building Kubermatic and the Docker image
* We retry pushing the Docker image
* We retry the `helm install`
* We build the `conformance-tests` cli _after_ the helm install to make sure we fail as fast as possible when something with the helm chart is wrong

/assign @mrIncompetent 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
