### PR TITLE
Use downstream triple package

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1518,7 +1518,7 @@
 
 [[projects]]
   branch = "release-8.0"
-  digest = "1:2727b9d70b14b584e8cf384a4e7b07a876cbab839893e3aaa5715c6daa4e06ce"
+  digest = "1:2233904b75340fd684969376c7c3ffd1b90d1caf3c5494d53828deb658467bf6"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1675,7 +1675,6 @@
     "transport",
     "util/buffer",
     "util/cert",
-    "util/cert/triple",
     "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
@@ -1975,7 +1974,6 @@
     "k8s.io/client-go/tools/metrics",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/cert",
-    "k8s.io/client-go/util/cert/triple",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/homedir",
     "k8s.io/client-go/util/retry",

--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -21,6 +21,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	"k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -41,7 +42,6 @@ import (
 	listersbatchv1beta1 "k8s.io/client-go/listers/batch/v1beta1"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/cert/triple"
 	"k8s.io/client-go/util/workqueue"
 )
 

--- a/api/pkg/controller/openshift/data.go
+++ b/api/pkg/controller/openshift/data.go
@@ -10,11 +10,11 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	kubernetesresources "github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/cert/triple"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/api/pkg/controller/openshift/resources/interfaces.go
+++ b/api/pkg/controller/openshift/resources/interfaces.go
@@ -7,10 +7,10 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/cert/triple"
 )
 
 // Openshift data contains all data required for Openshift control plane components

--- a/api/pkg/controller/openshift/resources/loopback_kubeconfig.go
+++ b/api/pkg/controller/openshift/resources/loopback_kubeconfig.go
@@ -6,11 +6,11 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	"github.com/golang/glog"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/util/cert/triple"
 )
 
 const apiserverLoopbackKubeconfigName = "apiserver-loopback-kubeconfig"

--- a/api/pkg/resources/certificates/client-certificate.go
+++ b/api/pkg/resources/certificates/client-certificate.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	corev1 "k8s.io/api/core/v1"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/cert/triple"
 )
 
 type caGetter func() (*triple.KeyPair, error)

--- a/api/pkg/resources/certificates/root-ca.go
+++ b/api/pkg/resources/certificates/root-ca.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	corev1 "k8s.io/api/core/v1"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/cert/triple"
 )
 
 // GetCACreator returns a function to create a secret containing a CA with the specified name

--- a/api/pkg/resources/certificates/triple/triple.go
+++ b/api/pkg/resources/certificates/triple/triple.go
@@ -1,13 +1,10 @@
 /*
 Copyright 2016 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
+ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -11,12 +11,12 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1lister "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/util/cert/triple"
 )
 
 // TemplateData is a group of data required for template generation

--- a/api/pkg/resources/kubeconfig.go
+++ b/api/pkg/resources/kubeconfig.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	"github.com/golang/glog"
 
@@ -13,7 +14,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/cert/triple"
 )
 
 type adminKubeconfigCreatorData interface {

--- a/api/pkg/resources/kubeconfig_test.go
+++ b/api/pkg/resources/kubeconfig_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/cert/triple"
 )
 
 func TestGetBaseKubeconfig(t *testing.T) {

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -6,6 +6,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/cert/triple"
 )
 
 var (

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	"github.com/golang/glog"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/cert/triple"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 )
 


### PR DESCRIPTION
Upstream removed the triple package[0], in order to be able to upgrade
client-go we need to have a downsream version.

[0] https://github.com/kubernetes/kubernetes/pull/70966

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
