### PR TITLE
Remove -v flag from go test commands

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -34,10 +34,10 @@ showenv:
 check: gofmt lint
 
 test:
-	$(GO) test -v ./...
+	$(GO) test ./...
 
 test-update:
-	-$(GO) test -v ./... -update
+	-$(GO) test ./... -update
 
 clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```
