### PR TITLE
backport .drone.yaml improvements from master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -310,7 +310,7 @@ pipeline:
     pull: true
     template: |
       :heart: A new API & controller version has been deployed to dev & cloud.
-      <https://github.com/kubermatic/kubermatic/pull/${DRONE_PULL_REQUEST}|PR #${DRONE_PULL_REQUEST}>: ${DRONE_COMMIT_MESSAGE}
+      <${DRONE_COMMIT_LINK}|:github:>: ${DRONE_COMMIT_MESSAGE}
     username: drone
     webhook: https://hooks.slack.com/services/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
     when:
@@ -325,7 +325,7 @@ pipeline:
     pull: true
     template: |
       :seemssadman: I failed to deploy a new API & controller to dev/cloud.
-      <${DRONE_BUILD_LINK}|Drone build #${DRONE_BUILD_NUMBER}> <${DRONE_COMMIT_LINK}|GitHub>
+      <${DRONE_BUILD_LINK}|:drone: build #${DRONE_BUILD_NUMBER}> <${DRONE_COMMIT_LINK}|:github:>
     username: drone
     webhook: https://hooks.slack.com/services/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
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -301,8 +301,8 @@ pipeline:
     values:
     - values
     when:
-      branch: release/v2.8
-  slack:
+      branch: release/v2.9
+  slack-master:
     channel: dev
     group: slack
     icon_url: https://avatars2.githubusercontent.com/u/2181346?v=4&s=200
@@ -315,6 +315,21 @@ pipeline:
     webhook: https://hooks.slack.com/services/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
     when:
       branch: master
+      status:
+      - success
+  slack-release-branch:
+    channel: dev
+    group: slack
+    icon_url: https://avatars2.githubusercontent.com/u/2181346?v=4&s=200
+    image: kubermaticbot/drone-slack
+    pull: true
+    template: |
+      :heart: A new API & controller version has been deployed to run.kubermatic.io.
+      <${DRONE_COMMIT_LINK}|:github:>: ${DRONE_COMMIT_MESSAGE}
+    username: drone
+    webhook: https://hooks.slack.com/services/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
+    when:
+      branch: release/v2.9
       status:
       - success
   slack-failure:

--- a/.drone.yml
+++ b/.drone.yml
@@ -308,8 +308,9 @@ pipeline:
     icon_url: https://avatars2.githubusercontent.com/u/2181346?v=4&s=200
     image: kubermaticbot/drone-slack
     pull: true
-    template: '${DRONE_COMMIT_AUTHOR} deployed a new API & Controller to dev & cloud.
-      :heart:'
+    template: |
+      :heart: A new API & controller version has been deployed to dev & cloud.
+      <${DRONE_COMMIT_LINK}|${DRONE_COMMIT_SHA}>: ${DRONE_COMMIT_MESSAGE}
     username: drone
     webhook: https://hooks.slack.com/services/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
     when:
@@ -317,35 +318,18 @@ pipeline:
       status:
       - success
   slack-failure:
-    author_recipient_mapping:
-    - alvaroaleman=alvaro
-    - glower=igor.komlew
-    - guusvw=guus
-    - kdomanski=kamil
-    - kgroschoff=kristin.groschoff
-    - kron4eg=artiom
-    - mrIncompetent=henrik
-    - p0lyn0mial=lukasz
-    - scheeles=sebastian
-    - thz=tobias.hintze
-    - toschneck=tobias.schneck
-    - xrstf=christoph
-    - xmudrii=marko
-    - maciaszczykm=marcin
-    - floreks=sebastian.florek
-    - lindtdev=irina
+    channel: dev
     group: slack
     icon_url: https://avatars2.githubusercontent.com/u/2181346?v=4&s=200
     image: kubermaticbot/drone-slack
-    image_url: https://media.giphy.com/media/m6tmCnGCNvTby/giphy-downsized.gif
     pull: true
-    recipient: ${DRONE_COMMIT_AUTHOR}
-    template: |-
-      Your build failed! Shame. Shame. Shame.
-            ${DRONE_BUILD_LINK}
+    template: |
+      :seemssadman: I failed to deploy a new API & controller to dev/cloud.
+      <${DRONE_BUILD_LINK}|Drone build #${DRONE_BUILD_NUMBER}> <${DRONE_COMMIT_LINK}|GitHub>
     username: drone
     webhook: https://hooks.slack.com/services/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
     when:
+      branch: master
       status:
       - failure
 workspace:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,18 +1,18 @@
 pipeline:
-  verify-addons-up-to-date:
-    commands:
-    - ./api/hack/verify-addon-version.sh
-    group: lint
-    image: docker:dind
-    pull: true
-    volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
   build:
     commands:
     - cd api
     - make build
     group: build
-    image: quay.io/kubermatic/go-111-docker:11.2-1806-0
+    image: quay.io/kubermatic/go-111-docker:11.5-1806-0
+    when:
+      branch:
+        exclude:
+        - release/v1.*
+        - release/*cherry*
+        include:
+        - release/*
+        - master
   docker:
     commands:
     - export VAULT_ADDR=https://vault.loodse.com/

--- a/.drone.yml
+++ b/.drone.yml
@@ -310,7 +310,7 @@ pipeline:
     pull: true
     template: |
       :heart: A new API & controller version has been deployed to dev & cloud.
-      <${DRONE_COMMIT_LINK}|${DRONE_COMMIT_SHA}>: ${DRONE_COMMIT_MESSAGE}
+      <https://github.com/kubermatic/kubermatic/pull/${DRONE_PULL_REQUEST}|PR #${DRONE_PULL_REQUEST}>: ${DRONE_COMMIT_MESSAGE}
     username: drone
     webhook: https://hooks.slack.com/services/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
     when:

--- a/containers/promtool/Dockerfile
+++ b/containers/promtool/Dockerfile
@@ -1,8 +1,0 @@
-FROM alpine
-
-RUN apk add --no-cache -U curl make jq
-
-RUN curl -L https://github.com/prometheus/prometheus/releases/download/v2.7.0/prometheus-2.7.0.linux-amd64.tar.gz | tar -xvz && \
-    mv prometheus-2.7.0.linux-amd64/promtool /usr/bin/promtool
-
-RUN curl -L -o /usr/bin/yaml2json https://github.com/bronze1man/yaml2json/releases/download/v1.3/yaml2json_linux_amd64 && chmod +x /usr/bin/yaml2json

--- a/containers/promtool/release.sh
+++ b/containers/promtool/release.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-NUMBER=2
-VERSION=2.7.0
-
-set -euox pipefail
-
-docker build --no-cache --pull -t quay.io/kubermatic/promtool:${VERSION}-${NUMBER} .
-docker push quay.io/kubermatic/promtool:${VERSION}-${NUMBER}


### PR DESCRIPTION
 - Remove addons check from drone (#2741)
 - send drone failures to #dev instead of nirvana (#2748)
 - link to the PR instead of the commit in drone slack messages (#2749)
 - there is no PR reference on merged commits anymore (#2752)
 - deploy branch v2.9 instead of v2.8 on run.kubermatic.io (#2796) 

**Release note:**
```release-note
NONE
```
