### PR TITLE
ucc: reconcile more resources

### DIFF
--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -11,8 +11,10 @@ import (
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
@@ -50,6 +52,9 @@ func main() {
 		glog.Fatal(err)
 	}
 	if err := apiregistrationv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+		glog.Fatal(err)
+	}
+	if err := rbacv1.AddToScheme(mgr.GetScheme()); err != nil {
 		glog.Fatal(err)
 	}
 

--- a/api/pkg/controller/cluster/userclusterresources.go
+++ b/api/pkg/controller/cluster/userclusterresources.go
@@ -8,17 +8,13 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"github.com/kubermatic/kubermatic/api/pkg/resources/controllermanager"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/ipamcontroller"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroller"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/metrics-server"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/openvpn"
-	"github.com/kubermatic/kubermatic/api/pkg/resources/scheduler"
-	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
 	admissionv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,23 +34,7 @@ func (cc *Controller) reconcileUserClusterResources(cluster *kubermaticv1.Cluste
 		}
 	}
 
-	if err = cc.userClusterEnsureRoles(cluster, client); err != nil {
-		return nil, err
-	}
-
 	if err = cc.userClusterEnsureConfigMaps(cluster, client); err != nil {
-		return nil, err
-	}
-
-	if err = cc.userClusterEnsureRoleBindings(cluster, client); err != nil {
-		return nil, err
-	}
-
-	if err = cc.userClusterEnsureClusterRoles(cluster, client); err != nil {
-		return nil, err
-	}
-
-	if err = cc.userClusterEnsureClusterRoleBindings(cluster, client); err != nil {
 		return nil, err
 	}
 
@@ -120,229 +100,6 @@ func (cc *Controller) userClusterEnsureInitializerConfiguration(c *kubermaticv1.
 			return fmt.Errorf("failed to update InitializerConfiguration %s: %v", initializerConfiguration.Name, err)
 		}
 		glog.V(4).Infof("Updated InitializerConfiguration %s inside user-cluster %s", initializerConfiguration.Name, c.Name)
