### PR TITLE
ensure Grafana dashboards are consistent and have no static variables

### DIFF
--- a/config/monitoring/Makefile
+++ b/config/monitoring/Makefile
@@ -10,4 +10,4 @@ check-rules:
 
 .PHONY: format-dashboards
 format-dashboards:
-	find grafana/dashboards -name '*.json' -exec sh -c "jq --sort-keys '.' {} > {}.tmp && mv {}.tmp {}" \;
+	./grafana/dashboards/cleanup.sh

--- a/config/monitoring/grafana/dashboards/cleanup.sh
+++ b/config/monitoring/grafana/dashboards/cleanup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+cd $(dirname $0)
+
+for dashboard in */*.json; do
+  echo "$dashboard"
+
+  tmpfile="$dashboard.tmp"
+
+  cat "$dashboard" | \
+    jq '(.templating.list[] | select(.type=="query") | .options) = []' | \
+    jq '(.templating.list[] | select(.type=="query") | .refresh) = 2' | \
+    jq '(.templating.list[] | select(.type=="query") | .current) = {}' | \
+    jq '(.annotations.list) = []' | \
+    jq '(.links) = []' | \
+    jq '(.refresh) = "<< refresh | default `30s` | toJson >>"' | \
+    jq '(.time.from) = "<< defaultRange | toJson >>"' | \
+    jq '(.time.to) = "now"' | \
+    jq '(.timezone) = ""' | \
+    jq '(.graphTooltip) = 1' | \
+    jq --sort-keys '.' > "$tmpfile"
+
+  mv "$tmpfile" "$dashboard"
+done

--- a/config/monitoring/grafana/dashboards/kubermatic/machine-controller.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/machine-controller.json
@@ -436,7 +436,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Machine Controller",
   "uid": "4b5fd6810d5c",
   "version": 1

--- a/config/monitoring/grafana/dashboards/kubermatic/nginx.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/nginx.json
@@ -4,7 +4,7 @@
   },
   "editable": "<< editable | default false | toJson >>",
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": "<< hideControls | default false | toJson >>",
   "iteration": 1534359654832,
   "links": [],
@@ -1080,10 +1080,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -1092,7 +1089,7 @@
         "name": "namespace",
         "options": [],
         "query": "label_values(nginx_ingress_controller_config_hash, controller_namespace)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 0,
         "tagValuesQuery": "",
@@ -1103,10 +1100,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -1115,7 +1109,7 @@
         "name": "controller_class",
         "options": [],
         "query": "label_values(nginx_ingress_controller_config_hash{namespace=~\"$namespace\"}, controller_class) ",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 0,
         "tagValuesQuery": "",
@@ -1126,10 +1120,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -1138,7 +1129,7 @@
         "name": "controller",
         "options": [],
         "query": "label_values(nginx_ingress_controller_config_hash{namespace=~\"$namespace\",controller_class=~\"$controller_class\"}, controller_pod) ",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 0,
         "tagValuesQuery": "",
@@ -1178,7 +1169,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "NGINX Ingress controller",
   "uid": "4ecf28ac7c24",
   "version": 1

--- a/config/monitoring/grafana/dashboards/kubernetes/etcd-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/etcd-overview.json
@@ -1765,7 +1765,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "etcd (cluster overview)",
   "uid": "aa6e22781c60",
   "version": 2

--- a/config/monitoring/grafana/dashboards/kubernetes/etcd.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/etcd.json
@@ -1941,10 +1941,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -1953,7 +1950,7 @@
         "name": "cluster",
         "options": [],
         "query": "label_values(job:etcd_server_has_leader:sum, cluster)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 1,
         "tagValuesQuery": "",
@@ -1994,7 +1991,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "etcd",
   "uid": "df15188d34cc",
   "version": 1

--- a/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
@@ -877,7 +877,7 @@
       }
     }
   ],
-  "refresh": "30s",
+  "refresh": "<< refresh | default `30s` | toJson >>",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
@@ -899,58 +899,16 @@
       },
       {
         "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "All",
-          "value": [
-            "$__all"
-          ]
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
         "label": "Node",
         "multi": true,
         "name": "node",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "gke-kubermatic-dev-stable-aaa4c0f0-b8t0",
-            "value": "gke-kubermatic-dev-stable-aaa4c0f0-b8t0"
-          },
-          {
-            "selected": false,
-            "text": "gke-kubermatic-dev-stable-aaa4c0f0-d4tm",
-            "value": "gke-kubermatic-dev-stable-aaa4c0f0-d4tm"
-          },
-          {
-            "selected": false,
-            "text": "gke-kubermatic-dev-stable-aaa4c0f0-fpmz",
-            "value": "gke-kubermatic-dev-stable-aaa4c0f0-fpmz"
-          },
-          {
-            "selected": false,
-            "text": "gke-kubermatic-dev-stable-aaa4c0f0-fwb5",
-            "value": "gke-kubermatic-dev-stable-aaa4c0f0-fwb5"
-          },
-          {
-            "selected": false,
-            "text": "gke-kubermatic-dev-stable-aaa4c0f0-kc0c",
-            "value": "gke-kubermatic-dev-stable-aaa4c0f0-kc0c"
-          },
-          {
-            "selected": false,
-            "text": "gke-kubermatic-dev-stable-aaa4c0f0-w23x",
-            "value": "gke-kubermatic-dev-stable-aaa4c0f0-w23x"
-          }
-        ],
+        "options": [],
         "query": "label_values(kube_node_info, node)",
-        "refresh": 0,
+        "refresh": 2,
         "regex": "",
         "sort": 1,
         "tagValuesQuery": "",
@@ -962,7 +920,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "<< defaultRange | toJson >>",
     "to": "now"
   },
   "timepicker": {

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
@@ -749,7 +749,7 @@
       }
     }
   ],
-  "refresh": "30s",
+  "refresh": "<< refresh | default `30s` | toJson >>",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
@@ -771,10 +771,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -795,7 +792,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "<< defaultRange | toJson >>",
     "to": "now"
   },
   "timepicker": {
@@ -823,7 +820,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Nodes Overview",
   "uid": "13yQpUxiz",
   "version": 1

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes.json
@@ -641,10 +641,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -694,7 +691,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Nodes",
   "uid": "9799befff62f",
   "version": 1

--- a/config/monitoring/grafana/dashboards/kubernetes/pods.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/pods.json
@@ -415,10 +415,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -438,10 +435,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -461,10 +455,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -513,7 +504,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Pods",
   "uid": "c2438b9deadd",
   "version": 1

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
@@ -1555,7 +1555,7 @@
       ]
     }
   ],
-  "refresh": "30s",
+  "refresh": "<< refresh | default `30s` | toJson >>",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
@@ -706,7 +706,7 @@
       ]
     }
   ],
-  "refresh": "30s",
+  "refresh": "<< refresh | default `30s` | toJson >>",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
@@ -728,11 +728,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -741,7 +737,7 @@
         "name": "namespace",
         "options": [],
         "query": "label_values(kube_pod_info, namespace)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 1,
         "tagValuesQuery": "",
@@ -753,7 +749,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "<< defaultRange | toJson >>",
     "to": "now"
   },
   "timepicker": {
@@ -781,7 +777,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Compute Resources / Namespace",
   "uid": "f9d729354e90",
   "version": 1

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
@@ -707,7 +707,7 @@
       ]
     }
   ],
-  "refresh": "30s",
+  "refresh": "<< refresh | default `30s` | toJson >>",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
@@ -729,10 +729,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -741,7 +738,7 @@
         "name": "namespace",
         "options": [],
         "query": "label_values(kube_pod_info, namespace)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 1,
         "tagValuesQuery": "",
@@ -752,10 +749,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -764,7 +758,7 @@
         "name": "pod",
         "options": [],
         "query": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 1,
         "tagValuesQuery": "",

--- a/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
@@ -726,10 +726,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -749,10 +746,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
@@ -801,7 +795,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "StatefulSets",
   "uid": "48fc78522ada",
   "version": 1

--- a/config/monitoring/grafana/dashboards/kubernetes/volumes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/volumes.json
@@ -821,13 +821,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "monitoring",
-          "value": [
-            "monitoring"
-          ]
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -836,7 +830,7 @@
         "name": "namespace",
         "options": [],
         "query": "label_values(kubelet_volume_stats_used_bytes{ [[ volumeDashboardNamespaceFilter ]] }, namespace)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 1,
         "tagValuesQuery": "",

--- a/config/monitoring/grafana/dashboards/prometheus/seed.json
+++ b/config/monitoring/grafana/dashboards/prometheus/seed.json
@@ -4,7 +4,7 @@
   },
   "editable": "<< editable | default false | toJson >>",
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "hideControls": "<< hideControls | default false | toJson >>",
   "links": [],
   "panels": [
@@ -2487,11 +2487,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -2500,7 +2496,7 @@
         "name": "pod",
         "options": [],
         "query": "label_values(prometheus_build_info, pod)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 0,
         "tagValuesQuery": "",


### PR DESCRIPTION
**What this PR does / why we need it**:
We previously accidentally had a dashboard with "cached" nodenames and their variable being set to "never ever refresh", leading customers to think we purposefully hardcoded the node names into dashboards.

This PR extends our efforts to sanitise and cleanup dashboard JSONs.

**Release note**:
```release-note
Fixed invalid variable caching in Grafana dashboards
```
