### PR TITLE
allows for adding multiple owners for a project

### DIFF
--- a/api/cmd/rbac-generator/main.go
+++ b/api/cmd/rbac-generator/main.go
@@ -132,7 +132,6 @@ func main() {
 
 	ctrlCtx.kubermaticMasterInformerFactory.Start(ctrlCtx.stopCh)
 	ctrlCtx.kubeMasterInformerFactory.Start(ctrlCtx.stopCh)
-
 	ctrlCtx.kubermaticMasterInformerFactory.WaitForCacheSync(ctrlCtx.stopCh)
 	ctrlCtx.kubeMasterInformerFactory.WaitForCacheSync(ctrlCtx.stopCh)
 

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -51,8 +51,9 @@ func NewMetrics() *Metrics {
 
 // Controller stores necessary components that are required to implement RBACGenerator
 type Controller struct {
-	projectQueue workqueue.RateLimitingInterface
-	metrics      *Metrics
+	projectQueue         workqueue.RateLimitingInterface
+	projectBindingsQueue workqueue.RateLimitingInterface
+	metrics              *Metrics
 
 	projectLister            kubermaticv1lister.ProjectLister
 	userLister               kubermaticv1lister.UserLister
@@ -80,6 +81,7 @@ type projectResource struct {
 func New(metrics *Metrics, allClusterProviders []*ClusterProvider) (*Controller, error) {
 	c := &Controller{
 		projectQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project"),
+		projectBindingsQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project_bindings"),
 		projectResourcesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "rbac_generator_project_resources"),
 		metrics:               metrics,
 	}
@@ -94,6 +96,7 @@ func New(metrics *Metrics, allClusterProviders []*ClusterProvider) (*Controller,
 		return nil, errors.New("cannot create controller because master cluster provider has not been found")
 	}
 
+	// sets up an informer for project resources
 	projectInformer := c.masterClusterProvider.kubermaticInformerFactory.Kubermatic().V1().Projects()
 	prometheus.MustRegister(metrics.Workers)
 
@@ -127,6 +130,34 @@ func New(metrics *Metrics, allClusterProviders []*ClusterProvider) (*Controller,
 	c.userLister = userInformer.Lister()
 	c.userProjectBindingLister = c.masterClusterProvider.kubermaticInformerFactory.Kubermatic().V1().UserProjectBindings().Lister()
 
+	// sets up an informer for project binding resources
+	projectBindingsInformer := c.masterClusterProvider.kubermaticInformerFactory.Kubermatic().V1().UserProjectBindings()
+	projectBindingsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueueProjectBinding(obj.(*kubermaticv1.UserProjectBinding))
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.enqueueProjectBinding(cur.(*kubermaticv1.UserProjectBinding))
+		},
+		DeleteFunc: func(obj interface{}) {
+			projectBinding, ok := obj.(*kubermaticv1.UserProjectBinding)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					runtime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+					return
+				}
+				projectBinding, ok = tombstone.Obj.(*kubermaticv1.UserProjectBinding)
+				if !ok {
+					runtime.HandleError(fmt.Errorf("tombstone contained object that is not a UserProjectBinding %#v", obj))
+					return
+				}
+			}
+			c.enqueueProjectBinding(projectBinding)
+		},
+	})
+
+	// sets up informers for project resources
 	// a list of dependent resources that we would like to watch/monitor
 	c.projectResources = []projectResource{
 		{
@@ -191,16 +222,9 @@ func New(metrics *Metrics, allClusterProviders []*ClusterProvider) (*Controller,
 func (c *Controller) Run(workerCount int, stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 
-	for _, seedClusterProvider := range c.seedClusterProviders {
-		err := seedClusterProvider.WaitForCachesToSync(stopCh)
-		if err != nil {
-			runtime.HandleError(err)
-			return
-		}
-	}
-
 	for i := 0; i < workerCount; i++ {
 		go wait.Until(c.runProjectWorker, time.Second, stopCh)
+		go wait.Until(c.runProjectBindingsWorker, time.Second, stopCh)
 		go wait.Until(c.runProjectResourcesWorker, time.Second, stopCh)
 	}
 
@@ -223,25 +247,25 @@ func (c *Controller) processProjectNextItem() bool {
 
 	err := c.sync(key.(string))
 
-	c.handleProjectErr(err, key)
+	c.handleErr(err, key, c.projectQueue)
 	return true
 }
 
-// handleProjectErr checks if an error happened and makes sure we will retry later.
-func (c *Controller) handleProjectErr(err error, key interface{}) {
+// handleErr checks if an error happened and makes sure we will retry later.
+func (c *Controller) handleErr(err error, key interface{}, queue workqueue.RateLimitingInterface) {
 	if err == nil {
 		// Forget about the #AddRateLimited history of the key on every successful synchronization.
 		// This ensures that future processing of updates for this key is not delayed because of
 		// an outdated error history.
-		c.projectQueue.Forget(key)
+		queue.Forget(key)
 		return
 	}
 
 	glog.V(0).Infof("Error syncing %v: %v", key, err)
 
-	// Re-enqueueProject the key rate limited. Based on the rate limiter on the
-	// projectQueue and the re-enqueueProject history, the key will be processed later again.
-	c.projectQueue.AddRateLimited(key)
+	// Re-enqueue an item, based on the rate limiter on the
+	// queue and the re-enqueueProject history, the key will be processed later again.
+	queue.AddRateLimited(key)
 }
 
 func (c *Controller) enqueueProject(project *kubermaticv1.Project) {
@@ -269,25 +293,8 @@ func (c *Controller) processProjectResourcesNextItem() bool {
 
 	err := c.syncProjectResource(queueItem)
 
-	c.handleProjectResourcesErr(err, queueItem)
+	c.handleErr(err, queueItem, c.projectResourcesQueue)
 	return true
-}
-
-// handleProjectResourcesErr checks if an error happened and makes sure we will retry later.
-func (c *Controller) handleProjectResourcesErr(err error, item *projectResourceQueueItem) {
-	if err == nil {
-		// Forget about the #AddRateLimited history of the key on every successful synchronization.
-		// This ensures that future processing of updates for this key is not delayed because of
-		// an outdated error history.
-		c.projectResourcesQueue.Forget(item)
-		return
-	}
-
-	glog.V(0).Infof("Error syncing gvr %s, kind %s, err %v", item.gvr.String(), item.kind, err)
-
-	// Re-enqueueProject the key rate limited. Based on the rate limiter on the
-	// projectQueue and the re-enqueueProject history, the key will be processed later again.
-	c.projectResourcesQueue.AddRateLimited(item)
 }
 
 func (c *Controller) enqueueProjectResource(obj interface{}, gvr schema.GroupVersionResource, kind string, clusterProvider *ClusterProvider) {
@@ -302,6 +309,34 @@ func (c *Controller) enqueueProjectResource(obj interface{}, gvr schema.GroupVer
 		clusterProvider: clusterProvider,
 	}
 	c.projectResourcesQueue.Add(item)
+}
+
+func (c *Controller) runProjectBindingsWorker() {
+	for c.processProjectBindingNextItem() {
+	}
+}
+
+func (c *Controller) processProjectBindingNextItem() bool {
+	key, quit := c.projectBindingsQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.projectBindingsQueue.Done(key)
+
+	err := c.syncProjectBindings(key.(string))
+
+	c.handleErr(err, key, c.projectQueue)
+	return true
+}
+
+func (c *Controller) enqueueProjectBinding(projectBinding *kubermaticv1.UserProjectBinding) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(projectBinding)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", projectBinding, err))
+		return
+	}
+
+	c.projectBindingsQueue.Add(key)
 }
 
 const projectResourcesResyncTime time.Duration = 5 * time.Minute

--- a/api/pkg/controller/rbac/sync_project.go
+++ b/api/pkg/controller/rbac/sync_project.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	cleanupFinalizerName = "kubermatic.io/controller-manager-rbac-cleanup"
+	CleanupFinalizerName = "kubermatic.io/controller-manager-rbac-cleanup"
 )
 
 func (c *Controller) sync(key string) error {
@@ -68,9 +68,9 @@ func (c *Controller) sync(key string) error {
 
 func (c *Controller) ensureCleanupFinalizerExists(project *kubermaticv1.Project) error {
 	var err error
-	if !sets.NewString(project.Finalizers...).Has(cleanupFinalizerName) {
+	if !sets.NewString(project.Finalizers...).Has(CleanupFinalizerName) {
 		finalizers := sets.NewString(project.Finalizers...)
-		finalizers.Insert(cleanupFinalizerName)
+		finalizers.Insert(CleanupFinalizerName)
 		project.Finalizers = finalizers.List()
 		project, err = c.masterClusterProvider.kubermaticClient.KubermaticV1().Projects().Update(project)
 		if err != nil {
@@ -128,7 +128,8 @@ func (c *Controller) ensureProjectOwner(project *kubermaticv1.Project) error {
 					Name:       project.Name,
 				},
 			},
-			Name: rand.String(10),
+			Name:       rand.String(10),
+			Finalizers: []string{CleanupFinalizerName},
 		},
 		Spec: kubermaticv1.UserProjectBindingSpec{
 			UserEmail: owner.Spec.Email,
@@ -321,7 +322,7 @@ func (c *Controller) ensureProjectCleanup(project *kubermaticv1.Project) error {
 	}
 
 	finalizers := sets.NewString(project.Finalizers...)
-	finalizers.Delete(cleanupFinalizerName)
+	finalizers.Delete(CleanupFinalizerName)
 	project.Finalizers = finalizers.List()
 	_, err := c.masterClusterProvider.kubermaticClient.KubermaticV1().Projects().Update(project)
 	return err
@@ -355,7 +356,7 @@ func cleanUpRBACRoleBindingFor(kubeClient kubernetes.Interface, groupName, resou
 }
 
 func (c *Controller) shouldDeleteProject(project *kubermaticv1.Project) bool {
-	return project.DeletionTimestamp != nil && sets.NewString(project.Finalizers...).Has(cleanupFinalizerName)
+	return project.DeletionTimestamp != nil && sets.NewString(project.Finalizers...).Has(CleanupFinalizerName)
 }
 
 // for some groups we actually don't create ClusterRole

--- a/api/pkg/controller/rbac/sync_project_binding.go
+++ b/api/pkg/controller/rbac/sync_project_binding.go
@@ -1,0 +1,137 @@
+package rbac
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func (c *Controller) syncProjectBindings(key string) error {
+	projectBindingFromCache, err := c.userProjectBindingLister.Get(key)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			glog.V(2).Infof("user project binding '%s' in queue no longer exists", key)
+			return nil
+		}
+		return err
+	}
+	projectBinding := projectBindingFromCache.DeepCopy()
+	if ExtractGroupPrefix(projectBinding.Spec.Group) == OwnerGroupNamePrefix {
+		return c.ensureProjectOwnerForBinding(projectBinding)
+	}
+	return c.ensureNotProjectOwnerForBinding(projectBinding)
+}
+
+// ensureProjectOwnerForBinding makes sure that the owner reference is set on the project resource for the given binding
+func (c *Controller) ensureProjectOwnerForBinding(projectBinding *kubermaticv1.UserProjectBinding) error {
+	project, err := getProjectForBinding(c.projectLister, projectBinding)
+	if err != nil {
+		return err
+	}
+
+	for _, ref := range project.OwnerReferences {
+		if ref.Kind == kubermaticv1.UserKindName {
+			existingOwner, err := c.userLister.Get(ref.Name)
+			if err != nil {
+				return err
+			}
+			if strings.EqualFold(existingOwner.Spec.Email, projectBinding.Spec.UserEmail) {
+				return nil
+			}
+		}
+	}
+
+	userObject, err := userForBinding(c.userLister, projectBinding)
+	if err != nil {
+		return err
+	}
+	project.OwnerReferences = append(project.OwnerReferences, metav1.OwnerReference{
+		APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+		Kind:       kubermaticv1.UserKindName,
+		UID:        userObject.GetUID(),
+		Name:       userObject.Name,
+	})
+
+	_, err = c.masterClusterProvider.kubermaticClient.KubermaticV1().Projects().Update(project)
+	return err
+}
+
+// ensureNotProjectOwnerForBinding checks if the owner reference entry is removed from the project for the given binding
+func (c *Controller) ensureNotProjectOwnerForBinding(projectBinding *kubermaticv1.UserProjectBinding) error {
+	project, err := getProjectForBinding(c.projectLister, projectBinding)
+	if err != nil {
+		return err
+	}
+
+	newOwnerRef := []metav1.OwnerReference{}
+	for _, ref := range project.OwnerReferences {
+		if ref.Kind == kubermaticv1.UserKindName {
+			existingOwner, err := c.userLister.Get(ref.Name)
+			if err != nil {
+				return err
+			}
+			if !strings.EqualFold(existingOwner.Spec.Email, projectBinding.Spec.UserEmail) {
+				newOwnerRef = append(newOwnerRef, ref)
+			}
+		}
+	}
+
+	if len(newOwnerRef) == len(project.OwnerReferences) {
+		return nil
+	}
+
+	project.OwnerReferences = newOwnerRef
+	_, err = c.masterClusterProvider.kubermaticClient.KubermaticV1().Projects().Update(project)
+	if err != nil {
+		return err
+	}
+
+	if sets.NewString(projectBinding.Finalizers...).Has(CleanupFinalizerName) {
+		finalizers := sets.NewString(projectBinding.Finalizers...)
+		finalizers.Delete(CleanupFinalizerName)
+		projectBinding.Finalizers = finalizers.List()
+		_, err = c.masterClusterProvider.kubermaticClient.KubermaticV1().UserProjectBindings().Update(projectBinding)
+		return err
+
+	}
+	return nil
+}
+
+func userForBinding(userLister kubermaticv1lister.UserLister, projectBinding *kubermaticv1.UserProjectBinding) (*kubermaticv1.User, error) {
+	users, err := userLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range users {
+		if strings.EqualFold(user.Spec.Email, projectBinding.Spec.UserEmail) {
+			return user, nil
+		}
+	}
+
+	return nil, fmt.Errorf("a user resource for the given project binding %s not found", projectBinding.Name)
+}
+
+func getProjectForBinding(projectLister kubermaticv1lister.ProjectLister, projectBinding *kubermaticv1.UserProjectBinding) (*kubermaticv1.Project, error) {
+	for _, ref := range projectBinding.OwnerReferences {
+		if ref.Kind == kubermaticv1.ProjectKindName {
+			var err error
+			var projectFromCache *kubermaticv1.Project
+			if projectFromCache, err = projectLister.Get(ref.Name); err != nil {
+				return nil, err
+			}
+			return projectFromCache.DeepCopy(), nil
+		}
+	}
+
+	return nil, fmt.Errorf("the given project binding %s doesn't have associated project", projectBinding.Name)
+}

--- a/api/pkg/controller/rbac/sync_project_binding.go
+++ b/api/pkg/controller/rbac/sync_project_binding.go
@@ -26,6 +26,9 @@ func (c *Controller) syncProjectBindings(key string) error {
 		return err
 	}
 	projectBinding := projectBindingFromCache.DeepCopy()
+	if projectBinding.DeletionTimestamp != nil {
+		return removeFinalizerFromBinding(projectBinding, c.masterClusterProvider.kubermaticClient)
+	}
 	if ExtractGroupPrefix(projectBinding.Spec.Group) == OwnerGroupNamePrefix {
 		return c.ensureProjectOwnerForBinding(projectBinding)
 	}

--- a/api/pkg/controller/rbac/sync_project_binding_test.go
+++ b/api/pkg/controller/rbac/sync_project_binding_test.go
@@ -1,0 +1,268 @@
+package rbac
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/tools/cache"
+
+	kubermaticfakeclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
+	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestEnsureNotProjectOwnerForBinding(t *testing.T) {
+	tests := []struct {
+		name             string
+		bindingToSync    *kubermaticv1.UserProjectBinding
+		existingProject  *kubermaticv1.Project
+		existingUsers    []*kubermaticv1.User
+		expectedProject  *kubermaticv1.Project
+		existingBindings []*kubermaticv1.UserProjectBinding
+	}{
+		{
+			name:            "scenario 1: the owner reference is removed from a project (no previous owners) for James Bond - an editor",
+			existingProject: createProject("thunderball", createUser("James Bond")),
+			existingUsers:   []*kubermaticv1.User{createUser("James Bond")},
+			bindingToSync:   createExpectedEditorBinding("James Bond", createProject("thunderball", createUser("James Bond"))),
+			expectedProject: func() *kubermaticv1.Project {
+				prj := createProject("thunderball", createUser("James Bond"))
+				prj.OwnerReferences = []metav1.OwnerReference{}
+				return prj
+			}(),
+		},
+		{
+			name: "scenario 2: no - op the owner reference already removed from a project (no previous owners) for James Bond - an editor",
+			existingProject: func() *kubermaticv1.Project {
+				prj := createProject("thunderball", createUser("James Bond"))
+				prj.OwnerReferences = []metav1.OwnerReference{}
+				return prj
+			}(),
+			existingUsers: []*kubermaticv1.User{createUser("James Bond")},
+			bindingToSync: createExpectedEditorBinding("James Bond", createProject("thunderball", createUser("James Bond"))),
+		},
+		{
+			name: "scenario 3: the owner reference was removed from a project (with previous owners) for James Bond - an editor",
+			existingProject: func() *kubermaticv1.Project {
+				prj := createProject("thunderball", createUser("James Bond"))
+				prj.OwnerReferences = append(prj.OwnerReferences, metav1.OwnerReference{
+					APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+					Kind:       kubermaticv1.UserKindName,
+					UID:        "",
+					Name:       "Bob",
+				})
+				return prj
+			}(),
+			existingUsers: []*kubermaticv1.User{createUser("James Bond"), createUser("Bob")},
+			bindingToSync: createExpectedEditorBinding("James Bond", createProject("thunderball", createUser("James Bond"))),
+			expectedProject: func() *kubermaticv1.Project {
+				prj := createProject("thunderball", createUser("James Bond"))
+				prj.OwnerReferences = []metav1.OwnerReference{
+					metav1.OwnerReference{
+						APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+						Kind:       kubermaticv1.UserKindName,
+						UID:        "",
+						Name:       "Bob",
+					},
+				}
+				return prj
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup the test scenario
+			objs := []runtime.Object{}
+			userIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, user := range test.existingUsers {
+				err := userIndexer.Add(user)
+				if err != nil {
+					t.Fatal(err)
+				}
+				objs = append(objs, user)
+			}
+			bindingIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, binding := range test.existingBindings {
+				err := bindingIndexer.Add(binding)
+				if err != nil {
+					t.Fatal(err)
+				}
+				objs = append(objs, binding)
+			}
+			projectIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if test.existingProject != nil {
+				err := projectIndexer.Add(test.existingProject)
+				if err != nil {
+					t.Fatal(err)
+				}
+				objs = append(objs, test.existingProject)
+			}
+			kubermaticFakeClient := kubermaticfakeclientset.NewSimpleClientset(objs...)
+			fakeMasterClusterProvider := &ClusterProvider{
+				kubermaticClient: kubermaticFakeClient,
+			}
+			userLister := kubermaticv1lister.NewUserLister(userIndexer)
+			bindingLister := kubermaticv1lister.NewUserProjectBindingLister(bindingIndexer)
+			projectLister := kubermaticv1lister.NewProjectLister(projectIndexer)
+
+			// act
+			target := Controller{}
+			target.masterClusterProvider = fakeMasterClusterProvider
+			target.userLister = userLister
+			target.userProjectBindingLister = bindingLister
+			target.projectLister = projectLister
+			err := target.ensureNotProjectOwnerForBinding(test.bindingToSync)
+
+			// validate
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.expectedProject == nil {
+				if len(kubermaticFakeClient.Actions()) != 0 {
+					t.Fatalf("unexpected actions %#v", kubermaticFakeClient.Actions())
+				}
+				return
+			}
+			if len(kubermaticFakeClient.Actions()) != 1 {
+				t.Fatalf("unexpected actions %#v", kubermaticFakeClient.Actions())
+			}
+
+			action := kubermaticFakeClient.Actions()[0]
+			if !action.Matches("update", "projects") {
+				t.Fatalf("unexpected action %#v", action)
+			}
+			updateAction, ok := action.(clienttesting.UpdateAction)
+			if !ok {
+				t.Fatalf("unexpected action %#v", action)
+			}
+			updatedProject := updateAction.GetObject().(*kubermaticv1.Project)
+			if !equality.Semantic.DeepEqual(updatedProject, test.expectedProject) {
+				t.Fatalf("%v", diff.ObjectDiff(updatedProject, test.expectedProject))
+			}
+		})
+	}
+}
+
+func TestEnsureProjectOwnerForBinding(t *testing.T) {
+	tests := []struct {
+		name             string
+		bindingToSync    *kubermaticv1.UserProjectBinding
+		existingProject  *kubermaticv1.Project
+		existingUsers    []*kubermaticv1.User
+		expectedProject  *kubermaticv1.Project
+		existingBindings []*kubermaticv1.UserProjectBinding
+	}{
+		{
+			name:            "scenario 1: no-op the owner reference already attached to the project",
+			existingProject: createProject("thunderball", createUser("James Bond")),
+			existingUsers:   []*kubermaticv1.User{createUser("James Bond")},
+			bindingToSync:   createExpectedOwnerBinding("James Bond", createProject("thunderball", createUser("James Bond"))),
+		},
+		{
+			name: "scenario 2: expected owner reference was added to a project - no previous owners)",
+			existingProject: func() *kubermaticv1.Project {
+				prj := createProject("thunderball", createUser("James Bond"))
+				prj.OwnerReferences = []metav1.OwnerReference{}
+				return prj
+			}(),
+			existingUsers:   []*kubermaticv1.User{createUser("James Bond")},
+			bindingToSync:   createExpectedOwnerBinding("James Bond", createProject("thunderball", createUser("James Bond"))),
+			expectedProject: createProject("thunderball", createUser("James Bond")),
+		},
+		{
+			name:            "scenario 3: expected owner reference was added to a project - with previous owners)",
+			existingProject: createProject("thunderball", createUser("James Bond")),
+			existingUsers:   []*kubermaticv1.User{createUser("James Bond"), createUser("Bob")},
+			bindingToSync:   createExpectedOwnerBinding("Bob", createProject("thunderball", createUser("Bob"))),
+			expectedProject: func() *kubermaticv1.Project {
+				prj := createProject("thunderball", createUser("James Bond"))
+				prj.OwnerReferences = append(prj.OwnerReferences, metav1.OwnerReference{
+					APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+					Kind:       kubermaticv1.UserKindName,
+					UID:        "",
+					Name:       "Bob",
+				})
+				return prj
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup the test scenario
+			objs := []runtime.Object{}
+			userIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, user := range test.existingUsers {
+				err := userIndexer.Add(user)
+				if err != nil {
+					t.Fatal(err)
+				}
+				objs = append(objs, user)
+			}
+			bindingIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, binding := range test.existingBindings {
+				err := bindingIndexer.Add(binding)
+				if err != nil {
+					t.Fatal(err)
+				}
+				objs = append(objs, binding)
+			}
+			projectIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if test.existingProject != nil {
+				err := projectIndexer.Add(test.existingProject)
+				if err != nil {
+					t.Fatal(err)
+				}
+				objs = append(objs, test.existingProject)
+			}
+			kubermaticFakeClient := kubermaticfakeclientset.NewSimpleClientset(objs...)
+			fakeMasterClusterProvider := &ClusterProvider{
+				kubermaticClient: kubermaticFakeClient,
+			}
+			userLister := kubermaticv1lister.NewUserLister(userIndexer)
+			bindingLister := kubermaticv1lister.NewUserProjectBindingLister(bindingIndexer)
+			projectLister := kubermaticv1lister.NewProjectLister(projectIndexer)
+
+			// act
+			target := Controller{}
+			target.masterClusterProvider = fakeMasterClusterProvider
+			target.userLister = userLister
+			target.userProjectBindingLister = bindingLister
+			target.projectLister = projectLister
+			err := target.ensureProjectOwnerForBinding(test.bindingToSync)
+
+			// validate
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.expectedProject == nil {
+				if len(kubermaticFakeClient.Actions()) != 0 {
+					t.Fatalf("unexpected actions %#v", kubermaticFakeClient.Actions())
+				}
+				return
+			}
+			if len(kubermaticFakeClient.Actions()) != 1 {
+				t.Fatalf("unexpected actions %#v", kubermaticFakeClient.Actions())
+			}
+
+			action := kubermaticFakeClient.Actions()[0]
+			if !action.Matches("update", "projects") {
+				t.Fatalf("unexpected action %#v", action)
+			}
+			updateAction, ok := action.(clienttesting.UpdateAction)
+			if !ok {
+				t.Fatalf("unexpected action %#v", action)
+			}
+			updatedProject := updateAction.GetObject().(*kubermaticv1.Project)
+			if !equality.Semantic.DeepEqual(updatedProject, test.expectedProject) {
+				t.Fatalf("%v", diff.ObjectDiff(updatedProject, test.expectedProject))
+			}
+		})
+	}
+}

--- a/api/pkg/controller/rbac/sync_project_binding_test.go
+++ b/api/pkg/controller/rbac/sync_project_binding_test.go
@@ -63,7 +63,7 @@ func TestEnsureNotProjectOwnerForBinding(t *testing.T) {
 			expectedProject: func() *kubermaticv1.Project {
 				prj := createProject("thunderball", createUser("James Bond"))
 				prj.OwnerReferences = []metav1.OwnerReference{
-					metav1.OwnerReference{
+					{
 						APIVersion: kubermaticv1.SchemeGroupVersion.String(),
 						Kind:       kubermaticv1.UserKindName,
 						UID:        "",

--- a/api/pkg/handler/v1/user/user.go
+++ b/api/pkg/handler/v1/user/user.go
@@ -289,9 +289,6 @@ func (r AddReq) Validate(authenticatesUserInfo *provider.UserInfo) error {
 	if strings.EqualFold(apiUserFromRequest.Email, authenticatesUserInfo.Email) {
 		return k8cerrors.New(http.StatusForbidden, "you cannot assign yourself to a different group")
 	}
-	if projectFromRequest.GroupPrefix == rbac.OwnerGroupNamePrefix {
-		return k8cerrors.New(http.StatusForbidden, fmt.Sprintf("the given user cannot be assigned to %s group", projectFromRequest.GroupPrefix))
-	}
 	isRequestedGroupPrefixValid := false
 	for _, existingGroupPrefix := range rbac.AllGroupsPrefixes {
 		if existingGroupPrefix == projectFromRequest.GroupPrefix {

--- a/api/pkg/handler/v1/user/user_test.go
+++ b/api/pkg/handler/v1/user/user_test.go
@@ -392,7 +392,7 @@ func TestEditUserInProject(t *testing.T) {
 		{
 			Name:          "scenario 3: john the owner of the plan9 project changes the group for bob from viewers to owners",
 			Body:          `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6", "email":"bob@acme.com", "projects":[{"id":"plan9-ID", "group":"owners"}]}`,
-			HTTPStatus:    http.StatusForbidden,
+			HTTPStatus:    http.StatusOK,
 			ProjectToSync: "plan9-ID",
 			ExistingKubermaticObjs: []runtime.Object{
 				/*add projects*/
@@ -408,7 +408,7 @@ func TestEditUserInProject(t *testing.T) {
 			},
 			UserIDToUpdate:   genDefaultUser().Name,
 			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
-			ExpectedResponse: `{"error":{"code":403,"message":"the given user cannot be assigned to owners group"}}`,
+			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"plan9-ID","group":"owners"}]}`,
 		},
 
 		// scenario 4
@@ -604,9 +604,9 @@ func TestAddUserToProject(t *testing.T) {
 		},
 
 		{
-			Name:          "scenario 4: john the owner of the plan9 project tries to invite bob to the project as an owner",
+			Name:          "scenario 4: john the owner of the plan9 project invites bob to the project as an owner",
 			Body:          `{"email":"bob@acme.com", "projects":[{"id":"plan9-ID", "group":"owners"}]}`,
-			HTTPStatus:    http.StatusForbidden,
+			HTTPStatus:    http.StatusCreated,
 			ProjectToSync: "plan9-ID",
 			ExistingKubermaticObjs: []runtime.Object{
 				/*add projects*/
@@ -622,7 +622,7 @@ func TestAddUserToProject(t *testing.T) {
 				genDefaultUser(), /*bob*/
 			},
 			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
-			ExpectedResponse: `{"error":{"code":403,"message":"the given user cannot be assigned to owners group"}}`,
+			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"plan9-ID","group":"owners"}]}`,
 		},
 
 		{

--- a/api/pkg/provider/kubernetes/member.go
+++ b/api/pkg/provider/kubernetes/member.go
@@ -4,15 +4,17 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // NewProjectMemberProvider returns a project members provider
@@ -36,6 +38,11 @@ type ProjectMemberProvider struct {
 
 // Create creates a binding for the given member and the given project
 func (p *ProjectMemberProvider) Create(userInfo *provider.UserInfo, project *kubermaticapiv1.Project, memberEmail, group string) (*kubermaticapiv1.UserProjectBinding, error) {
+	finalizers := []string{}
+	if rbac.ExtractGroupPrefix(group) == rbac.OwnerGroupNamePrefix {
+		finalizers = append(finalizers, rbac.CleanupFinalizerName)
+	}
+
 	binding := &kubermaticapiv1.UserProjectBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			OwnerReferences: []metav1.OwnerReference{
@@ -46,7 +53,8 @@ func (p *ProjectMemberProvider) Create(userInfo *provider.UserInfo, project *kub
 					Name:       project.Name,
 				},
 			},
-			Name: rand.String(10),
+			Name:       rand.String(10),
+			Finalizers: finalizers,
 		},
 		Spec: kubermaticapiv1.UserProjectBindingSpec{
 			ProjectID: project.Name,
@@ -121,6 +129,11 @@ func (p *ProjectMemberProvider) Delete(userInfo *provider.UserInfo, bindingName 
 
 // Update simply updates the given binding
 func (p *ProjectMemberProvider) Update(userInfo *provider.UserInfo, binding *kubermaticapiv1.UserProjectBinding) (*kubermaticapiv1.UserProjectBinding, error) {
+	if rbac.ExtractGroupPrefix(binding.Spec.Group) == rbac.OwnerGroupNamePrefix && !sets.NewString(binding.Finalizers...).Has(rbac.CleanupFinalizerName) {
+		finalizers := sets.NewString(binding.Finalizers...)
+		finalizers.Insert(rbac.CleanupFinalizerName)
+		binding.Finalizers = finalizers.List()
+	}
 	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**: this pull adds additional control loop to RBAC controller, it
observes UserProjectBinding resources and adds appropriate OwnerReferences to a project.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2673

**Special notes for your reviewer**: for local testing use https://github.com/kubermatic/dashboard-v2/pull/1042

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
allows assigning multiple owners to a project. 
```
