### PR TITLE
add missing permissions to the kube-state-metrics ClusterRole

### DIFF
--- a/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kube-state-metrics
@@ -23,9 +23,13 @@ rules:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
   resources:
+  - daemonsets
+  - deployments
+  - replicasets
   - statefulsets
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]
@@ -37,11 +41,7 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
-- apiGroups: ["authentication.k8s.io"]
+- apiGroups: ["policy"]
   resources:
-  - tokenreviews
-  verbs: ["create"]
-- apiGroups: ["authorization.k8s.io"]
-  resources:
-  - subjectaccessreviews
-  verbs: ["create"]
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing permissions to the kube-state-metrics ClusterRole.

**Release note**:
```release-note
Missing permissions have been added to the kube-state-metrics ClusterRole
```
