### PR TITLE
do not send pod annotations via fluentbit to elasticsearch

### DIFF
--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -39,6 +39,7 @@ data:
         Kube_URL            https://kubernetes.default.svc.cluster.local:443
         Merge_Log           On
         K8S-Logging.Parser  On
+        Annotations         Off
 
   outputs.conf: |
 {{- range .Values.logging.fluentbit.configuration.outputs }}

--- a/config/logging/fluentbit/templates/fluent-bit-ds.yaml
+++ b/config/logging/fluentbit/templates/fluent-bit-ds.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "2020"
         prometheus.io/path: /api/v1/metrics/prometheus
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - name: fluent-bit


### PR DESCRIPTION
**What this PR does / why we need it**:
Annotations do not provide much value when viewing logs in Kibana, but what they do is clutter the UI and blow up the index disk usage noticibly. Let's disable sending annotations at all, saving us the hassle to define Elasticsearch Mapping settings.

**Release note**:
```release-note
pod annotations are no longer logged in Elasticsearch
```
