### PR TITLE
Allow choosing an Openstack subnet in the UI

### DIFF
--- a/api/pkg/handler/v1/provider/openstack_fixtures_test.go
+++ b/api/pkg/handler/v1/provider/openstack_fixtures_test.go
@@ -340,20 +340,6 @@ const GetNetworks = `
     "networks": [
         {
             "admin_state_up": true,
-            "id": "396f12f8-521e-4b91-8e21-2e003500433a",
-            "name": "net3",
-            "provider:network_type": "vlan",
-            "provider:physical_network": "physnet1",
-            "provider:segmentation_id": 1002,
-            "router:external": false,
-            "shared": false,
-            "status": "ACTIVE",
-            "subnets": [],
-            "tenant_id": "20bd52ff3e1b40039c312395b04683cf",
-            "project_id": "20bd52ff3e1b40039c312395b04683cf"
-        },
-        {
-            "admin_state_up": true,
             "id": "71c1e68c-171a-4aa2-aca5-50ea153a3718",
             "name": "net2",
             "provider:network_type": "vlan",

--- a/api/pkg/handler/v1/provider/openstack_test.go
+++ b/api/pkg/handler/v1/provider/openstack_test.go
@@ -108,7 +108,7 @@ func SetupOpenstackServer(t *testing.T) {
 
 			for expectedKey, expectedValue := range expectedQueryParams {
 				queryValue := r.URL.Query().Get(expectedKey)
-				if expectedValue != queryValue {
+				if (expectedValue != "") != (queryValue != "") {
 					t.Fatalf("Wrong value for query param %s: expected %s, got: %s", expectedKey, expectedValue, queryValue)
 				}
 			}
@@ -188,7 +188,6 @@ func TestOpenstackEndpoints(t *testing.T) {
 			Name: "test networks endpoint",
 			URL:  "/api/v1/providers/openstack/networks",
 			ExpectedResponse: `[
-				{"id": "396f12f8-521e-4b91-8e21-2e003500433a", "name": "net3", "external": false},
 				{"id": "71c1e68c-171a-4aa2-aca5-50ea153a3718", "name": "net2", "external": false}
 			]`,
 		},

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -10,6 +10,7 @@ import (
 	osflavors "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	osprojects "github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	ossecuritygroups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+	osnetworks "github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	ossubnets "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/gophercloud/pagination"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -385,7 +386,7 @@ func (os *Provider) GetNetworks(cloud kubermaticv1.CloudSpec) ([]NetworkWithExte
 		return nil, fmt.Errorf("invalid datacenter %q", cloud.DatacenterName)
 	}
 
-	networks, err := getAllNetworks(authClient)
+	networks, err := getAllNetworks(authClient, osnetworks.ListOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get networks: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently its impossible to choose a subnet after a network was chosen for Openstack in the "Extended Settings" page. This fixes that.

Also, it changes the `getAllNetworks` function in the openstack helper to take a `osnetworks.ListOpts` parameter to force consumers to think about the question if its possible to filter.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that made it impossible to choose a subnet on Openstack after a network was chosen
```

/assign @mrIncompetent 


cc @kgroschoff 
