### PR TITLE
Use NamedDeploymentCreators

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -177,7 +177,8 @@ func getImagesFromCreators(templateData *resources.TemplateData) (images []strin
 	}
 
 	for _, createFunc := range deploymentCreators {
-		deployment, err := createFunc(&appsv1.Deployment{})
+		_, creator := createFunc()
+		deployment, err := creator(&appsv1.Deployment{})
 		if err != nil {
 			return nil, err
 		}

--- a/api/codegen/reconcile/main.go
+++ b/api/codegen/reconcile/main.go
@@ -48,8 +48,9 @@ func main() {
 				UseNamedObject:     true,
 			},
 			{
-				ResourceName: "Deployment",
-				ImportAlias:  "appsv1",
+				ResourceName:   "Deployment",
+				ImportAlias:    "appsv1",
+				UseNamedObject: true,
 				// Don't specify ResourceImportPath so this block does not create a new import line in the generated code
 			},
 			{

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -172,8 +172,8 @@ func (cc *Controller) ensureServices(c *kubermaticv1.Cluster, data *resources.Te
 }
 
 // GetDeploymentCreators returns all DeploymentCreators that are currently in use
-func GetDeploymentCreators(data resources.DeploymentDataProvider) []resources.DeploymentCreator {
-	creators := []resources.DeploymentCreator{
+func GetDeploymentCreators(data resources.DeploymentDataProvider) []resources.NamedDeploymentCreatorGetter {
+	creators := []resources.NamedDeploymentCreatorGetter{
 		openvpn.DeploymentCreator(data),
 		dns.DeploymentCreator(data),
 	}
@@ -193,7 +193,6 @@ func GetDeploymentCreators(data resources.DeploymentDataProvider) []resources.De
 
 func (cc *Controller) ensureDeployments(cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetDeploymentCreators(data)
-
 	return resources.ReconcileDeployments(creators, cluster.Status.NamespaceName, cc.dynamicClient, cc.dynamicCache, resources.ClusterRefWrapper(cluster))
 }
 

--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -69,8 +69,8 @@ func (c *Controller) ensureRoleBindings(cluster *kubermaticv1.Cluster, data *res
 }
 
 // GetDeploymentCreators returns all DeploymentCreators that are currently in use
-func GetDeploymentCreators(data resources.DeploymentDataProvider) []resources.DeploymentCreator {
-	creators := []resources.DeploymentCreator{
+func GetDeploymentCreators(data resources.DeploymentDataProvider) []resources.NamedDeploymentCreatorGetter {
+	creators := []resources.NamedDeploymentCreatorGetter{
 		kubestatemetrics.DeploymentCreator(data),
 	}
 

--- a/api/pkg/controller/openshift/resources/controller_manager_deployment.go
+++ b/api/pkg/controller/openshift/resources/controller_manager_deployment.go
@@ -35,156 +35,158 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the controller manager deployment
-func DeploymentCreator(ctx context.Context, data openshiftData) (string, resources.DeploymentCreator) {
-	return ControllerManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.ControllerManagerDeploymentName
-		dep.Labels = resources.BaseAppLabel(ControllerManagerDeploymentName, nil)
+func ControllerManagerDeploymentCreator(ctx context.Context, data openshiftData) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return ControllerManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.ControllerManagerDeploymentName
+			dep.Labels = resources.BaseAppLabel(ControllerManagerDeploymentName, nil)
 
-		dep.Spec.Replicas = resources.Int32(1)
-		if data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas != nil {
-			dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas
-		}
-
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(ControllerManagerDeploymentName, nil),
-		}
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 0,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
-
-		volumes := getControllerManagerVolumes()
-		podLabels, err := data.GetPodTemplateLabelsWithContext(ctx, ControllerManagerDeploymentName, volumes, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Labels: podLabels,
-			Annotations: map[string]string{
-				"prometheus.io/path":                  "/metrics",
-				"prometheus.io/scrape_with_kube_cert": "true",
-				"prometheus.io/port":                  "8444",
-			},
-		}
-
-		// Configure user cluster DNS resolver for this pod.
-		dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-		if err != nil {
-			return nil, err
-		}
-
-		dep.Spec.Template.Spec.Volumes = volumes
-
-		apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-		if err != nil {
-			return nil, err
-		}
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
-
-		openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
-		}
-
-		controllerManagerMounts := []corev1.VolumeMount{
-			{
-				Name:      resources.CASecretName,
-				MountPath: "/etc/kubernetes/pki/ca",
-				ReadOnly:  true,
-			},
-			{
-				Name:      resources.ServiceAccountKeySecretName,
-				MountPath: "/etc/kubernetes/service-account-key",
-				ReadOnly:  true,
-			},
-			{
-				Name:      resources.CloudConfigConfigMapName,
-				MountPath: "/etc/kubernetes/cloud",
-				ReadOnly:  true,
-			},
-			{
-				Name: resources.InternalUserClusterAdminKubeconfigSecretName,
-				// We have to mount a Kubeconfig that doesn't use 127.0.0.1 as address
-				// here
-				MountPath: "/etc/origin/master/loopback-kubeconfig",
-				ReadOnly:  true,
-			},
-			{
-				Name:      openshiftControllerMangerConfigMapName,
-				MountPath: "/etc/origin/master",
-			},
-			{
-				Name:      ServiceSignerCASecretName,
-				MountPath: "/etc/origin/master/service-signer-ca",
-			},
-			{
-				MountPath: "/etc/kubernetes/tls",
-				Name:      resources.ApiserverTLSSecretName,
-				ReadOnly:  true,
-			},
-		}
-		if data.Cluster().Spec.Cloud.VSphere != nil {
-			fakeVMWareUUIDMount := corev1.VolumeMount{
-				Name:      resources.CloudConfigConfigMapName,
-				SubPath:   cloudconfig.FakeVMWareUUIDKeyName,
-				MountPath: "/sys/class/dmi/id/product_serial",
-				ReadOnly:  true,
+			dep.Spec.Replicas = resources.Int32(1)
+			if data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas != nil {
+				dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas
 			}
-			// Required because of https://github.com/kubernetes/kubernetes/issues/65145
-			controllerManagerMounts = append(controllerManagerMounts, fakeVMWareUUIDMount)
-		}
 
-		resourceRequirements := controllerManagerDefaultResourceRequirements
-		if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
-			resourceRequirements = *data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources
-		}
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			*openvpnSidecar,
-			{
-				Name:                     ControllerManagerDeploymentName,
-				Image:                    data.ImageRegistry(resources.RegistryDocker) + "/openshift/origin-control-plane:v3.11",
-				ImagePullPolicy:          corev1.PullIfNotPresent,
-				Command:                  []string{"/usr/bin/openshift", "start", "master", "controllers"},
-				Args:                     []string{"--config=/etc/origin/master/master-config.yaml", "--listen=https://0.0.0.0:8444"},
-				Env:                      getControllerManagerEnvVars(data.Cluster()),
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				Resources:                resourceRequirements,
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: getHealthGetAction(),
-					},
-					FailureThreshold: 3,
-					PeriodSeconds:    10,
-					SuccessThreshold: 1,
-					TimeoutSeconds:   15,
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(ControllerManagerDeploymentName, nil),
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
 				},
-				LivenessProbe: &corev1.Probe{
-					FailureThreshold: 8,
-					Handler: corev1.Handler{
-						HTTPGet: getHealthGetAction(),
-					},
-					InitialDelaySeconds: 15,
-					PeriodSeconds:       10,
-					SuccessThreshold:    1,
-					TimeoutSeconds:      15,
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
 				},
-				VolumeMounts: controllerManagerMounts,
-			},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+
+			volumes := getControllerManagerVolumes()
+			podLabels, err := data.GetPodTemplateLabelsWithContext(ctx, ControllerManagerDeploymentName, volumes, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+				Annotations: map[string]string{
+					"prometheus.io/path":                  "/metrics",
+					"prometheus.io/scrape_with_kube_cert": "true",
+					"prometheus.io/port":                  "8444",
+				},
+			}
+
+			// Configure user cluster DNS resolver for this pod.
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
+			}
+
+			dep.Spec.Template.Spec.Volumes = volumes
+
+			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+
+			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
+			}
+
+			controllerManagerMounts := []corev1.VolumeMount{
+				{
+					Name:      resources.CASecretName,
+					MountPath: "/etc/kubernetes/pki/ca",
+					ReadOnly:  true,
+				},
+				{
+					Name:      resources.ServiceAccountKeySecretName,
+					MountPath: "/etc/kubernetes/service-account-key",
+					ReadOnly:  true,
+				},
+				{
+					Name:      resources.CloudConfigConfigMapName,
+					MountPath: "/etc/kubernetes/cloud",
+					ReadOnly:  true,
+				},
+				{
+					Name: resources.InternalUserClusterAdminKubeconfigSecretName,
+					// We have to mount a Kubeconfig that doesn't use 127.0.0.1 as address
+					// here
+					MountPath: "/etc/origin/master/loopback-kubeconfig",
+					ReadOnly:  true,
+				},
+				{
+					Name:      openshiftControllerMangerConfigMapName,
+					MountPath: "/etc/origin/master",
+				},
+				{
+					Name:      ServiceSignerCASecretName,
+					MountPath: "/etc/origin/master/service-signer-ca",
+				},
+				{
+					MountPath: "/etc/kubernetes/tls",
+					Name:      resources.ApiserverTLSSecretName,
+					ReadOnly:  true,
+				},
+			}
+			if data.Cluster().Spec.Cloud.VSphere != nil {
+				fakeVMWareUUIDMount := corev1.VolumeMount{
+					Name:      resources.CloudConfigConfigMapName,
+					SubPath:   cloudconfig.FakeVMWareUUIDKeyName,
+					MountPath: "/sys/class/dmi/id/product_serial",
+					ReadOnly:  true,
+				}
+				// Required because of https://github.com/kubernetes/kubernetes/issues/65145
+				controllerManagerMounts = append(controllerManagerMounts, fakeVMWareUUIDMount)
+			}
+
+			resourceRequirements := controllerManagerDefaultResourceRequirements
+			if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
+				resourceRequirements = *data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources
+			}
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				*openvpnSidecar,
+				{
+					Name:                     ControllerManagerDeploymentName,
+					Image:                    data.ImageRegistry(resources.RegistryDocker) + "/openshift/origin-control-plane:v3.11",
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					Command:                  []string{"/usr/bin/openshift", "start", "master", "controllers"},
+					Args:                     []string{"--config=/etc/origin/master/master-config.yaml", "--listen=https://0.0.0.0:8444"},
+					Env:                      getControllerManagerEnvVars(data.Cluster()),
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Resources:                resourceRequirements,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: getHealthGetAction(),
+						},
+						FailureThreshold: 3,
+						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   15,
+					},
+					LivenessProbe: &corev1.Probe{
+						FailureThreshold: 8,
+						Handler: corev1.Handler{
+							HTTPGet: getHealthGetAction(),
+						},
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
+					},
+					VolumeMounts: controllerManagerMounts,
+				},
+			}
+
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(ControllerManagerDeploymentName, data.Cluster().Name, nil))
+
+			return dep, nil
 		}
