### PR TITLE
multiple projects with the same name

### DIFF
--- a/api/pkg/handler/v1/project/project.go
+++ b/api/pkg/handler/v1/project/project.go
@@ -112,19 +112,9 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, memberProvider pro
 		}
 
 		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
-		user := ctx.Value(middleware.UserCRContextKey).(*kubermaticapiv1.User)
-
 		kubermaticProject, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
-		}
-
-		alreadyExistingProjects, err := projectProvider.List(&provider.ProjectListOptions{ProjectName: req.Name, OwnerUID: user.UID})
-		if err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
-		}
-		if len(alreadyExistingProjects) > 0 {
-			return nil, errors.NewAlreadyExists("project name", req.Name)
 		}
 
 		kubermaticProject.Spec.Name = req.Name

--- a/api/pkg/handler/v1/project/project_test.go
+++ b/api/pkg/handler/v1/project/project_test.go
@@ -55,7 +55,7 @@ func TestRenameProjectEndpoint(t *testing.T) {
 		{
 			Name:            "scenario 2: rename existing project with existing name",
 			Body:            `{"Name": "my-second-project"}`,
-			HTTPStatus:      http.StatusConflict,
+			HTTPStatus:      http.StatusOK,
 			ProjectToRename: "my-first-project-ID",
 			ExistingKubermaticObjects: []runtime.Object{
 				// add some projects
@@ -68,7 +68,7 @@ func TestRenameProjectEndpoint(t *testing.T) {
 				test.GenBinding("my-third-project-ID", test.GenDefaultUser().Spec.Email, "owners"),
 			},
 			ExistingAPIUser:  *test.GenDefaultAPIUser(),
-			ExpectedResponse: `{"error":{"code":409,"message":"project name \"my-second-project\" already exists"}}`,
+			ExpectedResponse: `{"id":"my-first-project-ID","name":"my-second-project","creationTimestamp":"2013-02-03T19:54:00Z","status":"Active","owners":[{"name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com"}]}`,
 		},
 		{
 			Name:            "scenario 3: rename existing project with existing name where user is not the owner",
@@ -298,10 +298,11 @@ func TestCreateProjectEndpoint(t *testing.T) {
 		},
 
 		{
-			Name:                      "scenario 2: a user has a project with the given name, thus creating one fails",
+			Name:                      "scenario 2: having more than one project with the same name is allowed",
 			Body:                      fmt.Sprintf(`{"name":"%s"}`, test.GenDefaultProject().Spec.Name),
-			ExpectedResponse:          `{"error":{"code":409,"message":"projects.kubermatic.k8s.io \"my-first-project\" already exists"}}`,
-			HTTPStatus:                http.StatusConflict,
+			RewriteProjectID:          true,
+			ExpectedResponse:          `{"id":"%s","name":"my-first-project","creationTimestamp":"0001-01-01T00:00:00Z","status":"Inactive","owners":[{"name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com"}]}`,
+			HTTPStatus:                http.StatusCreated,
 			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(),
 			ExistingAPIUser:           test.GenDefaultAPIUser(),
 		},

--- a/api/pkg/provider/kubernetes/member.go
+++ b/api/pkg/provider/kubernetes/member.go
@@ -84,21 +84,6 @@ func (p *ProjectMemberProvider) List(userInfo *provider.UserInfo, project *kuber
 		}
 	}
 
-	// Note:
-	// After we get the list of members we try to get at least one item using unprivileged account to see if the user have read access
-	if len(projectMembers) > 0 {
-		masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
-		if err != nil {
-			return nil, err
-		}
-
-		memberToGet := projectMembers[0]
-		_, err = masterImpersonatedClient.UserProjectBindings().Get(memberToGet.Name, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	if options == nil {
 		options = &provider.ProjectMemberListOptions{}
 	}

--- a/api/pkg/provider/kubernetes/member.go
+++ b/api/pkg/provider/kubernetes/member.go
@@ -84,6 +84,21 @@ func (p *ProjectMemberProvider) List(userInfo *provider.UserInfo, project *kuber
 		}
 	}
 
+	// Note:
+	// After we get the list of members we try to get at least one item using unprivileged account to see if the user have read access
+	if len(projectMembers) > 0 {
+		masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+		if err != nil {
+			return nil, err
+		}
+
+		memberToGet := projectMembers[0]
+		_, err = masterImpersonatedClient.UserProjectBindings().Get(memberToGet.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if options == nil {
 		options = &provider.ProjectMemberListOptions{}
 	}

--- a/api/pkg/provider/kubernetes/project.go
+++ b/api/pkg/provider/kubernetes/project.go
@@ -11,7 +11,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
 	restclient "k8s.io/client-go/rest"
 )
@@ -54,14 +53,6 @@ type ProjectProvider struct {
 func (p *ProjectProvider) New(user *kubermaticapiv1.User, projectName string) (*kubermaticapiv1.Project, error) {
 	if user == nil {
 		return nil, errors.New("a user is missing but required")
-	}
-
-	alreadyExistingProjects, err := p.List(&provider.ProjectListOptions{ProjectName: projectName, OwnerUID: user.UID})
-	if err != nil {
-		return nil, err
-	}
-	if len(alreadyExistingProjects) > 0 {
-		return nil, kerrors.NewAlreadyExists(schema.GroupResource{Group: kubermaticapiv1.SchemeGroupVersion.Group, Resource: kubermaticapiv1.ProjectResourceName}, projectName)
 	}
 
 	project := &kubermaticapiv1.Project{


### PR DESCRIPTION
**What this PR does / why we need it**: this pull removes the constraint we had in our code that prevented owners from having more than one project with the same name. Instead we decided to extend the project list page in the dashboard and display more info about project for the distinction.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2762

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
Kubermatic API allows users to have more than one project with the same name.
```
