### PR TITLE
ucc: add apiregistrationv1beta1 to scheme and fix flag name

### DIFF
--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	apiextensionv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
@@ -46,6 +47,9 @@ func main() {
 
 	glog.Info("registering components")
 	if err := apiextensionv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+		glog.Fatal(err)
+	}
+	if err := apiregistrationv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
 		glog.Fatal(err)
 	}
 

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -25,7 +25,7 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-listen-address
+        - -internal-address
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/user-cluster-controller-manager

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -79,7 +79,7 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 				Command:         []string{"/usr/local/bin/user-cluster-controller-manager"},
 				Args: []string{
 					"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-					"-internal-listen-address", "0.0.0.0:8085",
+					"-internal-address", "0.0.0.0:8085",
 				},
 				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 				TerminationMessagePolicy: corev1.TerminationMessageReadFile,


### PR DESCRIPTION
- Adds apiregistrationv1beta1 to scheme.
- Fixes the flag name for `-internal-address`.

/kind bug
/priority critical-urgent
/assign @alvaroaleman 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
