### PR TITLE
remove OwnerRef from in-cluster dnatcontroller clusterrole

### DIFF
--- a/api/pkg/resources/vpnsidecar/dnatControllerClusterRole.go
+++ b/api/pkg/resources/vpnsidecar/dnatControllerClusterRole.go
@@ -4,7 +4,6 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DnatControllerClusterRole returns a cluster role for the kubeletdnat controller
@@ -15,7 +14,6 @@ func DnatControllerClusterRole(data resources.ClusterRoleDataProvider, existing 
 	}
 
 	r.Name = resources.KubeletDnatControllerClusterRoleName
-	r.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	r.Rules = []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove OwnerRef from in-cluster dnatcontroller clusterrole as it lives inside the user cluster and the cluster inside the seed cluster.

**Release note**:
```release-note
NONE
```
