### PR TITLE
add an endpoint that returns the api server's build version string

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -8,7 +8,9 @@ TAGS?=$(GITTAG)
 DOCKERTAGS=$(TAGS) latestbuild
 DOCKER_BUILD_FLAG += $(foreach tag, $(DOCKERTAGS), -t $(REPO):$(tag))
 KUBERMATICCOMMIT?=$(shell git log -1 --format=%H)
-LDFLAGS += -extldflags '-static' -X github.com/kubermatic/kubermatic/api/pkg/resources.KUBERMATICCOMMIT=$(KUBERMATICCOMMIT)
+LDFLAGS += -extldflags '-static' \
+  -X github.com/kubermatic/kubermatic/api/pkg/resources.KUBERMATICCOMMIT=$(KUBERMATICCOMMIT) \
+  -X github.com/kubermatic/kubermatic/api/pkg/resources.KUBERMATICGITTAG=$(GITTAG)
 HAS_DEP:= $(shell command -v dep 2> /dev/null)
 HAS_GIT:= $(shell command -v git 2> /dev/null)
 BUILD_DEST?=_build

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2617,6 +2617,29 @@
         }
       }
     },
+    "/api/v1/version": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "versions"
+        ],
+        "summary": "Get versions of running Kubermatic components.",
+        "operationId": "getKubermaticVersion",
+        "responses": {
+          "200": {
+            "description": "KubermaticVersions",
+            "schema": {
+              "$ref": "#/definitions/KubermaticVersions"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/versions": {
       "get": {
         "description": "Lists all versions which don't result in automatic updates",
@@ -3709,6 +3732,18 @@
             "$ref": "#/definitions/NamedAuthInfo"
           },
           "x-go-name": "AuthInfos"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "KubermaticVersions": {
+      "type": "object",
+      "title": "KubermaticVersions describes the versions of running Kubermatic components.",
+      "properties": {
+        "api": {
+          "description": "Version of the Kubermatic API server.",
+          "type": "string",
+          "x-go-name": "API"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+
 	"github.com/Masterminds/semver"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	ksemver "github.com/kubermatic/kubermatic/api/pkg/semver"
@@ -685,4 +686,11 @@ type Event struct {
 
 	// The number of times this event has occurred.
 	Count int32 `json:"count,omitempty"`
+}
+
+// KubermaticVersions describes the versions of running Kubermatic components.
+// swagger:model KubermaticVersions
+type KubermaticVersions struct {
+	// Version of the Kubermatic API server.
+	API string `json:"api"`
 }

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -69,6 +69,10 @@ func (r Routing) RegisterV1(mux *mux.Router) {
 		Handler(r.getMasterVersions())
 
 	mux.Methods(http.MethodGet).
+		Path("/version").
+		Handler(r.getKubermaticVersion())
+
+	mux.Methods(http.MethodGet).
 		Path("/providers/vsphere/networks").
 		Handler(r.listVSphereNetworks())
 
@@ -588,6 +592,28 @@ func (r Routing) getMasterVersions() http.Handler {
 			r.oidcAuthenticator.Verifier(),
 			middleware.UserSaver(r.userProvider),
 		)(getMasterVersions(r.updateManager)),
+		decodeEmptyReq,
+		EncodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/version versions getKubermaticVersion
+//
+// Get versions of running Kubermatic components.
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: KubermaticVersions
+func (r Routing) getKubermaticVersion() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			r.oidcAuthenticator.Verifier(),
+			middleware.UserSaver(r.userProvider),
+		)(getKubermaticVersion()),
 		decodeEmptyReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/handler/version.go
+++ b/api/pkg/handler/version.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+)
+
+// getKubermaticVersion returns the versions of running Kubermatic components.
+//
+// At this time we're only interested in the version of the API server,
+// since it knows its own version and can answer the endpoint promptly.
+//
+// This version string is constructed with `git describe` and embedded in the binary during build.
+func getKubermaticVersion() endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		versions := apiv1.KubermaticVersions{API: resources.KUBERMATICGITTAG}
+		return versions, nil
+	}
+}

--- a/api/pkg/handler/version_test.go
+++ b/api/pkg/handler/version_test.go
@@ -1,0 +1,41 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-test/deep"
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestKubermaticVersion(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/version", nil)
+	res := httptest.NewRecorder()
+	ep, err := test.CreateTestEndpoint(*test.GenDefaultAPIUser(), []runtime.Object{}, nil, nil, nil, hack.NewTestRouting)
+	if err != nil {
+		t.Fatalf("failed to create testStruct endpoint due to %v", err)
+	}
+	ep.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("Expected status code to be 200, got %d\nResponse body: %q", res.Code, res.Body.String())
+	}
+
+	var gotVersion apiv1.KubermaticVersions
+	err = json.Unmarshal(res.Body.Bytes(), &gotVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedVersions := apiv1.KubermaticVersions{
+		API: "manual_build",
+	}
+
+	if diff := deep.Equal(gotVersion, expectedVersions); diff != nil {
+		t.Fatalf("got different upgrade response than expected. Diff: %v", diff)
+	}
+}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -40,6 +40,9 @@ import (
 // KUBERMATICCOMMIT is a magic variable containing the git commit hash of the current (as in currently executing) kubermatic api. It gets feeded by Makefile as a ldflag.
 var KUBERMATICCOMMIT string
 
+// KUBERMATICGITTAG is a magic variable containing the output of `git describe` for the current (as in currently executing) kubermatic api. It gets fed by Makefile as an ldflag.
+var KUBERMATICGITTAG = "manual_build"
+
 const (
 	// KubermaticNamespaceName specifies the name of the kubermatic namespace
 	KubermaticNamespaceName = "kubermatic"


### PR DESCRIPTION
**What this PR does / why we need it**:
In the UI we will be able to show not only the UI version, but the version of the backend as well.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
