### PR TITLE
Log duration for etcd backup creation

### DIFF
--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -581,6 +581,7 @@ func (c *Controller) cronJob(cluster *kubermaticv1.Cluster, existing *batchv1bet
 				},
 			},
 			Command: []string{
+				"/usr/bin/time",
 				"/usr/local/bin/etcdctl",
 				"--endpoints", strings.Join(endpoints, ","),
 				"--cacert", "/etc/etcd/client/ca.crt",


### PR DESCRIPTION
**What this PR does / why we need it**:

We're getting frequent alerts for etcd backup jobs taking too long. I'd like to know how long the actual snapshot creation takes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 
