### PR TITLE
add promtail and loki to the logging stack

### DIFF
--- a/config/logging/loki/Chart.yaml
+++ b/config/logging/loki/Chart.yaml
@@ -1,0 +1,3 @@
+name: loki
+version: 0.1.0
+description: Logging Server

--- a/config/logging/loki/templates/configmap.yaml
+++ b/config/logging/loki/templates/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki
+data:
+  loki.yaml: |
+    auth_enabled: {{ .Values.logging.loki.config.auth_enabled }}
+    server:
+      http_listen_port: 3100
+    limits_config:
+      enforce_metric_name: false
+    ingester:
+      lifecycler:
+        ring:
+          store: {{ .Values.logging.loki.config.ingester.lifecycler.ring.store }}
+          replication_factor: {{ .Values.logging.loki.config.ingester.lifecycler.ring.replication_factor }}
+      chunk_idle_period: 15m
+
+{{- if .Values.logging.loki.config.schema_configs }}
+    schema_config:
+      configs:
+  {{- range .Values.logging.loki.config.schema_configs }}
+      - from: {{ .from }}
+        store: {{ .store }}
+        object_store: {{ .object_store }}
+        schema: {{ .schema }}
+        index:
+          prefix: {{ .index.prefix }}
+          period: {{ .index.period }}
+  {{- end -}}
+{{- end -}}
+
+{{- if .Values.logging.loki.config.storage_configs }}
+    storage_config:
+  {{- range .Values.logging.loki.config.storage_configs }}
+      {{ .name }}:
+        directory: {{ .directory }}
+  {{- end -}}
+{{- end -}}

--- a/config/logging/loki/templates/deployment.yaml
+++ b/config/logging/loki/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: loki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      serviceAccountName: loki-service-account
+      containers:
+      - name: loki
+        image: '{{ .Values.logging.loki.image.repository }}:{{ .Values.logging.loki.image.tag }}'
+        imagePullPolicy: {{ .Values.logging.loki.image.pullPolicy }}
+        args:
+        - '-config.file=/etc/loki/loki.yaml'
+        volumeMounts:
+        - name: config
+          mountPath: /etc/loki
+        - name: storage
+          mountPath: '/data'
+        ports:
+        - name: loki
+          containerPort: 3100
+          protocol: TCP
+      volumes:
+      - name: config
+        configMap:
+          name: loki
+      - name: storage
+        persistentVolumeClaim:
+          claimName: loki

--- a/config/logging/loki/templates/pvc.yaml
+++ b/config/logging/loki/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: kubermatic-fast

--- a/config/logging/loki/templates/role.yaml
+++ b/config/logging/loki/templates/role.yaml
@@ -1,0 +1,4 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: loki

--- a/config/logging/loki/templates/rolebinding.yaml
+++ b/config/logging/loki/templates/rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: loki
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: loki
+subjects:
+- kind: ServiceAccount
+  name: loki-serviceaccount

--- a/config/logging/loki/templates/service.yaml
+++ b/config/logging/loki/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+spec:
+  ports:
+    - name: loki
+      port: 3100
+      protocol: TCP
+      targetPort: 3100
+  selector:
+    app: loki

--- a/config/logging/loki/templates/serviceaccount.yaml
+++ b/config/logging/loki/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-service-account

--- a/config/logging/loki/values.yaml
+++ b/config/logging/loki/values.yaml
@@ -1,0 +1,27 @@
+logging:
+  loki:
+    image:
+      repository: grafana/loki
+      tag: master
+      pullPolicy: Always # Always pull while in BETA
+
+    config:
+      auth_enabled: false
+      ingester:
+        lifecycler:
+          ring:
+            store: inmemory
+            replication_factor: 1
+      schema_configs:
+        - from: 0
+          store: boltdb
+          object_store: filesystem
+          schema: v9
+          index:
+            prefix: index_
+            period: 168h
+      storage_configs:
+        - name: boltdb
+          directory: /data/loki/index
+        - name: filesystem
+          directory: /data/loki/chunks

--- a/config/logging/promtail/Chart.yaml
+++ b/config/logging/promtail/Chart.yaml
@@ -1,0 +1,3 @@
+name: promtail
+version: 0.1.0
+description: Log shipper for Loki

--- a/config/logging/promtail/templates/clusterrole.yaml
+++ b/config/logging/promtail/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: promtail-clusterrole
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "watch", "list"]

--- a/config/logging/promtail/templates/clusterrolebinding.yaml
+++ b/config/logging/promtail/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: promtail-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: promtail-service-account
+  namespace: logging

