### PR TITLE
add missing prometheus federation service

### DIFF
--- a/api/cmd/kubermatic-controller-manager-cleanup/main.go
+++ b/api/cmd/kubermatic-controller-manager-cleanup/main.go
@@ -201,7 +201,6 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) {
 		cleanupHeapsterAddon,
 		cleanupMetricsServerAddon,
 		migrateClusterUserLabel,
-		cleanupPrometheusService,
 		cleanupKubeStateMetricsService,
 	}
 
@@ -509,18 +508,6 @@ func migrateUserID(user *kubermaticv1.User, ctx *cleanupContext) error {
 			return err
 		}
 	}
-	return nil
-}
-
-// We removed the Prometheus services as its no longer in use
-func cleanupPrometheusService(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
-	ns := cluster.Status.NamespaceName
-
-	err := ctx.kubeClient.CoreV1().Services(ns).Delete("prometheus", nil)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-
 	return nil
 }
 

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -355,6 +355,11 @@ func (c *Controller) sync(key string) error {
 		return err
 	}
 
+	// check that all Services's are created
+	if err := c.ensureServices(cluster, data); err != nil {
+		return err
+	}
+
 	if !clusterFromCache.Status.Health.AllHealthy() {
 		glog.V(6).Infof("waiting for cluster %s to become healthy", key)
 		c.enqueueAfter(cluster, healthCheckPeriod)

--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -176,3 +176,16 @@ func (c *Controller) ensureVerticalPodAutoscalers(cluster *kubermaticv1.Cluster)
 	}
 	return resources.ReconcileVerticalPodAutoscalers(creators, cluster.Status.NamespaceName, c.dynamicClient, c.dynamicCache)
 }
+
+// GetServiceCreators returns all service creators that are currently in use
+func GetServiceCreators(data *resources.TemplateData) []resources.ServiceCreator {
+	return []resources.ServiceCreator{
+		prometheus.ServiceCreator(data),
+	}
+}
+
+func (c *Controller) ensureServices(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
+	creators := GetServiceCreators(data)
+
+	return resources.ReconcileServices(creators, cluster.Status.NamespaceName, c.dynamicClient, c.dynamicCache, resources.ClusterRefWrapper(cluster))
+}

--- a/api/pkg/resources/prometheus/federation_service.go
+++ b/api/pkg/resources/prometheus/federation_service.go
@@ -1,0 +1,36 @@
+package prometheus
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// ServiceCreator returns the function to reconcile the prometheus service used for federation
+func ServiceCreator(data resources.ServiceDataProvider) resources.ServiceCreator {
+	return func(se *corev1.Service) (*corev1.Service, error) {
+		se.Name = name
+		se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
+		se.Labels = resources.BaseAppLabel(name, nil)
+		// We need to set cluster: user for the ServiceMonitor which federates metrics8
+		se.Labels["cluster"] = "user"
+
+		se.Spec.ClusterIP = "None"
+		se.Spec.Selector = map[string]string{
+			resources.AppLabelKey: "prometheus",
+			"cluster":             data.Cluster().Name,
+		}
+		se.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       "web",
+				Port:       9090,
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromString("web"),
+			},
+		}
+
+		return se, nil
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
I deleted the Prometheus service in https://github.com/kubermatic/kubermatic/pull/2722.
But this service is actually being used for the prometheus federation. 
As the service is missing atm, we don't have any cluster metrics in our seed Prometheus.

**Release note**:
```release-note
NONE
```
