### PR TITLE
ensure no clashes with top-level keys in values.yaml

### DIFF
--- a/api/hack/sync-charts.sh
+++ b/api/hack/sync-charts.sh
@@ -110,6 +110,24 @@ for CHART in ${BACKUP_CHARTS}; do
   echo "" >> ${TARGET_VALUES_FILE}
 done
 
+# merge duplicate top-level keys
+KNOWN_KEYS=()
+
+while IFS= read LINE; do
+  MATCH=$(echo "${LINE}" | grep -oE "^[a-zA-Z0-9]+" || true)
+
+  if [ -z "${MATCH}" ]; then
+    echo "${LINE}"
+  else
+    if ! [[ " ${KNOWN_KEYS[@]} " =~ " ${MATCH} " ]]; then
+      KNOWN_KEYS+=("${MATCH}")
+      echo "${LINE}"
+    fi
+  fi
+done < ${TARGET_VALUES_FILE} > ${TARGET_DIR}/values.example.tmp.yaml
+
+mv ${TARGET_DIR}/values.example.{tmp.,}yaml
+
 # commit and push
 cd ${TARGET_DIR}
 git add .


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of our charts use their top-top-level directory inside their values.yaml, like the logging charts. This leads to us creating a broken example values.yaml because we have the same top-level keys multiple times.

This PR extends the sync-charts.sh script to filter the YAML line by line and keep track of known top-level keys. This works under the assumption that charts with the same top-level key are added one after another with no gaps to the values.yaml.

For the next point release (i.e. 2.10) of Kubermatic we should instead fix the charts, but this would be too much for a bugfix release in the 2.9 branch.

**Release note**:
```release-note
NONE
```
