### PR TITLE
moves kubeconfig files to cluster pkg

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -37,6 +37,7 @@ import (
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
 	"github.com/kubermatic/kubermatic/api/pkg/handler"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/auth"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/metrics"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud"
@@ -222,7 +223,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcAuthenticato
 	r.RegisterV1(v1Router)
 	r.RegisterV1Optional(v1Router,
 		options.featureGates.Enabled(OIDCKubeCfgEndpoint),
-		handler.OIDCConfiguration{
+		common.OIDCConfiguration{
 			URL:                  options.oidcURL,
 			ClientID:             options.oidcIssuerClientID,
 			ClientSecret:         options.oidcIssuerClientSecret,

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -910,9 +910,9 @@ func (r Routing) getClusterKubeconfig() http.Handler {
 			middleware.UserSaver(r.userProvider),
 			middleware.Datacenter(r.clusterProviders, r.datacenters),
 			middleware.UserInfo(r.userProjectMapper),
-		)(getClusterKubeconfig(r.projectProvider)),
-		decodeGetClusterKubeconfig,
-		encodeKubeconfig,
+		)(cluster.GetAdminKubeconfigEndpoint(r.projectProvider)),
+		cluster.DecodeGetAdminKubeconfig,
+		cluster.EncodeKubeconfig,
 		r.defaultServerOptions()...,
 	)
 }

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/handler"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/auth"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
@@ -58,8 +59,8 @@ func NewTestRouting(
 }
 
 // generateDefaultOicdCfg creates test configuration for OpenID clients
-func generateDefaultOicdCfg() *handler.OIDCConfiguration {
-	return &handler.OIDCConfiguration{
+func generateDefaultOicdCfg() *common.OIDCConfiguration {
+	return &common.OIDCConfiguration{
 		URL:                  test.IssuerURL,
 		ClientID:             test.IssuerClientID,
 		ClientSecret:         test.IssuerClientSecret,

--- a/api/pkg/handler/v1/cluster/kubeconfig_test.go
+++ b/api/pkg/handler/v1/cluster/kubeconfig_test.go
@@ -1,4 +1,4 @@
-package handler_test
+package cluster_test
 
 import (
 	"encoding/base64"
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/handler"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/cluster"
 
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -221,7 +221,7 @@ func genTestKubeconfigKubermaticObjects() []runtime.Object {
 	}
 }
 
-func marshalEncodeState(oidcState handler.State) (string, error) {
+func marshalEncodeState(oidcState cluster.OIDCState) (string, error) {
 
 	rawState, err := json.Marshal(oidcState)
 	if err != nil {
@@ -232,10 +232,10 @@ func marshalEncodeState(oidcState handler.State) (string, error) {
 
 }
 
-func unmarshalState(rawState []byte) (handler.State, error) {
-	oidcState := handler.State{}
+func unmarshalState(rawState []byte) (cluster.OIDCState, error) {
+	oidcState := cluster.OIDCState{}
 	if err := json.Unmarshal(rawState, &oidcState); err != nil {
-		return handler.State{}, err
+		return cluster.OIDCState{}, err
 	}
 	return oidcState, nil
 }

--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -1,0 +1,20 @@
+package common
+
+// OIDCConfiguration is a struct that holds
+// OIDC provider configuration data, read from command line arguments
+type OIDCConfiguration struct {
+	// URL holds OIDC Issuer URL address
+	URL string
+	// ClientID holds OIDC ClientID
+	ClientID string
+	// ClientSecret holds OIDC ClientSecret
+	ClientSecret string
+	// CookieHashKey is required, used to authenticate the cookie value using HMAC
+	// It is recommended to use a key with 32 or 64 bytes.
+	CookieHashKey string
+	// CookieSecureMode if true then cookie received only with HTTPS otherwise with HTTP.
+	CookieSecureMode bool
+	// OfflineAccessAsScope if true then "offline_access" scope will be used
+	// otherwise 'access_type=offline" query param will be passed
+	OfflineAccessAsScope bool
+}


### PR DESCRIPTION
**What this PR does / why we need it**: simply move `kubeconfig` files to `cluster` pkg

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
