### PR TITLE
enable prometheus endpoint for metrics

### DIFF
--- a/api/cmd/rbac-generator/main.go
+++ b/api/cmd/rbac-generator/main.go
@@ -1,17 +1,25 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"time"
 
-	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
-
 	"github.com/golang/glog"
+	"github.com/oklog/run"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	rbaccontroller "github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
+	"github.com/kubermatic/kubermatic/api/pkg/metrics"
 	"github.com/kubermatic/kubermatic/api/pkg/signals"
+	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,8 +29,9 @@ import (
 )
 
 type controllerRunOptions struct {
-	kubeconfig string
-	masterURL  string
+	kubeconfig   string
+	masterURL    string
+	internalAddr string
 
 	workerName  string
 	workerCount int
@@ -39,11 +48,13 @@ type controllerContext struct {
 }
 
 func main() {
+	var g run.Group
 	ctrlCtx := controllerContext{}
 	flag.StringVar(&ctrlCtx.runOptions.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&ctrlCtx.runOptions.masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&ctrlCtx.runOptions.workerName, "worker-name", "", "The name of the worker that will only processes resources with label=worker-name.")
 	flag.IntVar(&ctrlCtx.runOptions.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
+	flag.StringVar(&ctrlCtx.runOptions.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the internal server is running on")
 	flag.Parse()
 
 	config, err := clientcmd.BuildConfigFromFlags(ctrlCtx.runOptions.masterURL, ctrlCtx.runOptions.kubeconfig)
@@ -56,7 +67,13 @@ func main() {
 		glog.Fatal(err)
 	}
 
+	//Register the global error metric. Ensures that runtime.HandleError() increases the error metric
+	metrics.RegisterRuntimErrorMetricCounter("kubermatic_rbac_generator", prometheus.DefaultRegisterer)
+
 	ctrlCtx.stopCh = signals.SetupSignalHandler()
+	ctx, ctxDone := context.WithCancel(context.Background())
+	defer ctxDone()
+
 	ctrlCtx.kubeMasterClient = kubernetes.NewForConfigOrDie(config)
 	ctrlCtx.kubermaticMasterClient = kubermaticclientset.NewForConfigOrDie(config)
 	ctrlCtx.kubermaticMasterInformerFactory = externalversions.NewFilteredSharedInformerFactory(ctrlCtx.kubermaticMasterClient, informer.DefaultInformerResyncPeriod, metav1.NamespaceAll, selector)
@@ -129,7 +146,63 @@ func main() {
 		}
 	}
 
-	go ctrl.Run(ctrlCtx.runOptions.workerCount, ctrlCtx.stopCh)
+	// This group is forever waiting in a goroutine for signals to stop
+	{
+		g.Add(func() error {
+			<-ctrlCtx.stopCh
+			return errors.New("user requested to stop the application")
 
-	<-ctrlCtx.stopCh
+		}, func(err error) {
+			ctxDone()
+		})
+	}
+
+	// This group is running an internal http server with metrics and other debug information
+	{
+		m := http.NewServeMux()
+		m.Handle("/metrics", promhttp.Handler())
+
+		s := http.Server{
+			Addr:         ctrlCtx.runOptions.internalAddr,
+			Handler:      m,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+
+		g.Add(func() error {
+			glog.Infof("Starting the internal http server: %s\n", ctrlCtx.runOptions.internalAddr)
+			err := s.ListenAndServe()
+			if err != nil {
+				return fmt.Errorf("internal http server failed: %v", err)
+			}
+			return nil
+		}, func(err error) {
+
+			glog.Errorf("Stopping internal http server: %v", err)
+			timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+
+			glog.Info("Shutting down the internal http server")
+			if err := s.Shutdown(timeoutCtx); err != nil {
+				glog.Error("failed to shutdown the internal http server gracefully:", err)
+			}
+		})
+	}
+
+	// This group is running the actual controller logic
+	{
+		g.Add(func() error {
+			go ctrl.Run(ctrlCtx.runOptions.workerCount, ctrlCtx.stopCh)
+			<-ctrlCtx.stopCh
+			return nil
+		}, func(err error) {
+			glog.Errorf("Stopping controller: %v", err)
+			ctxDone()
+		})
+	}
+
+	if err := g.Run(); err != nil {
+		glog.Fatal(err)
+	}
+
 }

--- a/config/kubermatic/templates/rbac-generator-dep.yaml
+++ b/config/kubermatic/templates/rbac-generator-dep.yaml
@@ -37,6 +37,7 @@ spec:
         command:
         - rbac-generator
         args:
+        - -internal-address=0.0.0.0:8085
         - -v=4
         - -logtostderr
         - -kubeconfig=/opt/.kube/kubeconfig


### PR DESCRIPTION
**What this PR does / why we need it**: this PR enable Prometheus endpoint for metrics 

```release-note
a new command line flag `internal-address` has been added to `rbac-generator` application for specifying an endpoint (IP:Port) on which `/metrics` HTTP endpoint will be exposed.
```
