### PR TITLE
Add an endpoint to return possible kubelet versions inside the cluster

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1185,7 +1185,7 @@
     },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/upgrades": {
       "get": {
-        "description": "Gets possible node versions for a cluster",
+        "description": "Gets possible node upgrades for a cluster",
         "produces": [
           "application/json"
         ],

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1986,6 +1986,29 @@
           "project"
         ],
         "operationId": "getClusterVersions",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "MasterVersion",

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1976,6 +1976,38 @@
         }
       }
     },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/versions": {
+      "get": {
+        "description": "Gets possible node versions for a cluster",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "project"
+        ],
+        "operationId": "getClusterVersions",
+        "responses": {
+          "200": {
+            "description": "MasterVersion",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MasterVersion"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/projects/{project_id}/sshkeys": {
       "get": {
         "description": "The returned collection is sorted by creation timestamp.",

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1183,6 +1183,61 @@
         }
       }
     },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/upgrades": {
+      "get": {
+        "description": "Gets possible node versions for a cluster",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "project"
+        ],
+        "operationId": "getClusterNodeUpgrades",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MasterVersion",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MasterVersion"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/{node_id}": {
       "get": {
         "description": "This endpoint is deprecated, please create a Node Deployment instead.",
@@ -1931,61 +1986,6 @@
           "project"
         ],
         "operationId": "getClusterUpgrades",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "ProjectID",
-            "name": "project_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "DC",
-            "name": "dc",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "ClusterID",
-            "name": "cluster_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MasterVersion",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MasterVersion"
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/responses/empty"
-          },
-          "403": {
-            "$ref": "#/responses/empty"
-          },
-          "default": {
-            "$ref": "#/responses/errorResponse"
-          }
-        }
-      }
-    },
-    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/versions": {
-      "get": {
-        "description": "Gets possible node versions for a cluster",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "project"
-        ],
-        "operationId": "getClusterVersions",
         "parameters": [
           {
             "type": "string",

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -142,6 +142,10 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/upgrades").
 		Handler(r.getClusterUpgrades())
 
+	mux.Methods(http.MethodGet).
+		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/versions").
+		Handler(r.getClusterVersions())
+
 	//
 	// Defines set of HTTP endpoints for SSH Keys that belong to a cluster
 	mux.Methods(http.MethodPut).
@@ -1163,6 +1167,32 @@ func (r Routing) getClusterUpgrades() http.Handler {
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			middleware.UserInfo(r.userProjectMapper),
 		)(getClusterUpgrades(r.updateManager, r.projectProvider)),
+		common.DecodeGetClusterReq,
+		EncodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/versions project getClusterVersions
+//
+//    Gets possible node versions for a cluster
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: []MasterVersion
+//       401: empty
+//       403: empty
+func (r Routing) getClusterVersions() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.oidcAuthenticator.Verifier(),
+			middleware.UserSaver(r.userProvider),
+			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.UserInfo(r.userProjectMapper),
+		)(getClusterVersions(r.updateManager, r.projectProvider)),
 		common.DecodeGetClusterReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1175,7 +1175,7 @@ func (r Routing) getClusterUpgrades() http.Handler {
 
 // swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/upgrades project getClusterNodeUpgrades
 //
-//    Gets possible node versions for a cluster
+//    Gets possible node upgrades for a cluster
 //
 //     Produces:
 //     - application/json

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -143,8 +143,8 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 		Handler(r.getClusterUpgrades())
 
 	mux.Methods(http.MethodGet).
-		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/versions").
-		Handler(r.getClusterVersions())
+		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/upgrades").
+		Handler(r.getClusterNodeUpgrades())
 
 	//
 	// Defines set of HTTP endpoints for SSH Keys that belong to a cluster
@@ -1173,7 +1173,7 @@ func (r Routing) getClusterUpgrades() http.Handler {
 	)
 }
 
-// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/versions project getClusterVersions
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/nodes/upgrades project getClusterNodeUpgrades
 //
 //    Gets possible node versions for a cluster
 //
@@ -1185,14 +1185,14 @@ func (r Routing) getClusterUpgrades() http.Handler {
 //       200: []MasterVersion
 //       401: empty
 //       403: empty
-func (r Routing) getClusterVersions() http.Handler {
+func (r Routing) getClusterNodeUpgrades() http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(
 			r.oidcAuthenticator.Verifier(),
 			middleware.UserSaver(r.userProvider),
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			middleware.UserInfo(r.userProjectMapper),
-		)(getClusterVersions(r.updateManager, r.projectProvider)),
+		)(getClusterNodeUpgrades(r.updateManager, r.projectProvider)),
 		common.DecodeGetClusterReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/handler/upgrade.go
+++ b/api/pkg/handler/upgrade.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"fmt"
-	"github.com/kubermatic/kubermatic/api/pkg/version"
 
 	"github.com/go-kit/kit/endpoint"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
+	"github.com/kubermatic/kubermatic/api/pkg/version"
 )
 
 func getClusterUpgrades(updateManager UpdateManager, projectProvider provider.ProjectProvider) endpoint.Endpoint {

--- a/api/pkg/handler/upgrade_test.go
+++ b/api/pkg/handler/upgrade_test.go
@@ -131,7 +131,7 @@ func TestGetClusterVersions(t *testing.T) {
 		apiUser                apiv1.User
 		versions               []*version.MasterVersion
 		updates                []*version.MasterUpdate
-		compatible            []*apiv1.MasterVersion
+		compatible             []*apiv1.MasterVersion
 	}{
 		{
 			name: "only the same major version and no more than 2 minor versions behind the control plane",

--- a/api/pkg/handler/upgrade_test.go
+++ b/api/pkg/handler/upgrade_test.go
@@ -121,3 +121,125 @@ func TestGetClusterUpgradesV1(t *testing.T) {
 		})
 	}
 }
+
+func TestGetClusterVersions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                   string
+		cluster                *kubermaticv1.Cluster
+		existingKubermaticObjs []runtime.Object
+		apiUser                apiv1.User
+		versions               []*version.MasterVersion
+		updates                []*version.MasterUpdate
+		compatible            []*apiv1.MasterVersion
+	}{
+		{
+			name: "only the same major version and no more than 2 minor versions behind the control plane",
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"user": test.UserName},
+				},
+				Spec: kubermaticv1.ClusterSpec{Version: *ksemver.NewSemverOrDie("1.6.0")},
+			},
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(),
+			apiUser:                *test.GenDefaultAPIUser(),
+			compatible: []*apiv1.MasterVersion{
+				{
+					Version: semver.MustParse("1.6.0"),
+				},
+				{
+					Version: semver.MustParse("1.6.1"),
+				},
+				{
+					Version: semver.MustParse("1.4.0"),
+				},
+				{
+					Version: semver.MustParse("1.4.1"),
+				},
+				{
+					Version: semver.MustParse("1.5.0"),
+				},
+				{
+					Version: semver.MustParse("1.5.1"),
+				},
+			},
+			versions: []*version.MasterVersion{
+				{
+					Version: semver.MustParse("0.0.1"),
+				},
+				{
+					Version: semver.MustParse("0.1.0"),
+				},
+				{
+					Version: semver.MustParse("1.0.0"),
+				},
+				{
+					Version: semver.MustParse("1.4.0"),
+				},
+				{
+					Version: semver.MustParse("1.4.1"),
+				},
+				{
+					Version: semver.MustParse("1.5.0"),
+				},
+				{
+					Version: semver.MustParse("1.5.1"),
+				},
+				{
+					Version: semver.MustParse("1.6.0"),
+				},
+				{
+					Version: semver.MustParse("1.6.1"),
+				},
+				{
+					Version: semver.MustParse("1.7.0"),
+				},
+				{
+					Version: semver.MustParse("1.7.1"),
+				},
+				{
+					Version: semver.MustParse("2.0.0"),
+				},
+			},
+			updates: []*version.MasterUpdate{
+				{
+					From:      "1.6.0",
+					To:        "1.6.1",
+					Automatic: false,
+				},
+				{
+					From:      "1.6.x",
+					To:        "1.7.0",
+					Automatic: false,
+				},
+			},
+		},
+	}
+	for _, testStruct := range tests {
+		t.Run(testStruct.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/foo/versions", test.ProjectName), nil)
+			res := httptest.NewRecorder()
+			kubermaticObj := []runtime.Object{testStruct.cluster}
+			kubermaticObj = append(kubermaticObj, testStruct.existingKubermaticObjs...)
+			ep, err := test.CreateTestEndpoint(testStruct.apiUser, []runtime.Object{}, kubermaticObj, testStruct.versions, testStruct.updates, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create testStruct endpoint due to %v", err)
+			}
+			ep.ServeHTTP(res, req)
+			if res.Code != http.StatusOK {
+				t.Fatalf("Expected status code to be 200, got %d\nResponse body: %q", res.Code, res.Body.String())
+			}
+
+			var gotUpdates []*apiv1.MasterVersion
+			err = json.Unmarshal(res.Body.Bytes(), &gotUpdates)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := deep.Equal(gotUpdates, testStruct.compatible); diff != nil {
+				t.Fatalf("got different versions response than expected. Diff: %v", diff)
+			}
+		})
+	}
+}

