### PR TITLE
add elasticsearch lifecycle hooks

### DIFF
--- a/config/logging/elasticsearch/config/elasticsearch/post-start.sh
+++ b/config/logging/elasticsearch/config/elasticsearch/post-start.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Following best practices from https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html
+
+# Wait until the node joined the cluster again
+until [[ "$(curl --silent --show-error --connect-timeout 1 -H 'Content-Type: application/json' -X GET http://${POD_IP}:9200/_cat/nodes | grep ${POD_IP})" ]];
+do
+  echo "Node has not joined the cluster"
+  sleep 1
+done
+
+# Enable shard allocation
+curl --retry 10 --retry-delay 1 -X PUT "${POD_IP}:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
+{
+  "persistent": {
+    "cluster.routing.allocation.enable": null
+  }
+}
+'

--- a/config/logging/elasticsearch/config/elasticsearch/pre-stop.sh
+++ b/config/logging/elasticsearch/config/elasticsearch/pre-stop.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Following best practices from https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html
+
+# Disable shard allocation
+curl --retry 10 --retry-delay 1 -X PUT "${POD_IP}:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
+{
+  "persistent": {
+    "cluster.routing.allocation.enable": "none"
+  }
+}
+'
+
+# Execute a synced flush
+curl --retry 10 --retry-delay 1 -X POST "${POD_IP}:9200/_flush/synced"

--- a/config/logging/elasticsearch/templates/es-data-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-data-stateful.yaml
@@ -17,6 +17,8 @@ spec:
       role: data
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/es-config-configmap.yaml") . | sha256sum }}
       labels:
         component: elasticsearch
         role: data
@@ -60,6 +62,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: NODE_MASTER
               value: "false"
             - name: NODE_INGEST
@@ -81,9 +87,19 @@ spec:
           readinessProbe:
             tcpSocket:
               port: transport
-            initialDelaySeconds: 120
             timeoutSeconds: 10
             periodSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - /pre-stop.sh
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - /post-start.sh
           resources:
             requests:
               cpu: 200m
@@ -97,6 +113,12 @@ spec:
             - name: config
               mountPath: /usr/share/elasticsearch/config/jvm.options
               subPath: jvm.options
+            - name: config
+              mountPath: /post-start.sh
+              subPath: post-start.sh
+            - name: config
+              mountPath: /pre-stop.sh
+              subPath: pre-stop.sh
       volumes:
         - name: config
           configMap:

--- a/config/logging/elasticsearch/templates/es-master-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-master-stateful.yaml
@@ -17,6 +17,8 @@ spec:
       role: master
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/es-config-configmap.yaml") . | sha256sum }}
       labels:
         component: elasticsearch
         role: master
@@ -60,6 +62,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: NODE_MASTER
               value: "true"
             - name: NODE_INGEST
@@ -83,9 +89,19 @@ spec:
           readinessProbe:
             tcpSocket:
               port: transport
-            initialDelaySeconds: 120
             timeoutSeconds: 10
             periodSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - /pre-stop.sh
+            postStart:
+              exec:
+                command:
+                - /bin/bash
+                - /post-start.sh
           resources:
             requests:
               cpu: 75m
@@ -99,6 +115,12 @@ spec:
             - name: config
               mountPath: /usr/share/elasticsearch/config/jvm.options
               subPath: jvm.options
+            - name: config
+              mountPath: /post-start.sh
+              subPath: post-start.sh
+            - name: config
+              mountPath: /pre-stop.sh
+              subPath: pre-stop.sh
       volumes:
         - name: config
           configMap:
@@ -111,4 +133,4 @@ spec:
         accessModes: [ ReadWriteOnce ]
         resources:
           requests:
-            storage: 1Gi
+            storage: {{ .Values.logging.elasticsearch.masterStorageSize }}

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -3,6 +3,7 @@ logging:
     dataReplicas: 5
     masterReplicas: 4
     storageSize: 10Gi
+    masterStorageSize: 1Gi
     image:
       repository: docker.elastic.co/elasticsearch/elasticsearch
       tag: "6.5.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This follows the best practices described in the ES docs: https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html

Instead of moving data, this just deactivates the shard allocation, which should be enough for our use case.

**Release note**:
```release-note
Add lifecycle hooks to the Elasticsearch StatefulSet
```