-	}
-
-	return nil
-}
-
-func (cc *Controller) userClusterEnsureRoles(c *kubermaticv1.Cluster, client kubernetes.Interface) error {
-	creators := []resources.RoleCreator{
-		machinecontroller.EndpointReaderRole,
-		machinecontroller.KubeSystemRole,
-		machinecontroller.KubePublicRole,
-		machinecontroller.ClusterInfoReaderRole,
-	}
-
-	data, err := cc.getClusterTemplateData(c)
-	if err != nil {
-		return err
-	}
-
-	for _, create := range creators {
-		var existing *rbacv1.Role
-		role, err := create(data, nil)
-		if err != nil {
-			return fmt.Errorf("failed to build Role: %v", err)
-		}
-
-		if existing, err = client.RbacV1().Roles(role.Namespace).Get(role.Name, metav1.GetOptions{}); err != nil {
-			if !errors.IsNotFound(err) {
-				return err
-			}
-
-			if _, err = client.RbacV1().Roles(role.Namespace).Create(role); err != nil {
-				return fmt.Errorf("failed to create Role %s in namespace %s: %v", role.Name, role.Namespace, err)
-			}
-			glog.V(4).Infof("Created Role %s inside user-cluster %s", role.Name, c.Name)
-			continue
-		}
-
-		role, err = create(data, existing.DeepCopy())
-		if err != nil {
-			return fmt.Errorf("failed to build Role: %v", err)
-		}
-
-		if resources.DeepEqual(role, existing) {
-			continue
-		}
-
-		if _, err = client.RbacV1().Roles(role.Namespace).Update(role); err != nil {
-			return fmt.Errorf("failed to update Role %s in namespace %s: %v", role.Name, role.Namespace, err)
-		}
-		glog.V(4).Infof("Updated Role %s inside user-cluster %s", role.Name, c.Name)
-	}
-
-	return nil
-}
-
-func (cc *Controller) userClusterEnsureRoleBindings(c *kubermaticv1.Cluster, client kubernetes.Interface) error {
-	creators := []resources.RoleBindingCreator{
-		machinecontroller.DefaultRoleBinding,
-		machinecontroller.KubeSystemRoleBinding,
-		machinecontroller.KubePublicRoleBinding,
-		machinecontroller.ClusterInfoAnonymousRoleBinding,
-		metricsserver.RolebindingAuthReader,
-		scheduler.RoleBindingAuthDelegator,
-		controllermanager.RoleBindingAuthDelegator,
-	}
-
-	for _, create := range creators {
-		var existing *rbacv1.RoleBinding
-		rb, err := create(nil, nil)
-		if err != nil {
-			return fmt.Errorf("failed to build RoleBinding: %v", err)
-		}
-
-		if existing, err = client.RbacV1().RoleBindings(rb.Namespace).Get(rb.Name, metav1.GetOptions{}); err != nil {
-			if !errors.IsNotFound(err) {
-				return err
-			}
-
-			if _, err = client.RbacV1().RoleBindings(rb.Namespace).Create(rb); err != nil {
-				return fmt.Errorf("failed to create RoleBinding %s in namespace %s: %v", rb.Name, rb.Namespace, err)
-			}
-			glog.V(4).Infof("Created RoleBinding %s inside user-cluster %s", rb.Name, c.Name)
-			continue
-		}
-
-		rb, err = create(nil, existing.DeepCopy())
-		if err != nil {
-			return fmt.Errorf("failed to build RoleBinding: %v", err)
-		}
-
-		if equality.Semantic.DeepEqual(rb, existing) {
-			continue
-		}
-
-		if _, err = client.RbacV1().RoleBindings(rb.Namespace).Update(rb); err != nil {
-			return fmt.Errorf("failed to update RoleBinding %s in namespace %s: %v", rb.Name, rb.Namespace, err)
-		}
-		glog.V(4).Infof("Updated RoleBinding %s inside user-cluster %s", rb.Name, c.Name)
-	}
-
-	return nil
-}
-
-// GetUserClusterRoleCreators returns a list of GetUserClusterRoleCreators
-func GetUserClusterRoleCreators(c *kubermaticv1.Cluster) []resources.ClusterRoleCreator {
-	creators := []resources.ClusterRoleCreator{
-		machinecontroller.ClusterRole,
-		vpnsidecar.DnatControllerClusterRole,
-		metricsserver.ClusterRole,
-	}
-
-	if len(c.Spec.MachineNetworks) > 0 {
-		creators = append(creators, ipamcontroller.ClusterRole)
-	}
-
-	return creators
-}
-
-func (cc *Controller) userClusterEnsureClusterRoles(c *kubermaticv1.Cluster, client kubernetes.Interface) error {
-	creators := GetUserClusterRoleCreators(c)
-
-	data, err := cc.getClusterTemplateData(c)
-	if err != nil {
-		return err
-	}
-
-	for _, create := range creators {
-		var existing *rbacv1.ClusterRole
-		cRole, err := create(data, nil)
-		if err != nil {
-			return fmt.Errorf("failed to build ClusterRole: %v", err)
-		}
-
-		if existing, err = client.RbacV1().ClusterRoles().Get(cRole.Name, metav1.GetOptions{}); err != nil {
-			if !errors.IsNotFound(err) {
-				return err
-			}
-
-			if _, err = client.RbacV1().ClusterRoles().Create(cRole); err != nil {
-				return fmt.Errorf("failed to create ClusterRole %s: %v", cRole.Name, err)
-			}
-			glog.V(4).Infof("Created ClusterRole %s inside user-cluster %s", cRole.Name, c.Name)
-			continue
-		}
-
-		cRole, err = create(data, existing.DeepCopy())
-		if err != nil {
-			return fmt.Errorf("failed to build ClusterRole: %v", err)
-		}
-
-		if equality.Semantic.DeepEqual(cRole, existing) {
-			continue
-		}
-
-		if _, err = client.RbacV1().ClusterRoles().Update(cRole); err != nil {
-			return fmt.Errorf("failed to update ClusterRole %s: %v", cRole.Name, err)
-		}
-		glog.V(4).Infof("Updated ClusterRole %s inside user-cluster %s", cRole.Name, c.Name)
-	}
-
-	return nil
-}
-
-// GetUserClusterRoleBindingCreators returns a list of ClusterRoleBindingCreators which should be used to - guess what - create user cluster role bindings.
-func GetUserClusterRoleBindingCreators(c *kubermaticv1.Cluster) []resources.ClusterRoleBindingCreator {
-	creators := []resources.ClusterRoleBindingCreator{
-		machinecontroller.ClusterRoleBinding,
-		machinecontroller.NodeBootstrapperClusterRoleBinding,
-		machinecontroller.NodeSignerClusterRoleBinding,
-		vpnsidecar.DnatControllerClusterRoleBinding,
-		metricsserver.ClusterRoleBindingResourceReader,
-		metricsserver.ClusterRoleBindingAuthDelegator,
-		scheduler.ClusterRoleBindingAuthDelegator,
-		controllermanager.ClusterRoleBindingAuthDelegator,
-	}
-
-	if len(c.Spec.MachineNetworks) > 0 {
-		creators = append(creators, ipamcontroller.ClusterRoleBinding)
-	}
-
-	return creators
-}
-
-func (cc *Controller) userClusterEnsureClusterRoleBindings(c *kubermaticv1.Cluster, client kubernetes.Interface) error {
-	creators := GetUserClusterRoleBindingCreators(c)
-
-	data, err := cc.getClusterTemplateData(c)
-	if err != nil {
-		return err
-	}
-
-	for _, create := range creators {
-		var existing *rbacv1.ClusterRoleBinding
-		crb, err := create(data, nil)
-		if err != nil {
-			return fmt.Errorf("failed to build ClusterRoleBinding: %v", err)
-		}
-
-		if existing, err = client.RbacV1().ClusterRoleBindings().Get(crb.Name, metav1.GetOptions{}); err != nil {
-			if !errors.IsNotFound(err) {
-				return err
-			}
-
-			if _, err = client.RbacV1().ClusterRoleBindings().Create(crb); err != nil {
-				return fmt.Errorf("failed to create ClusterRoleBinding %s: %v", crb.Name, err)
-			}
-			glog.V(4).Infof("Created ClusterRoleBinding %s inside user-cluster %s", crb.Name, c.Name)
-			continue
-		}
-
-		crb, err = create(data, existing.DeepCopy())
-		if err != nil {
-			return fmt.Errorf("failed to build ClusterRoleBinding: %v", err)
-		}
-
-		if equality.Semantic.DeepEqual(crb, existing) {
-			continue
-		}
-
-		if _, err = client.RbacV1().ClusterRoleBindings().Update(crb); err != nil {
-			return fmt.Errorf("failed to update ClusterRoleBinding %s: %v", crb.Name, err)
-		}
-		glog.V(4).Infof("Updated ClusterRoleBinding %s inside user-cluster %s", crb.Name, c.Name)
 	}
 
 	return nil

--- a/api/pkg/controller/usercluster/controller.go
+++ b/api/pkg/controller/usercluster/controller.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 )
 
