### PR TITLE
Allow naming Node Deployments

### DIFF
--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -1026,7 +1026,7 @@ func patchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 
 		machineDeployment, err = machineClient.ClusterV1alpha1().MachineDeployments(machineDeployment.Namespace).Update(machineDeployment)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create machine deployment: %v", err)
+			return nil, fmt.Errorf("failed to update machine deployment: %v", err)
 		}
 
 		return outputMachineDeployment(machineDeployment)

--- a/api/pkg/resources/machine/machinedeployment.go
+++ b/api/pkg/resources/machine/machinedeployment.go
@@ -26,6 +26,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc provider.D
 	md := clusterv1alpha1.MachineDeployment{}
 
 	md.Namespace = metav1.NamespaceSystem
+	md.Name = nd.Name
 	md.GenerateName = fmt.Sprintf("kubermatic-%s-", c.Name)
 
 	md.Spec.Selector.MatchLabels = map[string]string{

--- a/api/pkg/resources/machine/machinedeployment.go
+++ b/api/pkg/resources/machine/machinedeployment.go
@@ -25,9 +25,15 @@ import (
 func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc provider.DatacenterMeta, keys []*kubermaticv1.UserSSHKey) (*clusterv1alpha1.MachineDeployment, error) {
 	md := clusterv1alpha1.MachineDeployment{}
 
+	if nd.Name != "" {
+		md.Name = nd.Name
+	} else {
+		// GenerateName can be set only if Name is empty to avoid confusing error:
+		// https://github.com/kubernetes/kubernetes/issues/32220
+		md.GenerateName = fmt.Sprintf("kubermatic-%s-", c.Name)
+	}
+
 	md.Namespace = metav1.NamespaceSystem
-	md.Name = nd.Name
-	md.GenerateName = fmt.Sprintf("kubermatic-%s-", c.Name)
 
 	md.Spec.Selector.MatchLabels = map[string]string{
 		"machine": fmt.Sprintf("md-%s-%s", c.Name, rand.String(10)),


### PR DESCRIPTION
**What this PR does / why we need it**: Allows changing Node Deployment names during their creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Related to https://github.com/kubermatic/dashboard-v2/issues/978

**Special notes for your reviewer**: 

- [x] allow naming node deployments during their creation
- [x] ~~check for duplicated names (error message `Error 500: failed to create machine deployment: The POST operation against MachineDeployment.cluster.k8s.io could not be completed at this time, please try again.` is not precise enough)~~ Solved by not setting `GenerateName` in all cases (see: https://github.com/kubernetes/kubernetes/issues/32220).

**Documentation**: n/a
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Allowed setting Node Deployment names during their creation.
```