--- a/api/pkg/handler/v1/common/request.go
+++ b/api/pkg/handler/v1/common/request.go
@@ -69,7 +69,7 @@ func DecodeDcReq(c context.Context, r *http.Request) (interface{}, error) {
 }
 
 // GetClusterReq defines HTTP request for deleteCluster and getClusterKubeconfig endpoints
-// swagger:parameters getCluster deleteCluster getClusterKubeconfig getClusterHealth getClusterUpgrades getClusterMetrics
+// swagger:parameters getCluster deleteCluster getClusterKubeconfig getClusterHealth getClusterUpgrades getClusterMetrics getClusterVersions
 type GetClusterReq struct {
 	DCReq
 	// in: path

--- a/api/pkg/handler/v1/common/request.go
+++ b/api/pkg/handler/v1/common/request.go
@@ -69,7 +69,7 @@ func DecodeDcReq(c context.Context, r *http.Request) (interface{}, error) {
 }
 
 // GetClusterReq defines HTTP request for deleteCluster and getClusterKubeconfig endpoints
-// swagger:parameters getCluster deleteCluster getClusterKubeconfig getClusterHealth getClusterUpgrades getClusterMetrics getClusterVersions
+// swagger:parameters getCluster deleteCluster getClusterKubeconfig getClusterHealth getClusterUpgrades getClusterMetrics getClusterNodeUpgrades
 type GetClusterReq struct {
 	DCReq
 	// in: path


### PR DESCRIPTION
**What this PR does / why we need it**: Adds an endpoint to return possible kubelet versions inside the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes #1386.

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
