### PR TITLE
fix image tag of the conformance tests image

### DIFF
--- a/containers/conformance-tests/release.sh
+++ b/containers/conformance-tests/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=v0.7-alpha1
+TAG=v0.7
 
 set -euox pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix image tag of the conformance tests image

**Release note**:
```release-note
NONE
```
