### PR TITLE
Update Prometheus to 2.7.1

### DIFF
--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.6.0"
+	tag  = "v2.7.1"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"
@@ -90,7 +90,7 @@ func StatefulSetCreator(data *resources.TemplateData) resources.StatefulSetCreat
 					"--storage.tsdb.path=/var/prometheus/data",
 					"--storage.tsdb.min-block-duration=15m",
 					"--storage.tsdb.max-block-duration=30m",
-					"--storage.tsdb.retention=1h",
+					"--storage.tsdb.retention.time=1h",
 					"--web.enable-lifecycle",
 					"--storage.tsdb.no-lockfile",
 					"--web.route-prefix=/",

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention=1h
+        - --storage.tsdb.retention.time=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.6.0
+        image: quay.io/prometheus/prometheus:v2.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -1,5 +1,5 @@
 alertmanager:
-  version: v0.16.0
+  version: v0.16.1
   host: ""
   config:
     global:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
         - --config.file=/etc/prometheus/config/prometheus.yaml
         - --storage.tsdb.no-lockfile
         - --storage.tsdb.path=/prometheus
-        - --storage.tsdb.retention=360h
+        - --storage.tsdb.retention.time=360h
         - --web.enable-lifecycle
         - --web.external-url=https://{{ .Values.prometheus.host | trim }}
         - --web.route-prefix=/
@@ -67,7 +67,7 @@ spec:
         - mountPath: /etc/prometheus/rules/
           name: prometheus-kubermatic-rules
           readOnly: false
-        - mountPath: /prometheus
+        - mountPath: /var/prometheus/data
           name: prometheus-kubermatic-db
           readOnly: false
           subPath: prometheus-db

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,7 +1,7 @@
 prometheus:
   # admin:loodse123
   auth: 'YWRtaW46JGFwcjEkUFR0Y3lQc0MkWVZFTk9nZmpiVE52RWtSeVk1ZjJULgo='
-  version: 'v2.6.0'
+  version: 'v2.7.1'
   host: ""
   storageSize: 100Gi
   backups: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus 2.7 allows for fancier queries and should just be a good update all around.

`storage.tsdb.retention` has been deprecated in favor of `storage.tsdb.retention.time`.

**Release note**:
```release-note
update to Prometheus 2.7.1 & Alertmanager 0.16.1
```
