### PR TITLE
add ShortNames to ClusterAPI CRDs

### DIFF
--- a/api/pkg/resources/machinecontroller/customresourcedefinition.go
+++ b/api/pkg/resources/machinecontroller/customresourcedefinition.go
@@ -26,6 +26,7 @@ func MachineCRD(_ semver.Semver, existing *apiextensionsv1beta1.CustomResourceDe
 	existing.Spec.Names.ListKind = "MachineList"
 	existing.Spec.Names.Plural = "machines"
 	existing.Spec.Names.Singular = "machine"
+	existing.Spec.Names.ShortNames = []string{"ma"}
 
 	return existing, nil
 }
@@ -44,6 +45,8 @@ func MachineSetCRD(clusterVersion semver.Semver, existing *apiextensionsv1beta1.
 	existing.Spec.Names.ListKind = "MachineSetList"
 	existing.Spec.Names.Plural = "machinesets"
 	existing.Spec.Names.Singular = "machineset"
+	existing.Spec.Names.ShortNames = []string{"ms"}
+
 	if clusterVersion.Semver().Minor() > 9 {
 		existing.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{}}
 	}
@@ -65,6 +68,8 @@ func MachineDeploymentCRD(clusterVersion semver.Semver, existing *apiextensionsv
 	existing.Spec.Names.ListKind = "MachineDeploymentList"
 	existing.Spec.Names.Plural = "machinedeployments"
 	existing.Spec.Names.Singular = "machinedeployment"
+	existing.Spec.Names.ShortNames = []string{"md"}
+
 	if clusterVersion.Semver().Minor() > 9 {
 		existing.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{}}
 	}
@@ -86,6 +91,8 @@ func ClusterCRD(clusterVersion semver.Semver, existing *apiextensionsv1beta1.Cus
 	existing.Spec.Names.ListKind = "ClusterList"
 	existing.Spec.Names.Plural = "clusters"
 	existing.Spec.Names.Singular = "cluster"
+	existing.Spec.Names.ShortNames = []string{"cl"}
+
 	if clusterVersion.Semver().Minor() > 9 {
 		existing.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{}}
 	}

--- a/config/kubermatic/crd/crd-clusters.yaml
+++ b/config/kubermatic/crd/crd-clusters.yaml
@@ -9,6 +9,8 @@ spec:
     listKind: ClusterList
     plural: clusters
     singular: cluster
+    shortNames:
+      - cl
   scope: Cluster
   version: v1
   additionalPrinterColumns:


### PR DESCRIPTION
add ShortNames to ClusterAPI CRD

**What this PR does / why we need it**:

Add a few short names to the ClusterAPI CRDs to enable, e.g. `kubectl
get ma`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will     close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to   the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add short names to the ClusterAPI CRDs to enable, e.g.:

#clusters
kubectl get cl

#machines
kubectl get ma

#machinesets
kubectl get ms

#machinedeployments
kubectl get md
```