### PR TITLE
Actually fix scraping for 1.13 scheduler and controller-manager

### DIFF
--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -220,9 +220,11 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
 	}
 
-	// New flag in v1.12 which gets used to perform permission checks
 	if cluster.Spec.Version.Semver().Minor() >= 12 {
+		// New flag in v1.12 which gets used to perform permission checks for tokens
 		flags = append(flags, "--authentication-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig")
+		// New flag in v1.12 which gets used to perform permission checks for certs
+		flags = append(flags, "--client-ca-file", "/etc/kubernetes/pki/ca/ca.crt")
 	}
 
 	// With 1.13 we're using the secure port for scraping metrics as the insecure port got marked deprecated

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -117,6 +117,11 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 						MountPath: "/etc/kubernetes/kubeconfig",
 						ReadOnly:  true,
 					},
+					{
+						Name:      resources.CASecretName,
+						MountPath: "/etc/kubernetes/pki/ca",
+						ReadOnly:  true,
+					},
 				},
 				Resources: resourceRequirements,
 				ReadinessProbe: &corev1.Probe{
@@ -192,8 +197,11 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 
 	// With 1.13 we're using the secure port for scraping metrics as the insecure port got marked deprecated
 	if cluster.Spec.Version.Semver().Minor() >= 13 {
+		// These are used to validate tokens
 		flags = append(flags, "--authentication-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig")
 		flags = append(flags, "--authorization-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig")
+		// This is used to validate certs
+		flags = append(flags, "--client-ca-file", "/etc/kubernetes/pki/ca/ca.crt")
 		// We're going to use the https endpoints for scraping the metrics starting from 1.13. Thus we can deactivate the http endpoint
 		flags = append(flags, "--port", "0")
 		if cluster.Spec.Version.Semver().Patch() > 0 {

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -123,6 +123,8 @@ spec:
         - /etc/kubernetes/cloud/config
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -138,6 +138,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -123,6 +123,8 @@ spec:
         - /etc/kubernetes/cloud/config
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -102,6 +102,8 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --port
         - "0"
         - --feature-gates
@@ -143,6 +145,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
           readOnly: true
       dnsConfig:
         nameservers:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -123,6 +123,8 @@ spec:
         - /etc/kubernetes/cloud/config
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -138,6 +138,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -123,6 +123,8 @@ spec:
         - /etc/kubernetes/cloud/config
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -102,6 +102,8 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --port
         - "0"
         - --feature-gates
@@ -143,6 +145,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
           readOnly: true
       dnsConfig:
         nameservers:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -119,6 +119,8 @@ spec:
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -138,6 +138,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -119,6 +119,8 @@ spec:
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -102,6 +102,8 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --port
         - "0"
         - --feature-gates
@@ -143,6 +145,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
           readOnly: true
       dnsConfig:
         nameservers:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -119,6 +119,8 @@ spec:
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -138,6 +138,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -119,6 +119,8 @@ spec:
         - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -102,6 +102,8 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --port
         - "0"
         - --feature-gates
@@ -143,6 +145,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
           readOnly: true
       dnsConfig:
         nameservers:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -123,6 +123,8 @@ spec:
         - /etc/kubernetes/cloud/config
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -138,6 +138,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -123,6 +123,8 @@ spec:
         - /etc/kubernetes/cloud/config
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -102,6 +102,8 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --port
         - "0"
         - --feature-gates
@@ -143,6 +145,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
           readOnly: true
       dnsConfig:
         nameservers:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -136,6 +136,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -123,6 +123,8 @@ spec:
         - /etc/kubernetes/cloud/config
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-skip-lookup=true
         command:
         - /hyperkube

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -138,6 +138,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
       dnsConfig:
         nameservers:
         - 192.0.2.14

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -123,6 +123,8 @@ spec:
         - /etc/kubernetes/cloud/config
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -102,6 +102,8 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
         - --port
         - "0"
         - --feature-gates
@@ -143,6 +145,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
           readOnly: true
       dnsConfig:
         nameservers:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed an issue with scraping the metrics for the controller-manager and scheduler in 1.13 user clusters
```
