### PR TITLE
make cert-manager's webhook be less noisy

### DIFF
--- a/config/cert-manager/templates/webhook-deployment.yaml
+++ b/config/cert-manager/templates/webhook-deployment.yaml
@@ -18,7 +18,7 @@ spec:
           image: '{{ .Values.certManager.webhookImage.repository }}:{{ .Values.certManager.webhookImage.tag }}'
           imagePullPolicy: {{ .Values.certManager.webhookImage.pullPolicy }}
           args:
-          - --v=12
+          - --v=4
           - --secure-port=6443
           - --tls-cert-file=/certs/tls.crt
           - --tls-private-key-file=/certs/tls.key


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the webhook is logging *everything*, including request and response headers. This is not useful beyond shortlived debugging sessions, so in general we should reduce the log level. 4 is what Kubermatic uses itself.

**Release note**:
```release-note
NONE
```
