### PR TITLE
Elasticsearch exporter

### DIFF
--- a/config/logging/elasticsearch/templates/exporter-dep.yaml
+++ b/config/logging/elasticsearch/templates/exporter-dep.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: elasticsearch-exporter
+      annotations:
+        kubermatic/scrape: "true"
+        kubermatic/scrape_port: "9108"
+    spec:
+      containers:
+      - name: exporter
+        image: "{{ .Values.logging.elasticsearch.exporter.image.repository }}:{{ .Values.logging.elasticsearch.exporter.image.tag }}"
+        imagePullPolicy: {{ .Values.logging.elasticsearch.exporter.image.pullPolicy }}
+        command:
+        - elasticsearch_exporter
+        args:
+        - '-es.uri=http://es-data:9200'
+        - '-es.all={{ .Values.logging.elasticsearch.exporter.all }}'
+        - '-es.indices={{ .Values.logging.elasticsearch.exporter.indices }}'
+        resources:
+{{ toYaml .Values.logging.elasticsearch.exporter.resources | indent 10 }}
+        ports:
+        - containerPort: 9108
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -19,3 +19,17 @@ logging:
         repository: docker.io/busybox
         tag: "1.27.2"
         pullPolicy: IfNotPresent
+    exporter:
+      image:
+        repository: justwatch/elasticsearch_exporter
+        tag: "1.0.2"
+        pullPolicy: IfNotPresent
+      all: true
+      indices: false
+      resources: {}
+        # requests:
+        #   cpu: 100m
+        #   memory: 128Mi
+        # limits:
+        #   cpu: 100m
+        #   memory: 128Mi

--- a/config/monitoring/prometheus/rules/general-elasticsearch-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-elasticsearch-exporter.yaml
@@ -1,0 +1,38 @@
+# This file has been generated, do not edit.
+groups:
+- name: elasticsearch
+  rules:
+  - alert: ElasticsearchHeapTooHigh
+    annotations:
+      description: The heap usage of Elasticsearch node {{ $labels.name }} is over
+        90%.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchheaptoohigh
+    expr: elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"}
+      > 0.9
+    for: 15m
+    labels:
+      severity: warning
+  - alert: ElasticsearchClusterUnavailable
+    annotations:
+      description: The Elasticsearch cluster health endpoint does not respond to scrapes.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunavailable
+    expr: elasticsearch_cluster_health_up == 0
+    for: 15m
+    labels:
+      severity: warning
+  - alert: ElasticsearchClusterUnhealthy
+    annotations:
+      description: The Elasticsearch cluster is not healthy.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunhealthy
+    expr: elasticsearch_cluster_health_status{color="green"} == 0
+    for: 15m
+    labels:
+      severity: critical
+  - alert: ElasticsearchUnassignedShards
+    annotations:
+      description: There are {{ $value }} unassigned shards in the Elasticsearch cluster.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchunassignedshards
+    expr: elasticsearch_cluster_health_unassigned_shards > 0
+    for: 15m
+    labels:
+      severity: critical

--- a/config/monitoring/prometheus/rules/src/general/elasticsearch-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/elasticsearch-exporter.yaml
@@ -1,0 +1,45 @@
+groups:
+- name: elasticsearch
+  rules:
+  - alert: ElasticsearchHeapTooHigh
+    annotations:
+      description: The heap usage of Elasticsearch node {{ $labels.name }} is over 90%.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchheaptoohigh
+    expr: elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"} > 0.9
+    for: 15m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check the pod's logs for anomalities.
+      - If it is a data node, check the shard allocation via `http://es-data:9200/_cat/shards?v`.
+
+  - alert: ElasticsearchClusterUnavailable
+    annotations:
+      description: The Elasticsearch cluster health endpoint does not respond to scrapes.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunavailable
+    expr: elasticsearch_cluster_health_up == 0
+    for: 15m
+    labels:
+      severity: warning
+
+  - alert: ElasticsearchClusterUnhealthy
+    annotations:
+      description: The Elasticsearch cluster is not healthy.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunhealthy
+    expr: elasticsearch_cluster_health_status{color="green"} == 0
+    for: 15m
+    labels:
+      severity: critical
+
+  - alert: ElasticsearchUnassignedShards
+    annotations:
+      description: There are {{ $value }} unassigned shards in the Elasticsearch cluster.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchunassignedshards
+    expr: elasticsearch_cluster_health_unassigned_shards > 0
+    for: 15m
+    labels:
+      severity: critical
+    runbook:
+      steps:
+      - Check the shard allocation via `http://es-data:9200/_cat/shards?v`.


### PR DESCRIPTION
**What this PR does / why we need it**:
This extends the elasticsearch chart to deploy the elasticsearch-exporter app to monitor the cluster's health. The PR also adds a couple of basic Prometheus alerts.

**Which issue(s) this PR fixes**:
Fixes #2663

**Release note**:
```release-note
add elasticsearch-exporter to logging stack to improve monitoring
```