-
-		dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(ControllerManagerDeploymentName, data.Cluster().Name, nil))
-
-		return dep, nil
 	}
 }
 func getControllerManagerVolumes() []corev1.Volume {

--- a/api/pkg/controller/openshift/resources/interfaces.go
+++ b/api/pkg/controller/openshift/resources/interfaces.go
@@ -6,7 +6,6 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,5 +29,3 @@ type openshiftData interface {
 	InClusterApiserverURL() (*url.URL, error)
 	DC() *provider.DatacenterMeta
 }
-
-type NamedDeploymentCreator func(context.Context, openshiftData) (string, resources.DeploymentCreator)

--- a/api/pkg/controller/openshift/resources/machinecontroller.go
+++ b/api/pkg/controller/openshift/resources/machinecontroller.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
@@ -12,17 +11,19 @@ import (
 
 const machineControllerImage = "quay.io/kubermatic/machine-controller-private:8936af2a674563e8350ee2084546d40b71c665ea-dirty"
 
-func MachineController(_ context.Context, osData openshiftData) (string, resources.DeploymentCreator) {
-	creator := machinecontroller.DeploymentCreator(osData)
-	creator = deploymentImageAddingWrapper(creator, "machine-controller", machineControllerImage)
-	return resources.MachineControllerDeploymentName, creator
+func MachineController(osData openshiftData) resources.NamedDeploymentCreatorGetter {
+	name, creator := machinecontroller.DeploymentCreator(osData)()
+	return func() (string, resources.DeploymentCreator) {
+		return name, deploymentImageAddingWrapper(creator, "machine-controller", machineControllerImage)
+	}
 }
 
-func MachineControllerWebhook(_ context.Context, osData openshiftData) (string, resources.DeploymentCreator) {
+func MachineControllerWebhook(osData openshiftData) resources.NamedDeploymentCreatorGetter {
 
-	creator := machinecontroller.WebhookDeploymentCreator(osData)
-	creator = deploymentImageAddingWrapper(creator, "machine-controller", machineControllerImage)
-	return resources.MachineControllerWebhookDeploymentName, creator
+	name, creator := machinecontroller.WebhookDeploymentCreator(osData)()
+	return func() (string, resources.DeploymentCreator) {
+		return name, deploymentImageAddingWrapper(creator, "machine-controller", machineControllerImage)
+	}
 }
 
 func deploymentImageAddingWrapper(creator resources.DeploymentCreator, containerName, image string) resources.DeploymentCreator {

--- a/api/pkg/controller/openshift/resources/usercluster.go
+++ b/api/pkg/controller/openshift/resources/usercluster.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
@@ -10,11 +9,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-func UserClusterController(_ context.Context, osData openshiftData) (string, resources.DeploymentCreator) {
+func UserClusterController(osData openshiftData) resources.NamedDeploymentCreatorGetter {
 
-	creator := usercluster.DeploymentCreator(osData)
-	creator = addContainerArg(creator, "usercluster-controller", "-openshift", "true")
-	return resources.UserClusterControllerDeploymentName, creator
+	name, creator := usercluster.DeploymentCreator(osData)()
+	return func() (string, resources.DeploymentCreator) {
+		return name, addContainerArg(creator, "usercluster-controller", "-openshift", "true")
+	}
 }
 
 func addContainerArg(creator resources.DeploymentCreator, containerName string, arg ...string) resources.DeploymentCreator {

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -37,166 +37,168 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the API server deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		var enableDexCA bool
-		if len(data.OIDCCAFile()) > 0 {
-			enableDexCA = true
-		}
+func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.ApiserverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			var enableDexCA bool
+			if len(data.OIDCCAFile()) > 0 {
+				enableDexCA = true
+			}
 
-		dep.Name = resources.ApiserverDeploymentName
-		dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Name = resources.ApiserverDeploymentName
+			dep.Labels = resources.BaseAppLabel(name, nil)
 
-		dep.Spec.Replicas = resources.Int32(1)
-		if data.Cluster().Spec.ComponentsOverride.Apiserver.Replicas != nil {
-			dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.Apiserver.Replicas
-		}
+			dep.Spec.Replicas = resources.Int32(1)
+			if data.Cluster().Spec.ComponentsOverride.Apiserver.Replicas != nil {
+				dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.Apiserver.Replicas
+			}
 
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(name, nil),
-		}
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 0,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
-
-		volumes := getVolumes()
-
-		if len(data.OIDCCAFile()) > 0 {
-			volumes = append(volumes, getDexCASecretVolume())
-		}
-
-		podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		externalNodePort, err := data.GetApiserverExternalNodePort()
-		if err != nil {
-			return nil, err
-		}
-
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Labels: podLabels,
-			Annotations: map[string]string{
-				"prometheus.io/scrape_with_kube_cert": "true",
-				"prometheus.io/path":                  "/metrics",
-				"prometheus.io/port":                  strconv.Itoa(int(externalNodePort)),
-			},
-		}
-
-		etcdEndpoints := etcd.GetClientEndpoints(data.Cluster().Status.NamespaceName)
-
-		// Configure user cluster DNS resolver for this pod.
-		dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-		if err != nil {
-			return nil, err
-		}
-		dep.Spec.Template.Spec.Volumes = volumes
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{
-			{
-				Name:            "etcd-running",
-				Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag,
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command: []string{
-					"/bin/sh",
-					"-ec",
-					// Write a key to etcd. If we have quorum it will succeed.
-					fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(name, nil),
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
 				},
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      resources.ApiserverEtcdClientCertificateSecretName,
-						MountPath: "/etc/etcd/pki/client",
-						ReadOnly:  true,
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
+				},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+
+			volumes := getVolumes()
+
+			if len(data.OIDCCAFile()) > 0 {
+				volumes = append(volumes, getDexCASecretVolume())
+			}
+
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			externalNodePort, err := data.GetApiserverExternalNodePort()
+			if err != nil {
+				return nil, err
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+				Annotations: map[string]string{
+					"prometheus.io/scrape_with_kube_cert": "true",
+					"prometheus.io/path":                  "/metrics",
+					"prometheus.io/port":                  strconv.Itoa(int(externalNodePort)),
+				},
+			}
+
+			etcdEndpoints := etcd.GetClientEndpoints(data.Cluster().Status.NamespaceName)
+
+			// Configure user cluster DNS resolver for this pod.
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
+				{
+					Name:            "etcd-running",
+					Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command: []string{
+						"/bin/sh",
+						"-ec",
+						// Write a key to etcd. If we have quorum it will succeed.
+						fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
 					},
-				},
-			},
-		}
-
-		openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get openvpn-client sidecar: %v", err)
-		}
-
-		dnatControllerSidecar, err := vpnsidecar.DnatControllerContainer(data, "dnat-controller")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
-		}
-
-		flags, err := getApiserverFlags(data, externalNodePort, etcdEndpoints)
-		if err != nil {
-			return nil, err
-		}
-
-		resourceRequirements := defaultResourceRequirements.DeepCopy()
-		if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
-			resourceRequirements = data.Cluster().Spec.ComponentsOverride.Apiserver.Resources
-		}
-
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			*openvpnSidecar,
-			*dnatControllerSidecar,
-			{
-				Name:                     name,
-				Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
-				ImagePullPolicy:          corev1.PullIfNotPresent,
-				Command:                  []string{"/hyperkube", "apiserver"},
-				Env:                      getEnvVars(data.Cluster()),
-				Args:                     flags,
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				Resources:                *resourceRequirements,
-				Ports: []corev1.ContainerPort{
-					{
-						ContainerPort: externalNodePort,
-						Protocol:      corev1.ProtocolTCP,
-					},
-				},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/healthz",
-							Port:   intstr.FromInt(int(externalNodePort)),
-							Scheme: "HTTPS",
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.ApiserverEtcdClientCertificateSecretName,
+							MountPath: "/etc/etcd/pki/client",
+							ReadOnly:  true,
 						},
 					},
