### PR TITLE
[release/v2.9] Create internal-admin-kubeconfig so CI cleanup can work

### DIFF
--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -214,6 +214,7 @@ func GetSecretCreatorOperations(c *kubermaticv1.Cluster, dockerPullConfigJSON []
 		{resources.OpenVPNClientCertificatesSecretName, openvpn.InternalClientCertificate},
 		{resources.TokensSecretName, apiserver.TokenUsers},
 		{resources.AdminKubeconfigSecretName, resources.AdminKubeconfig},
+		{resources.InternalUserClusterAdminKubeconfigSecretName, resources.GetInternalKubeconfigCreator(resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"})},
 		{resources.SchedulerKubeconfigSecretName, resources.GetInternalKubeconfigCreator(resources.SchedulerKubeconfigSecretName, resources.SchedulerCertUsername, nil)},
 		{resources.KubeletDnatControllerKubeconfigSecretName, resources.GetInternalKubeconfigCreator(resources.KubeletDnatControllerKubeconfigSecretName, resources.KubeletDnatControllerCertUsername, nil)},
 		{resources.MachineControllerKubeconfigSecretName, resources.GetInternalKubeconfigCreator(resources.MachineControllerKubeconfigSecretName, resources.MachineControllerCertUsername, nil)},

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -279,6 +279,12 @@ const (
 	// MachineControllerMutatingWebhookConfigurationName is the name of the machine-controllers mutating webhook
 	// configuration
 	MachineControllerMutatingWebhookConfigurationName = "machine-controller.kubermatic.io"
+
+	// InternalUserClusterAdminKubeconfigSecretName is the name of the secret containing an admin kubeconfig that can only be used from
+	// within the seed cluster
+	InternalUserClusterAdminKubeconfigSecretName = "internal-admin-kubeconfig"
+	// InternalUserClusterAdminKubeconfigCertUsername is the name of the user coming from kubeconfig cert
+	InternalUserClusterAdminKubeconfigCertUsername = "kubermatic-controllers"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the cleanup of clusters created during e2e tests against the release/v2.9 branch doesn't work at all, it fails with a `failed to get user cluster client: secret "internal-admin-kubeconfig" not found`. Which makes perfect sense, because we don't create that secret in release/v2.9

This PR fixes that so the cleanup can work again

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
