### PR TITLE
Remove unused argument in ci-deploy-* scripts

### DIFF
--- a/api/hack/ci/ci-deploy-dev-cloud.sh
+++ b/api/hack/ci/ci-deploy-dev-cloud.sh
@@ -5,13 +5,6 @@ export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 echodate() { echo "$(date) $@"; }
 cd $(dirname $0)/../../..
 
-if [ "$#" -lt 1 ] || [ "${1}" == "--help" ]; then
-  cat <<EOF
-Usage: $(basename $0) (master|seed)
-EOF
-  exit 0
-fi
-
 function retry {
   local retries=$1
   shift

--- a/api/hack/ci/ci-deploy-run.sh
+++ b/api/hack/ci/ci-deploy-run.sh
@@ -5,13 +5,6 @@ export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 echodate() { echo "$(date) $@"; }
 cd $(dirname $0)/../../..
 
-if [ "$#" -lt 1 ] || [ "${1}" == "--help" ]; then
-  cat <<EOF
-Usage: $(basename $0) (master|seed)
-EOF
-  exit 0
-fi
-
 function retry {
   local retries=$1
   shift


### PR DESCRIPTION
Ref: https://github.com/kubermatic/infra/pull/141#discussion_r261518268
/assign @alvaroaleman 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
