### PR TITLE
[release/v2.9] Validate via events that LB services actually got deleted (#2780)

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1767,6 +1767,7 @@
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/fields",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -56,6 +56,7 @@ type userClusterConnectionProvider interface {
 	GetApiextensionsClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (apiextensionsclientset.Interface, error)
 	GetAdmissionRegistrationClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (admissionregistrationclientset.AdmissionregistrationV1beta1Interface, error)
 	GetKubeAggregatorClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (aggregationclientset.Interface, error)
+	GetDynamicClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
 }
 
 // Controller is a controller which is responsible for managing clusters

--- a/api/pkg/controller/cluster/deleting.go
+++ b/api/pkg/controller/cluster/deleting.go
@@ -1,7 +1,10 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
@@ -13,12 +16,18 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+
+	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	InClusterPVCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-pv"
 	InClusterLBCleanupFinalizer = "kubermatic.io/cleanup-in-cluster-lb"
+	deletedLBAnnotationName     = "kubermatic.io/cleaned-up-loadbalancers"
 )
 
 // cleanupCluster is the function which handles clusters in the deleting phase.
@@ -78,11 +87,36 @@ func (cc *Controller) cleanupInClusterResources(c *kubermaticv1.Cluster) (*kuber
 		}
 
 		for _, service := range serviceList.Items {
+			// Need to change the scope so the inline func in the updateCluster call always has the service from the current iteration
+			service := service
 			if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
 				if err := client.CoreV1().Services(service.Namespace).Delete(service.Name, &metav1.DeleteOptions{}); err != nil {
 					return nil, fmt.Errorf("failed to delete Service '%s/%s' from user cluster: %v", service.Namespace, service.Name, err)
 				}
 				deletedSomeResource = true
+				c, err = cc.updateCluster(c.Name, func(cluster *kubermaticv1.Cluster) {
+					if cluster.Annotations == nil {
+						cluster.Annotations = map[string]string{}
+					}
+					cluster.Annotations[deletedLBAnnotationName] = cluster.Annotations[deletedLBAnnotationName] + fmt.Sprintf(",%s", string(service.UID))
+				})
+				if err != nil {
+					return nil, fmt.Errorf("failed to update cluster when trying to add UID of deleted LoadBalancer: %v", err)
+				}
+				// Wait for the update to appear in the lister as we use the data from the lister later on to verify if the LoadBalancers
+				// are gone
+				if err := wait.Poll(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+					clusterFromLister, err := cc.clusterLister.Get(c.Name)
+					if err != nil {
+						return false, err
+					}
+					if strings.Contains(clusterFromLister.Annotations[deletedLBAnnotationName], string(service.UID)) {
+						return true, nil
+					}
+					return false, nil
+				}); err != nil {
+					return nil, fmt.Errorf("failed to wait for deletedLBAnnotation to appear in the lister: %v", err)
+				}
 			}
 		}
 	}
@@ -115,7 +149,22 @@ func (cc *Controller) cleanupInClusterResources(c *kubermaticv1.Cluster) (*kuber
 		}
 	}
 
+	// If we deleted something it is implied that there was still something left. Just return
+	// here so the finalizers stay, it will make the cluster controller requeue us after a delay
+	// This also means that we may end up issuing multiple DELETE calls against the same ressource
+	// if cleaning up takes some time, but that shouldn't cause any harm
+	// We also need to return when something was deleted so the checkIfAllLoadbalancersAreGone
+	// call gets an updated version of the cluster from the lister
 	if deletedSomeResource {
+		return c, nil
+	}
+
+	lbsAreGone, err := cc.checkIfAllLoadbalancersAreGone(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if all Loadbalancers are gone: %v", err)
+	}
+	// Return so we check again later
+	if !lbsAreGone {
 		return c, nil
 	}
 
@@ -255,4 +304,62 @@ func (cc *Controller) deletingCloudProviderCleanup(c *kubermaticv1.Cluster) (*ku
 	}
 
 	return c, nil
