### PR TITLE
Use 2 replicas of the metrics-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This covers the existing, developer focusing, documentation:
   - [Logging guideline](docs/logging.md)
   - [Events guideline](docs/events.md)
 - [Proposals](docs/proposals)
+- [Things that break](docs/things-that-break.md)
 
 
 Customer facing documentation can be found at https://github.com/kubermatic/docs which gets published at https://docs.kubermatic.io 

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -284,6 +284,7 @@ func GetPodDisruptionBudgetCreators() []resources.PodDisruptionBudgetCreator {
 	return []resources.PodDisruptionBudgetCreator{
 		etcd.PodDisruptionBudget,
 		apiserver.PodDisruptionBudget,
+		metricsserver.PodDisruptionBudget,
 	}
 }
 

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -47,7 +47,7 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 
 	dep.Labels = resources.BaseAppLabel(name, nil)
 
-	dep.Spec.Replicas = resources.Int32(1)
+	dep.Spec.Replicas = resources.Int32(2)
 	dep.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: resources.BaseAppLabel(name, nil),
 	}
@@ -123,6 +123,8 @@ func Deployment(data resources.DeploymentDataProvider, existing *appsv1.Deployme
 		*openvpnSidecar,
 		*dnatControllerSidecar,
 	}
+
+	dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
 
 	return dep, nil
 }

--- a/api/pkg/resources/metrics-server/pdb.go
+++ b/api/pkg/resources/metrics-server/pdb.go
@@ -25,7 +25,6 @@ func PodDisruptionBudget(data *resources.TemplateData, existing *policyv1beta1.P
 		Selector: &metav1.LabelSelector{
 			MatchLabels: resources.BaseAppLabel(name, nil),
 		},
-		// we can only specify maxUnavailable as minAvailable would block in case we have replicas=1. See https://github.com/kubernetes/kubernetes/issues/66811
 		MaxUnavailable: &maxUnavailable,
 	}
 

--- a/api/pkg/resources/metrics-server/pdb.go
+++ b/api/pkg/resources/metrics-server/pdb.go
@@ -1,0 +1,33 @@
+package metricsserver
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodDisruptionBudget returns the metrics-server PodDisruptionBudget
+func PodDisruptionBudget(data *resources.TemplateData, existing *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
+	var pdb *policyv1beta1.PodDisruptionBudget
+	if existing != nil {
+		pdb = existing
+	} else {
+		pdb = &policyv1beta1.PodDisruptionBudget{}
+	}
+
+	pdb.Name = resources.MetricsServerPodDisruptionBudgetName
+	pdb.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
+
+	maxUnavailable := intstr.FromInt(1)
+	pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: resources.BaseAppLabel(name, nil),
+		},
+		// we can only specify maxUnavailable as minAvailable would block in case we have replicas=1. See https://github.com/kubernetes/kubernetes/issues/66811
+		MaxUnavailable: &maxUnavailable,
+	}
+
+	return pdb, nil
+}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -242,6 +242,8 @@ const (
 	EtcdPodDisruptionBudgetName = "etcd"
 	// ApiserverPodDisruptionBudgetName is the name of the PDB for the apiserver deployment
 	ApiserverPodDisruptionBudgetName = "apiserver"
+	// MetricsServerPodDisruptionBudgetName is the name of the PDB for the metrics-server deployment
+	MetricsServerPodDisruptionBudgetName = "metrics-server"
 
 	// DefaultOwnerReadOnlyMode represents file mode with read permission for owner only
 	DefaultOwnerReadOnlyMode = 0400

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -11,7 +11,7 @@ metadata:
     name: de-test-01
     uid: "1234567890"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: metrics-server
@@ -30,6 +30,16 @@ spec:
         metrics-server-secret-revision: "123456"
         openvpn-client-certificates-secret-revision: "123456"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.6-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.1-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.12.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.13.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.6-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.1-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.12.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.13.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.6-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.1-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.12.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.13.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.6-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.1-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.12.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.13.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.6-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.1-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.12.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.13.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.6-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.1-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.12.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.13.0-metrics-server.yaml
@@ -1,0 +1,21 @@
+metadata:
+  creationTimestamp: null
+  name: metrics-server
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptedPods: null
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/docs/things-that-break.md
+++ b/docs/things-that-break.md
@@ -1,0 +1,19 @@
+# Failures
+
+There are a number of failures a Kubernetes cluster operator can encounter over time.
+Some of them are caused by humans - some are caused by infrastructure.
+This list aims to be a "nice-to-know" list of things that can break and have severe impact in the cluster's health.
+
+## metrics-server not available
+
+The [metrics-server](https://github.com/kubernetes-incubator/metrics-server) is a component which scrapes resource metrics from Pods & Nodes on a regular interval (default=30s).
+It works as an [Extension API server](https://kubernetes.io/docs/tasks/access-kubernetes-api/setup-extension-api-server/) and metrics can be gathered using `kubectl top [pod|node]`.
+
+### Caveat
+
+When the metrics-server is not available anymore, the Kubernetes controller-manager stops the processing of namespace deletions as it requires access to the metrics API group.
+It seems that the garbage-collector is trying to cleanup metric resources in a terminating namespace judging by the following line found in the logs:
+```
+W0125 10:48:39.278977       1 garbagecollector.go:647] failed to discover some groups: map[metrics.k8s.io/v1beta1:the server is currently unable to handle the request]
+```
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Use 2 replicas of the metrics-server for stability reason.
As a downtime of the metrics-servers causes the controller-manager to stop certain processing, a downtime is undesirable. 

**Release note**:
```release-note monitoring
metrics-server will use 2 replicas
```