-					FailureThreshold: 3,
-					PeriodSeconds:    5,
-					SuccessThreshold: 1,
-					TimeoutSeconds:   15,
 				},
-				LivenessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/healthz",
-							Port:   intstr.FromInt(int(externalNodePort)),
-							Scheme: "HTTPS",
+			}
+
+			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get openvpn-client sidecar: %v", err)
+			}
+
+			dnatControllerSidecar, err := vpnsidecar.DnatControllerContainer(data, "dnat-controller")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
+			}
+
+			flags, err := getApiserverFlags(data, externalNodePort, etcdEndpoints)
+			if err != nil {
+				return nil, err
+			}
+
+			resourceRequirements := defaultResourceRequirements.DeepCopy()
+			if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
+				resourceRequirements = data.Cluster().Spec.ComponentsOverride.Apiserver.Resources
+			}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				*openvpnSidecar,
+				*dnatControllerSidecar,
+				{
+					Name:                     name,
+					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					Command:                  []string{"/hyperkube", "apiserver"},
+					Env:                      getEnvVars(data.Cluster()),
+					Args:                     flags,
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Resources:                *resourceRequirements,
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: externalNodePort,
+							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					InitialDelaySeconds: 15,
-					FailureThreshold:    8,
-					PeriodSeconds:       10,
-					SuccessThreshold:    1,
-					TimeoutSeconds:      15,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromInt(int(externalNodePort)),
+								Scheme: "HTTPS",
+							},
+						},
+						FailureThreshold: 3,
+						PeriodSeconds:    5,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   15,
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromInt(int(externalNodePort)),
+								Scheme: "HTTPS",
+							},
+						},
+						InitialDelaySeconds: 15,
+						FailureThreshold:    8,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
+					},
+					VolumeMounts: getVolumeMounts(enableDexCA),
 				},
-				VolumeMounts: getVolumeMounts(enableDexCA),
-			},
+			}
+
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
+
+			return dep, nil
 		}
