### PR TITLE
deploy branch v2.9 instead of v2.8 on run.kubermatic.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -302,7 +302,7 @@ pipeline:
     - values
     when:
       branch: release/v2.9
-  slack:
+  slack-master:
     channel: dev
     group: slack
     icon_url: https://avatars2.githubusercontent.com/u/2181346?v=4&s=200
@@ -315,6 +315,21 @@ pipeline:
     webhook: https://hooks.slack.com/services/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
     when:
       branch: master
+      status:
+      - success
+  slack-release-branch:
+    channel: dev
+    group: slack
+    icon_url: https://avatars2.githubusercontent.com/u/2181346?v=4&s=200
+    image: kubermaticbot/drone-slack
+    pull: true
+    template: |
+      :heart: A new API & controller version has been deployed to run.kubermatic.io.
+      <${DRONE_COMMIT_LINK}|:github:>: ${DRONE_COMMIT_MESSAGE}
+    username: drone
+    webhook: https://hooks.slack.com/services/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
+    when:
+      branch: release/v2.9
       status:
       - success
   slack-failure:

--- a/.drone.yml
+++ b/.drone.yml
@@ -301,7 +301,7 @@ pipeline:
     values:
     - values
     when:
-      branch: release/v2.8
+      branch: release/v2.9
   slack:
     channel: dev
     group: slack


### PR DESCRIPTION
This will update only the `master` branch, which ends up serving as a template for release branch `.drone.yaml` files. PRs will follow to backport the changes to `release/v2.9` and `release/v2.8` branches.

```release-note
NONE
```
