### PR TITLE
make sure alertmanager can be deployed without any changes

### DIFF
--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -3,7 +3,7 @@ alertmanager:
   host: ""
   config:
     global:
-      slack_api_url: https://
+      slack_api_url: https://hooks.slack.com/services/YOUR_KEYS_HERE
     route:
       receiver: 'default'
       repeat_interval: 1h


### PR DESCRIPTION
**What this PR does / why we need it**:
(Newer) Alertmanager versions do not start up if they cannot parse the Slack URL. We either have to remove the Slack stuff alltogether or put a dummy link in here like done in this PR.

**Release note**:
```release-note
NONE
```
