### PR TITLE
Only sync charts on releases, not for each commit

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,7 +44,7 @@ pipeline:
     - sed -i "s/__KUBERMATIC_TAG__/$LATEST_VERSION/g" config/kubermatic/values.yaml
     - git config --global user.email "dev@loodse.com"
     - git config --global user.name "drone"
-    - cd api && ./hack/sync-charts.sh ${DRONE_BRANCH} ../config
+    - cd api && ./hack/sync-charts.sh ../config
     image: alpine:3.8
     pull: true
     when:

--- a/api/hack/sync-charts.sh
+++ b/api/hack/sync-charts.sh
@@ -6,11 +6,13 @@ if ! git describe --exact-match --tags HEAD &>/dev/null; then
   exit 0
 fi
 
-if [ "$#" -lt 2 ] || [ "${1}" == "--help" ]; then
+export INSTALLER_BRANCH="$(git branch --contains HEAD --all \
+  |tr -d ' '|grep -E 'remotes/origin/release/v2.[0-9]+$'|cut -d '/' -f3-)"
+
+if [ "$#" -lt 1 ] || [ "${1}" == "--help" ]; then
   cat <<EOF
 Usage: $(basename $0) <branch-name> <path-to-charts>
 
-  <branch-name>                  Name of the target branch in the kubermatic-installer repository
   <path-to-charts>               The path to the kubermatic charts to sync
 
 Example:
@@ -23,7 +25,6 @@ export CHARTS='kubermatic cert-manager certs nginx-ingress-controller nodeport-p
 export MONITORING_CHARTS='alertmanager grafana kube-state-metrics node-exporter prometheus'
 export LOGGING_CHARTS='elasticsearch kibana fluentbit'
 export BACKUP_CHARTS='ark ark-config'
-export INSTALLER_BRANCH=$1
 export CHARTS_DIR=$2
 export TARGET_DIR='sync_target'
 export TARGET_VALUES_FILE=${TARGET_DIR}/values.example.yaml

--- a/api/hack/sync-charts.sh
+++ b/api/hack/sync-charts.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! git describe --exact-match --tags HEAD &>/dev/null; then
+  echo "No tag matches current HEAD, exitting..."
+  exit 0
+fi
+
 if [ "$#" -lt 2 ] || [ "${1}" == "--help" ]; then
   cat <<EOF
 Usage: $(basename $0) <branch-name> <path-to-charts>
@@ -132,7 +137,7 @@ mv ${TARGET_DIR}/values.example.{tmp.,}yaml
 cd ${TARGET_DIR}
 git add .
 if ! git status|grep 'nothing to commit'; then
-  git commit -m "Syncing charts from commit ${COMMIT}"
+  git commit -m "Syncing charts from release $(git describe --exact-match --tags HEAD)"
   git push origin ${INSTALLER_BRANCH}
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we sync the charts on every commit in a release branch. This has already caused some confusion, especially as the installer repo does not contain the release tags. This PR changes that behavior to only sync when there is a tag on the commit and also changes the commit message to indicate for which release the sync was.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
