### PR TITLE
enable logs for user cluster controller manager

### DIFF
--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -31,6 +31,9 @@ spec:
         - /etc/kubernetes/kubeconfig/kubeconfig
         - -internal-address
         - 0.0.0.0:8085
+        - -logtostderr
+        - -v
+        - "4"
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -85,6 +85,8 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 				Args: []string{
 					"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 					"-internal-address", "0.0.0.0:8085",
+					"-logtostderr",
+					"-v", "4",
 				},
 				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 				TerminationMessagePolicy: corev1.TerminationMessageReadFile,


### PR DESCRIPTION
**What this PR does / why we need it**: there are no logs in usercluster-controller container, this PR configures logs for pod deployment

```release-note
NONE
```