-
-		dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
-
-		return dep, nil
 	}
 }
 

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -35,142 +35,144 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the controller manager deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.ControllerManagerDeploymentName
-		dep.Labels = resources.BaseAppLabel(name, nil)
+func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.ControllerManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.ControllerManagerDeploymentName
+			dep.Labels = resources.BaseAppLabel(name, nil)
 
-		flags, err := getFlags(data.Cluster())
-		if err != nil {
-			return nil, err
-		}
-
-		dep.Spec.Replicas = resources.Int32(1)
-		if data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas != nil {
-			dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas
-		}
-
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(name, nil),
-		}
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 0,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
-
-		volumes := getVolumes()
-		podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Labels:      podLabels,
-			Annotations: getPodAnnotations(data),
-		}
-
-		// Configure user cluster DNS resolver for this pod.
-		dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-		if err != nil {
-			return nil, err
-		}
-
-		dep.Spec.Template.Spec.Volumes = volumes
-
-		apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-		if err != nil {
-			return nil, err
-		}
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
-
-		openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
-		}
-
-		controllerManagerMounts := []corev1.VolumeMount{
-			{
-				Name:      resources.CASecretName,
-				MountPath: "/etc/kubernetes/pki/ca",
-				ReadOnly:  true,
-			},
-			{
-				Name:      resources.ServiceAccountKeySecretName,
-				MountPath: "/etc/kubernetes/service-account-key",
-				ReadOnly:  true,
-			},
-			{
-				Name:      resources.CloudConfigConfigMapName,
-				MountPath: "/etc/kubernetes/cloud",
-				ReadOnly:  true,
-			},
-			{
-				Name:      resources.ControllerManagerKubeconfigSecretName,
-				MountPath: "/etc/kubernetes/kubeconfig",
-				ReadOnly:  true,
-			},
-		}
-		if data.Cluster().Spec.Cloud.VSphere != nil {
-			fakeVMWareUUIDMount := corev1.VolumeMount{
-				Name:      resources.CloudConfigConfigMapName,
-				SubPath:   cloudconfig.FakeVMWareUUIDKeyName,
-				MountPath: "/sys/class/dmi/id/product_serial",
-				ReadOnly:  true,
+			flags, err := getFlags(data.Cluster())
+			if err != nil {
+				return nil, err
 			}
-			// Required because of https://github.com/kubernetes/kubernetes/issues/65145
-			controllerManagerMounts = append(controllerManagerMounts, fakeVMWareUUIDMount)
-		}
 
-		resourceRequirements := defaultResourceRequirements
-		if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
-			resourceRequirements = *data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources
-		}
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			*openvpnSidecar,
-			{
-				Name:                     name,
-				Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
-				ImagePullPolicy:          corev1.PullIfNotPresent,
-				Command:                  []string{"/hyperkube", "controller-manager"},
-				Args:                     flags,
-				Env:                      getEnvVars(data.Cluster()),
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				Resources:                resourceRequirements,
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: getHealthGetAction(data),
-					},
-					FailureThreshold: 3,
-					PeriodSeconds:    10,
-					SuccessThreshold: 1,
-					TimeoutSeconds:   15,
+			dep.Spec.Replicas = resources.Int32(1)
+			if data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas != nil {
+				dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas
+			}
+
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(name, nil),
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
 				},
-				LivenessProbe: &corev1.Probe{
-					FailureThreshold: 8,
-					Handler: corev1.Handler{
-						HTTPGet: getHealthGetAction(data),
-					},
-					InitialDelaySeconds: 15,
-					PeriodSeconds:       10,
-					SuccessThreshold:    1,
-					TimeoutSeconds:      15,
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
 				},
-				VolumeMounts: controllerManagerMounts,
-			},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+
+			volumes := getVolumes()
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels:      podLabels,
+				Annotations: getPodAnnotations(data),
+			}
+
+			// Configure user cluster DNS resolver for this pod.
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
+			}
+
+			dep.Spec.Template.Spec.Volumes = volumes
+
+			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+
+			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
+			}
+
+			controllerManagerMounts := []corev1.VolumeMount{
+				{
+					Name:      resources.CASecretName,
+					MountPath: "/etc/kubernetes/pki/ca",
+					ReadOnly:  true,
+				},
+				{
+					Name:      resources.ServiceAccountKeySecretName,
+					MountPath: "/etc/kubernetes/service-account-key",
+					ReadOnly:  true,
+				},
+				{
+					Name:      resources.CloudConfigConfigMapName,
+					MountPath: "/etc/kubernetes/cloud",
+					ReadOnly:  true,
+				},
+				{
+					Name:      resources.ControllerManagerKubeconfigSecretName,
+					MountPath: "/etc/kubernetes/kubeconfig",
+					ReadOnly:  true,
+				},
+			}
+			if data.Cluster().Spec.Cloud.VSphere != nil {
+				fakeVMWareUUIDMount := corev1.VolumeMount{
+					Name:      resources.CloudConfigConfigMapName,
+					SubPath:   cloudconfig.FakeVMWareUUIDKeyName,
+					MountPath: "/sys/class/dmi/id/product_serial",
+					ReadOnly:  true,
+				}
+				// Required because of https://github.com/kubernetes/kubernetes/issues/65145
+				controllerManagerMounts = append(controllerManagerMounts, fakeVMWareUUIDMount)
+			}
+
+			resourceRequirements := defaultResourceRequirements
+			if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
+				resourceRequirements = *data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources
+			}
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				*openvpnSidecar,
+				{
+					Name:                     name,
+					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					Command:                  []string{"/hyperkube", "controller-manager"},
+					Args:                     flags,
+					Env:                      getEnvVars(data.Cluster()),
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Resources:                resourceRequirements,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: getHealthGetAction(data),
+						},
+						FailureThreshold: 3,
+						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   15,
+					},
+					LivenessProbe: &corev1.Probe{
+						FailureThreshold: 8,
+						Handler: corev1.Handler{
+							HTTPGet: getHealthGetAction(data),
+						},
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
+					},
+					VolumeMounts: controllerManagerMounts,
+				},
+			}
+
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
+
+			return dep, nil
 		}
-
-		dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
-
-		return dep, nil
 	}
 }
 

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -48,79 +48,81 @@ func ServiceCreator() resources.NamedServiceCreatorGetter {
 }
 
 // DeploymentCreator returns the function to create and update the DNS resolver deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.DNSResolverDeploymentName
-		dep.Labels = resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil)
-		dep.Spec.Replicas = resources.Int32(2)
+func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.DNSResolverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.DNSResolverDeploymentName
+			dep.Labels = resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil)
+			dep.Spec.Replicas = resources.Int32(2)
 
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil),
-		}
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 0,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
-
-		volumes := getVolumes()
-		podLabels, err := data.GetPodTemplateLabels(resources.DNSResolverDeploymentName, volumes, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get podlabels: %v", err)
-		}
-
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: podLabels}
-		openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get openvpn sidecar for dns resolver: %v", err)
-		}
-
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			*openvpnSidecar,
-			{
-				Name:                     resources.DNSResolverDeploymentName,
-				Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.1.3",
-				ImagePullPolicy:          corev1.PullIfNotPresent,
-				Args:                     []string{"-conf", "/etc/coredns/Corefile"},
-				Resources:                defaultResourceRequirements,
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      resources.DNSResolverConfigMapName,
-						MountPath: "/etc/coredns",
-						ReadOnly:  true,
-					},
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil),
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
 				},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/health",
