### PR TITLE
add e2e tests for user cluster RBAC controller

### DIFF
--- a/api/cmd/conformance-tests/usercluster_controller_tests.go
+++ b/api/cmd/conformance-tests/usercluster_controller_tests.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac-user-cluster"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *testRunner) testUserclusterControllerRBAC(log *logrus.Entry, cluster *kubermaticv1.Cluster, kubeClient, seedKubeClient kubernetes.Interface) error {
+	log.Info("Testing user cluster RBAC controller")
+
+	clusterNamespace := fmt.Sprintf("cluster-%s", cluster.Name)
+
+	// check if usercluster-controller was deployed on seed cluster
+	deployment, err := seedKubeClient.ExtensionsV1beta1().Deployments(clusterNamespace).Get(resources.UserClusterControllerDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get Deployment: %s, error: %v", resources.UserClusterControllerDeploymentName, err)
+	}
+	if deployment.Status.AvailableReplicas == 0 {
+		return fmt.Errorf("%s deployment is not ready", resources.UserClusterControllerDeploymentName)
+	}
+
+	// check user cluster resources: ClusterRoles and ClusterRoleBindings
+	for _, resourceName := range rbacResourceNames() {
+		log.Info("Getting a Cluster Role: ", resourceName)
+		clusterRole, err := kubeClient.RbacV1().ClusterRoles().Get(resourceName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get Cluster Role: %s, error: %v", clusterRole, err)
+		}
+
+		defaultClusterRole, err := rbacusercluster.GenerateRBACClusterRole(resourceName)
+		if err != nil {
+			return fmt.Errorf("failed to generate default Cluster Role: %s, error: %v", resourceName, err)
+		}
+
+		if !equality.Semantic.DeepEqual(clusterRole.Rules, defaultClusterRole.Rules) {
+			return fmt.Errorf("incorrect Cluster Role Rules were returned, got: %v, want: %v", clusterRole.Rules, defaultClusterRole.Rules)
+		}
+
+		log.Info("Getting a Cluster Role Binding: ", resourceName)
+		clusterRoleBinding, err := kubeClient.RbacV1().ClusterRoleBindings().Get(resourceName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get Cluster Role Binding: %s, error: %v", resourceName, err)
+		}
+
+		defaultClusterRoleBinding, err := rbacusercluster.GenerateRBACClusterRoleBinding(resourceName)
+		if err != nil {
+			return fmt.Errorf("failed to generate default Cluster Role Binding: %s, error: %v", resourceName, err)
+		}
+
+		if !equality.Semantic.DeepEqual(clusterRoleBinding.RoleRef, defaultClusterRoleBinding.RoleRef) {
+			return fmt.Errorf("incorrect Cluster Role Binding RoleRef were returned, got: %v, want: %v", clusterRoleBinding.RoleRef, defaultClusterRoleBinding.RoleRef)
+		}
+		if !equality.Semantic.DeepEqual(clusterRoleBinding.Subjects, defaultClusterRoleBinding.Subjects) {
+			return fmt.Errorf("incorrect Cluster Role Binding Subjects were returned, got: %v, want: %v", clusterRoleBinding.Subjects, defaultClusterRoleBinding.Subjects)
+		}
+	}
+
+	return nil
+}
+
+func rbacResourceNames() []string {
+	return []string{rbacusercluster.ResourceOwnerName, rbacusercluster.ResourceEditorName, rbacusercluster.ResourceViewerName}
+}

