### PR TITLE
Revert "Update Prometheus to 2.7.1 (#2728)"

### DIFF
--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.7.1"
+	tag  = "v2.6.0"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"
@@ -89,7 +89,7 @@ func StatefulSetCreator(data *resources.TemplateData) resources.StatefulSetCreat
 					"--storage.tsdb.path=/var/prometheus/data",
 					"--storage.tsdb.min-block-duration=15m",
 					"--storage.tsdb.max-block-duration=30m",
-					"--storage.tsdb.retention.time=1h",
+					"--storage.tsdb.retention=1h",
 					"--web.enable-lifecycle",
 					"--storage.tsdb.no-lockfile",
 					"--web.route-prefix=/",

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -34,11 +34,11 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.min-block-duration=15m
         - --storage.tsdb.max-block-duration=30m
-        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.retention=1h
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.7.1
+        image: quay.io/prometheus/prometheus:v2.6.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -1,5 +1,5 @@
 alertmanager:
-  version: v0.16.1
+  version: v0.16.0
   host: ""
   config:
     global:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
         - --config.file=/etc/prometheus/config/prometheus.yaml
         - --storage.tsdb.no-lockfile
         - --storage.tsdb.path=/prometheus
-        - --storage.tsdb.retention.time=360h
+        - --storage.tsdb.retention=360h
         - --web.enable-lifecycle
         - --web.external-url=https://{{ .Values.prometheus.host | trim }}
         - --web.route-prefix=/
@@ -67,7 +67,7 @@ spec:
         - mountPath: /etc/prometheus/rules/
           name: prometheus-kubermatic-rules
           readOnly: false
-        - mountPath: /var/prometheus/data
+        - mountPath: /prometheus
           name: prometheus-kubermatic-db
           readOnly: false
           subPath: prometheus-db

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,7 +1,7 @@
 prometheus:
   # admin:loodse123
   auth: 'YWRtaW46JGFwcjEkUFR0Y3lQc0MkWVZFTk9nZmpiVE52RWtSeVk1ZjJULgo='
-  version: 'v2.7.1'
+  version: 'v2.6.0'
   host: ""
   storageSize: 100Gi
   backups: true


### PR DESCRIPTION
This reverts commit c30448b8ff7b429cd7496ce624d62d8626a9bae5.

Causes CrashLoop with message:
"opening storage failed: create dir: mkdir /prometheus/wal: permission denied"

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
