### PR TITLE
bumps k8s dashboard version to 1.10.1

### DIFF
--- a/addons/dashboard/dashboard-controller.yaml
+++ b/addons/dashboard/dashboard-controller.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: {{default "k8s.gcr.io/" .OverwriteRegistry}}kubernetes-dashboard-amd64:v1.10.0
+        image: {{default "k8s.gcr.io/" .OverwriteRegistry}}kubernetes-dashboard-amd64:v1.10.1
         resources:
           limits:
             cpu: 100m

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.1.17
+export TAG=v0.1.18
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -53,7 +53,7 @@ kubermatic:
     addons:
       image:
         repository: "quay.io/kubermatic/addons"
-        tag: "v0.1.17"
+        tag: "v0.1.18"
         pullPolicy: "IfNotPresent"
       # list of Addons to install into every user-cluster. All need to exist in the addons image
       defaultAddons:


### PR DESCRIPTION
**What this PR does / why we need it**: the new version protects agains CVE-2018-18264

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
Kubermatic deploys Kubernetes Dashboard in version 1.10.1
```
