### PR TITLE
Define PDB for Elasticseasrch

### DIFF
--- a/config/logging/elasticsearch/templates/es-data-pdb.yaml
+++ b/config/logging/elasticsearch/templates/es-data-pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    component: elasticsearch
+  name: es-data
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: data

--- a/config/logging/elasticsearch/templates/es-master-pdb.yaml
+++ b/config/logging/elasticsearch/templates/es-master-pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    component: elasticsearch
+  name: es-master
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: master

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -1,7 +1,7 @@
 logging:
   elasticsearch:
     dataReplicas: 5
-    masterReplicas: 3
+    masterReplicas: 4
     storageSize: 10Gi
     image:
       repository: docker.elastic.co/elasticsearch/elasticsearch


### PR DESCRIPTION
**What this PR does / why we need it**:
This attempts to stabilize the ES cluster on systems with premtible nodes by forbidding too many unavailable nodes.

**Release note**:
```release-note
NONE
```
