### PR TITLE
fix kibana's empty configmap

### DIFF
--- a/config/logging/kibana/templates/configmap.yaml
+++ b/config/logging/kibana/templates/configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: kibana-config
 data:
-  {{- (.Files.Glob "config/kibana/*").AsConfig | nindent 2 }}
+  {{- (.Files.Glob "config/*").AsConfig | nindent 2 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
I made a typo when copying the script stuff from Elasticsearch. This fixes the empty configmap, which made kibana not start anymore.

**Release note**:
```release-note
NONE
```
