### PR TITLE
Wait for cloud infra before attempting to render the cloud-config

### DIFF
--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -52,6 +52,10 @@ func (cc *Controller) ensureResourcesAreDeployed(cluster *kubermaticv1.Cluster) 
 
 	// Wait until the cloud provider infra is ready before attempting
 	// to render the cloud-config
+	// TODO: Model resource deployment as a DAG so we don't need hacks
+	// like this combined with tribal knowledge and "someone is noticing this
+	// isn't working correctly"
+	// https://github.com/kubermatic/kubermatic/issues/2948
 	if !cluster.Status.Health.CloudProviderInfrastructure {
 		cc.enqueueAfter(cluster, 1*time.Second)
 		return nil


### PR DESCRIPTION

**What this PR does / why we need it**:

Currently we often times create a cloud-config before the cloud-provider infrastructure is ready, resulting in the cloud-config getting updated shortly after and the apiserver & controller-manager to start off with two different replicasets with one pod each, because no pod is ready yet because they are blocked on etcd startup/apiserver startup.

With this change we wont create the cloud-config before the cloud-provider infrastructure is ready, making sure at the point in time where we create the apiserver & controller manager deployments an up-to-date cloud-config based on the ready infrastructure is available.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
