### PR TITLE
Dont keep defrag jobs

### DIFF
--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -30,7 +30,7 @@ func CronJob(data *resources.TemplateData, existing *batchv1beta1.CronJob) (*bat
 	job.Name = resources.EtcdDefragCronJobName
 	job.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	job.Spec.ConcurrencyPolicy = batchv1beta1.ForbidConcurrent
-	var historyLimit int32 = 0
+	var historyLimit int32
 	job.Spec.SuccessfulJobsHistoryLimit = &historyLimit
 	job.Spec.Schedule = "@every 3h"
 	job.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure

--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -30,6 +30,8 @@ func CronJob(data *resources.TemplateData, existing *batchv1beta1.CronJob) (*bat
 	job.Name = resources.EtcdDefragCronJobName
 	job.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 	job.Spec.ConcurrencyPolicy = batchv1beta1.ForbidConcurrent
+	var historyLimit int32 = 0
+	job.Spec.SuccessfulJobsHistoryLimit = &historyLimit
 	job.Spec.Schedule = "@every 3h"
 	job.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
 	job.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.13.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.13.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.13.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.13.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.13.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.13.0-etcd-defragger.yaml
@@ -63,4 +63,5 @@ spec:
               defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
 status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will instruct the etcd defrag cronjob to delete all successful defrag jobs after they finished successfully.
There is no value in keeping the last 3 successful finished jobs.

**Release note**:
```release-note
NONE
```
