### PR TITLE
Scrape cert-manager

### DIFF
--- a/config/cert-manager/templates/cert-manager-deployment.yaml
+++ b/config/cert-manager/templates/cert-manager-deployment.yaml
@@ -11,6 +11,9 @@ spec:
     metadata:
       labels:
         app: cert-manager
+      annotations:
+        kubermatic/scrape: "true"
+        kubermatic/scrape_port: "9402"
     spec:
       serviceAccountName: cert-manager
       {{- if .Values.certManager.securityContext.enabled }}
@@ -44,3 +47,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          ports:
+          - name: metrics
+            containerPort: 9402

--- a/config/monitoring/prometheus/rules/src/general/cert-manager.yaml
+++ b/config/monitoring/prometheus/rules/src/general/cert-manager.yaml
@@ -1,0 +1,18 @@
+groups:
+- name: cert-manager
+  rules:
+  - alert: CertManagerCertExpiresSoon
+    annotations:
+      message: The certificate {{ $labels.name }} expires in less than 3 days.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-certmanagercertexpiressoon
+    expr: certmanager_certificate_expiration_timestamp_seconds - time() < 3*24*3600
+    labels:
+      severity: warning
+
+  - alert: CertManagerCertExpiresVerySoon
+    annotations:
+      message: The certificate {{ $labels.name }} expires in less than 24 hours.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-certmanagercertexpiresverysoon
+    expr: certmanager_certificate_expiration_timestamp_seconds - time() < 24*3600
+    labels:
+      severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes Prometheus scrape the cert-manager and then alert on soon expiring certificates.

**Which issue(s) this PR fixes**:
Fixes #2664

**Release note**:
```release-note
new alerts for cert-manager created certificates about to expire
```
