### PR TITLE
Create monitoring components in the seed as soon as possible

### DIFF
--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -77,6 +78,13 @@ func StatefulSetCreator(data *resources.TemplateData) resources.StatefulSetCreat
 		if data.Cluster().Spec.ComponentsOverride.Prometheus.Resources != nil {
 			resourceRequirements = *data.Cluster().Spec.ComponentsOverride.Prometheus.Resources
 		}
+
+		apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+		if err != nil {
+			return nil, err
+		}
+		set.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+
 		set.Spec.Template.Spec.Containers = []corev1.Container{
 			{
 				Name:                     name,

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -88,6 +88,25 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        command:
+        - /usr/local/bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.1
+        imagePullPolicy: IfNotPresent
+        name: apiserver-running
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       restartPolicy: Always
       securityContext:
         fsGroup: 2000


### PR DESCRIPTION
The goal of this change is to speed up the deployment of the monitoring
components by starting to deploy them onto the seed as soon as the
cluster has a namespace.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
