### PR TITLE
Kubermatic Cluster: Set `omitemtpy` for deprecated fields

### DIFF
--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -76,7 +76,7 @@ type ClusterSpec struct {
 	// Version defines the wanted version of the control plane
 	Version semver.Semver `json:"version"`
 	// MasterVersion is Deprecated
-	MasterVersion string `json:"masterVersion"`
+	MasterVersion string `json:"masterVersion,omitempty"`
 
 	// HumanReadableName is the cluster name provided by the user
 	HumanReadableName string `json:"humanReadableName"`
@@ -154,20 +154,20 @@ type ClusterStatus struct {
 	Health ClusterHealth `json:"health,omitempty"`
 
 	// Deprecated
-	RootCA KeyCert `json:"rootCA"`
+	RootCA *KeyCert `json:"rootCA,omitempty"`
 	// Deprecated
-	ApiserverCert KeyCert `json:"apiserverCert"`
+	ApiserverCert *KeyCert `json:"apiserverCert,omitempty"`
 	// Deprecated
-	KubeletCert KeyCert `json:"kubeletCert"`
+	KubeletCert *KeyCert `json:"kubeletCert,omitempty"`
 	// Deprecated
-	ApiserverSSHKey RSAKeys `json:"apiserverSshKey"`
+	ApiserverSSHKey *RSAKeys `json:"apiserverSshKey,omitempty"`
 	// Deprecated
-	ServiceAccountKey Bytes `json:"serviceAccountKey"`
+	ServiceAccountKey Bytes `json:"serviceAccountKey,omitempty"`
 	// NamespaceName defines the namespace the control plane of this cluster is deployed in
 	NamespaceName string `json:"namespaceName"`
 
 	// UserName contains the name of the owner of this cluster
-	UserName string `json:"userName"`
+	UserName string `json:"userName,omitempty"`
 	// UserEmail contains the email of the owner of this cluster
 	UserEmail string `json:"userEmail"`
 
@@ -203,7 +203,7 @@ type CloudSpec struct {
 // ClusterHealth stores health information of a cluster and the timestamp of the last change.
 type ClusterHealth struct {
 	ClusterHealthStatus `json:",inline"`
-	LastTransitionTime  metav1.Time `json:"lastTransitionTime"`
+	LastTransitionTime  metav1.Time `json:"lastTransitionTime,omitempty"`
 }
 
 // KeyCert is a pair of key and cert.

--- a/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -373,10 +373,26 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 	*out = *in
 	in.LastUpdated.DeepCopyInto(&out.LastUpdated)
 	in.Health.DeepCopyInto(&out.Health)
-	in.RootCA.DeepCopyInto(&out.RootCA)
-	in.ApiserverCert.DeepCopyInto(&out.ApiserverCert)
-	in.KubeletCert.DeepCopyInto(&out.KubeletCert)
-	in.ApiserverSSHKey.DeepCopyInto(&out.ApiserverSSHKey)
+	if in.RootCA != nil {
+		in, out := &in.RootCA, &out.RootCA
+		*out = new(KeyCert)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ApiserverCert != nil {
+		in, out := &in.ApiserverCert, &out.ApiserverCert
+		*out = new(KeyCert)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.KubeletCert != nil {
+		in, out := &in.KubeletCert, &out.KubeletCert
+		*out = new(KeyCert)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ApiserverSSHKey != nil {
+		in, out := &in.ApiserverSSHKey, &out.ApiserverSSHKey
+		*out = new(RSAKeys)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ServiceAccountKey != nil {
 		in, out := &in.ServiceAccountKey, &out.ServiceAccountKey
 		*out = make(Bytes, len(*in))


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `omitempty` to deprecated fields in the Kubermatic Cluster type to avoid marshalling if possible. This makes inspecting a Cluster CR easier, as it avoids a ton of currently always empty fields

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```