### PR TITLE
remove redundant deployVPA flag in favor of featureGate

### DIFF
--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -169,7 +169,6 @@ retry 3 helm upgrade --install --force --wait --timeout 300 \
   --set-string=kubermatic.rbac.image.repository=docker.io/kubermatic/api \
   --set-string=kubermatic.rbac.image.tag=$GIT_HEAD_HASH \
   --set-string=kubermatic.worker_name=$BUILD_ID \
-  --set=kubermatic.deployVPA=false \
   --set=kubermatic.ingressClass=non-existent \
   --set=kubermatic.checks.crd.disable=true \
   --values ${VALUES_FILE} \

--- a/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
+++ b/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.kubermatic.deployVPA }}
+{{ if (contains "VerticalPodAutoscaler=true" .Values.kubermatic.controller.featureGates) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/config/kubermatic/templates/vpa-rbac.yaml
+++ b/config/kubermatic/templates/vpa-rbac.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.kubermatic.deployVPA }}
+{{ if (contains "VerticalPodAutoscaler=true" .Values.kubermatic.controller.featureGates) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.kubermatic.deployVPA }}
+{{ if (contains "VerticalPodAutoscaler=true" .Values.kubermatic.controller.featureGates) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/config/kubermatic/templates/vpa-tls.yaml
+++ b/config/kubermatic/templates/vpa-tls.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.kubermatic.deployVPA }}
+{{ if (contains "VerticalPodAutoscaler=true" .Values.kubermatic.controller.featureGates) }}
 {{- $ca := genCA "deployment-admission-controller" 3650 -}}
 {{- $cn := "vpa-webhook" -}}
 {{- $altName1 := "vpa-webhook.kube-system" -}}

--- a/config/kubermatic/templates/vpa-updater-deployment.yaml
+++ b/config/kubermatic/templates/vpa-updater-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.kubermatic.deployVPA }}
+{{ if (contains "VerticalPodAutoscaler=true" .Values.kubermatic.controller.featureGates) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -19,7 +19,6 @@ kubermatic:
   kubeconfig: ""
   # The prefix for monitoring annotations in the user cluster. Default: monitoring.kubermatic.io -> monitoring.kubermatic.io/scrape, monitoring.kubermatic.io/path
   monitoringScrapeAnnotationPrefix: ""
-  deployVPA: true
 
   # helm hooks/checks
   checks:


### PR DESCRIPTION
**What this PR does / why we need it**:
Having two flags for the same feature is redundant.

**Release note**:
```release-note
Vertical Pod Autoscaler is not deployed by default anymore
```