--- a/config/logging/promtail/templates/configmap.yaml
+++ b/config/logging/promtail/templates/configmap.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail
+data:
+  promtail.yaml: |
+    scrape_configs:
+    - job_name: kubernetes-pods
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: drop
+        regex: ^$
+        source_labels:
+        - __meta_kubernetes_pod_label_name
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_label_name
+        target_label: job
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container_name
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - replacement: /var/log/pods/$1/*.log
+        separator: /
+        source_labels:
+        - __meta_kubernetes_pod_uid
+        - __meta_kubernetes_pod_container_name
+        target_label: __path__
+
+    - job_name: kubernetes-pods-app
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: drop
+        regex: ^$
+        source_labels:
+        - __meta_kubernetes_pod_label_app
+      - action: drop
+        regex: .+
+        source_labels:
+        - __meta_kubernetes_pod_label_name
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_label_app
+        target_label: job
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: instance
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_container_name
+        target_label: container_name
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - replacement: /var/log/pods/$1/*.log
+        separator: /
+        source_labels:
+        - __meta_kubernetes_pod_uid
+        - __meta_kubernetes_pod_container_name
+        target_label: __path__

--- a/config/logging/promtail/templates/daemonset.yaml
+++ b/config/logging/promtail/templates/daemonset.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: promtail
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail-service-account
+      containers:
+        - name: promtail
+          image: '{{ .Values.logging.promtail.image.repository }}:{{ .Values.logging.promtail.image.tag }}'
+          imagePullPolicy: {{ .Values.logging.promtail.image.pullPolicy }}
+          args:
+          - '-config.file=/etc/promtail/promtail.yaml'
+          - '-client.url=http://loki:3100/api/prom/push'
+          volumeMounts:
+          - name: config
+            mountPath: /etc/promtail
+          - name: varlog
+            mountPath: /var/log
+          - name: varlibdockercontainers
+            mountPath: /var/lib/docker/containers
+            readOnly: true
+          env:
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          ports:
+          - containerPort: 80
+            name: http-metrics
+          securityContext:
+            privileged: true
+            runAsUser: 0
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      volumes:
+      - name: config
+        configMap:
+          name: promtail
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/config/logging/promtail/templates/role.yaml
+++ b/config/logging/promtail/templates/role.yaml
@@ -1,0 +1,4 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: promtail

--- a/config/logging/promtail/templates/rolebinding.yaml
+++ b/config/logging/promtail/templates/rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: promtail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: promtail
+subjects:
+- kind: ServiceAccount
+  name: promtail-service-account

--- a/config/logging/promtail/templates/serviceaccount.yaml
+++ b/config/logging/promtail/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail-service-account

--- a/config/logging/promtail/values.yaml
+++ b/config/logging/promtail/values.yaml
@@ -1,0 +1,6 @@
+logging:
+  promtail:
+    image:
+      repository: grafana/promtail
+      tag: master
+      pullPolicy: Always # Always pull while in BETA

--- a/config/monitoring/grafana/provisioning/datasources/loki.yaml
+++ b/config/monitoring/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+- name: Loki
+  type: loki
+  org_id: 1
+  url: http://loki.logging.svc.cluster.local:3100
+  version: 1
+  editable: false

--- a/config/monitoring/grafana/templates/deployment-master.yaml
+++ b/config/monitoring/grafana/templates/deployment-master.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: grafana-master
+  name: grafana-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana-master
+  template:
+    metadata:
+      labels:
+        app: grafana-master
+    spec:
+      containers:
+      - image: '{{ .Values.grafana.image.repository }}:master'
+        name: grafana
+        ports:
+        - containerPort: 3000
+          name: http
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /var/lib/grafana
+          name: grafana-storage
+          readOnly: false
+        - mountPath: /etc/grafana
+          name: grafana-config
+          readOnly: true
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: grafana-datasources
+          readOnly: true
+        - mountPath: /etc/grafana/provisioning/dashboards
+          name: grafana-dashboards
+          readOnly: true
+        - mountPath: /grafana-dashboard-definitions
+          name: grafana-dashboard-definitions
+          readOnly: true
+        {{- if .Values.grafana.volumes }}
+        {{- range .Values.grafana.volumes }}
+        - mountPath: {{ .mountPath }}
+          name: {{ .name }}
+          readOnly: true
+        {{- end }}
+        {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: grafana
+      volumes:
+      - emptyDir: {}
+        name: grafana-storage
+      - name: grafana-config
+        secret:
+          secretName: grafana-config
+      - name: grafana-datasources
+        configMap:
+          name: grafana-datasources
+      - name: grafana-dashboards
+        configMap:
+          name: grafana-dashboards
+      - name: grafana-dashboard-definitions
+        configMap:
+          name: grafana-dashboard-definitions
+          items:
+          {{- range $file, $content := (.Files.Glob "dashboards/**") }}
+          - key: {{ $file | replace "dashboards/" "" | replace "/" "-" }}
+            path: {{ $file | replace "dashboards/" "" }}
+          {{- end }}
+      {{- if .Values.grafana.volumes }}
+      {{- range .Values.grafana.volumes }}
+      - name: {{ .name }}
+        {{- if .configMap }}
+        configMap:
+          name: {{ .configMap }}
+        {{- else }}
+        secret:
+          secretName: {{ .secretName }}
+        {{- end }}
+      {{- end }}
+      {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Elasticsearch is unreliable on preemptible nodes. This PR adds Loki+Promtail as an alternative logging stack.

This requires Grafana 6.0, which is not yet released. That's why there is a new `grafana-master` deployment.

Right now promtail does not work at all, but this PR can serve as a reference for later when the whole stack is not pre-alpha anymore.

**Release note**:
```release-note
add promtail and Loki as part of the logging stack
```
