### PR TITLE
Fix apiserver init check

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -109,7 +109,8 @@ func DeploymentCreator(data resources.DeploymentDataProvider) resources.Deployme
 				Command: []string{
 					"/bin/sh",
 					"-ec",
-					fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' endpoint health; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
+					// Write a key to etcd. If we have quorum it will succeed.
+					fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
 				},
 				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 				TerminationMessagePolicy: corev1.TerminationMessageReadFile,

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -305,7 +305,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -305,7 +305,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -303,7 +303,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -303,7 +303,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -303,7 +303,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -303,7 +303,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -296,7 +296,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -296,7 +296,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -292,7 +292,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -292,7 +292,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -290,7 +290,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -290,7 +290,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -290,7 +290,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -290,7 +290,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -292,7 +292,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -292,7 +292,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -290,7 +290,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -290,7 +290,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -290,7 +290,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -290,7 +290,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -296,7 +296,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -296,7 +296,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -296,7 +296,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -296,7 +296,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -294,7 +294,8 @@ spec:
         - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
           --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
-          endpoint health; do echo waiting for etcd; sleep 2; done;
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
         image: gcr.io/etcd-development/etcd:v3.3.9
         imagePullPolicy: IfNotPresent
         name: etcd-running


### PR DESCRIPTION
**What this PR does / why we need it**:
This replaces the `etcdctl endpoint health` with a `etcdctl put quorum-check something`.

The difference is that `etcdctl endpoint health` checks if all specified endpoints are healthy - in our case 3. This can lead to downtime of the API server if only 1 etcd is down.

`etcdctl put quorum-check something` Does a simple write to etcd. If it succeeds we have a quorum and know that the API server can start.

**Release note**:
```release-note
Ensure that the API server init container only waits for etcd quorum and not all members.
```
