### PR TITLE
add new endpoint to list all the clusters from the project

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -320,7 +320,7 @@
         }
       }
     },
-    "/api/v1/projects/{project_id}/dc/{dc}/clusters": {
+    "/api/v1/projects/{project_id}/clusters": {
       "get": {
         "produces": [
           "application/json"
@@ -329,6 +329,44 @@
           "project"
         ],
         "summary": "Lists clusters for the specified project.",
+        "operationId": "listClustersForProject",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ClusterList",
+            "schema": {
+              "$ref": "#/definitions/ClusterList"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "project"
+        ],
+        "summary": "Lists clusters for the specified project and data center.",
         "operationId": "listClusters",
         "parameters": [
           {

--- a/api/pkg/handler/v1/common/request.go
+++ b/api/pkg/handler/v1/common/request.go
@@ -31,7 +31,7 @@ type ProjectIDGetter interface {
 }
 
 // GetProjectRq defines HTTP request for getProject endpoint
-// swagger:parameters getProject getUsersForProject
+// swagger:parameters getProject getUsersForProject listClustersForProject
 type GetProjectRq struct {
 	ProjectReq
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Add new endpoint to list all the clusters from the project from all data centers. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2774

**Release note**:

```release-note
 Add new endpoint to list all the clusters from the project: `/api/v1/projects/{project_id}/clusters`
```
