### PR TITLE
E2E: Disable kubermatic-delete-cluster to improve speed

### DIFF
--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -202,4 +202,5 @@ timeout -s 9 90m ./conformance-tests \
   -aws-secret-access-key="$AWS_E2E_TESTS_SECRET" \
   -versions="$VERSIONS" \
   -providers=aws \
-  -exclude-distributions="ubuntu,centos"
+  -exclude-distributions="ubuntu,centos" \
+  -kubermatic-delete-cluster=false


### PR DESCRIPTION
**What this PR does / why we need it**:

This improves the runtime of e2e tests by not doing the actual deletion of the cluster within the test. This is done within the cleanup func of the `ci-run-minimal-conformance-tests.sh` script anyways so having that did not add anything useful

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
/assign @mrIncompetent 