### PR TITLE
Fix docker CVE-2019-573 for Ubuntu and CoreOS

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -719,7 +719,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:99975a8d5c87ed412ea341b07c6277911e309e081aa9e349dd13edf39d2ca6e7"
+  digest = "1:05490f1d97d386217a9bfdf572222ea974777affaa26b7b20b9a8dd8456339d8"
   name = "github.com/kubermatic/machine-controller"
   packages = [
     "pkg/cloudprovider/cloud",
@@ -744,8 +744,7 @@
     "pkg/userdata/ubuntu",
   ]
   pruneopts = "NUT"
-  revision = "3f15ca3bcbb4c18c408be72c59f2bcd80483d81a"
-  version = "v1.0.3"
+  revision = "ca4e9f31c60eed356bfeaecb41d842b95b3e6db4"
 
 [[projects]]
   digest = "1:d244f8666a838fe6ad70ec8fe77f50ebc29fdc3331a2729ba5886bef8435d10d"

--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -744,7 +744,8 @@
     "pkg/userdata/ubuntu",
   ]
   pruneopts = "NUT"
-  revision = "ca4e9f31c60eed356bfeaecb41d842b95b3e6db4"
+  revision = "fad960933a960f456859cb55dbbfe640468805d5"
+  version = "v1.0.4"
 
 [[projects]]
   digest = "1:d244f8666a838fe6ad70ec8fe77f50ebc29fdc3331a2729ba5886bef8435d10d"

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -120,7 +120,7 @@ required = [
 
 [[override]]
   name = "github.com/kubermatic/machine-controller"
-  revision = "ca4e9f31c60eed356bfeaecb41d842b95b3e6db4"
+  version = "v1.0.4"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -120,7 +120,7 @@ required = [
 
 [[override]]
   name = "github.com/kubermatic/machine-controller"
-  version = "v1.0.3"
+  revision = "ca4e9f31c60eed356bfeaecb41d842b95b3e6db4"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -10,7 +10,7 @@ export NAMESPACE="prow-kubermatic-${BUILD_ID}"
 echodate "Testing versions: ${VERSIONS}"
 cd $(dirname $0)/../..
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
-export EXCLUDE_DISRIBUTIONS=${EXCLUDE_DISRIBUTIONS:-ubuntu,centos}
+export EXCLUDE_DISTRIBUTIONS=${EXCLUDE_DISTRIBUTIONS:-ubuntu,centos}
 
 function retry {
   local retries=$1
@@ -199,5 +199,5 @@ timeout -s 9 90m ./conformance-tests \
   -aws-secret-access-key="$AWS_E2E_TESTS_SECRET" \
   -versions="$VERSIONS" \
   -providers=aws \
-  -exclude-distributions="${EXCLUDE_DISRIBUTIONS}" \
+  -exclude-distributions="${EXCLUDE_DISTRIBUTIONS}" \
   -kubermatic-delete-cluster=false

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -10,6 +10,7 @@ export NAMESPACE="prow-kubermatic-${BUILD_ID}"
 echodate "Testing versions: ${VERSIONS}"
 cd $(dirname $0)/../..
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
+export EXCLUDE_DISRIBUTIONS=${EXCLUDE_DISRIBUTIONS:-ubuntu,centos}
 
 function retry {
   local retries=$1
@@ -198,5 +199,5 @@ timeout -s 9 90m ./conformance-tests \
   -aws-secret-access-key="$AWS_E2E_TESTS_SECRET" \
   -versions="$VERSIONS" \
   -providers=aws \
-  -exclude-distributions="ubuntu,centos" \
+  -exclude-distributions="${EXCLUDE_DISRIBUTIONS}" \
   -kubermatic-delete-cluster=false

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -85,7 +85,7 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 		dep.Spec.Template.Spec.Containers = []corev1.Container{
 			{
 				Name:            name,
-				Image:           data.ImageRegistry(resources.RegistryDocker) + "alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4",
+				Image:           data.ImageRegistry(resources.RegistryDocker) + "/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4",
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/usr/local/bin/machine-controller"},
 				Args: []string{

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -29,7 +29,7 @@ var (
 const (
 	name = "machine-controller"
 
-	tag = "v1.0.3"
+	tag = "v1.0.4"
 )
 
 // DeploymentCreator returns the function to create and update the machine controller deployment
@@ -85,7 +85,7 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 		dep.Spec.Template.Spec.Containers = []corev1.Container{
 			{
 				Name:            name,
-				Image:           data.ImageRegistry(resources.RegistryDocker) + "/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4",
+				Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/usr/local/bin/machine-controller"},
 				Args: []string{

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -85,7 +85,7 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 		dep.Spec.Template.Spec.Containers = []corev1.Container{
 			{
 				Name:            name,
-				Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
+				Image:           data.ImageRegistry(resources.RegistryDocker) + "alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4",
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/usr/local/bin/machine-controller"},
 				Args: []string{

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.0.3
+        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.ioalvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/alvaroaleman/machine-controller:ca4e9f31c60eed356bfeaecb41d842b95b3e6db4
+        image: docker.io/kubermatic/machine-controller:v1.0.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/coreos/userdata.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/coreos/userdata.go
@@ -292,15 +292,6 @@ storage:
         inline: |
 {{ .KubernetesCACert | indent 10 }}
 
-{{- if semverCompare "<=1.11.*" .KubeletVersion }}
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-{{ end }}
-
 {{ if ne .CloudProvider "aws" }}
     - path: /etc/hostname
       filesystem: root

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/ubuntu/userdata.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/ubuntu/userdata.go
@@ -240,11 +240,7 @@ write_files:
     systemctl mask swap.target
     swapoff -a
 
-{{- if semverCompare "<1.12.0" .KubeletVersion }}
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
-{{- else }}
-    export CR_PKG='docker-ce=18.06.0~ce~3-0~ubuntu'
-{{- end }}
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes CVE-2019-573. For now it just verifies using a newer docker version doesn't break anything. I will create a machine-controller release once this passed E2E tests for both CoreOS and Ubuntu

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Use a docker version that has a fix for CVE-2019-573 on CoreOS and Ubuntu. It is advised to roll over all your worker nodes to make sure that fix is applied.
```

/hold
