### PR TITLE
uses unprivileged credentials when connecting to user clusters

### DIFF
--- a/api/pkg/handler/node_v1.go
+++ b/api/pkg/handler/node_v1.go
@@ -58,9 +58,7 @@ func deleteNodeForClusterLegacy(projectProvider provider.ProjectProvider) endpoi
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		// TODO: change to
-		// machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
-		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a machine client: %v", err)
 		}
@@ -575,12 +573,7 @@ func createNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvide
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		// TODO:
-		// normally we have project, user and sshkey providers
-		// but here we decided to use machineClient and kubeClient directly to access the user cluster.
-		//
-		// how about moving machineClient and kubeClient to their own provider ?
-		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -715,7 +708,7 @@ func listNodeDeployments(projectProvider provider.ProjectProvider) endpoint.Endp
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -797,7 +790,7 @@ func getNodeDeployment(projectProvider provider.ProjectProvider) endpoint.Endpoi
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -846,9 +839,9 @@ func decodeListNodeDeploymentNodes(c context.Context, r *http.Request) (interfac
 	return req, nil
 }
 
-func getMachinesForNodeDeployment(clusterProvider provider.ClusterProvider, cluster *v1.Cluster, nodeDeploymentID string) (*clusterv1alpha1.MachineList, error) {
+func getMachinesForNodeDeployment(clusterProvider provider.ClusterProvider, userInfo *provider.UserInfo, cluster *v1.Cluster, nodeDeploymentID string) (*clusterv1alpha1.MachineList, error) {
 
-	machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
+	machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -882,7 +875,7 @@ func listNodeDeploymentNodes(projectProvider provider.ProjectProvider) endpoint.
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machines, err := getMachinesForNodeDeployment(clusterProvider, cluster, req.NodeDeploymentID)
+		machines, err := getMachinesForNodeDeployment(clusterProvider, userInfo, cluster, req.NodeDeploymentID)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -961,7 +954,7 @@ func patchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -1082,7 +1075,7 @@ func deleteNodeDeployment(projectProvider provider.ProjectProvider) endpoint.End
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
+		machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a machine client: %v", err)
 		}
@@ -1156,7 +1149,7 @@ func listNodeDeploymentNodesEvents() endpoint.Endpoint {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		machines, err := getMachinesForNodeDeployment(clusterProvider, cluster, req.NodeDeploymentID)
+		machines, err := getMachinesForNodeDeployment(clusterProvider, userInfo, cluster, req.NodeDeploymentID)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/version_skew.go
+++ b/api/pkg/handler/version_skew.go
@@ -55,8 +55,8 @@ func ensureVersionCompatible(controlPlane *semver.Version, kubelet *semver.Versi
 
 // checkClusterVersionSkew returns a list of machines and/or machine deployments
 // that are running kubelet at a version incompatible with the cluster's control plane.
-func checkClusterVersionSkew(_ *provider.UserInfo, clusterProvider provider.ClusterProvider, cluster *kubermaticapiv1.Cluster) ([]string, error) {
-	machineClient, err := clusterProvider.GetAdminMachineClientForCustomerCluster(cluster)
+func checkClusterVersionSkew(userInfo *provider.UserInfo, clusterProvider provider.ClusterProvider, cluster *kubermaticapiv1.Cluster) ([]string, error) {
+	machineClient, err := clusterProvider.GetMachineClientForCustomerCluster(userInfo, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a machine client: %v", err)
 	}

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -216,13 +216,8 @@ func (p *ClusterProvider) GetAdminKubernetesClientForCustomerCluster(c *kubermat
 //
 // Note that the client doesn't use admin account instead it authn/authz as userInfo(email, group)
 // This implies that you have to make sure the user has the appropriate permissions inside the user cluster
-// Please verify manually that all calls to this function work, this has zero end-to-end coverage and unit tests
-// don't know anything about RBAC
 func (p *ClusterProvider) GetMachineClientForCustomerCluster(userInfo *provider.UserInfo, c *kubermaticapiv1.Cluster) (clusterv1alpha1clientset.Interface, error) {
-	return nil, errors.New("Not fully implemented")
-	// TODO when this is fully implemented and deactivated: Remove
-	// `func `(*ClusterProvider).withImpersonation` is unused"` linting exception
-	//return p.userClusterConnProvider.GetMachineClient(c, p.withImpersonation(userInfo))
+	return p.userClusterConnProvider.GetMachineClient(c, p.withImpersonation(userInfo))
 }
 
 func (p *ClusterProvider) withImpersonation(userInfo *provider.UserInfo) k8cuserclusterclient.ConfigOption {


### PR DESCRIPTION
**What this PR does / why we need it**: Up to this moment the API server used an admin credentials for retrieving and storing data in user cluster. The changes in this pull make the API server to use unprivileged credentials tied to the user interacting with the server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2695 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
