### PR TITLE
Validate via events that LB services actually got deleted

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,4 +37,3 @@ issues:
   - "`updateManager` can be `github.com/kubermatic/kubermatic/api/pkg/handler.UpdateManager`"
   - "`store` can be `github.com/kubermatic/kubermatic/api/vendor/k8s.io/client-go/tools/cache.KeyGetter`"
   - 'func `\(\*ClusterProvider\)\.withImpersonation` is unused'
-  - 'cyclomatic complexity 36 of func `\(\*Controller\)\.cleanupInClusterResources`'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,3 +37,4 @@ issues:
   - "`updateManager` can be `github.com/kubermatic/kubermatic/api/pkg/handler.UpdateManager`"
   - "`store` can be `github.com/kubermatic/kubermatic/api/vendor/k8s.io/client-go/tools/cache.KeyGetter`"
   - 'func `\(\*ClusterProvider\)\.withImpersonation` is unused'
+  - 'cyclomatic complexity 36 of func `\(\*Controller\)\.cleanupInClusterResources`'

--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1769,6 +1769,7 @@
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/fields",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -56,6 +56,7 @@ type userClusterConnectionProvider interface {
 	GetApiextensionsClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (apiextensionsclientset.Interface, error)
 	GetAdmissionRegistrationClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error)
 	GetKubeAggregatorClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (aggregationclientset.Interface, error)
+	GetDynamicClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
 }
 
 // Controller is a controller which is responsible for managing clusters

--- a/api/pkg/controller/cluster/deleting.go
+++ b/api/pkg/controller/cluster/deleting.go
@@ -355,7 +355,6 @@ func (cc *Controller) checkIfAllLoadbalancersAreGone(c *kubermaticv1.Cluster) (b
 		if deletedLoadBalancers.Len() > 0 {
 			cluster.Annotations[deletedLBAnnotationName] = strings.Join(deletedLoadBalancers.List(), ",")
 		} else {
-			cc.recorder.Event(cluster, corev1.EventTypeNormal, "deleting lb map key", "deleting lb map key")
 			delete(cluster.Annotations, deletedLBAnnotationName)
 		}
 	})

--- a/api/pkg/controller/cluster/metrics.go
+++ b/api/pkg/controller/cluster/metrics.go
@@ -11,17 +11,22 @@ const (
 )
 
 var (
-	workers = prometheus.NewGauge(
+	registerMetrics sync.Once
+	workers         = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Subsystem: clusterControllerSubsystem,
 			Name:      "workers",
 			Help:      "The number of running cluster controller workers.",
 		},
 	)
-)
-
-var (
-	registerMetrics sync.Once
+	staleLBs = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: clusterControllerSubsystem,
+			Name:      "stale_lbs",
+			Help:      "The number of cloud load balancers that couldn't be cleaned up within the 2h grace period",
+		},
+		[]string{"cluster"},
+	)
 )
 
 // Register the metrics that are to be monitored.
@@ -29,5 +34,6 @@ func init() {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(workers)
 		workers.Set(0)
+		prometheus.MustRegister(staleLBs)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensures we properly wait until all services of type Loadbalancer are gone

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that prevented Loadbalancers from getting properly cleaned up on cluster deletion
```

/assign @mrIncompetent 