### PR TITLE
Automatically add team/* labels as per OWNERS files

### DIFF
--- a/api/cmd/OWNERS
+++ b/api/cmd/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-lifecycle
 
+labels:
+  - team/lifecycle
+
 options:
   no_parent_owners: true

--- a/api/cmd/kubermatic-api/OWNERS
+++ b/api/cmd/kubermatic-api/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-ui
 
+labels:
+  - team/ui
+
 options:
   no_parent_owners: true

--- a/api/cmd/projects-migrator/OWNERS
+++ b/api/cmd/projects-migrator/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-ui
 
+labels:
+  - team/ui
+
 options:
   no_parent_owners: true

--- a/api/cmd/rbac-generator/OWNERS
+++ b/api/cmd/rbac-generator/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-ui
 
+labels:
+  - team/ui
+
 options:
   no_parent_owners: true

--- a/api/pkg/api/OWNERS
+++ b/api/pkg/api/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-ui
 
+labels:
+  - team/ui
+
 options:
   no_parent_owners: true

--- a/api/pkg/controller/OWNERS
+++ b/api/pkg/controller/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-lifecycle
 
+labels:
+  - team/lifecycle
+
 options:
   no_parent_owners: true

--- a/api/pkg/controller/monitoring/OWNERS
+++ b/api/pkg/controller/monitoring/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-seed
 
+labels:
+  - team/seed
+
 options:
   no_parent_owners: true

--- a/api/pkg/controller/rbac/OWNERS
+++ b/api/pkg/controller/rbac/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-ui
 
+labels:
+  - team/ui
+
 options:
   no_parent_owners: true

--- a/api/pkg/exporters/s3/OWNERS
+++ b/api/pkg/exporters/s3/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-lifecycle
 
+labels:
+  - team/lifecycle
+
 options:
   no_parent_owners: true

--- a/api/pkg/handler/OWNERS
+++ b/api/pkg/handler/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-ui
 
+labels:
+  - team/ui
+
 options:
   no_parent_owners: true

--- a/api/pkg/provider/cloud/OWNERS
+++ b/api/pkg/provider/cloud/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-lifecycle
 
+labels:
+  - team/lifecycle
+
 options:
   no_parent_owners: true

--- a/api/pkg/provider/kubernetes/OWNERS
+++ b/api/pkg/provider/kubernetes/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-ui
 
+labels:
+  - team/ui
+
 options:
   no_parent_owners: true

--- a/api/pkg/resources/OWNERS
+++ b/api/pkg/resources/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-lifecycle
 
+team:
+  - team/lifecycle
+
 options:
   no_parent_owners: true

--- a/api/pkg/resources/kubestatemetrics/OWNERS
+++ b/api/pkg/resources/kubestatemetrics/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-seed
 
+labels:
+  - team/seed
+
 options:
   no_parent_owners: true

--- a/api/pkg/resources/metrics-server/OWNERS
+++ b/api/pkg/resources/metrics-server/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-lifecycle
 
+team:
+  - team/lifecycle
+
 options:
   no_parent_owners: true

--- a/api/pkg/resources/prometheus/OWNERS
+++ b/api/pkg/resources/prometheus/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-seed
 
+labels:
+  - team/seed
+
 options:
   no_parent_owners: true

--- a/config/backup/OWNERS
+++ b/config/backup/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-seed
 
+labels:
+  - team/seed
+
 options:
   no_parent_owners: true

--- a/config/kubermatic/static/master/OWNERS
+++ b/config/kubermatic/static/master/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-lifecycle
 
+labels:
+  - team/lifecycle
+
 options:
   no_parent_owners: true

--- a/config/logging/OWNERS
+++ b/config/logging/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-seed
 
+labels:
+  - team/seed
+
 options:
   no_parent_owners: true

--- a/config/monitoring/OWNERS
+++ b/config/monitoring/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-seed
 
+labels:
+  - team/seed
+
 options:
   no_parent_owners: true

--- a/config/s3-exporter/OWNERS
+++ b/config/s3-exporter/OWNERS
@@ -6,5 +6,8 @@ approvers:
 reviewers:
   - team-seed
 
+labels:
+  - team/seed
+
 options:
   no_parent_owners: true


### PR DESCRIPTION
This will automatically add the `team/lifecycle` label to PRs modifying files which have `team-lifecycle` as reviewers/approvers.

This will help PRs to get automatically added to the "Review/QA" column in ZenHub. We can then filter using `team/*` labels and check which PRs are under review.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
