### PR TITLE
extend health endpoint by CloudProviderInfrastructure

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3215,6 +3215,10 @@
           "type": "boolean",
           "x-go-name": "Apiserver"
         },
+        "cloudProviderInfrastructure": {
+          "type": "boolean",
+          "x-go-name": "CloudProviderInfrastructure"
+        },
         "controller": {
           "type": "boolean",
           "x-go-name": "Controller"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -435,11 +435,12 @@ type ClusterStatus struct {
 // ClusterHealth stores health information about the cluster's components.
 // swagger:model ClusterHealth
 type ClusterHealth struct {
-	Apiserver         bool `json:"apiserver"`
-	Scheduler         bool `json:"scheduler"`
-	Controller        bool `json:"controller"`
-	MachineController bool `json:"machineController"`
-	Etcd              bool `json:"etcd"`
+	Apiserver                   bool `json:"apiserver"`
+	Scheduler                   bool `json:"scheduler"`
+	Controller                  bool `json:"controller"`
+	MachineController           bool `json:"machineController"`
+	Etcd                        bool `json:"etcd"`
+	CloudProviderInfrastructure bool `json:"cloudProviderInfrastructure"`
 }
 
 // ClusterList represents a list of clusters

--- a/api/pkg/handler/cluster.go
+++ b/api/pkg/handler/cluster.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 	prometheusapi "github.com/prometheus/client_golang/api"
@@ -228,11 +228,12 @@ func getClusterHealth(projectProvider provider.ProjectProvider) endpoint.Endpoin
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 		return apiv1.ClusterHealth{
-			Apiserver:         existingCluster.Status.Health.Apiserver,
-			Scheduler:         existingCluster.Status.Health.Scheduler,
-			Controller:        existingCluster.Status.Health.Controller,
-			MachineController: existingCluster.Status.Health.MachineController,
-			Etcd:              existingCluster.Status.Health.Etcd,
+			Apiserver:                   existingCluster.Status.Health.Apiserver,
+			Scheduler:                   existingCluster.Status.Health.Scheduler,
+			Controller:                  existingCluster.Status.Health.Controller,
+			MachineController:           existingCluster.Status.Health.MachineController,
+			Etcd:                        existingCluster.Status.Health.Etcd,
+			CloudProviderInfrastructure: existingCluster.Status.Health.CloudProviderInfrastructure,
 		}, nil
 	}
 }

--- a/api/pkg/handler/cluster_test.go
+++ b/api/pkg/handler/cluster_test.go
@@ -772,7 +772,7 @@ func TestGetClusterHealth(t *testing.T) {
 		{
 			Name:             "scenario 1: get existing cluster health status",
 			Body:             ``,
-			ExpectedResponse: `{"apiserver":true,"scheduler":false,"controller":true,"machineController":false,"etcd":true}`,
+			ExpectedResponse: `{"apiserver":true,"scheduler":false,"controller":true,"machineController":false,"etcd":true,"cloudProviderInfrastructure":true}`,
 			HTTPStatus:       http.StatusOK,
 			ClusterToGet:     "keen-snyder",
 			ProjectToSync:    test.GenDefaultProject().Name,
@@ -784,11 +784,12 @@ func TestGetClusterHealth(t *testing.T) {
 					cluster := test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 					cluster.Status.Health = kubermaticv1.ClusterHealth{
 						ClusterHealthStatus: kubermaticv1.ClusterHealthStatus{
-							Apiserver:         true,
-							Scheduler:         false,
-							Controller:        true,
-							MachineController: false,
-							Etcd:              true,
+							Apiserver:                   true,
+							Scheduler:                   false,
+							Controller:                  true,
+							MachineController:           false,
+							Etcd:                        true,
+							CloudProviderInfrastructure: true,
 						},
 					}
 					return cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
With adding `CloudProviderInfrastructure` to health endpoint, we could check in ui, if cluster is ready so we could start node deployment creation. 

As this is part of the [AllHealthy()](https://github.com/kubermatic/kubermatic/blob/master/api/pkg/crd/kubermatic/v1/cluster.go#L347) method which is checked [here](https://github.com/kubermatic/kubermatic/blob/master/api/pkg/provider/kubernetes/cluster.go#L160), we will get error `Cluster components are not ready yet`, if we have no possibility to also check it in ui.

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
