### PR TITLE
Restructure events responses

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3457,35 +3457,18 @@
       "type": "object",
       "title": "Event is a report of an event somewhere in the cluster.",
       "properties": {
+        "involvedObject": {
+          "$ref": "#/definitions/ObjectReference"
+        },
         "message": {
           "description": "A human-readable description of the status of this operation.",
           "type": "string",
           "x-go-name": "Message"
         },
         "type": {
-          "description": "Type of this event (normal, warning), new types could be added in the future",
+          "description": "Type of this event (i.e. normal or warning). New types could be added in the future.",
           "type": "string",
           "x-go-name": "Type"
-        }
-      },
-      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-    },
-    "EventList": {
-      "type": "object",
-      "title": "EventList is an events response structure.",
-      "properties": {
-        "events": {
-          "description": "List of events",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Event"
-          },
-          "x-go-name": "Events"
-        },
-        "name": {
-          "description": "The object name that those events are about.",
-          "type": "string",
-          "x-go-name": "Name"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
@@ -4106,6 +4089,27 @@
           "description": "Name represents human readable name for the resource",
           "type": "string",
           "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "ObjectReference": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "Kind of the referent.",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "name": {
+          "description": "Name of the referent.",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "namespace": {
+          "description": "Namespace of the referent.",
+          "type": "string",
+          "x-go-name": "Namespace"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3457,8 +3457,10 @@
       "type": "object",
       "title": "Event is a report of an event somewhere in the cluster.",
       "properties": {
-        "involvedObject": {
-          "$ref": "#/definitions/ObjectReference"
+        "involvedObjectName": {
+          "description": "The object name that those events are about.",
+          "type": "string",
+          "x-go-name": "InvolvedObjectName"
         },
         "message": {
           "description": "A human-readable description of the status of this operation.",
@@ -4089,27 +4091,6 @@
           "description": "Name represents human readable name for the resource",
           "type": "string",
           "x-go-name": "Name"
-        }
-      },
-      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-    },
-    "ObjectReference": {
-      "type": "object",
-      "properties": {
-        "kind": {
-          "description": "Kind of the referent.",
-          "type": "string",
-          "x-go-name": "Kind"
-        },
-        "name": {
-          "description": "Name of the referent.",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "namespace": {
-          "description": "Namespace of the referent.",
-          "type": "string",
-          "x-go-name": "Namespace"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -681,6 +681,6 @@ type Event struct {
 	// Type of this event (i.e. normal or warning). New types could be added in the future.
 	Type string `json:"type,omitempty"`
 
-	// The object name that those events are about.
+	// The object reference that those events are about.
 	InvolvedObject ObjectReference `json:"involvedObject"`
 }

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -664,15 +664,6 @@ type NodeDeploymentSpec struct {
 	Paused *bool `json:"paused,omitempty"`
 }
 
-type ObjectReference struct {
-	// Kind of the referent.
-	Kind string `json:"kind,omitempty"`
-	// Namespace of the referent.
-	Namespace string `json:"namespace,omitempty"`
-	// Name of the referent.
-	Name string `json:"name,omitempty"`
-}
-
 // Event is a report of an event somewhere in the cluster.
 type Event struct {
 	// A human-readable description of the status of this operation.
@@ -681,6 +672,6 @@ type Event struct {
 	// Type of this event (i.e. normal or warning). New types could be added in the future.
 	Type string `json:"type,omitempty"`
 
-	// The object reference that those events are about.
-	InvolvedObject ObjectReference `json:"involvedObject"`
+	// The object name that those events are about.
+	InvolvedObjectName string `json:"involvedObjectName"`
 }

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"encoding/json"
 	"github.com/Masterminds/semver"
-
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	ksemver "github.com/kubermatic/kubermatic/api/pkg/semver"
 
@@ -665,13 +664,13 @@ type NodeDeploymentSpec struct {
 	Paused *bool `json:"paused,omitempty"`
 }
 
-// EventList is an events response structure.
-type EventList struct {
-	// The object name that those events are about.
-	Name string `json:"name"`
-
-	// List of events
-	Events []Event `json:"events"`
+type ObjectReference struct {
+	// Kind of the referent.
+	Kind string `json:"kind,omitempty"`
+	// Namespace of the referent.
+	Namespace string `json:"namespace,omitempty"`
+	// Name of the referent.
+	Name string `json:"name,omitempty"`
 }
 
 // Event is a report of an event somewhere in the cluster.
@@ -679,6 +678,9 @@ type Event struct {
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty"`
 
-	// Type of this event (normal, warning), new types could be added in the future
+	// Type of this event (i.e. normal or warning). New types could be added in the future.
 	Type string `json:"type,omitempty"`
+
+	// The object name that those events are about.
+	InvolvedObject ObjectReference `json:"involvedObject"`
 }

--- a/api/pkg/handler/event.go
+++ b/api/pkg/handler/event.go
@@ -24,13 +24,9 @@ func FilterEventsByType(events []v1.Event, eventType string) []v1.Event {
 // toEvent converts Kubernetes Events to Kubermatic ones (used in the API).
 func toEvent(event corev1.Event) v1.Event {
 	result := v1.Event{
-		Message: event.Message,
-		Type:    event.Type,
-		InvolvedObject: v1.ObjectReference{
-			Name:      event.InvolvedObject.Name,
-			Namespace: event.InvolvedObject.Namespace,
-			Kind:      event.InvolvedObject.Kind,
-		},
+		Message:            event.Message,
+		Type:               event.Type,
+		InvolvedObjectName: event.InvolvedObject.Name,
 	}
 	return result
 }

--- a/api/pkg/handler/event.go
+++ b/api/pkg/handler/event.go
@@ -6,30 +6,31 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// FilterEventsByType filters kubernetes API event objects based on event type.
-// Empty string will return all events.
-func FilterEventsByType(eventList v1.EventList, eventType string) v1.EventList {
-	if len(eventType) == 0 || len(eventList.Events) == 0 {
-		return eventList
+// FilterEventsByType filters Kubernetes Events based on their type. Empty type string will return all of them.
+func FilterEventsByType(events []v1.Event, eventType string) []v1.Event {
+	if len(eventType) == 0 || len(events) == 0 {
+		return events
 	}
 
 	resultEvents := make([]v1.Event, 0)
-	for _, event := range eventList.Events {
+	for _, event := range events {
 		if event.Type == eventType {
 			resultEvents = append(resultEvents, event)
 		}
 	}
-	return v1.EventList{
-		Name:   eventList.Name,
-		Events: resultEvents,
-	}
+	return resultEvents
 }
 
-// toEvent converts event api Event to Event model object.
+// toEvent converts Kubernetes Events to Kubermatic ones (used in the API).
 func toEvent(event corev1.Event) v1.Event {
 	result := v1.Event{
 		Message: event.Message,
 		Type:    event.Type,
+		InvolvedObject: v1.ObjectReference{
+			Name:      event.InvolvedObject.Name,
+			Namespace: event.InvolvedObject.Namespace,
+			Kind:      event.InvolvedObject.Kind,
+		},
 	}
 	return result
 }

--- a/api/pkg/handler/event_test.go
+++ b/api/pkg/handler/event_test.go
@@ -15,7 +15,7 @@ func TestFilterEventsByType(t *testing.T) {
 		Name           string
 		Filter         string
 		ExpectedEvents []v1.Event
-		InputEvents    v1.EventList
+		InputEvents    []v1.Event
 	}{
 		{
 			Name:   "scenario 1, filter out warning event types",
@@ -24,14 +24,11 @@ func TestFilterEventsByType(t *testing.T) {
 				genEvent("test1", corev1.EventTypeWarning),
 				genEvent("test2", corev1.EventTypeWarning),
 			},
-			InputEvents: v1.EventList{
-				Name: "machine",
-				Events: []v1.Event{
-					genEvent("test1", corev1.EventTypeWarning),
-					genEvent("test2", corev1.EventTypeWarning),
-					genEvent("test3", corev1.EventTypeNormal),
-					genEvent("test4", corev1.EventTypeNormal),
-				},
+			InputEvents: []v1.Event{
+				genEvent("test1", corev1.EventTypeWarning),
+				genEvent("test2", corev1.EventTypeWarning),
+				genEvent("test3", corev1.EventTypeNormal),
+				genEvent("test4", corev1.EventTypeNormal),
 			},
 		},
 		{
@@ -41,14 +38,11 @@ func TestFilterEventsByType(t *testing.T) {
 				genEvent("test3", corev1.EventTypeNormal),
 				genEvent("test4", corev1.EventTypeNormal),
 			},
-			InputEvents: v1.EventList{
-				Name: "machine",
-				Events: []v1.Event{
-					genEvent("test1", corev1.EventTypeWarning),
-					genEvent("test2", corev1.EventTypeWarning),
-					genEvent("test3", corev1.EventTypeNormal),
-					genEvent("test4", corev1.EventTypeNormal),
-				},
+			InputEvents: []v1.Event{
+				genEvent("test1", corev1.EventTypeWarning),
+				genEvent("test2", corev1.EventTypeWarning),
+				genEvent("test3", corev1.EventTypeNormal),
+				genEvent("test4", corev1.EventTypeNormal),
 			},
 		},
 	}
@@ -56,7 +50,7 @@ func TestFilterEventsByType(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 
 			result := handler.FilterEventsByType(tc.InputEvents, tc.Filter)
-			if !equal(result.Events, tc.ExpectedEvents) {
+			if !equal(result, tc.ExpectedEvents) {
 				t.Fatalf("event list %v is not the same as expected %v", result, tc.ExpectedEvents)
 			}
 

--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -1108,7 +1108,6 @@ type NodeDeploymentNodesEventsReq struct {
 }
 
 func decodeListNodeDeploymentNodesEvents(c context.Context, r *http.Request) (interface{}, error) {
-
 	var req NodeDeploymentNodesEventsReq
 
 	clusterID, err := common.DecodeClusterID(c, r)
@@ -1143,7 +1142,6 @@ func decodeListNodeDeploymentNodesEvents(c context.Context, r *http.Request) (in
 
 func listNodeDeploymentNodesEvents() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		apiv1Events := make([]apiv1.EventList, 0)
 		req := request.(NodeDeploymentNodesEventsReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
@@ -1163,50 +1161,43 @@ func listNodeDeploymentNodesEvents() endpoint.Endpoint {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
+		events := make([]apiv1.Event, 0)
 		for _, machine := range machines.Items {
-			eventList, err := getMachineEvents(customerClusterClient, machine)
+			machineEvents, err := getMachineEvents(customerClusterClient, machine)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 
-			if len(eventList.Events) > 0 {
+			if len(machineEvents) > 0 {
 				if len(req.Type) > 0 {
 					if req.Type == warningType {
-						eventList = FilterEventsByType(eventList, corev1.EventTypeWarning)
+						machineEvents = FilterEventsByType(machineEvents, corev1.EventTypeWarning)
 					}
 					if req.Type == normalType {
-						eventList = FilterEventsByType(eventList, corev1.EventTypeNormal)
+						machineEvents = FilterEventsByType(machineEvents, corev1.EventTypeNormal)
 					}
 				}
-				apiv1Events = append(apiv1Events, eventList)
+
+				events = append(events, machineEvents...)
 			}
 		}
 
-		return apiv1Events, nil
+		return events, nil
 	}
 }
 
-// GetMachineEvents returns kubernetes API event objects assigned to the machine.
-func getMachineEvents(client kubernetes.Interface, machine clusterv1alpha1.Machine) (apiv1.EventList, error) {
+// getMachineEvents returns Kubernetes API event objects assigned to the Machine.
+func getMachineEvents(client kubernetes.Interface, machine clusterv1alpha1.Machine) ([]apiv1.Event, error) {
 	events, err := client.CoreV1().Events(metav1.NamespaceSystem).Search(runtime.NewScheme(), &machine)
 	if err != nil {
-		return apiv1.EventList{}, err
+		return nil, err
 	}
 
-	return createMachineEventList(events.Items, machine), nil
-}
-
-// createMachineEventList converts array of api events to kubermatic EventList
-func createMachineEventList(events []corev1.Event, machine clusterv1alpha1.Machine) apiv1.EventList {
 	kubermaticEvents := make([]apiv1.Event, 0)
-
-	for _, event := range events {
+	for _, event := range events.Items {
 		kubermaticEvent := toEvent(event)
 		kubermaticEvents = append(kubermaticEvents, kubermaticEvent)
 	}
 
-	return apiv1.EventList{
-		Name:   machine.Name,
-		Events: kubermaticEvents,
-	}
+	return kubermaticEvents, nil
 }

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -937,7 +937,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"name":"venus-1","events":[{"message":"message started","type":"Normal"},{"message":"message killed","type":"Warning"}]}]`,
+			ExpectedResult: `[{"message":"message started","type":"Normal","involvedObject":{"namespace":"kube-system"}},{"message":"message killed","type":"Warning","involvedObject":{"namespace":"kube-system"}}]`,
 		},
 		// scenario 2
 		{
@@ -959,7 +959,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"name":"venus-1","events":[{"message":"message killed","type":"Warning"}]}]`,
+			ExpectedResult: `[{"message":"message killed","type":"Warning","involvedObject":{"namespace":"kube-system"}}]`,
 		},
 		// scenario 3
 		{
@@ -981,7 +981,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"name":"venus-1","events":[{"message":"message started","type":"Normal"}]}]`,
+			ExpectedResult: `[{"message":"message started","type":"Normal","involvedObject":{"namespace":"kube-system"}}]`,
 		},
 	}
 

--- a/api/pkg/handler/node_v1_test.go
+++ b/api/pkg/handler/node_v1_test.go
@@ -937,7 +937,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"message":"message started","type":"Normal","involvedObject":{"namespace":"kube-system"}},{"message":"message killed","type":"Warning","involvedObject":{"namespace":"kube-system"}}]`,
+			ExpectedResult: `[{"message":"message started","type":"Normal","involvedObjectName":"testMachine"},{"message":"message killed","type":"Warning","involvedObjectName":"testMachine"}]`,
 		},
 		// scenario 2
 		{
@@ -959,7 +959,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"message":"message killed","type":"Warning","involvedObject":{"namespace":"kube-system"}}]`,
+			ExpectedResult: `[{"message":"message killed","type":"Warning","involvedObjectName":"testMachine"}]`,
 		},
 		// scenario 3
 		{
@@ -981,7 +981,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"message":"message started","type":"Normal","involvedObject":{"namespace":"kube-system"}}]`,
+			ExpectedResult: `[{"message":"message started","type":"Normal","involvedObjectName":"testMachine"}]`,
 		},
 	}
 
@@ -1347,6 +1347,7 @@ func genTestEvent(eventName, eventType, eventReason, eventMessage string) *corev
 			Namespace: metav1.NamespaceSystem,
 		},
 		InvolvedObject: corev1.ObjectReference{
+			Name:      "testMachine",
 			Namespace: metav1.NamespaceSystem,
 		},
 		Reason:  eventReason,


### PR DESCRIPTION
**What this PR does / why we need it**: Restructures event responses for the Dashboard client. Events specific for Nodes will be put in REST subresource or directly in the structures. This change is connected only to group endpoint (grouping events from all Nodes created by Node Deployment).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: n/a

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
