### PR TITLE
fix leader election for user cluster controller manager

### DIFF
--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -40,7 +40,7 @@ func main() {
 	// Create Context
 	done := ctx.Done()
 
-	mgr, err := manager.New(cfg, manager.Options{LeaderElection: true})
+	mgr, err := manager.New(cfg, manager.Options{LeaderElection: true, LeaderElectionNamespace: "default"})
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	apiextensionv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -40,7 +41,7 @@ func main() {
 	// Create Context
 	done := ctx.Done()
 
-	mgr, err := manager.New(cfg, manager.Options{LeaderElection: true, LeaderElectionNamespace: "default"})
+	mgr, err := manager.New(cfg, manager.Options{LeaderElection: true, LeaderElectionNamespace: metav1.NamespaceSystem})
 	if err != nil {
 		glog.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:this PR fixes usercluster-controller deployment. Currently, it can't start:
```
I0225 16:15:43.467762       1 main.go:48] registering components
I0225 16:15:43.469178       1 main.go:57] registering controllers
I0225 16:15:43.469800       1 controllers.go:45] new controller user-cluster-controller added
I0225 16:15:43.470096       1 controllers.go:45] new controller rbac-user-cluster-controller added
I0225 16:15:43.470250       1 leaderelection.go:185] attempting to acquire leader lease  cluster-6jtdrzvnx5/controller-leader-election-helper...
I0225 16:15:43.470302       1 main.go:89] starting the internal HTTP metrics server: 0.0.0.0:8085
E0225 16:15:43.529617       1 leaderelection.go:238] error initially creating leader election record: namespaces "cluster-6jtdrzvnx5" not found
I0225 16:15:43.529666       1 leaderelection.go:190] failed to acquire lease cluster-6jtdrzvnx5/controller-leader-election-helper
E0225 16:15:47.187137       1 leaderelection.go:238] error initially creating leader election record: namespaces "cluster-6jtdrzvnx5" not found

```

```release-note
NONE
```