+}
+
+// checkIfAllLoadbalancersAreGone checks if all the services of type LoadBalancer were successfully
+// deleted. The in-tree cloud providers do this without a finalizer and only after the service
+// object is gone from the API, the only way to check is to wait for the relevant event
+func (cc *Controller) checkIfAllLoadbalancersAreGone(c *kubermaticv1.Cluster) (bool, error) {
+	// This check is only required for in-tree cloud provider that support LoadBalancers
+	// TODO once we start external cloud controllers for one of these three: Make this check
+	// a bit smarter, external cloud controllers will most likely not emit the event we wait for
+	if c.Spec.Cloud.AWS == nil && c.Spec.Cloud.Azure == nil && c.Spec.Cloud.Openstack == nil {
+		return true, nil
+	}
+
+	// We only need to wait for this if there were actually services of type Loadbalancer deleted
+	if c.Annotations[deletedLBAnnotationName] == "" {
+		return true, nil
+	}
+
+	deletedLoadBalancers := sets.NewString(strings.Split(strings.TrimPrefix(c.Annotations[deletedLBAnnotationName], ","), ",")...)
+
+	// Kubernetes gives no guarantees at all about events, it is possible we don't get the event
+	// so bail out after 2h
+	if c.DeletionTimestamp.UTC().Add(2 * time.Hour).Before(time.Now().UTC()) {
+		staleLBs.WithLabelValues(c.Name).Set(float64(deletedLoadBalancers.Len()))
+		return true, nil
+	}
+
+	userClusterDynamicClient, err := cc.userClusterConnProvider.GetDynamicClient(c)
+	if err != nil {
+		return false, fmt.Errorf("failed to get dynamic client for user cluster: %v", err)
+	}
+	for deletedLB := range deletedLoadBalancers {
+		selector := fields.OneTermEqualSelector("involvedObject.uid", deletedLB)
+		events := &corev1.EventList{}
+		if err := userClusterDynamicClient.List(context.Background(), &controllerruntimeclient.ListOptions{FieldSelector: selector}, events); err != nil {
+			return false, fmt.Errorf("failed to get service events: %v", err)
+		}
+		for _, event := range events.Items {
+			if event.Reason == "DeletedLoadBalancer" {
+				deletedLoadBalancers.Delete(deletedLB)
+			}
+		}
+
+	}
+	c, err = cc.updateCluster(c.Name, func(cluster *kubermaticv1.Cluster) {
+		if deletedLoadBalancers.Len() > 0 {
+			cluster.Annotations[deletedLBAnnotationName] = strings.Join(deletedLoadBalancers.List(), ",")
+		} else {
+			delete(cluster.Annotations, deletedLBAnnotationName)
+		}
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to update cluster: %v", err)
+	}
+	if deletedLoadBalancers.Len() > 0 {
+		return false, nil
+	}
+	return true, nil
 }

--- a/api/pkg/controller/cluster/metrics.go
+++ b/api/pkg/controller/cluster/metrics.go
@@ -11,17 +11,22 @@ const (
 )
 
 var (
-	workers = prometheus.NewGauge(
+	registerMetrics sync.Once
+	workers         = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Subsystem: clusterControllerSubsystem,
 			Name:      "workers",
 			Help:      "The number of running cluster controller workers.",
 		},
 	)
-)
-
-var (
-	registerMetrics sync.Once
+	staleLBs = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: clusterControllerSubsystem,
+			Name:      "stale_lbs",
+			Help:      "The number of cloud load balancers that couldn't be cleaned up within the 2h grace period",
+		},
+		[]string{"cluster"},
+	)
 )
 
 // Register the metrics that are to be monitored.
@@ -29,5 +34,6 @@ func init() {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(workers)
 		workers.Set(0)
+		prometheus.MustRegister(staleLBs)
 	})
 }


### PR DESCRIPTION
* Validate via events that services actually got deleted

* Fix dependencies

* Move loadbalancer cleanup check in a dedicated func

* Add metric for stale lbs and fix caching issues

* Remove debug output

* PR feedback, mark loadbalancers as gone once they are gone

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Manual cherrypick of #2780

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that prevented Loadbalancers from getting properly cleaned up on cluster deletion
```

/assign @mrIncompetent 