### PR TITLE
Fix openshift networking config

### DIFF
--- a/api/pkg/controller/openshift/resources/apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/apiserver_deployment.go
@@ -122,12 +122,10 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) (string, reso
 			return nil, fmt.Errorf("failed to get openvpn-client sidecar: %v", err)
 		}
 
-		// TODO: This breaks the apiserver->kubelet connection for logs/exec. Why? It _looks_
-		// like it is working correctly
-		//	dnatControllerSidecar, err := vpnsidecar.DnatControllerContainer(data, "dnat-controller")
-		//	if err != nil {
-		//		return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
-		//	}
+		dnatControllerSidecar, err := vpnsidecar.DnatControllerContainer(data, "dnat-controller")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
+		}
 
 		resourceRequirements := apiServerDefaultResourceRequirements.DeepCopy()
 		if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
@@ -136,7 +134,7 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) (string, reso
 
 		dep.Spec.Template.Spec.Containers = []corev1.Container{
 			*openvpnSidecar,
-			//*dnatControllerSidecar,
+			*dnatControllerSidecar,
 			{
 				Name:                     ApiserverDeploymentName,
 				Image:                    data.ImageRegistry(resources.RegistryDocker) + "/openshift/origin-control-plane:v3.11",

--- a/api/pkg/controller/openshift/resources/controlplane_configmap.go
+++ b/api/pkg/controller/openshift/resources/controlplane_configmap.go
@@ -259,7 +259,6 @@ kubernetesMasterConfig:
     - /etc/origin/master/recycler_pod.yaml
   # For some reason this field results in an error: Encountered config error json: unknown field "masterCount" in object *config.MasterConfig, raw JSON:
   #masterCount: 1
-  #TODO: Should we put something here?
   masterIP: "{{ .MasterIP }}"
   podEvictionTimeout: null
 {{ if eq .ControlPlaneType "apiserver" }}

--- a/api/pkg/controller/openshift/resources/controlplane_configmap.go
+++ b/api/pkg/controller/openshift/resources/controlplane_configmap.go
@@ -69,6 +69,7 @@ type openshiftConfigInput struct {
 	DNSDomain        string
 	ListenPort       string
 	ControlPlaneType string
+	MasterIP         string
 }
 
 func getMasterConfig(ctx context.Context, data openshiftData, controlPlaneType string) (string, error) {
@@ -89,6 +90,7 @@ func getMasterConfig(ctx context.Context, data openshiftData, controlPlaneType s
 		DNSDomain:        data.Cluster().Spec.ClusterNetwork.DNSDomain,
 		ListenPort:       fmt.Sprintf("%d", apiserverListenPort),
 		ControlPlaneType: controlPlaneType,
+		MasterIP:         data.Cluster().Address.IP,
 	}
 	if err := tmpl.Execute(&controlPlaneConfigBuffer, templateInput); err != nil {
 		return "", fmt.Errorf("failed to execute template: %v", err)
@@ -258,7 +260,7 @@ kubernetesMasterConfig:
   # For some reason this field results in an error: Encountered config error json: unknown field "masterCount" in object *config.MasterConfig, raw JSON:
   #masterCount: 1
   #TODO: Should we put something here?
-  masterIP: ""
+  masterIP: "{{ .MasterIP }}"
   podEvictionTimeout: null
 {{ if eq .ControlPlaneType "apiserver" }}
   proxyClientInfo:


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the `kubernetes.default` service for openshift, hence allowing its kube-proxy equivalent that is run within the `sdn` DaemonSet in the `openshift-infra` namespace to connect to the API and properly publish services

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```