### PR TITLE
add optional cerebro deployment to debug Elasticsearch cluster

### DIFF
--- a/config/logging/elasticsearch/templates/cerebro-configmap.yaml
+++ b/config/logging/elasticsearch/templates/cerebro-configmap.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.logging.elasticsearch.cerebro.deploy }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cerebro-config
+data:
+  # replace randAlphaNum with cryptoRandAlphaNum once more
+  # recent Helm versions are available
+  application.conf: |
+    secret = "{{ randAlphaNum 30 }}"
+    hosts = [
+      {
+        host = "http://es-data:9200"
+        name = "Logging Cluster"
+      }
+    ]
+{{ end }}

--- a/config/logging/elasticsearch/templates/cerebro-dep.yaml
+++ b/config/logging/elasticsearch/templates/cerebro-dep.yaml
@@ -1,0 +1,52 @@
+{{ if .Values.logging.elasticsearch.cerebro.deploy }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cerebro
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cerebro
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: cerebro
+    spec:
+      containers:
+      - name: cerebro
+        image: "{{ .Values.logging.elasticsearch.cerebro.image.repository }}:{{ .Values.logging.elasticsearch.cerebro.image.tag }}"
+        imagePullPolicy: {{ .Values.logging.elasticsearch.cerebro.image.pullPolicy }}
+        command:
+        - bin/cerebro
+        args:
+        - '-Dconfig.file=/cerebro/application.conf'
+        ports:
+        - containerPort: 9000
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 400Mi
+        volumeMounts:
+          - name: config
+            mountPath: /cerebro
+      volumes:
+        - name: config
+          configMap:
+            name: cerebro-config
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+{{ end }}

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -33,3 +33,9 @@ logging:
         # limits:
         #   cpu: 100m
         #   memory: 128Mi
+    cerebro:
+      image:
+        repository: yannart/cerebro
+        tag: "0.8.1"
+        pullPolicy: IfNotPresent
+      deploy: false


### PR DESCRIPTION
**What this PR does / why we need it**:
[Cerebro](https://github.com/lmenezes/cerebro) is an Elasticsearch cluster admin UI thingy to visualize the shard distribution and perform admin tasks like configuring index settings. It could maybe help debugging why clusters sometimes shred themselves.

As cerebro consumes roughly 400MB, I made its deployment optional for now. We can deploy it on all of our clusters though. This is also why I didn't bother to make it accessible through nginx/dex, but rather rely on port-forwarding and why I would not even mention it in the release notes.

**Release note**:
```release-note
NONE
```
