### PR TITLE
fix bad volume mount for Prometheus 2.7+

### DIFF
--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - --config.file=/etc/prometheus/config/prometheus.yaml
         - --storage.tsdb.no-lockfile
-        - --storage.tsdb.path=/prometheus
+        - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.retention.time=360h
         - --web.enable-lifecycle
         - --web.external-url=https://{{ .Values.prometheus.host | trim }}


### PR DESCRIPTION
**What this PR does / why we need it**:
The Prometheus 2.7.1 update PR missed changing the tsdb path parameter.

**Release note**:
```release-note
NONE
```