@@ -33,6 +34,18 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	if err = c.Watch(&source.Kind{Type: &apiregistrationv1beta1.APIService{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	if err = c.Watch(&source.Kind{Type: &rbacv1.Role{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	if err = c.Watch(&source.Kind{Type: &rbacv1.RoleBinding{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	if err = c.Watch(&source.Kind{Type: &rbacv1.ClusterRole{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	if err = c.Watch(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
 

--- a/api/pkg/controller/usercluster/reconciler.go
+++ b/api/pkg/controller/usercluster/reconciler.go
@@ -9,8 +9,14 @@ import (
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/controllermanager"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/ipamcontroller"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroller"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/metrics-server"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/scheduler"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -29,6 +35,18 @@ type reconciler struct {
 // Reconcile creates, updates, or deletes Kubernetes resources to match the desired state.
 func (r *reconciler) Reconcile() error {
 	if err := r.ensureAPIServices(); err != nil {
+		return err
+	}
+	if err := r.ensureRoles(); err != nil {
+		return err
+	}
+	if err := r.ensureRoleBindings(); err != nil {
+		return err
+	}
+	if err := r.ensureClusterEnsureRoles(); err != nil {
+		return err
+	}
+	if err := r.ensureClusterEnsureRoleBindings(); err != nil {
 		return err
 	}
 	return nil
@@ -75,6 +93,200 @@ func (r *reconciler) ensureAPIServices() error {
 			return fmt.Errorf("failed to update APIService %s in namespace %s: %v", apiService.Name, apiService.Namespace, err)
 		}
 		glog.V(debugLevel).Infof("updated APIService %s in namespace %s", apiService.Name, apiService.Namespace)
+	}
+
+	return nil
+}
+
+func (r *reconciler) ensureRoles() error {
+	creators := []resources.RoleCreator{
+		machinecontroller.EndpointReaderRole,
+		machinecontroller.KubeSystemRole,
+		machinecontroller.KubePublicRole,
+		machinecontroller.ClusterInfoReaderRole,
+	}
+
+	for _, create := range creators {
+		role, err := create(nil, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build Role: %v", err)
+		}
+
+		existing := &rbacv1.Role{}
+		err = r.client.Get(r.ctx, controllerclient.ObjectKey{Namespace: role.Namespace, Name: role.Name}, existing)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				if err := r.client.Create(r.ctx, role); err != nil {
+					return fmt.Errorf("failed to create Role %s in namespace %s: %v", role.Name, role.Namespace, err)
+				}
+				glog.V(debugLevel).Infof("created a new Role %s in namespace %s", role.Name, role.Namespace)
+				return nil
+			}
+			return err
+		}
+
+		role, err = create(nil, existing.DeepCopy())
+		if err != nil {
+			return fmt.Errorf("failed to build Role : %v", err)
+		}
+		if equality.Semantic.DeepEqual(role, existing) {
+			continue
+		}
+
+		if err := r.client.Update(r.ctx, role); err != nil {
+			return fmt.Errorf("failed to update Role %s in namespace %s: %v", role.Name, role.Namespace, err)
+		}
+		glog.V(debugLevel).Infof("updated Role %s in namespace %s", role.Name, role.Namespace)
+	}
+
+	return nil
+}
+
+func (r *reconciler) ensureRoleBindings() error {
+	creators := []resources.RoleBindingCreator{
+		machinecontroller.DefaultRoleBinding,
+		machinecontroller.KubeSystemRoleBinding,
+		machinecontroller.KubePublicRoleBinding,
+		machinecontroller.ClusterInfoAnonymousRoleBinding,
+		metricsserver.RolebindingAuthReader,
+		scheduler.RoleBindingAuthDelegator,
+		controllermanager.RoleBindingAuthDelegator,
+	}
+
+	for _, create := range creators {
+		rb, err := create(nil, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build RoleBinding: %v", err)
+		}
+
+		existing := &rbacv1.RoleBinding{}
+		err = r.client.Get(r.ctx, controllerclient.ObjectKey{Namespace: rb.Namespace, Name: rb.Name}, existing)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				if err := r.client.Create(r.ctx, rb); err != nil {
+					return fmt.Errorf("failed to create RoleBinding %s in namespace %s: %v", rb.Name, rb.Namespace, err)
+				}
+				glog.V(debugLevel).Infof("created a new RoleBinding %s in namespace %s", rb.Name, rb.Namespace)
+				return nil
+			}
+			return err
+		}
+
+		rb, err = create(nil, existing.DeepCopy())
+		if err != nil {
+			return fmt.Errorf("failed to build RoleBinding : %v", err)
+		}
+		if equality.Semantic.DeepEqual(rb, existing) {
+			continue
+		}
+
+		if err := r.client.Update(r.ctx, rb); err != nil {
+			return fmt.Errorf("failed to update RoleBinding %s in namespace %s: %v", rb.Name, rb.Namespace, err)
+		}
+		glog.V(debugLevel).Infof("updated RoleBinding %s in namespace %s", rb.Name, rb.Namespace)
+	}
+
+	return nil
+}
+
+// GetUserClusterRoleCreators returns a list of GetUserClusterRoleCreators
+func GetUserClusterRoleCreators() []resources.ClusterRoleCreator {
+	creators := []resources.ClusterRoleCreator{
+		machinecontroller.ClusterRole,
+		vpnsidecar.DnatControllerClusterRole,
+		metricsserver.ClusterRole,
+		ipamcontroller.ClusterRole,
+	}
+	return creators
+}
+
+func (r *reconciler) ensureClusterEnsureRoles() error {
+	creators := GetUserClusterRoleCreators()
+	for _, create := range creators {
+		cRole, err := create(nil, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build ClusterRole: %v", err)
+		}
+
+		existing := &rbacv1.ClusterRole{}
+		err = r.client.Get(r.ctx, controllerclient.ObjectKey{Namespace: cRole.Namespace, Name: cRole.Name}, existing)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				if err := r.client.Create(r.ctx, cRole); err != nil {
+					return fmt.Errorf("failed to create ClusterRole %s in namespace %s: %v", cRole.Name, cRole.Namespace, err)
+				}
+				glog.V(debugLevel).Infof("created a new ClusterRole %s in namespace %s", cRole.Name, cRole.Namespace)
+				return nil
+			}
+			return err
+		}
+
+		cRole, err = create(nil, existing.DeepCopy())
+		if err != nil {
+			return fmt.Errorf("failed to build ClusterRole : %v", err)
+		}
+		if equality.Semantic.DeepEqual(cRole, existing) {
+			continue
+		}
+
+		if err := r.client.Update(r.ctx, cRole); err != nil {
+			return fmt.Errorf("failed to update ClusterRole %s in namespace %s: %v", cRole.Name, cRole.Namespace, err)
+		}
+		glog.V(debugLevel).Infof("updated ClusterRole %s in namespace %s", cRole.Name, cRole.Namespace)
+	}
+
+	return nil
+}
+
+// GetUserClusterRoleBindingCreators returns a list of ClusterRoleBindingCreators which should be used to create user cluster role bindings.
+func GetUserClusterRoleBindingCreators() []resources.ClusterRoleBindingCreator {
+	creators := []resources.ClusterRoleBindingCreator{
+		machinecontroller.ClusterRoleBinding,
+		machinecontroller.NodeBootstrapperClusterRoleBinding,
+		machinecontroller.NodeSignerClusterRoleBinding,
+		vpnsidecar.DnatControllerClusterRoleBinding,
+		metricsserver.ClusterRoleBindingResourceReader,
+		metricsserver.ClusterRoleBindingAuthDelegator,
+		scheduler.ClusterRoleBindingAuthDelegator,
+		controllermanager.ClusterRoleBindingAuthDelegator,
+		ipamcontroller.ClusterRoleBinding,
+	}
+	return creators
+}
+
+func (r *reconciler) ensureClusterEnsureRoleBindings() error {
+	creators := GetUserClusterRoleBindingCreators()
+	for _, create := range creators {
+		crb, err := create(nil, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build ClusterRoleBinding: %v", err)
+		}
+
+		existing := &rbacv1.ClusterRoleBinding{}
+		err = r.client.Get(r.ctx, controllerclient.ObjectKey{Namespace: crb.Namespace, Name: crb.Name}, existing)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				if err := r.client.Create(r.ctx, crb); err != nil {
+					return fmt.Errorf("failed to create ClusterRoleBinding %s in namespace %s: %v", crb.Name, crb.Namespace, err)
+				}
+				glog.V(debugLevel).Infof("created a new ClusterRoleBinding %s in namespace %s", crb.Name, crb.Namespace)
+				return nil
+			}
+			return err
+		}
+
+		crb, err = create(nil, existing.DeepCopy())
+		if err != nil {
+			return fmt.Errorf("failed to build ClusterRoleBinding : %v", err)
+		}
+		if equality.Semantic.DeepEqual(crb, existing) {
+			continue
+		}
+
+		if err := r.client.Update(r.ctx, crb); err != nil {
+			return fmt.Errorf("failed to update ClusterRoleBinding %s in namespace %s: %v", crb.Name, crb.Namespace, err)
+		}
+		glog.V(debugLevel).Infof("updated ClusterRoleBinding %s in namespace %s", crb.Name, crb.Namespace)
 	}
 
 	return nil


### PR DESCRIPTION
Follow up of https://github.com/kubermatic/kubermatic/pull/2671

This PR moves reconciliation of `Role`, `RoleBinding`, `ClusterRole`, `ClusterRoleBinding` to the user cluster controller. The creators for these resources take `TemplateData` as an argument, but they are never used.

For example:

https://github.com/kubermatic/kubermatic/blob/3da7568e8aa898eb836f5182611e8dbc115b56d3/api/pkg/resources/machinecontroller/role.go#L80

This PR does not remove the `$typeDataProvider` interface as an argument from the creator though -- this is because some other functions like [`EnsureRole`](https://github.com/kubermatic/kubermatic/blob/3da7568e8aa898eb836f5182611e8dbc115b56d3/api/pkg/resources/ensure.go#L39) use this interface (to use `TemplateData`).


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
