### PR TITLE
Make OpenStack "manage-security-groups" configurable via the datacenters.yaml

### DIFF
--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -42,6 +42,10 @@ type OpenstackSpec struct {
 	// Used for automatic network creation
 	DNSServers []string  `yaml:"dns_servers"`
 	Images     ImageList `yaml:"images"`
+	// Gets mapped to the "manage-security-groups" setting in the cloud config.
+	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
+	// To make this change backwards compatible, this will default to true.
+	ManageSecurityGroups *bool `yaml:"manage_security_groups"`
 }
 
 // AzureSpec describes an Azure cloud datacenter

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -82,6 +82,7 @@ func CloudConfig(data resources.ConfigMapDataProvider) (cloudConfig string, err 
 			return cloudConfig, err
 		}
 	} else if cloud.Openstack != nil {
+		manageSecurityGroups := dc.Spec.Openstack.ManageSecurityGroups
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
 				AuthURL:    dc.Spec.Openstack.AuthURL,
@@ -97,7 +98,7 @@ func CloudConfig(data resources.ConfigMapDataProvider) (cloudConfig string, err 
 				IgnoreVolumeAZ:  dc.Spec.Openstack.IgnoreVolumeAZ,
 			},
 			LoadBalancer: openstack.LoadBalancerOpts{
-				ManageSecurityGroups: true,
+				ManageSecurityGroups: manageSecurityGroups == nil || *manageSecurityGroups,
 			},
 			Version: data.Cluster().Spec.Version.String(),
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables admins to set `manage-security-groups` inside the cloud-config for every cluster in a OpenStack datacenter via the datacenters.yaml.
For backwards compatibility this will default to `true`.

**Release note**:
```release-note
Enable configuration of the manage-security-groups cloud-config property of OpenStack clusters via the datacenters.yaml
```
