### PR TITLE
Fix runbook

### DIFF
--- a/config/monitoring/Makefile
+++ b/config/monitoring/Makefile
@@ -1,5 +1,9 @@
 .PHONY: prometheus
-prometheus: check-rules
+prometheus: build-rules check-rules
+
+build-rules:
+	cd prometheus/rules/src; \
+	for file in *.yaml; do echo $$file; yq r $$file -j | jq 'del(.groups[].rules[].runbook)' | yq r - > ../$$file; done
 
 check-rules:
 	promtool check rules prometheus/rules/*.yaml

--- a/config/monitoring/Makefile
+++ b/config/monitoring/Makefile
@@ -3,7 +3,7 @@ prometheus: build-rules check-rules
 
 build-rules:
 	cd prometheus/rules/src; \
-	for file in *.yaml; do echo $$file; yq r $$file -j | jq 'del(.groups[].rules[].runbook)' | yq r - > ../$$file; done
+	for file in *.yaml; do echo $$file; yq r $$file -j | jq 'del(.groups[].rules[].runbook)' | (echo "# This file has been generated, do not edit."; yq r -) > ../$$file; done
 
 check-rules:
 	promtool check rules prometheus/rules/*.yaml

--- a/config/monitoring/prometheus/rules/README.md
+++ b/config/monitoring/prometheus/rules/README.md
@@ -1,5 +1,10 @@
 # Prometheus Alerting/Recording Rules
 
-When editing these rules, please make sure to also update the
-runbook in the documentation repository by running
-`make runbook` in that repository.
+When editing these rules, make sure to not touch the generated files
+in this directory, but rather edit the files in `src/`. Afterwards,
+ensure to run `make` in the monitoring directory to re-generate the
+alert/rules files.
+
+When adding/removing alerts or changing the runbook information, make
+sure to also update the documentation repo by running `make runbook`
+in that repository.

--- a/config/monitoring/prometheus/rules/ark.yaml
+++ b/config/monitoring/prometheus/rules/ark.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: ark
   rules:

--- a/config/monitoring/prometheus/rules/ark.yaml
+++ b/config/monitoring/prometheus/rules/ark.yaml
@@ -3,27 +3,18 @@ groups:
   rules:
   - alert: ArkBackupTakesTooLong
     annotations:
-      message: Backup schedule {{ $labels.schedule }} has been taking more than 60min already.
+      message: Backup schedule {{ $labels.schedule }} has been taking more than 60min
+        already.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-arkbackuptakestoolong
     expr: (ark_backup_attempt_total - ark_backup_success_total) > 0
     for: 60m
     labels:
       severity: warning
-    runbook:
-      steps:
-      - Check if a backup is really in "InProgress" state via `ark -n ark backup get`.
-      - Check the backup logs via `ark -n ark backup logs [BACKUP_NAME]`.
-      - Depending on the backup, find the pod and check the processes inside that pod or any sidecar containers.
-
   - alert: ArkNoRecentBackup
     annotations:
-      message: There has not been a successful backup for schedule {{ $labels.schedule }} in the last 24 hours.
+      message: There has not been a successful backup for schedule {{ $labels.schedule
+        }} in the last 24 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-arknorecentbackup
     expr: changes(ark_backup_success_total{schedule!=""}[25h]) < 1
     labels:
       severity: warning
-    runbook:
-      steps:
-      - Check if really no backups happened via `ark -n ark backup get`.
-      - If a backup failed, check its logs via `ark -n ark backup logs [BACKUP_NAME]`.
-      - If a backup was not even triggered, check the Ark server's logs via `kubectl -n ark logs -l 'name=ark-server'`.

--- a/config/monitoring/prometheus/rules/kube-apiserver.rules.yaml
+++ b/config/monitoring/prometheus/rules/kube-apiserver.rules.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: kube-apiserver.rules
   rules:

--- a/config/monitoring/prometheus/rules/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: kubermatic
   rules:

--- a/config/monitoring/prometheus/rules/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic.yaml
@@ -3,16 +3,13 @@ groups:
   rules:
   - alert: KubermaticTooManyUnhandledErrors
     annotations:
-      message: Kubermatic controller manager in {{ $labels.namespace }} is experiencing too many errors.
+      message: Kubermatic controller manager in {{ $labels.namespace }} is experiencing
+        too many errors.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermatictoomanyunhandlederrors
     expr: sum(rate(kubermatic_controller_manager_unhandled_errors_total[5m])) > 0.01
     for: 10m
     labels:
       severity: warning
-    runbook:
-      steps:
-      - Ensure that the controller-manager pod's logs.
-
   - alert: KubermaticClusterDeletionTakesTooLong
     annotations:
       message: Cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
@@ -21,14 +18,6 @@ groups:
     for: 0m
     labels:
       severity: warning
-    runbook:
-      steps:
-      - Check the machine-controller's logs via `kubectl -n cluster-XYZ logs -l 'app=machine-controller'` for errors related to cloud provider integrations.
-        Expired credentials or manually deleted cloud provider resources are common reasons for failing deletions.
-      - Check the cluster's status itself via `kubectl describe cluster XYZ`.
-      - If all resources have been cleaned up, remove the blocking finalizer (e.g. `kubermatic.io/delete-nodes`) from the cluster resource.
-      - If nothing else helps, manually delete the cluster namespace as a last resort.
-
   - alert: KubermaticAPIDown
     annotations:
       message: KubermaticAPI has disappeared from Prometheus target discovery.
@@ -37,20 +26,13 @@ groups:
     for: 15m
     labels:
       severity: critical
-    runbook:
-      steps:
-      - Check the Prometheus Service Discovery page to find out why the target is unreachable.
-      - Ensure that the API pod's logs and that it is not crashlooping.
-
   - alert: KubermaticControllerManagerDown
     annotations:
-      message: KubermaticControllerManager has disappeared from Prometheus target discovery.
+      message: KubermaticControllerManager has disappeared from Prometheus target
+        discovery.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticcontrollermanagerdown
-    expr: absent(up{job="pods",namespace="kubermatic",role="controller-manager"} == 1)
+    expr: absent(up{job="pods",namespace="kubermatic",role="controller-manager"} ==
+      1)
     for: 15m
     labels:
       severity: critical
-    runbook:
-      steps:
-      - Check the Prometheus Service Discovery page to find out why the target is unreachable.
-      - Ensure that the controller-manager pod's logs and that it is not crashlooping.

--- a/config/monitoring/prometheus/rules/kubernetes-absent.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes-absent.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: kubernetes-absent
   rules:

--- a/config/monitoring/prometheus/rules/kubernetes-apps.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes-apps.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: kubernetes-apps
   rules:

--- a/config/monitoring/prometheus/rules/kubernetes-resources.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes-resources.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: kubernetes-resources
   rules:

--- a/config/monitoring/prometheus/rules/kubernetes-storage.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes-storage.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: kubernetes-storage
   rules:

--- a/config/monitoring/prometheus/rules/kubernetes-system.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes-system.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: kubernetes-system
   rules:

--- a/config/monitoring/prometheus/rules/kubernetes.rules.yaml
+++ b/config/monitoring/prometheus/rules/kubernetes.rules.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: kubernetes.rules
   rules:

--- a/config/monitoring/prometheus/rules/node-exporter.rules.yaml
+++ b/config/monitoring/prometheus/rules/node-exporter.rules.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: node-exporter.rules
   rules:

--- a/config/monitoring/prometheus/rules/node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/node-exporter.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: node-exporter
   rules:

--- a/config/monitoring/prometheus/rules/node.rules.yaml
+++ b/config/monitoring/prometheus/rules/node.rules.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: node.rules
   rules:

--- a/config/monitoring/prometheus/rules/prometheus.yaml
+++ b/config/monitoring/prometheus/rules/prometheus.yaml
@@ -1,3 +1,4 @@
+# This file has been generated, do not edit.
 groups:
 - name: prometheus
   rules:

--- a/config/monitoring/prometheus/rules/src/ark.yaml
+++ b/config/monitoring/prometheus/rules/src/ark.yaml
@@ -1,0 +1,29 @@
+groups:
+- name: ark
+  rules:
+  - alert: ArkBackupTakesTooLong
+    annotations:
+      message: Backup schedule {{ $labels.schedule }} has been taking more than 60min already.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-arkbackuptakestoolong
+    expr: (ark_backup_attempt_total - ark_backup_success_total) > 0
+    for: 60m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check if a backup is really in "InProgress" state via `ark -n ark backup get`.
+      - Check the backup logs via `ark -n ark backup logs [BACKUP_NAME]`.
+      - Depending on the backup, find the pod and check the processes inside that pod or any sidecar containers.
+
+  - alert: ArkNoRecentBackup
+    annotations:
+      message: There has not been a successful backup for schedule {{ $labels.schedule }} in the last 24 hours.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-arknorecentbackup
+    expr: changes(ark_backup_success_total{schedule!=""}[25h]) < 1
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check if really no backups happened via `ark -n ark backup get`.
+      - If a backup failed, check its logs via `ark -n ark backup logs [BACKUP_NAME]`.
+      - If a backup was not even triggered, check the Ark server's logs via `kubectl -n ark logs -l 'name=ark-server'`.

--- a/config/monitoring/prometheus/rules/src/kube-apiserver.rules.yaml
+++ b/config/monitoring/prometheus/rules/src/kube-apiserver.rules.yaml
@@ -1,18 +1,20 @@
 groups:
 - name: kube-apiserver.rules
   rules:
-  - expr: |
+  - record: cluster_quantile:apiserver_request_latencies:histogram_quantile
+    expr: |
       histogram_quantile(0.99, sum(rate(apiserver_request_latencies_bucket{job="apiserver"}[5m])) without(instance, pod)) / 1e+06
     labels:
       quantile: "0.99"
-    record: cluster_quantile:apiserver_request_latencies:histogram_quantile
-  - expr: |
+
+  - record: cluster_quantile:apiserver_request_latencies:histogram_quantile
+    expr: |
       histogram_quantile(0.9, sum(rate(apiserver_request_latencies_bucket{job="apiserver"}[5m])) without(instance, pod)) / 1e+06
     labels:
       quantile: "0.9"
-    record: cluster_quantile:apiserver_request_latencies:histogram_quantile
-  - expr: |
+
+  - record: cluster_quantile:apiserver_request_latencies:histogram_quantile
+    expr: |
       histogram_quantile(0.5, sum(rate(apiserver_request_latencies_bucket{job="apiserver"}[5m])) without(instance, pod)) / 1e+06
     labels:
       quantile: "0.5"
-    record: cluster_quantile:apiserver_request_latencies:histogram_quantile

--- a/config/monitoring/prometheus/rules/src/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic.yaml
@@ -1,0 +1,56 @@
+groups:
+- name: kubermatic
+  rules:
+  - alert: KubermaticTooManyUnhandledErrors
+    annotations:
+      message: Kubermatic controller manager in {{ $labels.namespace }} is experiencing too many errors.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermatictoomanyunhandlederrors
+    expr: sum(rate(kubermatic_controller_manager_unhandled_errors_total[5m])) > 0.01
+    for: 10m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Ensure that the controller-manager pod's logs.
+
+  - alert: KubermaticClusterDeletionTakesTooLong
+    annotations:
+      message: Cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticclusterdeletiontakestoolong
+    expr: (time() - max by (cluster) (kubermatic_cluster_deleted)) > 30*60
+    for: 0m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check the machine-controller's logs via `kubectl -n cluster-XYZ logs -l 'app=machine-controller'` for errors related to cloud provider integrations.
+        Expired credentials or manually deleted cloud provider resources are common reasons for failing deletions.
+      - Check the cluster's status itself via `kubectl describe cluster XYZ`.
+      - If all resources have been cleaned up, remove the blocking finalizer (e.g. `kubermatic.io/delete-nodes`) from the cluster resource.
+      - If nothing else helps, manually delete the cluster namespace as a last resort.
+
+  - alert: KubermaticAPIDown
+    annotations:
+      message: KubermaticAPI has disappeared from Prometheus target discovery.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapidown
+    expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+    runbook:
+      steps:
+      - Check the Prometheus Service Discovery page to find out why the target is unreachable.
+      - Ensure that the API pod's logs and that it is not crashlooping.
+
+  - alert: KubermaticControllerManagerDown
+    annotations:
+      message: KubermaticControllerManager has disappeared from Prometheus target discovery.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticcontrollermanagerdown
+    expr: absent(up{job="pods",namespace="kubermatic",role="controller-manager"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+    runbook:
+      steps:
+      - Check the Prometheus Service Discovery page to find out why the target is unreachable.
+      - Ensure that the controller-manager pod's logs and that it is not crashlooping.

--- a/config/monitoring/prometheus/rules/src/kubernetes-absent.yaml
+++ b/config/monitoring/prometheus/rules/src/kubernetes-absent.yaml
@@ -9,6 +9,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubernetesApiserverDown
     annotations:
       message: KubernetesApiserver has disappeared from Prometheus target discovery.
@@ -17,6 +18,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeControllerManagerDown
     annotations:
       message: KubeControllerManager has disappeared from Prometheus target discovery.
@@ -25,6 +27,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeSchedulerDown
     annotations:
       message: KubeScheduler has disappeared from Prometheus target discovery.
@@ -33,6 +36,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeStateMetricsDown
     annotations:
       message: KubeStateMetrics has disappeared from Prometheus target discovery.
@@ -41,6 +45,7 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeletDown
     annotations:
       message: Kubelet has disappeared from Prometheus target discovery.

--- a/config/monitoring/prometheus/rules/src/kubernetes-apps.yaml
+++ b/config/monitoring/prometheus/rules/src/kubernetes-apps.yaml
@@ -3,29 +3,35 @@ groups:
   rules:
   - alert: KubePodCrashLooping
     annotations:
-      message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
-        }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+      message:
+        Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting
+        {{ printf "%.2f" $value }} times / 5 minutes.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodcrashlooping
-    expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m])
-      * 60 * 5 > 0
+    expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
     for: 1h
     labels:
       severity: critical
+    runbook:
+      steps:
+      - Check the pod's logs.
+
   - alert: KubePodNotReady
     annotations:
-      message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
-        state for longer than an hour.
+      message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than an hour.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodnotready
-    expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics",
-      phase=~"Pending|Unknown"}) > 0
+    expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
     for: 30m
     labels:
       severity: critical
+    runbook:
+      steps:
+      - Check the pod via `kubectl describe pod [POD]` to find out about scheduling issues.
+
   - alert: KubeDeploymentGenerationMismatch
     annotations:
-      message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
-        }} does not match, this indicates that the Deployment has failed but has not
-        been rolled back.
+      message:
+        Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match,
+        this indicates that the Deployment has failed but has not been rolled back.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedeploymentgenerationmismatch
     expr: |
       kube_deployment_status_observed_generation{job="kube-state-metrics"}
@@ -34,10 +40,12 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeDeploymentReplicasMismatch
     annotations:
-      message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
-        matched the expected number of replicas for longer than an hour.
+      message:
+        Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected
+        number of replicas for longer than an hour.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedeploymentreplicasmismatch
     expr: |
       kube_deployment_spec_replicas{job="kube-state-metrics"}
@@ -46,10 +54,12 @@ groups:
     for: 1h
     labels:
       severity: critical
+
   - alert: KubeStatefulSetReplicasMismatch
     annotations:
-      message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not
-        matched the expected number of replicas for longer than 15 minutes.
+      message:
+        StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected
+        number of replicas for longer than 15 minutes.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetreplicasmismatch
     expr: |
       kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
@@ -58,11 +68,12 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeStatefulSetGenerationMismatch
     annotations:
-      message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
-        }} does not match, this indicates that the StatefulSet has failed but has
-        not been rolled back.
+      message:
+        StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match,
+        this indicates that the StatefulSet has failed but has not been rolled back.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetgenerationmismatch
     expr: |
       kube_statefulset_status_observed_generation{job="kube-state-metrics"}
@@ -71,10 +82,10 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeStatefulSetUpdateNotRolledOut
     annotations:
-      message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
-        has not been rolled out.
+      message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetupdatenotrolledout
     expr: |
       max without (revision) (
@@ -91,10 +102,12 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeDaemonSetRolloutStuck
     annotations:
-      message: Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace
-        }}/{{ $labels.daemonset }} are scheduled and ready.
+      message:
+        Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
+        are scheduled and ready.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetrolloutstuck
     expr: |
       kube_daemonset_status_number_ready{job="kube-state-metrics"}
@@ -103,10 +116,10 @@ groups:
     for: 15m
     labels:
       severity: critical
+
   - alert: KubeDaemonSetNotScheduled
     annotations:
-      message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
-        }} are not scheduled.'
+      message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled.'
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetnotscheduled
     expr: |
       kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
@@ -115,34 +128,34 @@ groups:
     for: 10m
     labels:
       severity: warning
+
   - alert: KubeDaemonSetMisScheduled
     annotations:
-      message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
-        }} are running where they are not supposed to run.'
+      message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run.'
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetmisscheduled
     expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
     for: 10m
     labels:
       severity: warning
+
   - alert: KubeCronJobRunning
     annotations:
-      message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
-        than 1h to complete.
+      message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecronjobrunning
     expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} > 3600
     for: 1h
     labels:
       severity: warning
+
   - alert: KubeJobCompletion
     annotations:
-      message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than
-        one hour to complete.
+      message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubejobcompletion
-    expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}
-      > 0
+    expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"} > 0
     for: 1h
     labels:
       severity: warning
+
   - alert: KubeJobFailed
     annotations:
       message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.

--- a/config/monitoring/prometheus/rules/src/kubernetes-resources.yaml
+++ b/config/monitoring/prometheus/rules/src/kubernetes-resources.yaml
@@ -3,8 +3,7 @@ groups:
   rules:
   - alert: KubeCPUOvercommit
     annotations:
-      message: Cluster has overcommitted CPU resource requests for pods and cannot
-        tolerate node failure.
+      message: Cluster has overcommitted CPU resource requests for pods and cannot tolerate node failure.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecpuovercommit
     expr: |
       sum(namespace_name:kube_pod_container_resource_requests_cpu_cores:sum)
@@ -15,10 +14,10 @@ groups:
     for: 5m
     labels:
       severity: warning
+
   - alert: KubeMemOvercommit
     annotations:
-      message: Cluster has overcommitted memory resource requests for pods and cannot
-        tolerate node failure.
+      message: Cluster has overcommitted memory resource requests for pods and cannot tolerate node failure.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubememovercommit
     expr: |
       sum(namespace_name:kube_pod_container_resource_requests_memory_bytes:sum)
@@ -31,6 +30,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+
   - alert: KubeCPUOvercommit
     annotations:
       message: Cluster has overcommitted CPU resource requests for namespaces.
@@ -43,6 +43,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+
   - alert: KubeMemOvercommit
     annotations:
       message: Cluster has overcommitted memory resource requests for namespaces.
@@ -55,10 +56,10 @@ groups:
     for: 5m
     labels:
       severity: warning
+
   - alert: KubeQuotaExceeded
     annotations:
-      message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
-        }}% of its {{ $labels.resource }} quota.
+      message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubequotaexceeded
     expr: |
       100 * kube_resourcequota{job="kube-state-metrics", type="used"}
@@ -68,10 +69,27 @@ groups:
     for: 15m
     labels:
       severity: warning
+
+  # triggered by kernel bug, see issue kubermatic#2367
+
+  # - alert: CPUThrottlingHigh
+  #   annotations:
+  #     message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace }} for {{ $labels.container_name }}.'
+  #     runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-cputhrottlinghigh
+  #   expr: |
+  #     100 * sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by (container_name, pod_name, namespace)
+  #       /
+  #     sum(increase(container_cpu_cfs_periods_total[5m])) by (container_name, pod_name, namespace)
+  #       > 25
+  #   for: 15m
+  #   labels:
+  #     severity: warning
+
   - alert: KubePodOOMKilled
     annotations:
-      message: Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{
-        $labels.pod }} has been OOMKilled {{ $value }} times in the last 30 minutes.
+      message:
+        Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }}
+        has been OOMKilled {{ $value }} times in the last 30 minutes.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodoomkilled
     expr: |
       (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 30m >= 2)

--- a/config/monitoring/prometheus/rules/src/kubernetes-storage.yaml
+++ b/config/monitoring/prometheus/rules/src/kubernetes-storage.yaml
@@ -3,9 +3,9 @@ groups:
   rules:
   - alert: KubePersistentVolumeUsageCritical
     annotations:
-      message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }}
-        in namespace {{ $labels.namespace }} is only {{ printf "%0.0f" $value }}%
-        free.
+      message:
+        The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace
+        {{ $labels.namespace }} is only {{ printf "%0.0f" $value }}% free.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepersistentvolumeusagecritical
     expr: |
       100 * kubelet_volume_stats_available_bytes{job="kubelet"}
@@ -15,11 +15,13 @@ groups:
     for: 1m
     labels:
       severity: critical
+
   - alert: KubePersistentVolumeFullInFourDays
     annotations:
-      message: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim
-        }} in namespace {{ $labels.namespace }} is expected to fill up within four
-        days. Currently {{ $value }} bytes are available.
+      message:
+        Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }}
+        in namespace {{ $labels.namespace }} is expected to fill up within four days.
+        Currently {{ $value }} bytes are available.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepersistentvolumefullinfourdays
     expr: |
       (

--- a/config/monitoring/prometheus/rules/src/kubernetes-system.yaml
+++ b/config/monitoring/prometheus/rules/src/kubernetes-system.yaml
@@ -5,24 +5,25 @@ groups:
     annotations:
       message: '{{ $labels.node }} has been unready for more than an hour.'
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubenodenotready
-    expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}
-      == 0
+    expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
     for: 1h
     labels:
       severity: warning
+
   - alert: KubeVersionMismatch
     annotations:
-      message: There are {{ $value }} different versions of Kubernetes components
-        running.
+      message: There are {{ $value }} different versions of Kubernetes components running.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeversionmismatch
     expr: count(count(kubernetes_build_info{job!="dns"}) by (gitVersion)) > 1
     for: 1h
     labels:
       severity: warning
+
+  # a dedicated rule for pods to include more helpful labels in the message like the instance and job name
   - alert: KubeClientErrors
     annotations:
-      message: The pod {{ $labels.namespace }}/{{ $labels.pod }} is experiencing {{
-        printf "%0.0f" $value }}% errors.
+      message:
+        The pod {{ $labels.namespace }}/{{ $labels.pod }} is experiencing {{ printf "%0.0f" $value }}% errors.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclienterrors
     expr: |
       (sum(rate(rest_client_requests_total{code=~"5..",job="pods"}[5m])) by (namespace, pod)
@@ -32,10 +33,11 @@ groups:
     for: 15m
     labels:
       severity: warning
+
   - alert: KubeClientErrors
     annotations:
-      message: The kubelet on {{ $labels.instance }} is experiencing {{ printf "%0.0f"
-        $value }}% errors.
+      message:
+        The kubelet on {{ $labels.instance }} is experiencing {{ printf "%0.0f" $value }}% errors.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclienterrors
     expr: |
       (sum(rate(rest_client_requests_total{code=~"5..",job="kubelet"}[5m])) by (instance)
@@ -45,35 +47,38 @@ groups:
     for: 15m
     labels:
       severity: warning
+
   - alert: KubeletTooManyPods
     annotations:
-      message: Kubelet {{ $labels.instance }} is running {{ $value }} pods, close
-        to the limit of 110.
+      message: Kubelet {{ $labels.instance }} is running {{ $value }} pods, close to the limit of 110.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubelettoomanypods
     expr: kubelet_running_pod_count{job="kubelet"} > 110 * 0.9
     for: 15m
     labels:
       severity: warning
+
   - alert: KubeAPILatencyHigh
     annotations:
-      message: The API server has a 99th percentile latency of {{ $value }} seconds
+      message:
+        The API server has a 99th percentile latency of {{ $value }} seconds
         for {{ $labels.verb }} {{ $labels.resource }}.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapilatencyhigh
-    expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"}
-      > 1
+    expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
     for: 10m
     labels:
       severity: warning
+
   - alert: KubeAPILatencyHigh
     annotations:
-      message: The API server has a 99th percentile latency of {{ $value }} seconds
+      message:
+        The API server has a 99th percentile latency of {{ $value }} seconds
         for {{ $labels.verb }} {{ $labels.resource }}.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapilatencyhigh
-    expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"}
-      > 4
+    expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
     for: 10m
     labels:
       severity: critical
+
   - alert: KubeAPIErrorsHigh
     annotations:
       message: API server is returning errors for {{ $value }}% of requests.
@@ -85,6 +90,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+
   - alert: KubeAPIErrorsHigh
     annotations:
       message: API server is returning errors for {{ $value }}% of requests.
@@ -96,6 +102,7 @@ groups:
     for: 10m
     labels:
       severity: warning
+
   - alert: KubeClientCertificateExpiration
     annotations:
       message: Kubernetes API certificate is expiring in less than 7 days.
@@ -104,6 +111,7 @@ groups:
       histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
     labels:
       severity: warning
+
   - alert: KubeClientCertificateExpiration
     annotations:
       message: Kubernetes API certificate is expiring in less than 24 hours.

--- a/config/monitoring/prometheus/rules/src/kubernetes.rules.yaml
+++ b/config/monitoring/prometheus/rules/src/kubernetes.rules.yaml
@@ -1,46 +1,52 @@
 groups:
 - name: kubernetes.rules
   rules:
-  - expr: |
+  - record: namespace:container_cpu_usage_seconds_total:sum_rate
+    expr: |
       sum by (namespace) (
         rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])
       )
-    record: namespace:container_cpu_usage_seconds_total:sum_rate
-  - expr: |
+
+  - record: namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate
+    expr: |
       sum by (namespace, pod_name, container_name) (
         rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])
       )
-    record: namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate
-  - expr: |
+
+  - record: namespace:container_memory_usage_bytes:sum
+    expr: |
       sum by (namespace) (
         container_memory_usage_bytes{job="cadvisor", image!="", container_name!=""}
       )
-    record: namespace:container_memory_usage_bytes:sum
-  - expr: |
+
+  - record: namespace_name:container_cpu_usage_seconds_total:sum_rate
+    expr: |
       sum by (namespace, label_name) (
           sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace, pod_name)
         * on (namespace, pod_name) group_left(label_name)
           label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
       )
-    record: namespace_name:container_cpu_usage_seconds_total:sum_rate
-  - expr: |
+
+  - record: namespace_name:container_memory_usage_bytes:sum
+    expr: |
       sum by (namespace, label_name) (
           sum(container_memory_usage_bytes{job="cadvisor",image!="", container_name!=""}) by (pod_name, namespace)
         * on (namespace, pod_name) group_left(label_name)
           label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
       )
-    record: namespace_name:container_memory_usage_bytes:sum
-  - expr: |
+
+  - record: namespace_name:kube_pod_container_resource_requests_memory_bytes:sum
+    expr: |
       sum by (namespace, label_name) (
           sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}) by (namespace, pod)
         * on (namespace, pod) group_left(label_name)
           label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
       )
-    record: namespace_name:kube_pod_container_resource_requests_memory_bytes:sum
-  - expr: |
+
+  - record: namespace_name:kube_pod_container_resource_requests_cpu_cores:sum
+    expr: |
       sum by (namespace, label_name) (
           sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} and on(pod) kube_pod_status_scheduled{condition="true"}) by (namespace, pod)
         * on (namespace, pod) group_left(label_name)
           label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
       )
-    record: namespace_name:kube_pod_container_resource_requests_cpu_cores:sum

--- a/config/monitoring/prometheus/rules/src/node-exporter.rules.yaml
+++ b/config/monitoring/prometheus/rules/src/node-exporter.rules.yaml
@@ -1,60 +1,69 @@
 groups:
 - name: node-exporter.rules
   rules:
-  - expr: |
+  - record: instance:node_num_cpu:sum
+    expr: |
       count by (instance) (
         sum by (instance, cpu) (
           node_cpu_seconds_total{app="node-exporter"}
         )
       )
-    record: instance:node_num_cpu:sum
-  - expr: |
+
+  - record: instance:node_cpu_utilisation:avg1m
+    expr: |
       1 - avg by (instance) (
         rate(node_cpu_seconds_total{app="node-exporter",mode="idle"}[1m])
       )
-    record: instance:node_cpu_utilisation:avg1m
-  - expr: |
+
+  - record: 'instance:node_cpu_saturation_load1:'
+    expr: |
       sum by (instance) (node_load1{app="node-exporter"})
       /
       instance:node_num_cpu:sum
-    record: 'instance:node_cpu_saturation_load1:'
-  - expr: |
+
+  - record: instance:node_memory_bytes_total:sum
+    expr: |
       sum by (instance) (
         node_memory_MemTotal_bytes{app="node-exporter"}
       )
-    record: instance:node_memory_bytes_total:sum
-  - expr: |
+
+  - record: instance:node_memory_utilisation:ratio
+    expr: |
       1 - (
           node_memory_MemAvailable_bytes{app="node-exporter"}
         /
           node_memory_MemTotal_bytes{app="node-exporter"}
       )
-    record: instance:node_memory_utilisation:ratio
-  - expr: |
+
+  - record: instance:node_memory_swap_io_bytes:sum_rate
+    expr: |
       1e3 * sum by (instance) (
         (rate(node_vmstat_pgpgin{app="node-exporter"}[1m])
           + rate(node_vmstat_pgpgout{app="node-exporter"}[1m]))
       )
-    record: instance:node_memory_swap_io_bytes:sum_rate
-  - expr: |
+
+  - record: instance:node_disk_utilisation:sum_irate
+    expr: |
       sum by (instance) (
         irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd).+"}[1m])
       )
-    record: instance:node_disk_utilisation:sum_irate
-  - expr: |
+
+  - record: instance:node_disk_saturation:sum_irate
+    expr: |
       sum by (instance) (
         irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd).+"}[1m])
       )
-    record: instance:node_disk_saturation:sum_irate
-  - expr: |
+
+  - record: instance:node_net_utilisation:sum_irate
+    expr: |
       sum by (instance) (
         (irate(node_network_receive_bytes_total{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
           irate(node_network_transmit_bytes_total{app="node-exporter",device=~"eth[0-9]+"}[1m]))
       )
-    record: instance:node_net_utilisation:sum_irate
-  - expr: |
+
+  - record: instance:node_net_saturation:sum_irate
+    expr: |
       sum by (instance) (
         (irate(node_network_receive_drop_total{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
           irate(node_network_transmit_drop_total{app="node-exporter",device=~"eth[0-9]+"}[1m]))
       )
-    record: instance:node_net_saturation:sum_irate

--- a/config/monitoring/prometheus/rules/src/node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/node-exporter.yaml
@@ -3,7 +3,8 @@ groups:
   rules:
   - alert: NodeFilesystemSpaceFillingUp
     annotations:
-      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
+      message:
+        Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of space within the next 24 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemspacefillingup
     expr: |
@@ -15,9 +16,11 @@ groups:
     for: 1h
     labels:
       severity: warning
+
   - alert: NodeFilesystemSpaceFillingUp
     annotations:
-      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
+      message:
+        Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of space within the next 4 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemspacefillingup
     expr: |
@@ -29,9 +32,11 @@ groups:
     for: 1h
     labels:
       severity: critical
+
   - alert: NodeFilesystemOutOfSpace
     annotations:
-      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
+      message:
+        Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
@@ -41,9 +46,11 @@ groups:
     for: 1h
     labels:
       severity: warning
+
   - alert: NodeFilesystemOutOfSpace
     annotations:
-      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
+      message:
+        Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
@@ -53,9 +60,11 @@ groups:
     for: 1h
     labels:
       severity: critical
+
   - alert: NodeFilesystemFilesFillingUp
     annotations:
-      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
+      message:
+        Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of files within the next 24 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemfilesfillingup
     expr: |
@@ -67,9 +76,11 @@ groups:
     for: 1h
     labels:
       severity: warning
+
   - alert: NodeFilesystemFilesFillingUp
     annotations:
-      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
+      message:
+        Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of files within the next 4 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemfilesfillingup
     expr: |
@@ -81,9 +92,11 @@ groups:
     for: 1h
     labels:
       severity: warning
+
   - alert: NodeFilesystemOutOfFiles
     annotations:
-      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
+      message:
+        Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available inodes left.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutoffiles
     expr: |
@@ -93,9 +106,11 @@ groups:
     for: 1h
     labels:
       severity: warning
+
   - alert: NodeFilesystemOutOfSpace
     annotations:
-      message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
+      message:
+        Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
@@ -105,18 +120,22 @@ groups:
     for: 1h
     labels:
       severity: critical
+
   - alert: NodeNetworkReceiveErrs
     annotations:
-      message: '{{ $labels.instance }} interface {{ $labels.device }} shows errors
+      message:
+        '{{ $labels.instance }} interface {{ $labels.device }} shows errors
         while receiving packets ({{ $value }} errors in two minutes).'
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodenetworkreceiveerrs
     expr: increase(node_network_receive_errs_total[2m]) > 10
     for: 1h
     labels:
       severity: critical
+
   - alert: NodeNetworkTransmitErrs
     annotations:
-      message: '{{ $labels.instance }} interface {{ $labels.device }} shows errors
+      message:
+        '{{ $labels.instance }} interface {{ $labels.device }} shows errors
         while transmitting packets ({{ $value }} errors in two minutes).'
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodenetworktransmiterrs
     expr: increase(node_network_transmit_errs_total[2m]) > 10

--- a/config/monitoring/prometheus/rules/src/node.rules.yaml
+++ b/config/monitoring/prometheus/rules/src/node.rules.yaml
@@ -1,34 +1,41 @@
 groups:
 - name: node.rules
   rules:
-  - expr: |
+  - record: ':kube_pod_info_node_count:'
+    expr: |
       sum(min(kube_pod_info) by (node))
-    record: ':kube_pod_info_node_count:'
-  - expr: |
+
+  - record: 'node_namespace_pod:kube_pod_info:'
+    expr: |
       max(label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
-    record: 'node_namespace_pod:kube_pod_info:'
-  - expr: |
+
+  - record: node:node_num_cpu:sum
+    expr: |
       count by (node) (sum by (node, cpu) (
         node_cpu_seconds_total{app="node-exporter"}
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       ))
-    record: node:node_num_cpu:sum
-  - expr: |
+
+  - record: :node_cpu_utilisation:avg1m
+    expr: |
       1 - avg(rate(node_cpu_seconds_total{app="node-exporter",mode="idle"}[1m]))
-    record: :node_cpu_utilisation:avg1m
-  - expr: |
+
+  - record: node:node_cpu_utilisation:avg1m
+    expr: |
       1 - avg by (node) (
         rate(node_cpu_seconds_total{app="node-exporter",mode="idle"}[1m])
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:)
-    record: node:node_cpu_utilisation:avg1m
-  - expr: |
+
+  - record: ':node_cpu_saturation_load1:'
+    expr: |
       sum(node_load1{app="node-exporter"})
       /
       sum(node:node_num_cpu:sum)
-    record: ':node_cpu_saturation_load1:'
-  - expr: |
+
+  - record: 'node:node_cpu_saturation_load1:'
+    expr: |
       sum by (node) (
         node_load1{app="node-exporter"}
       * on (namespace, pod) group_left(node)
@@ -36,45 +43,53 @@ groups:
       )
       /
       node:node_num_cpu:sum
-    record: 'node:node_cpu_saturation_load1:'
-  - expr: |
+
+  - record: ':node_memory_utilisation:'
+    expr: |
       1 -
       sum(node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
       /
       sum(node_memory_MemTotal_bytes{app="node-exporter"})
-    record: ':node_memory_utilisation:'
-  - expr: |
+
+  - record: :node_memory_MemFreeCachedBuffers:sum
+    expr: |
       sum(node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
-    record: :node_memory_MemFreeCachedBuffers:sum
-  - expr: |
+
+  - record: :node_memory_MemTotal:sum
+    expr: |
       sum(node_memory_MemTotal_bytes{app="node-exporter"})
-    record: :node_memory_MemTotal:sum
-  - expr: |
+
+  - record: node:node_memory_bytes_available:sum
+    expr: |
       sum by (node) (
         (node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
       )
-    record: node:node_memory_bytes_available:sum
-  - expr: |
+
+  - record: node:node_memory_bytes_total:sum
+    expr: |
       sum by (node) (
         node_memory_MemTotal_bytes{app="node-exporter"}
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
       )
-    record: node:node_memory_bytes_total:sum
-  - expr: |
+
+  - record: node:node_memory_utilisation:ratio
+    expr: |
       (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
       /
       scalar(sum(node:node_memory_bytes_total:sum))
-    record: node:node_memory_utilisation:ratio
-  - expr: |
+
+  - record: :node_memory_swap_io_bytes:sum_rate
+    expr: |
       1e3 * sum(
         (rate(node_vmstat_pgpgin{app="node-exporter"}[1m])
         + rate(node_vmstat_pgpgout{app="node-exporter"}[1m]))
       )
-    record: :node_memory_swap_io_bytes:sum_rate
-  - expr: |
+
+  - record: 'node:node_memory_utilisation:'
+    expr: |
       1 -
       sum by (node) (
         (node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
@@ -87,71 +102,82 @@ groups:
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
-    record: 'node:node_memory_utilisation:'
-  - expr: |
+
+  - record: 'node:node_memory_utilisation_2:'
+    expr: |
       1 - (node:node_memory_bytes_available:sum / node:node_memory_bytes_total:sum)
-    record: 'node:node_memory_utilisation_2:'
-  - expr: |
+
+  - record: node:node_memory_swap_io_bytes:sum_rate
+    expr: |
       1e3 * sum by (node) (
         (rate(node_vmstat_pgpgin{app="node-exporter"}[1m])
         + rate(node_vmstat_pgpgout{app="node-exporter"}[1m]))
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
       )
-    record: node:node_memory_swap_io_bytes:sum_rate
-  - expr: |
+
+  - record: :node_disk_utilisation:avg_irate
+    expr: |
       avg(irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]))
-    record: :node_disk_utilisation:avg_irate
-  - expr: |
+
+  - record: node:node_disk_utilisation:avg_irate
+    expr: |
       avg by (node) (
         irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m])
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
-    record: node:node_disk_utilisation:avg_irate
-  - expr: |
+
+  - record: :node_disk_saturation:avg_irate
+    expr: |
       avg(irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]))
-    record: :node_disk_saturation:avg_irate
-  - expr: |
+
+  - record: node:node_disk_saturation:avg_irate
+    expr: |
       avg by (node) (
         irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m])
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
-    record: node:node_disk_saturation:avg_irate
-  - expr: |
+
+  - record: 'node:node_filesystem_usage:'
+    expr: |
       max by (namespace, pod, device) (
         (node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
         /
         node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
       )
-    record: 'node:node_filesystem_usage:'
-  - expr: |
+
+  - record: 'node:node_filesystem_avail:'
+    expr: |
       max by (namespace, pod, device) (
         node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
       )
-    record: 'node:node_filesystem_avail:'
-  - expr: |
+
+  - record: :node_net_utilisation:sum_irate
+    expr: |
       sum(irate(node_network_receive_bytes_total{app="node-exporter",device="eth0"}[1m])) +
       sum(irate(node_network_transmit_bytes_total{app="node-exporter",device="eth0"}[1m]))
-    record: :node_net_utilisation:sum_irate
-  - expr: |
+
+  - record: node:node_net_utilisation:sum_irate
+    expr: |
       sum by (node) (
         (irate(node_network_receive_bytes_total{app="node-exporter",device="eth0"}[1m]) +
         irate(node_network_transmit_bytes_total{app="node-exporter",device="eth0"}[1m]))
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
-    record: node:node_net_utilisation:sum_irate
-  - expr: |
+
+  - record: :node_net_saturation:sum_irate
+    expr: |
       sum(irate(node_network_receive_drop_total{app="node-exporter",device="eth0"}[1m])) +
       sum(irate(node_network_transmit_drop_total{app="node-exporter",device="eth0"}[1m]))
-    record: :node_net_saturation:sum_irate
-  - expr: |
+
+  - record: node:node_net_saturation:sum_irate
+    expr: |
       sum by (node) (
         (irate(node_network_receive_drop_total{app="node-exporter",device="eth0"}[1m]) +
         irate(node_network_transmit_drop_total{app="node-exporter",device="eth0"}[1m]))
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
-    record: node:node_net_saturation:sum_irate

--- a/config/monitoring/prometheus/rules/src/prometheus.yaml
+++ b/config/monitoring/prometheus/rules/src/prometheus.yaml
@@ -3,13 +3,16 @@ groups:
   rules:
   - alert: PromScrapeFailed
     annotations:
-      message: Prometheus failed to scrape a target {{ $labels.job }} / {{ $labels.instance
-        }}.
+      message: Prometheus failed to scrape a target {{ $labels.job }} / {{ $labels.instance }}.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promscrapefailed
     expr: up != 1
     for: 15m
     labels:
       severity: warning
+    runbook:
+      steps:
+      - Check the Prometheus Service Discovery page to find out why the target is unreachable.
+
   - alert: PromBadConfig
     annotations:
       mesage: Prometheus failed to reload config.
@@ -18,6 +21,11 @@ groups:
     for: 15m
     labels:
       severity: critical
+    runbook:
+      steps:
+      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-kubermatic-0` and `-1`.
+      - Check the `prometheus-kubermatic-rules` configmap via `kubectl -n monitoring get configmap prometheus-kubermatic-rules -o yaml`.
+
   - alert: PromAlertmanagerBadConfig
     annotations:
       message: Alertmanager failed to reload config.
@@ -26,15 +34,24 @@ groups:
     for: 10m
     labels:
       severity: critical
+    runbook:
+      steps:
+      - Check Alertmanager pod's logs via `kubectl -n monitoring logs alertmanager-kubermatic-0`, `-1` and `-2`.
+      - Check the `alertmanager-kubermatic` secret via `kubectl -n monitoring get secret alertmanager-kubermatic -o yaml`.
+
   - alert: PromAlertsFailed
     annotations:
       message: Alertmanager failed to send an alert.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promalertsfailed
-    expr: sum(increase(alertmanager_notifications_failed_total{job="alertmanager"}[5m]))
-      by (namespace) > 0
+    expr: sum(increase(alertmanager_notifications_failed_total{job="alertmanager"}[5m])) by (namespace) > 0
     for: 5m
     labels:
       severity: critical
+    runbook:
+      steps:
+      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-kubermatic-0` and `-1`.
+      - 'Make sure the Alertmanager StatefulSet is running: `kubectl -n monitoring get pods`.'
+
   - alert: PromRemoteStorageFailures
     annotations:
       message: Prometheus failed to send {{ printf "%.1f" $value }}% samples.
@@ -47,12 +64,20 @@ groups:
     for: 15m
     labels:
       severity: critical
+    runbook:
+      steps:
+      - Ensure that the Prometheus volume has not reached capacity.
+      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-kubermatic-0` and `-1`.
+
   - alert: PromRuleFailures
     annotations:
       message: Prometheus failed to evaluate {{ printf "%.1f" $value }} rules/sec.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promrulefailures
-    expr: rate(prometheus_rule_evaluation_failures_total{job="prometheus"}[1m]) >
-      0
+    expr: rate(prometheus_rule_evaluation_failures_total{job="prometheus"}[1m]) > 0
     for: 15m
     labels:
       severity: critical
+    runbook:
+      steps:
+      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-kubermatic-0` and `-1`.
+      - Check CPU/memory pressure on the node.


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus does not allow custom fields on rules. To work around this, this PR introduces a build step to generate the Prometheus-compatible rules and moves the original source files into `rules/src`, so that our documentation can still find alerts with their rules in one single place.

**Release note**:
```release-note
NONE
```
