### PR TITLE
remove OwnerRef from in-cluster metrics-server service

### DIFF
--- a/api/pkg/resources/metrics-server/external-name-service.go
+++ b/api/pkg/resources/metrics-server/external-name-service.go
@@ -17,7 +17,6 @@ func ExternalNameService(data resources.ServiceDataProvider, existing *corev1.Se
 
 	se.Name = resources.MetricsServerExternalNameServiceName
 	se.Namespace = metav1.NamespaceSystem
-	se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	labels := resources.BaseAppLabel(name, nil)
 	se.Labels = labels
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As this Service is located inside the user cluster, the GC must have been removing it on a regular basis.

**Release note**:
```release-note
NONE
```
