### PR TITLE
get valid VM size types for azure provider

### DIFF
--- a/api/pkg/handler/v1/provider/azure.go
+++ b/api/pkg/handler/v1/provider/azure.go
@@ -62,16 +62,6 @@ func (s *azureClientSetImpl) ListVMSize(ctx context.Context, location string) ([
 	return *sizesResult.Value, nil
 }
 
-func isTierStandard(sku compute.ResourceSku) bool {
-	tier := sku.Tier
-	if tier != nil {
-		if *tier == "Standard" {
-			return true
-		}
-	}
-	return false
-}
-
 func isVirtualMachinesType(sku compute.ResourceSku) bool {
 	resourceType := sku.ResourceType
 	if resourceType != nil {
@@ -97,10 +87,6 @@ func isLocation(sku compute.ResourceSku, location string) bool {
 func isValidVM(sku compute.ResourceSku, location string) bool {
 
 	if !isLocation(sku, location) {
-		return false
-	}
-
-	if !isTierStandard(sku) {
 		return false
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**: filter out not valid VM types for azure provider. Checks SKUs restrictions for a given location and return only supported VM types

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2511

```release-note
filter out not valid VM types for azure provider
```
