### PR TITLE
Increase memory for kubermatic controller manager to avoid OOM

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -131,10 +131,10 @@ spec:
             {{- end }}
           resources:
             requests:
-              memory: "64Mi"
+              memory: "256Mi"
               cpu: "200m"
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "500m"
       imagePullSecrets:
         - name: dockercfg


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The memory requests/limits of the Kubermatic controller manager were increased to 256Mi/512Mi to keep up with added features
```

/assign @mrIncompetent 