### PR TITLE
Split Kubermatic alerts into master and seed

### DIFF
--- a/config/monitoring/prometheus/rules/general-cert-manager.yaml
+++ b/config/monitoring/prometheus/rules/general-cert-manager.yaml
@@ -1,0 +1,18 @@
+# This file has been generated, do not edit.
+groups:
+- name: cert-manager
+  rules:
+  - alert: CertManagerCertExpiresSoon
+    annotations:
+      message: The certificate {{ $labels.name }} expires in less than 3 days.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-certmanagercertexpiressoon
+    expr: certmanager_certificate_expiration_timestamp_seconds - time() < 3*24*3600
+    labels:
+      severity: warning
+  - alert: CertManagerCertExpiresVerySoon
+    annotations:
+      message: The certificate {{ $labels.name }} expires in less than 24 hours.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-certmanagercertexpiresverysoon
+    expr: certmanager_certificate_expiration_timestamp_seconds - time() < 24*3600
+    labels:
+      severity: critical

--- a/config/monitoring/prometheus/rules/general-elasticsearch-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-elasticsearch-exporter.yaml
@@ -4,8 +4,7 @@ groups:
   rules:
   - alert: ElasticsearchHeapTooHigh
     annotations:
-      description: The heap usage of Elasticsearch node {{ $labels.name }} is over
-        90%.
+      message: The heap usage of Elasticsearch node {{ $labels.name }} is over 90%.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchheaptoohigh
     expr: elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"}
       > 0.9
@@ -14,7 +13,7 @@ groups:
       severity: warning
   - alert: ElasticsearchClusterUnavailable
     annotations:
-      description: The Elasticsearch cluster health endpoint does not respond to scrapes.
+      message: The Elasticsearch cluster health endpoint does not respond to scrapes.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunavailable
     expr: elasticsearch_cluster_health_up == 0
     for: 15m
@@ -22,7 +21,7 @@ groups:
       severity: warning
   - alert: ElasticsearchClusterUnhealthy
     annotations:
-      description: The Elasticsearch cluster is not healthy.
+      message: The Elasticsearch cluster is not healthy.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunhealthy
     expr: elasticsearch_cluster_health_status{color="green"} == 0
     for: 15m
@@ -30,7 +29,7 @@ groups:
       severity: critical
   - alert: ElasticsearchUnassignedShards
     annotations:
-      description: There are {{ $value }} unassigned shards in the Elasticsearch cluster.
+      message: There are {{ $value }} unassigned shards in the Elasticsearch cluster.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchunassignedshards
     expr: elasticsearch_cluster_health_unassigned_shards > 0
     for: 15m

--- a/config/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
@@ -1,0 +1,21 @@
+# This file has been generated, do not edit.
+groups:
+- name: kubermatic
+  rules:
+  - alert: KubermaticAPIDown
+    annotations:
+      message: KubermaticAPI has disappeared from Prometheus target discovery.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapidown
+    expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+  - alert: KubermaticAPITooManyErrors
+    annotations:
+      message: Kubermatic API is returning a high rate of HTTP 5xx responses.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapitoomanyerrors
+    expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) >
+      0.1
+    for: 15m
+    labels:
+      severity: warning

--- a/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -19,14 +19,6 @@ groups:
     for: 0m
     labels:
       severity: warning
-  - alert: KubermaticAPIDown
-    annotations:
-      message: KubermaticAPI has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapidown
-    expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
-    for: 15m
-    labels:
-      severity: critical
   - alert: KubermaticControllerManagerDown
     annotations:
       message: KubermaticControllerManager has disappeared from Prometheus target
@@ -37,12 +29,3 @@ groups:
     for: 15m
     labels:
       severity: critical
-  - alert: KubermaticAPITooManyErrors
-    annotations:
-      message: Kubermatic API is returning a high rate of HTTP 5xx responses.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapitoomanyerrors
-    expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) >
-      0.1
-    for: 15m
-    labels:
-      severity: warning

--- a/config/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
@@ -1,0 +1,27 @@
+groups:
+- name: kubermatic
+  rules:
+  - alert: KubermaticAPIDown
+    annotations:
+      message: KubermaticAPI has disappeared from Prometheus target discovery.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapidown
+    expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+    runbook:
+      steps:
+      - Check the Prometheus Service Discovery page to find out why the target is unreachable.
+      - Ensure that the API pod's logs and that it is not crashlooping.
+
+  - alert: KubermaticAPITooManyErrors
+    annotations:
+      message: Kubermatic API is returning a high rate of HTTP 5xx responses.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapitoomanyerrors
+    expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) > 0.1
+    for: 15m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check the API pod's logs.

--- a/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -29,19 +29,6 @@ groups:
       - If all resources have been cleaned up, remove the blocking finalizer (e.g. `kubermatic.io/delete-nodes`) from the cluster resource.
       - If nothing else helps, manually delete the cluster namespace as a last resort.
 
-  - alert: KubermaticAPIDown
-    annotations:
-      message: KubermaticAPI has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapidown
-    expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
-    for: 15m
-    labels:
-      severity: critical
-    runbook:
-      steps:
-      - Check the Prometheus Service Discovery page to find out why the target is unreachable.
-      - Ensure that the API pod's logs and that it is not crashlooping.
-
   - alert: KubermaticControllerManagerDown
     annotations:
       message: KubermaticControllerManager has disappeared from Prometheus target discovery.
@@ -54,15 +41,3 @@ groups:
       steps:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.
       - Ensure that the controller-manager pod's logs and that it is not crashlooping.
-
-  - alert: KubermaticAPITooManyErrors
-    annotations:
-      message: Kubermatic API is returning a high rate of HTTP 5xx responses.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapitoomanyerrors
-    expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) > 0.1
-    for: 15m
-    labels:
-      severity: warning
-    runbook:
-      steps:
-      - Check the API pod's logs.

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -41,7 +41,8 @@ prometheus:
   # effectively disable the stock recordings and alerts.
   ruleFiles:
   - /etc/prometheus/rules/general-*.yaml
-  - /etc/prometheus/rules/kubermatic-*.yaml
+  - /etc/prometheus/rules/kubermatic-master-*.yaml
+  - /etc/prometheus/rules/kubermatic-seed-*.yaml
   # If you run in an environment where access to Kubernetes
   # scheduler and controller-manager is not possible (like GKE),
   # disable the expression below to not create false alerts


### PR DESCRIPTION
**What this PR does / why we need it**:
The Kubermatic chart now allows to not deploy master components, so we need to make sure that there are no false positive alerts being fired all the time.

Existing installations will continue to work because their `kubermatic-*.yaml` expression in the values.yaml will match both new alert YAML files.

**Which issue(s) this PR fixes**:
Fixes #2861 

**Release note**:
```release-note
NONE
```
