### PR TITLE
Fix the helm installation during e2e tests

### DIFF
--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -149,7 +149,11 @@ echodate "Deploying tiller"
 helm init --wait --service-account=tiller --tiller-namespace=$NAMESPACE
 
 echodate "Installing Kubermatic via Helm"
+# We must delete all templates for cluster-scoped resources
+# because those already exist because of the main Kubermatic installation
+# otherwise the helm upgrade --install fails
 rm -f config/kubermatic/templates/cluster-role-binding.yaml
+rm -f config/kubermatic/templates/vpa-*
 # --force is needed in case the first attempt at installing didn't succeed
 # see https://github.com/helm/helm/pull/3597
 retry 3 helm upgrade --install --force --wait --timeout 300 \


### PR DESCRIPTION
**What this PR does / why we need it**:

We have e2e failures because in #2805 we changed the chart to have one flag for both setting the feature gate on our controller and deploying the VPA resources, this makes the e2e tests fail as Helm tries to create some cluster-scoped for the VPA that already exist

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