--- a/api/pkg/controller/rbac-user-cluster/controller.go
+++ b/api/pkg/controller/rbac-user-cluster/controller.go
@@ -15,21 +15,24 @@ import (
 )
 
 const (
-	controllerName = "rbac-user-cluster-controller"
+	controllerName     = "rbac-user-cluster-controller"
+	ResourceOwnerName  = "system:kubermatic:owners"
+	ResourceEditorName = "system:kubermatic:editors"
+	ResourceViewerName = "system:kubermatic:viewers"
 )
 
 var mapFn = handler.ToRequestsFunc(func(o handler.MapObject) []reconcile.Request {
 	return []reconcile.Request{
 		{NamespacedName: types.NamespacedName{
-			Name:      "system:kubermatic:owners",
+			Name:      ResourceOwnerName,
 			Namespace: "",
 		}},
 		{NamespacedName: types.NamespacedName{
-			Name:      "system:kubermatic:editors",
+			Name:      ResourceEditorName,
 			Namespace: "",
 		}},
 		{NamespacedName: types.NamespacedName{
-			Name:      "system:kubermatic:viewers",
+			Name:      ResourceViewerName,
 			Namespace: "",
 		}},
 	}

--- a/api/pkg/controller/rbac-user-cluster/mapper.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper.go
@@ -36,8 +36,8 @@ func generateVerbsForGroup(groupName string) ([]string, error) {
 	return []string{}, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s", groupName)
 }
 
-// generateRBACClusterRole creates role for specific group
-func generateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
+// GenerateRBACClusterRole creates role for specific group
+func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 
 	groupName, err := getGroupName(resourceName)
 	if err != nil {
@@ -63,8 +63,8 @@ func generateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 	return clusterRole, nil
 }
 
-// generateRBACClusterRoleBinding creates role binding for specific group
-func generateRBACClusterRoleBinding(resourceName string) (*rbacv1.ClusterRoleBinding, error) {
+// GenerateRBACClusterRoleBinding creates role binding for specific group
+func GenerateRBACClusterRoleBinding(resourceName string) (*rbacv1.ClusterRoleBinding, error) {
 	groupName, err := getGroupName(resourceName)
 	if err != nil {
 		return nil, err

--- a/api/pkg/controller/rbac-user-cluster/mapper_test.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper_test.go
@@ -45,7 +45,7 @@ func TestGenerateVerbsForGroup(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			role, err := generateRBACClusterRole(test.resurceName)
+			role, err := GenerateRBACClusterRole(test.resurceName)
 
 			if test.expectError {
 				if err == nil {

--- a/api/pkg/controller/rbac-user-cluster/reconciler.go
+++ b/api/pkg/controller/rbac-user-cluster/reconciler.go
@@ -39,7 +39,7 @@ func (r *reconciler) Reconcile(resourceName string) error {
 }
 
 func (r *reconciler) ensureRBACClusterRole(resourceName string) error {
-	defaultClusterRole, err := generateRBACClusterRole(resourceName)
+	defaultClusterRole, err := GenerateRBACClusterRole(resourceName)
 	if err != nil {
 		return fmt.Errorf("failed to generate the RBAC Cluster Role: %v", err)
 	}
@@ -69,7 +69,7 @@ func (r *reconciler) ensureRBACClusterRole(resourceName string) error {
 }
 
 func (r *reconciler) ensureRBACClusterRoleBinding(resourceName string) error {
-	defaultClusterBinding, err := generateRBACClusterRoleBinding(resourceName)
+	defaultClusterBinding, err := GenerateRBACClusterRoleBinding(resourceName)
 	if err != nil {
 		return fmt.Errorf("failed to generate the RBAC Cluster Role Binding: %v", err)
 	}

--- a/api/pkg/controller/rbac-user-cluster/reconciler_test.go
+++ b/api/pkg/controller/rbac-user-cluster/reconciler_test.go
@@ -182,7 +182,7 @@ func TestReconcileUpdateRole(t *testing.T) {
 }
 
 func genTestClusterRole(t *testing.T, resourceName string) rbacv1.ClusterRole {
-	role, err := generateRBACClusterRole(resourceName)
+	role, err := GenerateRBACClusterRole(resourceName)
 	if err != nil {
 		t.Fatalf("can't generate role for %s, error: %v", resourceName, err)
 	}
@@ -190,7 +190,7 @@ func genTestClusterRole(t *testing.T, resourceName string) rbacv1.ClusterRole {
 }
 
 func genTestClusterRoleBinding(t *testing.T, resourceName string) rbacv1.ClusterRoleBinding {
-	roleBinding, err := generateRBACClusterRoleBinding(resourceName)
+	roleBinding, err := GenerateRBACClusterRoleBinding(resourceName)
 	if err != nil {
 		t.Fatalf("can't generate role for %s, error: %v", resourceName, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: adds e2e tests for user cluster RBAC controller
Fixes #2802

```release-note
NONE
```
