### PR TITLE
Do not offer Kubernetes 1.10 by default as its EOL

### DIFF
--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,11 +1,10 @@
 versions:
-# Kubernetes 1.10
-- version: "1.10.11"
-  default: false
 # Kubernetes 1.11
 - version: "1.11.5"
   default: false
 - version: "1.11.6"
+  default: false
+- version: "1.11.7"
   default: true
 # Kubernetes 1.12
 - version: "1.12.3"
@@ -16,4 +15,6 @@ versions:
 - version: "1.13.0"
   default: false
 - version: "1.13.1"
+  default: false
+- version: "1.13.2"
   default: false

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -5,12 +5,14 @@ versions:
 - version: "1.11.6"
   default: false
 - version: "1.11.7"
-  default: true
+  default: false
 # Kubernetes 1.12
 - version: "1.12.3"
   default: false
 - version: "1.12.4"
   default: false
+- version: "1.12.5"
+  default: true
 # Kubernetes 1.13
 - version: "1.13.0"
   default: false


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Kubernetes 1.10 was removed as officially supported version from Kubermatic as its EOL
```
