### PR TITLE
make fluentbit outputs configurable

### DIFF
--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
 
     @INCLUDE input-kubernetes.conf
     @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-elasticsearch.conf
+    @INCLUDE outputs.conf
 
   input-kubernetes.conf: |
     [INPUT]
@@ -40,14 +40,11 @@ data:
         Merge_Log           On
         K8S-Logging.Parser  On
 
-  output-elasticsearch.conf: |
+  outputs.conf: |
+{{- range .Values.logging.fluentbit.configuration.outputs }}
     [OUTPUT]
-        Name            es
-        Match           *
-        Host            ${FLUENT_ELASTICSEARCH_HOST}
-        Port            ${FLUENT_ELASTICSEARCH_PORT}
-        Logstash_Format On
-        Retry_Limit     False
+{{ . | indent 6 }}
+{{- end }}
 
   parsers.conf: |
     [PARSER]

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -4,3 +4,12 @@ logging:
       repository: fluent/fluent-bit
       tag: 1.0.3
       pullPolicy: "IfNotPresent"
+    configuration:
+      outputs:
+        - |
+          Name            es
+          Match           *
+          Host            ${FLUENT_ELASTICSEARCH_HOST}
+          Port            ${FLUENT_ELASTICSEARCH_PORT}
+          Logstash_Format On
+          Retry_Limit     False


### PR DESCRIPTION
**What this PR does / why we need it**:
To make it possible to deploy Bunker to our clusters without forcing it on our customers, we should make at least the outputs configurable. I was contemplating multiple solutions:

* Like Prometheus, putting all the ConfigMap files into distinct files in the chart. But then we would have an additional `output-bunker.conf` in our chart and would sync that back into the installer-repo, without special logic in sync-charts.sh to exclude this file. Plus the `@INCLUDE` directive does not take wildcards, so we would have to make the `fluentbit.conf` configurable as well.
* Putting everything (inputs, filters, outputs) in YAML is overkill for now.
* Adding a fixed Bunker target to the ConfigMap, but make the `@INCLUDE` statement optional. Would still leave a trace of Bunker in the chart and I would not like that.

This is the least worst option, especially considering we only want this to be a temporary solution. It allows us to keep the Bunker stuff in our values.yamls only.

**Release note**:
```release-note
NONE
```