-							Port:   intstr.FromInt(8080),
-							Scheme: corev1.URISchemeHTTP,
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
+				},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+
+			volumes := getVolumes()
+			podLabels, err := data.GetPodTemplateLabels(resources.DNSResolverDeploymentName, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get podlabels: %v", err)
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: podLabels}
+			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get openvpn sidecar for dns resolver: %v", err)
+			}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				*openvpnSidecar,
+				{
+					Name:                     resources.DNSResolverDeploymentName,
+					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.1.3",
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					Args:                     []string{"-conf", "/etc/coredns/Corefile"},
+					Resources:                defaultResourceRequirements,
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.DNSResolverConfigMapName,
+							MountPath: "/etc/coredns",
+							ReadOnly:  true,
 						},
 					},
-					InitialDelaySeconds: 2,
-					FailureThreshold:    3,
-					PeriodSeconds:       10,
-					SuccessThreshold:    1,
-					TimeoutSeconds:      15,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/health",
+								Port:   intstr.FromInt(8080),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						InitialDelaySeconds: 2,
+						FailureThreshold:    3,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
+					},
 				},
-			},
+			}
+
+			dep.Spec.Template.Spec.Volumes = volumes
+
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(resources.DNSResolverDeploymentName, data.Cluster().Name, nil))
+
+			return dep, nil
 		}
-
-		dep.Spec.Template.Spec.Volumes = volumes
-
-		dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(resources.DNSResolverDeploymentName, data.Cluster().Name, nil))
-
-		return dep, nil
 	}
 }
 

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -32,85 +32,87 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the kube-state-metrics deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.KubeStateMetricsDeploymentName
-		dep.Labels = resources.BaseAppLabel(name, nil)
+func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.KubeStateMetricsDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.KubeStateMetricsDeploymentName
+			dep.Labels = resources.BaseAppLabel(name, nil)
 
-		dep.Spec.Replicas = resources.Int32(1)
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(name, nil),
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+			dep.Spec.Replicas = resources.Int32(1)
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(name, nil),
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
-		volumes := getVolumes()
-		podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create pod labels: %v", err)
-		}
+			volumes := getVolumes()
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %v", err)
+			}
 
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Labels: podLabels,
-		}
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+			}
 
-		dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.Volumes = volumes
 
-		apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-		if err != nil {
-			return nil, err
-		}
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
 
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			{
-				Name:            name,
-				Image:           data.ImageRegistry(resources.RegistryQuay) + "/coreos/kube-state-metrics:" + version,
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"/kube-state-metrics"},
-				Args: []string{
-					"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-					"--port", "8080",
-					"--telemetry-port", "8081",
-				},
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      resources.KubeStateMetricsKubeconfigSecretName,
-						MountPath: "/etc/kubernetes/kubeconfig",
-						ReadOnly:  true,
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            name,
+					Image:           data.ImageRegistry(resources.RegistryQuay) + "/coreos/kube-state-metrics:" + version,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/kube-state-metrics"},
+					Args: []string{
+						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
+						"--port", "8080",
+						"--telemetry-port", "8081",
 					},
-				},
-				Ports: []corev1.ContainerPort{
-					{
-						Name:          "metrics",
-						ContainerPort: 8080,
-						Protocol:      corev1.ProtocolTCP,
-					},
-					{
-						Name:          "telemetry",
-						ContainerPort: 8081,
-						Protocol:      corev1.ProtocolTCP,
-					},
-				},
-				Resources: defaultResourceRequirements,
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/healthz",
-							Port:   intstr.FromInt(8080),
-							Scheme: corev1.URISchemeHTTP,
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.KubeStateMetricsKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
 						},
 					},
-					FailureThreshold: 3,
-					PeriodSeconds:    10,
-					SuccessThreshold: 1,
-					TimeoutSeconds:   15,
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "metrics",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+						{
+							Name:          "telemetry",
+							ContainerPort: 8081,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+					Resources: defaultResourceRequirements,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromInt(8080),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						FailureThreshold: 3,
+						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   15,
+					},
 				},
-			},
-		}
+			}
 
-		return dep, nil
+			return dep, nil
+		}
 	}
 }
 

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -31,100 +31,102 @@ var (
 )
 
 // WebhookDeploymentCreator returns the function to create and update the machine controller webhook deployment
-func WebhookDeploymentCreator(data machinecontrollerData) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.MachineControllerWebhookDeploymentName
-		dep.Labels = resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil)
-		dep.Spec.Replicas = resources.Int32(1)
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil),
-		}
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 0,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
-
-		volumes := []corev1.Volume{getKubeconfigVolume(), getServingCertVolume()}
-		dep.Spec.Template.Spec.Volumes = volumes
-		podLabels, err := data.GetPodTemplateLabels(resources.MachineControllerWebhookDeploymentName, volumes, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create pod labels: %v", err)
-		}
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: podLabels}
-
-		apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-		if err != nil {
-			return nil, err
-		}
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
-
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			{
-				Name:            Name,
-				Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"/usr/local/bin/webhook"},
-				Args: []string{
-					"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-					"-logtostderr",
-					"-v", "4",
-					"-listen-address", "0.0.0.0:9876",
+func WebhookDeploymentCreator(data machinecontrollerData) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.MachineControllerWebhookDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.MachineControllerWebhookDeploymentName
+			dep.Labels = resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil)
+			dep.Spec.Replicas = resources.Int32(1)
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil),
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
 				},
-				Env:                      getEnvVars(data),
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				Resources:                webhookResourceRequirements,
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/healthz",
-							Port:   intstr.FromInt(9876),
-							Scheme: corev1.URISchemeHTTPS,
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
+				},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+
+			volumes := []corev1.Volume{getKubeconfigVolume(), getServingCertVolume()}
+			dep.Spec.Template.Spec.Volumes = volumes
+			podLabels, err := data.GetPodTemplateLabels(resources.MachineControllerWebhookDeploymentName, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %v", err)
+			}
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: podLabels}
+
+			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            Name,
+					Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/usr/local/bin/webhook"},
+					Args: []string{
+						"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
+						"-logtostderr",
+						"-v", "4",
+						"-listen-address", "0.0.0.0:9876",
+					},
+					Env:                      getEnvVars(data),
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Resources:                webhookResourceRequirements,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromInt(9876),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+						FailureThreshold: 3,
+						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   15,
+					},
+					LivenessProbe: &corev1.Probe{
+						FailureThreshold: 8,
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromInt(9876),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.MachineControllerKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
+						},
+						{
+							Name:      resources.MachineControllerWebhookServingCertSecretName,
+							MountPath: "/tmp/cert",
+							ReadOnly:  true,
 						},
 					},
-					FailureThreshold: 3,
-					PeriodSeconds:    10,
-					SuccessThreshold: 1,
-					TimeoutSeconds:   15,
 				},
