### PR TITLE
force RollingUpdate strategy for all DaemonSets and StatefulSets

### DIFF
--- a/config/backup/ark/templates/daemonset.yaml
+++ b/config/backup/ark/templates/daemonset.yaml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       name: restic
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/config/monitoring/node-exporter/templates/daemonset.yaml
+++ b/config/monitoring/node-exporter/templates/daemonset.yaml
@@ -3,6 +3,8 @@ kind: DaemonSet
 metadata:
   name: node-exporter
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       name: node-exporter

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app: prometheus-kubermatic
   serviceName: prometheus-kubermatic
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
We have been bitten multiple times by pods not being rescheduled after a DaemonSet or StatefulSet has been updated. There is no good reason to only reschedule on pod deletions for our usecases, so this PR ensures the RollingUpdate strategy on all those sets.

**Release note**:
```release-note
NONE
```
