### PR TITLE
Run-controller.sh: Use pullable image for user-cluster/ipam controller

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -7,7 +7,7 @@ GITTAG=$(shell git describe --tags --always)
 TAGS?=$(GITTAG)
 DOCKERTAGS=$(TAGS) latestbuild
 DOCKER_BUILD_FLAG += $(foreach tag, $(DOCKERTAGS), -t $(REPO):$(tag))
-KUBERMATICCOMMIT=$(shell git log -1 --format=%H)
+KUBERMATICCOMMIT?=$(shell git log -1 --format=%H)
 LDFLAGS += -extldflags '-static' -X github.com/kubermatic/kubermatic/api/pkg/resources.KUBERMATICCOMMIT=$(KUBERMATICCOMMIT)
 HAS_DEP:= $(shell command -v dep 2> /dev/null)
 HAS_GIT:= $(shell command -v git 2> /dev/null)

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -5,6 +5,9 @@ set -o nounset
 set -o pipefail
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
+# Deploy a user-cluster/ipam-controller for which we actuallly
+# have a pushed image
+export KUBERMATICCOMMIT="${KUBERMATICCOMMIT:-$(git rev-parse master)}"
 make kubermatic-controller-manager
 
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently when using the `hack/run-controller.sh` script it will try to deploy a user cluster controller using the current refs HEAD as tag which doesn't have a corresponding image. This causes the cluster to not work and alerts to get triggered.

If a specific tag is desired, one can now `export KUBERMATICCOMMIT=$DESIRED_TAG`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @nikhita 