### PR TITLE
E2E tests: Wait for all controlplane pods to be ready

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -58,7 +58,7 @@ type Opts struct {
 	reportsRoot                    string
 	clusterLister                  kubermaticv1lister.ClusterLister
 	kubermaticClient               kubermaticclientset.Interface
-	kubeClient                     kubernetes.Interface
+	seedKubeClient                 kubernetes.Interface
 	clusterClientProvider          *clusterclient.Provider
 	dcFile                         string
 	repoRoot                       string
@@ -275,11 +275,11 @@ func main() {
 
 	kubermaticClient := kubermaticclientset.NewForConfigOrDie(config)
 	opts.kubermaticClient = kubermaticClient
-	kubeClient := kubernetes.NewForConfigOrDie(config)
-	opts.kubeClient = kubeClient
+	seedKubeClient := kubernetes.NewForConfigOrDie(config)
+	opts.seedKubeClient = seedKubeClient
 
 	kubermaticInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticClient, informer.DefaultInformerResyncPeriod)
-	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, informer.DefaultInformerResyncPeriod)
+	kubeInformerFactory := informers.NewSharedInformerFactory(seedKubeClient, informer.DefaultInformerResyncPeriod)
 
 	opts.clusterLister = kubermaticInformerFactory.Kubermatic().V1().Clusters().Lister()
 

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -35,6 +35,17 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+var (
+	podIsReady = func(p *corev1.Pod) bool {
+		for _, c := range p.Status.Conditions {
+			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}
+)
+
 type testScenario interface {
 	Name() string
 	Cluster(secrets secrets) *kubermaticv1.Cluster
@@ -593,8 +604,22 @@ func (r *testRunner) waitForControlPlane(log *logrus.Entry, clusterName string) 
 			}
 			return false, fmt.Errorf("failed to get the cluster %s from the lister: %v", clusterName, err)
 		}
+		// Check for this first, because otherwise we instantly return as the cluster-controller did not
+		// create any pods yet
+		if !cluster.Status.Health.AllHealthy() {
+			return false, nil
+		}
+		controlPlanePods, err := r.seedKubeClient.CoreV1().Pods(cluster.Status.NamespaceName).List(metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to list controlplane pods: %v", err)
+		}
+		for _, pod := range controlPlanePods.Items {
+			if !podIsReady(&pod) {
+				return false, nil
+			}
+		}
 
-		return cluster.Status.Health.AllHealthy(), nil
+		return true, nil
 	})
 	// Timeout or other error
 	if err != nil {
@@ -614,15 +639,6 @@ func (r *testRunner) waitForControlPlane(log *logrus.Entry, clusterName string) 
 func (r *testRunner) waitUntilAllPodsAreReady(log *logrus.Entry, client kubernetes.Interface) error {
 	log.Debug("Waiting for all pods to be ready...")
 	started := time.Now()
-
-	podIsReady := func(p *corev1.Pod) bool {
-		for _, c := range p.Status.Conditions {
-			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
-				return true
-			}
-		}
-		return false
-	}
 
 	err := wait.Poll(defaultUserClusterPollInterval, defaultTimeout, func() (done bool, err error) {
 		podList, err := client.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -60,7 +60,7 @@ func newRunner(scenarios []testScenario, opts *Opts) *testRunner {
 		PublicKeys:                   opts.publicKeys,
 		workerName:                   opts.workerName,
 		homeDir:                      opts.homeDir,
-		kubeClient:                   opts.kubeClient,
+		seedKubeClient:               opts.seedKubeClient,
 		log:                          opts.log,
 	}
 }
@@ -83,7 +83,7 @@ type testRunner struct {
 	clusterParallelCount         int
 
 	kubermaticClient      kubermaticclientset.Interface
-	kubeClient            kubernetes.Interface
+	seedKubeClient        kubernetes.Interface
 	clusterLister         kubermaticv1lister.ClusterLister
 	clusterClientProvider *clusterclient.Provider
 	dcs                   map[string]provider.DatacenterMeta
@@ -471,7 +471,7 @@ func (r *testRunner) getCloudConfig(log *logrus.Entry, cluster *kubermaticv1.Clu
 
 	var cmData string
 	err := retryNAttempts(defaultAPIRetries, func(attempt int) error {
-		cm, err := r.kubeClient.CoreV1().ConfigMaps(cluster.Status.NamespaceName).Get(resources.CloudConfigConfigMapName, metav1.GetOptions{})
+		cm, err := r.seedKubeClient.CoreV1().ConfigMaps(cluster.Status.NamespaceName).Get(resources.CloudConfigConfigMapName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to load cloud-config: %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Introducing this after we had e2e tests that passed even thought some of the control plane pods never came up in #1956. That is a situation in which I expect the tests to fail. The drawback of this is that it increases the runtime a little.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
/assign @mrIncompetent 