### PR TITLE
define an alert for catching high error rate of the kubermatic api

### DIFF
--- a/config/monitoring/prometheus/rules/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic.yaml
@@ -37,3 +37,12 @@ groups:
     for: 15m
     labels:
       severity: critical
+  - alert: KubermaticAPITooManyErrors
+    annotations:
+      message: Kubermatic API is returning a high rate of HTTP 5xx responses.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapitoomanyerrors
+    expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) >
+      0.1
+    for: 15m
+    labels:
+      severity: warning

--- a/config/monitoring/prometheus/rules/src/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic.yaml
@@ -54,3 +54,15 @@ groups:
       steps:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.
       - Ensure that the controller-manager pod's logs and that it is not crashlooping.
+
+  - alert: KubermaticAPITooManyErrors
+    annotations:
+      message: Kubermatic API is returning a high rate of HTTP 5xx responses.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapitoomanyerrors
+    expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) > 0.1
+    for: 15m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check the API pod's logs.


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #1387

We do have a couple of HTTP related metrics, but none that are truly useful for more alerts. Plus we wanted to avoid meaningless alerts with no real "action steps". Likewise, none of the metrics are really all that interesting to watch on an dashboard.

**Release note**:
```release-note
NONE
```