-				LivenessProbe: &corev1.Probe{
-					FailureThreshold: 8,
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/healthz",
-							Port:   intstr.FromInt(9876),
-							Scheme: corev1.URISchemeHTTPS,
-						},
-					},
-					InitialDelaySeconds: 15,
-					PeriodSeconds:       10,
-					SuccessThreshold:    1,
-					TimeoutSeconds:      15,
-				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      resources.MachineControllerKubeconfigSecretName,
-						MountPath: "/etc/kubernetes/kubeconfig",
-						ReadOnly:  true,
-					},
-					{
-						Name:      resources.MachineControllerWebhookServingCertSecretName,
-						MountPath: "/tmp/cert",
-						ReadOnly:  true,
-					},
-				},
-			},
-		}
+			}
 
-		return dep, nil
+			return dep, nil
+		}
 	}
 }
 

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -34,91 +34,93 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the metrics server deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.MetricsServerDeploymentName
-		dep.Labels = resources.BaseAppLabel(name, nil)
+func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.MetricsServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.MetricsServerDeploymentName
+			dep.Labels = resources.BaseAppLabel(name, nil)
 
-		dep.Spec.Replicas = resources.Int32(2)
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(name, nil),
-		}
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 0,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
-
-		volumes := getVolumes()
-		podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create pod labels: %v", err)
-		}
-
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Labels: podLabels,
-		}
-
-		dep.Spec.Template.Spec.Volumes = volumes
-
-		apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-		if err != nil {
-			return nil, err
-		}
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
-
-		openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get openvpn-client sidecar: %v", err)
-		}
-
-		dnatControllerSidecar, err := vpnsidecar.DnatControllerContainer(data, "dnat-controller")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
-		}
-
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			{
-				Name:            name,
-				Image:           data.ImageRegistry(resources.RegistryGCR) + "/google_containers/metrics-server-amd64:" + tag,
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"/metrics-server"},
-				Args: []string{
-					"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-					"--authentication-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-					"--authorization-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-					"--kubelet-port", "10250",
-					"--kubelet-insecure-tls",
-					// We use the same as the API server as we use the same dnat-controller
-					"--kubelet-preferred-address-types", "ExternalIP,InternalIP",
-					"--v", "1",
-					"--logtostderr",
+			dep.Spec.Replicas = resources.Int32(2)
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(name, nil),
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
 				},
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				Resources:                defaultResourceRequirements,
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      resources.MetricsServerKubeconfigSecretName,
-						MountPath: "/etc/kubernetes/kubeconfig",
-						ReadOnly:  true,
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
+				},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+
+			volumes := getVolumes()
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %v", err)
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+			}
+
+			dep.Spec.Template.Spec.Volumes = volumes
+
+			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+
+			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get openvpn-client sidecar: %v", err)
+			}
+
+			dnatControllerSidecar, err := vpnsidecar.DnatControllerContainer(data, "dnat-controller")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
+			}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            name,
+					Image:           data.ImageRegistry(resources.RegistryGCR) + "/google_containers/metrics-server-amd64:" + tag,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/metrics-server"},
+					Args: []string{
+						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
+						"--authentication-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
+						"--authorization-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
+						"--kubelet-port", "10250",
+						"--kubelet-insecure-tls",
+						// We use the same as the API server as we use the same dnat-controller
+						"--kubelet-preferred-address-types", "ExternalIP,InternalIP",
+						"--v", "1",
+						"--logtostderr",
+					},
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Resources:                defaultResourceRequirements,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.MetricsServerKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
+						},
 					},
 				},
-			},
-			*openvpnSidecar,
-			*dnatControllerSidecar,
+				*openvpnSidecar,
+				*dnatControllerSidecar,
+			}
+
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
+
+			return dep, nil
 		}
-
-		dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
-
-		return dep, nil
 	}
 }
 

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -42,77 +42,78 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the openvpn server deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.OpenVPNServerDeploymentName
-		dep.Labels = resources.BaseAppLabel(name, nil)
+func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.OpenVPNServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.OpenVPNServerDeploymentName
+			dep.Labels = resources.BaseAppLabel(name, nil)
 
-		dep.Spec.Replicas = resources.Int32(1)
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				resources.AppLabelKey: name,
-			},
-		}
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+			dep.Spec.Replicas = resources.Int32(1)
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					resources.AppLabelKey: name,
+				},
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+				},
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+				},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
-		volumes := getVolumes()
-		podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create pod labels: %v", err)
-		}
+			volumes := getVolumes()
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %v", err)
+			}
 
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Labels: podLabels,
-		}
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+			}
 
-		_, podNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks[0])
-		if err != nil {
-			return nil, err
-		}
+			_, podNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+			if err != nil {
+				return nil, err
+			}
 
-		_, serviceNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks[0])
-		if err != nil {
-			return nil, err
-		}
+			_, serviceNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Services.CIDRBlocks[0])
+			if err != nil {
+				return nil, err
+			}
 
-		pushRoutes := []string{
-			// pod and service routes
-			"--push", fmt.Sprintf("route %s %s", podNet.IP.String(), net.IP(podNet.Mask).String()),
-			"--route", podNet.IP.String(), net.IP(podNet.Mask).String(),
-			"--push", fmt.Sprintf("route %s %s", serviceNet.IP.String(), net.IP(serviceNet.Mask).String()),
-			"--route", serviceNet.IP.String(), net.IP(serviceNet.Mask).String(),
-		}
+			pushRoutes := []string{
+				// pod and service routes
+				"--push", fmt.Sprintf("route %s %s", podNet.IP.String(), net.IP(podNet.Mask).String()),
+				"--route", podNet.IP.String(), net.IP(podNet.Mask).String(),
+				"--push", fmt.Sprintf("route %s %s", serviceNet.IP.String(), net.IP(serviceNet.Mask).String()),
+				"--route", serviceNet.IP.String(), net.IP(serviceNet.Mask).String(),
+			}
 
-		// node access network route
-		_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork(), err)
-		}
-		pushRoutes = append(pushRoutes, []string{
-			"--push", fmt.Sprintf("route %s %s", nodeAccessNetwork.IP.String(), net.IP(nodeAccessNetwork.Mask).String()),
-			"--route", nodeAccessNetwork.IP.String(), net.IP(nodeAccessNetwork.Mask).String(),
-		}...)
+			// node access network route
+			_, nodeAccessNetwork, err := net.ParseCIDR(data.NodeAccessNetwork())
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse node access network %s: %v", data.NodeAccessNetwork(), err)
+			}
+			pushRoutes = append(pushRoutes, []string{
+				"--push", fmt.Sprintf("route %s %s", nodeAccessNetwork.IP.String(), net.IP(nodeAccessNetwork.Mask).String()),
+				"--route", nodeAccessNetwork.IP.String(), net.IP(nodeAccessNetwork.Mask).String(),
+			}...)
 
