### PR TITLE
do not add finalizers when cluster is unhealthy

### DIFF
--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -87,6 +87,25 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 			HeaderParams:    map[string]string{},
 			ExpectedUpdates: 0,
 		},
+		{
+			Name:             "scenario 4: deletion of a cluster works for an unhealthy cluster with finalizers",
+			Body:             ``,
+			ExpectedResponse: `{}`,
+			HTTPStatus:       http.StatusOK,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				// add a cluster
+				func() *kubermaticv1.Cluster {
+					cluster := test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+					cluster.Status.Health.MachineController = false
+					return cluster
+				}(),
+			),
+			ClusterToSync:   "clusterAbcID",
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			HeaderParams:    map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "true"},
+			ExpectedUpdates: 0,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**: when deletion of a cluster was requested and the cluster is unhealthy additional finalizers (if requested) for volumes and/or load balancers removal will not be added.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
