### PR TITLE
use own image when deploying to dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -63,7 +63,7 @@ pipeline:
     - export KUBECONFIG=$(pwd)/kubeconfig
     - export EXTRA_ARGS="--tiller-namespace=kubermatic-installer --set=kubermatic.isMaster=true --set=kubermatic.controller.image.tag=${DRONE_COMMIT_SHA} --set=kubermatic.api.image.tag=${DRONE_COMMIT_SHA} --set=kubermatic.rbac.image.tag=${DRONE_COMMIT_SHA}"
     - ./api/hack/deploy.sh master ./values.yaml "$EXTRA_ARGS"
-    image: kubeciio/helm
+    image: quay.io/kubermatic/helm:2.11.0-2
     secrets:
     - vault_secret_id
     - vault_role_id


### PR DESCRIPTION
**What this PR does / why we need it**:
Use own image when deploying to dev.
Current dev deployment is broken: https://drone.loodse.com/kubermatic/kubermatic/6136/6

**Release note**:
```release-note
NONE
```