-		dep.Spec.Template.Spec.Volumes = volumes
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{
-			{
-				Name:            "iptables-init",
-				Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/openvpn:v0.4",
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"/bin/bash"},
-				Args: []string{
-					"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but
+			dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
+				{
+					Name:            "iptables-init",
+					Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/openvpn:v0.4",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/bin/bash"},
+					Args: []string{
+						"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but
 # masquerade to openvpn-server's IP instead:
 iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
 
@@ -127,115 +128,116 @@ iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -i tun0 -p icmp -j ACCEPT
 iptables -A INPUT -i tun0 -j DROP
 `,
-				},
-				SecurityContext: &corev1.SecurityContext{
-					Capabilities: &corev1.Capabilities{
-						Add: []corev1.Capability{"NET_ADMIN"},
 					},
-				},
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				Resources:                defaultResourceRequirements,
-			},
-		}
-
-		vpnArgs := []string{
-			"--proto", "tcp",
-			"--dev", "tun",
-			"--mode", "server",
-			"--lport", "1194",
-			"--server", "10.20.0.0", "255.255.255.0",
-			"--ca", "/etc/kubernetes/pki/ca/ca.crt",
-			"--cert", "/etc/openvpn/pki/server/server.crt",
-			"--key", "/etc/openvpn/pki/server/server.key",
-			"--dh", "none",
-			"--duplicate-cn",
-			"--client-config-dir", "/etc/openvpn/clients",
-			"--status", "/run/openvpn-status",
-			"--link-mtu", "1432",
-			"--cipher", "AES-256-GCM",
-			"--auth", "SHA1",
-			"--keysize", "256",
-			"--script-security", "2",
-			"--ping", "5",
-			"--verb", "3",
-			"--log", "/dev/stdout",
-		}
-		vpnArgs = append(vpnArgs, pushRoutes...)
-
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			{
-				Name:                     name,
-				Image:                    data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/openvpn:v0.4",
-				ImagePullPolicy:          corev1.PullIfNotPresent,
-				Command:                  []string{"/usr/sbin/openvpn"},
-				Args:                     vpnArgs,
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				Ports: []corev1.ContainerPort{
-					{
-						ContainerPort: 1194,
-						Protocol:      corev1.ProtocolTCP,
-					},
-				},
-				SecurityContext: &corev1.SecurityContext{
-					Privileged: resources.Bool(true),
-				},
-				Resources: defaultResourceRequirements,
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						Exec: &corev1.ExecAction{
-							Command: []string{
-								"test",
-								"-s",
-								"/run/openvpn-status",
-							},
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"NET_ADMIN"},
 						},
 					},
-					FailureThreshold:    3,
-					InitialDelaySeconds: 5,
-					PeriodSeconds:       5,
-					SuccessThreshold:    1,
-					TimeoutSeconds:      1,
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Resources:                defaultResourceRequirements,
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      resources.OpenVPNServerCertificatesSecretName,
-						MountPath: "/etc/openvpn/pki/server",
-						ReadOnly:  true,
-					},
-					{
-						Name:      resources.CASecretName,
-						MountPath: "/etc/kubernetes/pki/ca",
-						ReadOnly:  true,
-					},
-					{
-						Name:      resources.OpenVPNClientConfigsConfigMapName,
-						MountPath: "/etc/openvpn/clients",
-						ReadOnly:  true,
-					},
-				},
-			},
-			{
-				Name:            "ip-forward",
-				Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/openvpn:v0.4",
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"/bin/bash"},
-				Args: []string{
-					"-c",
-					// Always set IP forwarding as a CNI plugin might reset this to 0 (Like Calico 3).
-					"while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done",
-				},
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				SecurityContext: &corev1.SecurityContext{
-					Privileged: resources.Bool(true),
-				},
-				Resources: ipForwardRequirements,
-			},
-		}
+			}
 
-		return dep, nil
+			vpnArgs := []string{
+				"--proto", "tcp",
+				"--dev", "tun",
+				"--mode", "server",
+				"--lport", "1194",
+				"--server", "10.20.0.0", "255.255.255.0",
+				"--ca", "/etc/kubernetes/pki/ca/ca.crt",
+				"--cert", "/etc/openvpn/pki/server/server.crt",
+				"--key", "/etc/openvpn/pki/server/server.key",
+				"--dh", "none",
+				"--duplicate-cn",
+				"--client-config-dir", "/etc/openvpn/clients",
+				"--status", "/run/openvpn-status",
+				"--link-mtu", "1432",
+				"--cipher", "AES-256-GCM",
+				"--auth", "SHA1",
+				"--keysize", "256",
+				"--script-security", "2",
+				"--ping", "5",
+				"--verb", "3",
+				"--log", "/dev/stdout",
+			}
+			vpnArgs = append(vpnArgs, pushRoutes...)
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:                     name,
+					Image:                    data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/openvpn:v0.4",
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					Command:                  []string{"/usr/sbin/openvpn"},
+					Args:                     vpnArgs,
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 1194,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: resources.Bool(true),
+					},
+					Resources: defaultResourceRequirements,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
+								Command: []string{
+									"test",
+									"-s",
+									"/run/openvpn-status",
+								},
+							},
+						},
+						FailureThreshold:    3,
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       5,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      1,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.OpenVPNServerCertificatesSecretName,
+							MountPath: "/etc/openvpn/pki/server",
+							ReadOnly:  true,
+						},
+						{
+							Name:      resources.CASecretName,
+							MountPath: "/etc/kubernetes/pki/ca",
+							ReadOnly:  true,
+						},
+						{
+							Name:      resources.OpenVPNClientConfigsConfigMapName,
+							MountPath: "/etc/openvpn/clients",
+							ReadOnly:  true,
+						},
+					},
+				},
+				{
+					Name:            "ip-forward",
+					Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/openvpn:v0.4",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/bin/bash"},
+					Args: []string{
+						"-c",
+						// Always set IP forwarding as a CNI plugin might reset this to 0 (Like Calico 3).
+						"while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done",
+					},
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: resources.Bool(true),
+					},
+					Resources: ipForwardRequirements,
+				},
+			}
+
+			return dep, nil
+		}
 	}
 }
 

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -35,120 +35,122 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the scheduler deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.SchedulerDeploymentName
-		dep.Labels = resources.BaseAppLabel(name, nil)
+func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.SchedulerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.SchedulerDeploymentName
+			dep.Labels = resources.BaseAppLabel(name, nil)
 
-		flags, err := getFlags(data.Cluster())
-		if err != nil {
-			return nil, err
-		}
+			flags, err := getFlags(data.Cluster())
+			if err != nil {
+				return nil, err
+			}
 
-		dep.Spec.Replicas = resources.Int32(1)
-		if data.Cluster().Spec.ComponentsOverride.Scheduler.Replicas != nil {
-			dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.Scheduler.Replicas
-		}
+			dep.Spec.Replicas = resources.Int32(1)
+			if data.Cluster().Spec.ComponentsOverride.Scheduler.Replicas != nil {
+				dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.Scheduler.Replicas
+			}
 
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(name, nil),
-		}
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(name, nil),
+			}
 
-		volumes := getVolumes()
-		podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create pod labels: %v", err)
-		}
+			volumes := getVolumes()
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %v", err)
+			}
 
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 0,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+				},
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
+				},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Labels:      podLabels,
-			Annotations: getPodAnnotations(data),
-		}
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels:      podLabels,
+				Annotations: getPodAnnotations(data),
+			}
 
-		openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
-		}
+			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
+			}
 
-		// Configure user cluster DNS resolver for this pod.
-		dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
-		if err != nil {
-			return nil, err
-		}
+			// Configure user cluster DNS resolver for this pod.
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
+			}
 
-		dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.Volumes = volumes
 
-		apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-		if err != nil {
-			return nil, err
-		}
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
 
-		resourceRequirements := defaultResourceRequirements
-		if data.Cluster().Spec.ComponentsOverride.Scheduler.Resources != nil {
-			resourceRequirements = *data.Cluster().Spec.ComponentsOverride.Scheduler.Resources
-		}
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			*openvpnSidecar,
-			{
-				Name:                     name,
-				Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
-				ImagePullPolicy:          corev1.PullIfNotPresent,
-				Command:                  []string{"/hyperkube", "scheduler"},
-				Args:                     flags,
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      resources.SchedulerKubeconfigSecretName,
-						MountPath: "/etc/kubernetes/kubeconfig",
-						ReadOnly:  true,
+			resourceRequirements := defaultResourceRequirements
+			if data.Cluster().Spec.ComponentsOverride.Scheduler.Resources != nil {
+				resourceRequirements = *data.Cluster().Spec.ComponentsOverride.Scheduler.Resources
+			}
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				*openvpnSidecar,
+				{
+					Name:                     name,
+					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					Command:                  []string{"/hyperkube", "scheduler"},
+					Args:                     flags,
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.SchedulerKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
+						},
+						{
+							Name:      resources.CASecretName,
+							MountPath: "/etc/kubernetes/pki/ca",
+							ReadOnly:  true,
+						},
 					},
-					{
-						Name:      resources.CASecretName,
-						MountPath: "/etc/kubernetes/pki/ca",
-						ReadOnly:  true,
+					Resources: resourceRequirements,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: getHealthGetAction(data),
+						},
+						FailureThreshold: 3,
+						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   15,
+					},
+					LivenessProbe: &corev1.Probe{
+						FailureThreshold: 8,
+						Handler: corev1.Handler{
+							HTTPGet: getHealthGetAction(data),
+						},
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
 					},
 				},
-				Resources: resourceRequirements,
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: getHealthGetAction(data),
-					},
-					FailureThreshold: 3,
-					PeriodSeconds:    10,
-					SuccessThreshold: 1,
-					TimeoutSeconds:   15,
-				},
-				LivenessProbe: &corev1.Probe{
-					FailureThreshold: 8,
-					Handler: corev1.Handler{
-						HTTPGet: getHealthGetAction(data),
-					},
-					InitialDelaySeconds: 15,
-					PeriodSeconds:       10,
-					SuccessThreshold:    1,
-					TimeoutSeconds:      15,
-				},
-			},
+			}
+
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
+
+			return dep, nil
 		}
-
-		dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
-
-		return dep, nil
 	}
 }
 

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -529,11 +529,12 @@ func TestLoadFiles(t *testing.T) {
 				kubeInformerFactory.Start(wait.NeverStop)
 				kubeInformerFactory.WaitForCacheSync(wait.NeverStop)
 
-				var deploymentCreators []resources.DeploymentCreator
+				var deploymentCreators []resources.NamedDeploymentCreatorGetter
 				deploymentCreators = append(deploymentCreators, clustercontroller.GetDeploymentCreators(data)...)
 				deploymentCreators = append(deploymentCreators, monitoringcontroller.GetDeploymentCreators(data)...)
 				for _, create := range deploymentCreators {
-					res, err := create(&appsv1.Deployment{})
+					_, creator := create()
+					res, err := creator(&appsv1.Deployment{})
 					if err != nil {
 						t.Fatalf("failed to create Deployment: %v", err)
 					}

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -45,77 +45,79 @@ type userclusterControllerData interface {
 }
 
 // DeploymentCreator returns the function to create and update the user cluster controller deployment
-func DeploymentCreator(data userclusterControllerData) resources.DeploymentCreator {
-	return func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-		dep.Name = resources.UserClusterControllerDeploymentName
-		dep.Labels = resources.BaseAppLabel(name, nil)
+func DeploymentCreator(data userclusterControllerData) resources.NamedDeploymentCreatorGetter {
+	return func() (string, resources.DeploymentCreator) {
+		return resources.UserClusterControllerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.UserClusterControllerDeploymentName
+			dep.Labels = resources.BaseAppLabel(name, nil)
 
-		dep.Spec.Replicas = resources.Int32(1)
-		dep.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: resources.BaseAppLabel(name, nil),
-		}
-		dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
-		dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 0,
-			},
-		}
-		dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+			dep.Spec.Replicas = resources.Int32(1)
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(name, nil),
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+				},
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
+				},
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
-		volumes := getVolumes()
-		podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create pod labels: %v", err)
-		}
+			volumes := getVolumes()
+			podLabels, err := data.GetPodTemplateLabels(name, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %v", err)
+			}
 
-		dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-			Labels: podLabels,
-			Annotations: map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/path":   "/metrics",
-				"prometheus.io/port":   "8085",
-			},
-		}
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+				Annotations: map[string]string{
+					"prometheus.io/scrape": "true",
+					"prometheus.io/path":   "/metrics",
+					"prometheus.io/port":   "8085",
+				},
+			}
 
-		dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.Volumes = volumes
 
-		apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-		if err != nil {
-			return nil, err
-		}
-		dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
 
-		dep.Spec.Template.Spec.Containers = []corev1.Container{
-			{
-				Name:            name,
-				Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/api:" + resources.KUBERMATICCOMMIT,
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"/usr/local/bin/user-cluster-controller-manager"},
-				Args: append([]string{
-					"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-					"-internal-address", "0.0.0.0:8085",
-					"-logtostderr",
-					"-v", "2",
-				}, getNetworkArgs(data)...),
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				Resources:                defaultResourceRequirements,
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
-						MountPath: "/etc/kubernetes/kubeconfig",
-						ReadOnly:  true,
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            name,
+					Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/api:" + resources.KUBERMATICCOMMIT,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/usr/local/bin/user-cluster-controller-manager"},
+					Args: append([]string{
+						"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
+						"-internal-address", "0.0.0.0:8085",
+						"-logtostderr",
+						"-v", "2",
+					}, getNetworkArgs(data)...),
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Resources:                defaultResourceRequirements,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
+						},
 					},
 				},
-			},
-		}
+			}
 
-		return dep, nil
+			return dep, nil
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the handling of Deployments from Deployment creators to NamedDeploymentCreators. This has two advantages:

* We don't have to always call `create` at least twice, once just to get the name
* In the openshift controller, this gets rid of the `NamedDeploymentCreator` type, which so far forced all `NamedDeploymentCreators` to have the same signature and take args even when they didn't use them (happend e.G. for the machine-controller)

Adjusting the codegen unfortunately required to adjust the whole codebase, sorry for the big PR

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
