### PR TITLE
ClusterConnectionProvider: Allow using internal apiserver address

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -283,7 +283,7 @@ func main() {
 
 	opts.clusterLister = kubermaticInformerFactory.Kubermatic().V1().Clusters().Lister()
 
-	clusterClientProvider := clusterclient.New(kubeInformerFactory.Core().V1().Secrets().Lister())
+	clusterClientProvider := clusterclient.New(kubeInformerFactory.Core().V1().Secrets().Lister(), true)
 	opts.clusterClientProvider = clusterClientProvider
 
 	kubermaticInformerFactory.Start(rootCtx.Done())

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -283,7 +283,7 @@ func main() {
 
 	opts.clusterLister = kubermaticInformerFactory.Kubermatic().V1().Clusters().Lister()
 
-	clusterClientProvider := clusterclient.New(kubeInformerFactory.Core().V1().Secrets().Lister(), true)
+	clusterClientProvider := clusterclient.NewExternal(kubeInformerFactory.Core().V1().Secrets().Lister())
 	opts.clusterClientProvider = clusterClientProvider
 
 	kubermaticInformerFactory.Start(rootCtx.Done())

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -323,7 +323,7 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 		resources.PrometheusApiserverClientCertificateSecretName,
 		resources.MetricsServerKubeconfigSecretName,
 		resources.MachineControllerWebhookServingCertSecretName,
-		resources.UserClusterControllerKubeconfigSecretName,
+		resources.InternalUserClusterAdminKubeconfigSecretName,
 	})
 	objects := []runtime.Object{configMapList, secretList, serviceList}
 	client := kubefake.NewSimpleClientset(objects...)

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -116,7 +116,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 
 			clusterProviders[ctx] = kubernetesprovider.NewClusterProvider(
 				defaultImpersonationClientForSeed.CreateImpersonatedClientSet,
-				client.New(kubeInformerFactory.Core().V1().Secrets().Lister(), true),
+				client.NewExternal(kubeInformerFactory.Core().V1().Secrets().Lister()),
 				kubermaticSeedInformerFactory.Kubermatic().V1().Clusters().Lister(),
 				options.workerName,
 				rbac.ExtractGroupPrefix,

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -116,7 +116,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 
 			clusterProviders[ctx] = kubernetesprovider.NewClusterProvider(
 				defaultImpersonationClientForSeed.CreateImpersonatedClientSet,
-				client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
+				client.New(kubeInformerFactory.Core().V1().Secrets().Lister(), true),
 				kubermaticSeedInformerFactory.Kubermatic().V1().Clusters().Lister(),
 				options.workerName,
 				rbac.ExtractGroupPrefix,

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -123,7 +123,7 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 	}
 
 	var clientProvider *client.Provider
-	if ctrlCtx.runOptions.runOutsideOfSeed {
+	if ctrlCtx.runOptions.kubeconfig != "" {
 		clientProvider = client.NewExternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
 	} else {
 		clientProvider = client.NewInternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
@@ -213,7 +213,7 @@ func createMonitoringController(ctrlCtx *controllerContext) (runner, error) {
 	}
 
 	var clientProvider *client.Provider
-	if ctrlCtx.runOptions.runOutsideOfSeed {
+	if ctrlCtx.runOptions.kubeconfig != "" {
 		clientProvider = client.NewExternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
 	} else {
 		clientProvider = client.NewInternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
@@ -291,7 +291,7 @@ func createUpdateController(ctrlCtx *controllerContext) (runner, error) {
 
 func createAddonController(ctrlCtx *controllerContext) (runner, error) {
 	var clientProvider *client.Provider
-	if ctrlCtx.runOptions.runOutsideOfSeed {
+	if ctrlCtx.runOptions.kubeconfig != "" {
 		clientProvider = client.NewExternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
 	} else {
 		clientProvider = client.NewInternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -129,7 +129,7 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.runOptions.externalURL,
 		ctrlCtx.runOptions.dc,
 		dcs,
-		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
+		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister(), false),
 		ctrlCtx.runOptions.overwriteRegistry,
 		ctrlCtx.runOptions.nodePortRange,
 		ctrlCtx.runOptions.nodeAccessNetwork,
@@ -208,7 +208,7 @@ func createMonitoringController(ctrlCtx *controllerContext) (runner, error) {
 	return monitoring.New(
 		ctrlCtx.kubeClient,
 		ctrlCtx.dynamicClient,
-		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
+		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister(), false),
 
 		ctrlCtx.runOptions.dc,
 		dcs,
@@ -285,7 +285,7 @@ func createAddonController(ctrlCtx *controllerContext) (runner, error) {
 		},
 		ctrlCtx.runOptions.addonsPath,
 		ctrlCtx.runOptions.overwriteRegistry,
-		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
+		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister(), false),
 		ctrlCtx.kubermaticClient,
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Addons(),
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -129,7 +129,7 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.runOptions.externalURL,
 		ctrlCtx.runOptions.dc,
 		dcs,
-		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister(), false),
+		client.NewInternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
 		ctrlCtx.runOptions.overwriteRegistry,
 		ctrlCtx.runOptions.nodePortRange,
 		ctrlCtx.runOptions.nodeAccessNetwork,
@@ -208,7 +208,7 @@ func createMonitoringController(ctrlCtx *controllerContext) (runner, error) {
 	return monitoring.New(
 		ctrlCtx.kubeClient,
 		ctrlCtx.dynamicClient,
-		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister(), false),
+		client.NewInternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
 
 		ctrlCtx.runOptions.dc,
 		dcs,
@@ -285,7 +285,7 @@ func createAddonController(ctrlCtx *controllerContext) (runner, error) {
 		},
 		ctrlCtx.runOptions.addonsPath,
 		ctrlCtx.runOptions.overwriteRegistry,
-		client.New(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister(), false),
+		client.NewInternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister()),
 		ctrlCtx.kubermaticClient,
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Addons(),
 		ctrlCtx.kubermaticInformerFactory.Kubermatic().V1().Clusters(),

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	"github.com/kubermatic/kubermatic/api/pkg/collectors"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
@@ -230,6 +231,14 @@ func newControllerContext(
 	if err != nil {
 		return nil, err
 	}
+
+	var clientProvider *client.Provider
+	if ctrlCtx.runOptions.kubeconfig != "" {
+		clientProvider = client.NewExternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
+	} else {
+		clientProvider = client.NewInternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
+	}
+	ctrlCtx.clientProvider = clientProvider
 
 	ctrlCtx.kubermaticInformerFactory = kubermaticinformers.NewFilteredSharedInformerFactory(ctrlCtx.kubermaticClient, informer.DefaultInformerResyncPeriod, metav1.NamespaceAll, selector)
 	ctrlCtx.kubeInformerFactory = kubeinformers.NewSharedInformerFactory(ctrlCtx.kubeClient, informer.DefaultInformerResyncPeriod)

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -232,6 +232,9 @@ func newControllerContext(
 		return nil, err
 	}
 
+	ctrlCtx.kubermaticInformerFactory = kubermaticinformers.NewFilteredSharedInformerFactory(ctrlCtx.kubermaticClient, informer.DefaultInformerResyncPeriod, metav1.NamespaceAll, selector)
+	ctrlCtx.kubeInformerFactory = kubeinformers.NewSharedInformerFactory(ctrlCtx.kubeClient, informer.DefaultInformerResyncPeriod)
+
 	var clientProvider *client.Provider
 	if ctrlCtx.runOptions.kubeconfig != "" {
 		clientProvider = client.NewExternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
@@ -239,9 +242,6 @@ func newControllerContext(
 		clientProvider = client.NewInternal(ctrlCtx.kubeInformerFactory.Core().V1().Secrets().Lister())
 	}
 	ctrlCtx.clientProvider = clientProvider
-
-	ctrlCtx.kubermaticInformerFactory = kubermaticinformers.NewFilteredSharedInformerFactory(ctrlCtx.kubermaticClient, informer.DefaultInformerResyncPeriod, metav1.NamespaceAll, selector)
-	ctrlCtx.kubeInformerFactory = kubeinformers.NewSharedInformerFactory(ctrlCtx.kubeClient, informer.DefaultInformerResyncPeriod)
 
 	return ctrlCtx, nil
 }

--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -54,7 +54,6 @@ type controllerRunOptions struct {
 	inClusterPrometheusScrapingConfigsFile           string
 	monitoringScrapeAnnotationPrefix                 string
 	dockerPullConfigJSONFile                         string
-	runOutsideOfSeed                                 bool
 
 	// OIDC configuration
 	oidcCAFile         string
@@ -96,7 +95,6 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.inClusterPrometheusScrapingConfigsFile, "in-cluster-prometheus-scraping-configs-file", "", "The file containing the custom scraping configs for the prometheus running in the cluster-foo namespaces.")
 	flag.StringVar(&c.monitoringScrapeAnnotationPrefix, "monitoring-scrape-annotation-prefix", "monitoring.kubermatic.io", "The prefix for monitoring annotations in the user cluster. Default: monitoring.kubermatic.io -> monitoring.kubermatic.io/port, monitoring.kubermatic.io/path")
 	flag.StringVar(&rawFeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for various features.")
-	flag.BoolVar(&c.runOutsideOfSeed, "run-outside-of-seed", false, "Whether the controller runs outside of the seed cluster")
 	flag.StringVar(&c.oidcCAFile, "oidc-ca-file", "", "The path to the certificate for the CA that signed your identity provider’s web certificate.")
 	flag.StringVar(&c.oidcIssuerURL, "oidc-issuer-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
 	flag.StringVar(&c.oidcIssuerClientID, "oidc-issuer-client-id", "", "Issuer client ID")

--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -54,6 +54,7 @@ type controllerRunOptions struct {
 	inClusterPrometheusScrapingConfigsFile           string
 	monitoringScrapeAnnotationPrefix                 string
 	dockerPullConfigJSONFile                         string
+	runOutsideOfSeed                                 bool
 
 	// OIDC configuration
 	oidcCAFile         string
@@ -95,6 +96,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.inClusterPrometheusScrapingConfigsFile, "in-cluster-prometheus-scraping-configs-file", "", "The file containing the custom scraping configs for the prometheus running in the cluster-foo namespaces.")
 	flag.StringVar(&c.monitoringScrapeAnnotationPrefix, "monitoring-scrape-annotation-prefix", "monitoring.kubermatic.io", "The prefix for monitoring annotations in the user cluster. Default: monitoring.kubermatic.io -> monitoring.kubermatic.io/port, monitoring.kubermatic.io/path")
 	flag.StringVar(&rawFeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for various features.")
+	flag.BoolVar(&c.runOutsideOfSeed, "run-outside-of-seed", false, "Whether the controller runs outside of the seed cluster")
 	flag.StringVar(&c.oidcCAFile, "oidc-ca-file", "", "The path to the certificate for the CA that signed your identity provider’s web certificate.")
 	flag.StringVar(&c.oidcIssuerURL, "oidc-issuer-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
 	flag.StringVar(&c.oidcIssuerClientID, "oidc-issuer-client-id", "", "Issuer client ID")

--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	backupcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/backup"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
@@ -210,4 +211,5 @@ type controllerContext struct {
 	dynamicClient             ctrlruntimeclient.Client
 	dynamicCache              ctrlruntimecache.Cache
 	mgr                       manager.Manager
+	clientProvider            *client.Provider
 }

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -28,4 +28,5 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
   -oidc-ca-file=../../secrets/seed-clusters/dev.kubermatic.io/caBundle.pem \
   -monitoring-scrape-annotation-prefix='kubermatic.io' \
   -logtostderr=1 \
+  -run-outside-of-seed=true \
   -v=6 $@ 2>&1|tee /tmp/kubermatic-controller-manager.log

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -28,5 +28,4 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
   -oidc-ca-file=../../secrets/seed-clusters/dev.kubermatic.io/caBundle.pem \
   -monitoring-scrape-annotation-prefix='kubermatic.io' \
   -logtostderr=1 \
-  -run-outside-of-seed=true \
   -v=6 $@ 2>&1|tee /tmp/kubermatic-controller-manager.log

--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -22,11 +22,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-// New returns a new instance of the client connection provider
-// useExternalAddress describes whether we are going to access the user cluster from outside
-// of the seed cluster
-func New(secretLister corev1lister.SecretLister, useExternalAddress bool) *Provider {
-	return &Provider{secretLister: secretLister, useExternalAddress: useExternalAddress}
+// NewInternal returns a new instance of the client connection provider that
+// only works from within the seed cluster but has the advantage that it doesn't leave
+// the seed clusters network
+func NewInternal(secretLister corev1lister.SecretLister) *Provider {
+	return &Provider{secretLister: secretLister, useExternalAddress: false}
+}
+
+// NewExternal returns a new instance of the client connection provider that
+// that uses the external cluster address and hence works from everywhere.
+// Use NewInternal if possible
+func NewExternal(secretLister corev1lister.SecretLister) *Provider {
+	return &Provider{secretLister: secretLister, useExternalAddress: true}
 }
 
 // Provider offers functions to interact with a user cluster

--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -50,9 +50,8 @@ func (p *Provider) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
 		// Load the admin kubeconfig secret, it uses the external apiserver address
 		s, err = p.secretLister.Secrets(c.Status.NamespaceName).Get(resources.AdminKubeconfigSecretName)
 	} else {
-		// Load the UserClusterControllerKubeconfigSecret, it has cluster-admin privileges
-		// and uses the internal apiserver address
-		s, err = p.secretLister.Secrets(c.Status.NamespaceName).Get(resources.UserClusterControllerKubeconfigSecretName)
+		// Load the internal admin kubeconfig secret
+		s, err = p.secretLister.Secrets(c.Status.NamespaceName).Get(resources.InternalUserClusterAdminKubeconfigSecretName)
 	}
 	if err != nil {
 		return nil, err

--- a/api/pkg/controller/cluster/cluster_controller_test.go
+++ b/api/pkg/controller/cluster/cluster_controller_test.go
@@ -40,7 +40,7 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		TestExternalURL,
 		TestDC,
 		dcs,
-		client.New(kubeInformerFactory.Core().V1().Secrets().Lister(), false),
+		client.NewInternal(kubeInformerFactory.Core().V1().Secrets().Lister()),
 		"",
 		"",
 		"192.0.2.0/24",

--- a/api/pkg/controller/cluster/cluster_controller_test.go
+++ b/api/pkg/controller/cluster/cluster_controller_test.go
@@ -40,7 +40,7 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 		TestExternalURL,
 		TestDC,
 		dcs,
-		client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
+		client.New(kubeInformerFactory.Core().V1().Secrets().Lister(), false),
 		"",
 		"",
 		"192.0.2.0/24",

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -208,7 +208,7 @@ func GetSecretCreators(data *resources.TemplateData) []resources.NamedSecretCrea
 		resources.GetInternalKubeconfigCreator(resources.ControllerManagerKubeconfigSecretName, resources.ControllerManagerCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.MetricsServerKubeconfigSecretName, resources.MetricsServerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.InternalUserClusterAdminKubeconfigSecretName, resources.resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data),
+		resources.GetInternalKubeconfigCreator(resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data),
 	}
 
 	if len(data.OIDCCAFile()) > 0 {

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -208,7 +208,7 @@ func GetSecretCreators(data *resources.TemplateData) []resources.NamedSecretCrea
 		resources.GetInternalKubeconfigCreator(resources.ControllerManagerKubeconfigSecretName, resources.ControllerManagerCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.MetricsServerKubeconfigSecretName, resources.MetricsServerCertUsername, nil, data),
-		resources.GetInternalKubeconfigCreator(resources.UserClusterControllerKubeconfigSecretName, resources.UserClusterControllerCertUsername, []string{"system:masters"}, data),
+		resources.GetInternalKubeconfigCreator(resources.InternalUserClusterAdminKubeconfigSecretName, resources.resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data),
 	}
 
 	if len(data.OIDCCAFile()) > 0 {

--- a/api/pkg/controller/monitoring/monitoring_controller_test.go
+++ b/api/pkg/controller/monitoring/monitoring_controller_test.go
@@ -46,7 +46,7 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 	controller, err := New(
 		kubeClient,
 		dynamicClient,
-		client.New(kubeInformerFactory.Core().V1().Secrets().Lister()),
+		client.New(kubeInformerFactory.Core().V1().Secrets().Lister(), false),
 		TestDC,
 		dcs,
 		"",

--- a/api/pkg/controller/monitoring/monitoring_controller_test.go
+++ b/api/pkg/controller/monitoring/monitoring_controller_test.go
@@ -46,7 +46,7 @@ func newTestController(kubeObjects []runtime.Object, kubermaticObjects []runtime
 	controller, err := New(
 		kubeClient,
 		dynamicClient,
-		client.New(kubeInformerFactory.Core().V1().Secrets().Lister(), false),
+		client.NewInternal(kubeInformerFactory.Core().V1().Secrets().Lister()),
 		TestDC,
 		dcs,
 		"",

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -278,10 +278,11 @@ const (
 	// configuration
 	MachineControllerMutatingWebhookConfigurationName = "machine-controller.kubermatic.io"
 
-	// UserClusterControllerKubeconfigSecretName is the name for the secret containing the kubeconfig used by the user cluster controller
-	UserClusterControllerKubeconfigSecretName = "usercluster-controller"
+	// InternalUserClusterAdminKubeconfigSecretName is the name of the secret containing an admin kubeconfig that can only be used from
+	// within the seed cluster
+	InternalUserClusterAdminKubeconfigSecretName = "internal-admin-kubeconfig"
 	// UserClusterControllerCertUsername is the name of the user coming from kubeconfig cert
-	UserClusterControllerCertUsername = "usercluster-controller"
+	InternalUserClusterAdminKubeconfigCertUsername = "kubermatic-controllers"
 )
 
 const (

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: usercluster-controller
         cluster: de-test-01
-        usercluster-controller-secret-revision: "123456"
+        internal-admin-kubeconfig-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -50,7 +50,7 @@ spec:
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
-          name: usercluster-controller
+          name: internal-admin-kubeconfig
           readOnly: true
       imagePullSecrets:
       - name: dockercfg
@@ -74,8 +74,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:
-      - name: usercluster-controller
+      - name: internal-admin-kubeconfig
         secret:
           defaultMode: 292
-          secretName: usercluster-controller
+          secretName: internal-admin-kubeconfig
 status: {}

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -375,7 +375,7 @@ func TestLoadFiles(t *testing.T) {
 					&v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "123456",
-							Name:            resources.UserClusterControllerKubeconfigSecretName,
+							Name:            resources.InternalUserClusterAdminKubeconfigSecretName,
 							Namespace:       cluster.Status.NamespaceName,
 						},
 					},

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -93,7 +93,7 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 				Resources:                defaultResourceRequirements,
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      resources.UserClusterControllerKubeconfigSecretName,
+						Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
 						MountPath: "/etc/kubernetes/kubeconfig",
 						ReadOnly:  true,
 					},
@@ -108,10 +108,10 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 func getVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
-			Name: resources.UserClusterControllerKubeconfigSecretName,
+			Name: resources.InternalUserClusterAdminKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.UserClusterControllerKubeconfigSecretName,
+					SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
 					// We have to make the secret readable for all for now because owner/group cannot be changed.
 					// ( upstream proposal: https://github.com/kubernetes/kubernetes/pull/28733 )
 					DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),


### PR DESCRIPTION
**What this PR does / why we need it**:

    This change makes us not use the external apiserver address when
    components running in the seed connect to the user cluster, saving one
    unnecessary hop

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
