### PR TITLE
check if a cluster is healthy before deletion

### DIFF
--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -87,6 +87,44 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 			HeaderParams:    map[string]string{},
 			ExpectedUpdates: 0,
 		},
+		{
+			Name:             "scenario 4: deletion of a cluster fails for an unhealthy cluster with finalizers",
+			Body:             ``,
+			ExpectedResponse: `{"error":{"code":503,"message":"the cluster must be healthy when cleanup of additional resources (e.g. volumes) was requested, try one more time","details":"Cluster components are not ready yet"}}`,
+			HTTPStatus:       http.StatusServiceUnavailable,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				// add a cluster
+				func() *kubermaticv1.Cluster {
+					cluster := test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+					cluster.Status.Health.MachineController = false
+					return cluster
+				}(),
+			),
+			ClusterToSync:   "clusterAbcID",
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			HeaderParams:    map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "true"},
+			ExpectedUpdates: 0,
+		},
+		{
+			Name:             "scenario 5: deletion of a cluster \"works\" for an unhealthy cluster without finalizers",
+			Body:             ``,
+			ExpectedResponse: `{}`,
+			HTTPStatus:       http.StatusOK,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				// add a cluster
+				func() *kubermaticv1.Cluster {
+					cluster := test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+					cluster.Status.Health.MachineController = false
+					return cluster
+				}(),
+			),
+			ClusterToSync:   "clusterAbcID",
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			HeaderParams:    map[string]string{},
+			ExpectedUpdates: 0,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**: prevents a cluster deletion when the cluster is not healthy and removal of additional resources (volumes, load balancers) was requested.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
