### PR TITLE
rbac-generator deployment chart: add missing checksum for kubeconfig

### DIFF
--- a/config/kubermatic/templates/rbac-generator-dep.yaml
+++ b/config/kubermatic/templates/rbac-generator-dep.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '8085'
+        checksum/kubeconfig: {{ include (print $.Template.BasePath "/kubeconfig-secret.yaml") . | sha256sum }}
     spec:
       initContainers:
       - name: projects-migrator


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a checksumm annotation to the rbac-generator deployment to ensure it is reloaded if the kubeconfig changes.

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
