### PR TITLE
Blackbox-Exporter

### DIFF
--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -20,7 +20,7 @@ export INSTALLER_BRANCH="$(git branch --contains HEAD --all \
   |tr -d ' '|grep -E 'remotes/origin/release/v2.[0-9]+$'|cut -d '/' -f3-)"
 
 export CHARTS='kubermatic cert-manager certs nginx-ingress-controller nodeport-proxy oauth minio iap'
-export MONITORING_CHARTS='alertmanager grafana kube-state-metrics node-exporter prometheus'
+export MONITORING_CHARTS='alertmanager blackbox-exporter grafana kube-state-metrics node-exporter prometheus'
 export LOGGING_CHARTS='elasticsearch kibana fluentbit'
 export BACKUP_CHARTS='ark ark-config'
 export CHARTS_DIR=$(pwd)/config

--- a/config/monitoring/blackbox-exporter/Chart.yaml
+++ b/config/monitoring/blackbox-exporter/Chart.yaml
@@ -1,0 +1,3 @@
+name: blackbox-exporter
+version: 1.0.0
+description: Deploys the Prometheus Blackbox Exporter

--- a/config/monitoring/blackbox-exporter/templates/configmap.yaml
+++ b/config/monitoring/blackbox-exporter/templates/configmap.yaml
@@ -5,11 +5,4 @@ metadata:
 data:
   config.yml: |
     modules:
-      https_2xx:
-        prober: http
-        timeout: 5s
-        http:
-          method: GET
-          valid_http_versions: ["HTTP/1.1", "HTTP/2"]
-          fail_if_not_ssl: true
-          preferred_ip_protocol: "ip4"
+{{ .Values.blackboxExporter.modules | toYaml | indent 6 }}

--- a/config/monitoring/blackbox-exporter/templates/configmap.yaml
+++ b/config/monitoring/blackbox-exporter/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-config
+data:
+  config.yml: |
+    modules:
+      https_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          method: GET
+          valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+          fail_if_not_ssl: true
+          preferred_ip_protocol: "ip4"

--- a/config/monitoring/blackbox-exporter/templates/deployment.yaml
+++ b/config/monitoring/blackbox-exporter/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter
+      annotations:
+        kubermatic/scrape: "true"
+        kubermatic/scrape_port: "9115"
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+      - name: exporter
+        image: '{{ .Values.blackboxExporter.image.repository }}:{{ .Values.blackboxExporter.image.tag }}'
+        imagePullPolicy: {{ .Values.blackboxExporter.image.pullPolicy }}
+        ports:
+        - containerPort: 9115
+          name: web
+        volumeMounts:
+        - name: config
+          mountPath: /etc/blackbox_exporter
+        resources:
+{{ toYaml .Values.blackboxExporter.containers.blackboxExporter.resources | indent 10 }}
+      volumes:
+      - name: config
+        configMap:
+          name: blackbox-exporter-config

--- a/config/monitoring/blackbox-exporter/templates/service.yaml
+++ b/config/monitoring/blackbox-exporter/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: blackbox-exporter
+  name: blackbox-exporter
+spec:
+  ports:
+  - name: web
+    port: 9115
+    targetPort: web
+  selector:
+    app: blackbox-exporter

--- a/config/monitoring/blackbox-exporter/values.yaml
+++ b/config/monitoring/blackbox-exporter/values.yaml
@@ -13,3 +13,14 @@ blackboxExporter:
         requests:
           cpu: 20m
           memory: 25Mi
+
+  modules:
+    # A module that requires HTTPS and HTTP 2xx codes on its targets.
+    https_2xx:
+      prober: http
+      timeout: 5s
+      http:
+        method: GET
+        valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+        fail_if_not_ssl: true
+        preferred_ip_protocol: "ip4"

--- a/config/monitoring/blackbox-exporter/values.yaml
+++ b/config/monitoring/blackbox-exporter/values.yaml
@@ -1,0 +1,15 @@
+blackboxExporter:
+  image:
+    repository: prom/blackbox-exporter
+    tag: v0.14.0
+    pullPolicy: IfNotPresent
+
+  containers:
+    blackboxExporter:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 50Mi
+        requests:
+          cpu: 20m
+          memory: 25Mi

--- a/config/monitoring/prometheus/rules/general-blackbox-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-blackbox-exporter.yaml
@@ -1,0 +1,35 @@
+# This file has been generated, do not edit.
+groups:
+- name: blackbox-exporter
+  rules:
+  - alert: HttpProbeFailed
+    annotations:
+      message: Probing the blackbox-exporter target {{ $labels.instance }} failed.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpprobefailed
+    expr: probe_success != 1
+    for: 5m
+    labels:
+      severity: warning
+  - alert: HttpProbeSlow
+    annotations:
+      message: '{{ $labels.instance }} takes {{ $value }} seconds to respond.'
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpprobeslow
+    expr: sum by (instance) (probe_http_duration_seconds) > 3
+    for: 15m
+    labels:
+      severity: warning
+  - alert: HttpCertExpiresSoon
+    annotations:
+      message: The certificate for {{ $labels.instance }} expires in less than 3 days.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpcertexpiressoon
+    expr: probe_ssl_earliest_cert_expiry - time() < 3*24*3600
+    labels:
+      severity: warning
+  - alert: HttpCertExpiresVerySoon
+    annotations:
+      message: The certificate for {{ $labels.instance }} expires in less than 24
+        hours.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpcertexpiresverysoon
+    expr: probe_ssl_earliest_cert_expiry - time() < 24*3600
+    labels:
+      severity: critical

--- a/config/monitoring/prometheus/rules/src/general/blackbox-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/blackbox-exporter.yaml
@@ -1,0 +1,40 @@
+groups:
+- name: blackbox-exporter
+  rules:
+  - alert: HttpProbeFailed
+    annotations:
+      message: Probing the blackbox-exporter target {{ $labels.instance }} failed.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpprobefailed
+    expr: probe_success != 1
+    for: 5m
+    labels:
+      severity: warning
+
+  - alert: HttpProbeSlow
+    annotations:
+      message: '{{ $labels.instance }} takes {{ $value }} seconds to respond.'
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpprobeslow
+    expr: sum by (instance) (probe_http_duration_seconds) > 3
+    for: 15m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check the target system's resource usage for anomalias.
+      - Check if the target application has been recently rescheduled and is still settling.
+
+  - alert: HttpCertExpiresSoon
+    annotations:
+      message: The certificate for {{ $labels.instance }} expires in less than 3 days.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpcertexpiressoon
+    expr: probe_ssl_earliest_cert_expiry - time() < 3*24*3600
+    labels:
+      severity: warning
+
+  - alert: HttpCertExpiresVerySoon
+    annotations:
+      message: The certificate for {{ $labels.instance }} expires in less than 24 hours.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpcertexpiresverysoon
+    expr: probe_ssl_earliest_cert_expiry - time() < 24*3600
+    labels:
+      severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding the exporter chart allows us to easily monitor external reachability of ingresses. To not force it on customers, we will keep the actual probe configuration in our values.yaml (i.e. specify it in the values.yaml unter `prometheus.scraping.configs`). The newly defined alerts should not fire if the exporter is not installed.

Since the new chart is so simple, we will publish it in our installer distribution.

**Release note**:
```release-note
add blackbox-exporter chart
```
