### PR TITLE
enforce kubelet-apiserver version constaints on cluster upgrade

### DIFF
--- a/api/pkg/handler/version_skew.go
+++ b/api/pkg/handler/version_skew.go
@@ -3,8 +3,15 @@ package handler
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1alpha1clientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 // errVersionSkew denotes an error condition where a given kubelet/controlplane version pair is not supported
@@ -44,4 +51,89 @@ func ensureVersionCompatible(controlPlane *semver.Version, kubelet *semver.Versi
 	}
 
 	return nil
+}
+
+// checkClusterVersionSkew returns a list of machines and/or machine deployments
+// that are running kubelet at a version incompatible with the cluster's control plane.
+func checkClusterVersionSkew(userInfo *provider.UserInfo, clusterProvider provider.ClusterProvider, cluster *kubermaticapiv1.Cluster) ([]string, error) {
+	machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a machine client: %v", err)
+	}
+
+	// get deduplicated list of all used kubelet versions
+	kubeletVersions, err := getKubeletVersions(machineClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the list of kubelet versions used in the cluster: %v", err)
+	}
+
+	// this is where the incompatible versions shall be saved
+	incompatibleVersionsSet := map[string]bool{}
+
+	clusterVersion := cluster.Spec.Version.Semver()
+	for _, ver := range kubeletVersions {
+		kubeletVersion, parseErr := semver.NewVersion(ver)
+		if parseErr != nil {
+			return nil, fmt.Errorf("failed to parse kubelet version: %v", parseErr)
+		}
+
+		if err = ensureVersionCompatible(clusterVersion, kubeletVersion); err != nil {
+			// errVersionSkew says it's incompatible
+			if _, ok := err.(errVersionSkew); ok {
+				incompatibleVersionsSet[kubeletVersion.String()] = true
+				continue
+			}
+
+			// other error types
+			return nil, fmt.Errorf("failed to check compatibility between kubelet %q and control plane %q: %v", kubeletVersion, clusterVersion, err)
+		}
+	}
+
+	// deduplicate
+	incompatibleVersionsList := []string{}
+	for ver := range incompatibleVersionsSet {
+		incompatibleVersionsList = append(incompatibleVersionsList, ver)
+	}
+
+	return incompatibleVersionsList, nil
+}
+
+// getKubeletVersions returns the list of all kubelet versions used by a given cluster's Machines and MachineDeployments
+func getKubeletVersions(machineClient clusterv1alpha1clientset.Interface) ([]string, error) {
+	machineList, err := machineClient.ClusterV1alpha1().Machines(metav1.NamespaceSystem).List(metav1.ListOptions{IncludeUninitialized: true})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load machines from cluster: %v", err)
+	}
+
+	machineDeployments, err := machineClient.ClusterV1alpha1().MachineDeployments(metav1.NamespaceSystem).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, common.KubernetesErrorToHTTPError(err)
+	}
+
+	kubeletVersionsSet := map[string]bool{}
+
+	// first let's go through the legacy non-MD nodes
+	for _, m := range machineList.Items {
+		// Do not list Machines that are controlled, i.e. by Machine Set.
+		if len(m.ObjectMeta.OwnerReferences) != 0 {
+			continue
+		}
+
+		ver := strings.TrimSpace(m.Spec.Versions.Kubelet)
+		kubeletVersionsSet[ver] = true
+	}
+
+	// now the deployments
+	for _, md := range machineDeployments.Items {
+		ver := strings.TrimSpace(md.Spec.Template.Spec.Versions.Kubelet)
+		kubeletVersionsSet[ver] = true
+	}
+
+	// deduplicated list
+	kubeletVersionList := []string{}
+	for ver := range kubeletVersionsSet {
+		kubeletVersionList = append(kubeletVersionList, ver)
+	}
+
+	return kubeletVersionList, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
To prevent clusters from being upgraded to versions incompatible with existing nodes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2542

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Clusters can no longer be upgraded to versions incompatible with existing nodes.
```
