### PR TITLE
Conformance tests: Enable monitor mode

### DIFF
--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
 
 export BUILD_ID=${BUILD_ID:-BUILD_ID_UNDEF}
 echodate() { echo "$(date) $@"; }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes cleanup when the job receives a signal:

```
$ cat test.sh 
#!/bin/bash

set -o monitor

trap 'echo FOO' EXIT
echo "sleeping"
sleep 1000

$ docker run --rm -v $PWD:/script -e ENTRYPOINT_OPTIONS='{"args":["/script/test.sh"],"process_log":"/log","marker_file":"/marker"}' gcr.io/k8s-prow/entrypoint:v20190301-1278de5-with-bash /entrypoint
sleeping
{"component":"entrypoint","level":"error","msg":"Entrypoint received interrupt: terminated","time":"2019-03-06T21:13:02Z"}
FOO
{"component":"entrypoint","level":"error","msg":"Process did not exit before 15s grace period","time":"2019-03-06T21:13:17Z"}
{"component":"entrypoint","error":"os: process already finished","level":"error","msg":"Could not kill process after grace period","time":"2019-03-06T21:13:17Z"}
{"component":"entrypoint","error":"process aborted","level":"error","msg":"Error executing test process","time":"2019-03-06T21:13:17Z"}

vs

$ cat test.sh 
#!/bin/bash

#set -o monitor

trap 'echo FOO' EXIT
echo "sleeping"
sleep 1000

$ docker run --rm -v $PWD:/script -e ENTRYPOINT_OPTIONS='{"args":["/script/test.sh"],"process_log":"/log","marker_file":"/marker"}' gcr.io/k8s-prow/entrypoint:v20190301-1278de5-with-bash /entrypoint
sleeping
{"component":"entrypoint","level":"error","msg":"Entrypoint received interrupt: terminated","time":"2019-03-06T21:27:58Z"}
{"component":"entrypoint","level":"error","msg":"Process did not exit before 15s grace period","time":"2019-03-06T21:28:13Z"}
{"component":"entrypoint","error":"process aborted","level":"error","msg":"Error executing test process","time":"2019-03-06T21:28:13Z"}
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
