### PR TITLE
adds InformerProvider for RBAC Controller

### DIFF
--- a/api/cmd/rbac-generator/main.go
+++ b/api/cmd/rbac-generator/main.go
@@ -113,17 +113,17 @@ func main() {
 				glog.Fatal(err)
 			}
 
-			kubeInformerFactory := kuberinformers.NewSharedInformerFactory(kubeClient, time.Minute*5)
 			kubermaticClient := kubermaticclientset.NewForConfigOrDie(cfg)
 			kubermaticInformerFactory := externalversions.NewFilteredSharedInformerFactory(kubermaticClient, time.Minute*5, metav1.NamespaceAll, selector)
-			ctrlCtx.allClusterProviders = append(ctrlCtx.allClusterProviders, rbaccontroller.NewClusterProvider(fmt.Sprintf("%s/%s", clusterPrefix, ctxName), kubeClient, kubeInformerFactory, kubermaticClient, kubermaticInformerFactory))
+			kubeInformerProvider := rbaccontroller.NewInformerProvider(kubeClient, time.Minute*5)
+			ctrlCtx.allClusterProviders = append(ctrlCtx.allClusterProviders, rbaccontroller.NewClusterProvider(fmt.Sprintf("%s/%s", clusterPrefix, ctxName), kubeClient, kubeInformerProvider, kubermaticClient, kubermaticInformerFactory))
 
 			// special case the current context/master is also a seed cluster
 			// we keep cluster resources also on master
 			if ctxName == clientcmdConfig.CurrentContext {
 				glog.V(2).Infof("Special case adding %s (current context) also as seed cluster", ctxName)
 				clusterPrefix = rbaccontroller.SeedProviderPrefix
-				ctrlCtx.allClusterProviders = append(ctrlCtx.allClusterProviders, rbaccontroller.NewClusterProvider(fmt.Sprintf("%s/%s", clusterPrefix, ctxName), kubeClient, kubeInformerFactory, kubermaticClient, kubermaticInformerFactory))
+				ctrlCtx.allClusterProviders = append(ctrlCtx.allClusterProviders, rbaccontroller.NewClusterProvider(fmt.Sprintf("%s/%s", clusterPrefix, ctxName), kubeClient, kubeInformerProvider, kubermaticClient, kubermaticInformerFactory))
 			}
 		}
 	}

--- a/api/pkg/controller/rbac/fake/informer_factory.go
+++ b/api/pkg/controller/rbac/fake/informer_factory.go
@@ -9,26 +9,26 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-type fakeSharedInformerFactory struct {
+type SharedInformerFactory struct {
 	kubeinformers.SharedInformerFactory
 }
 
 // NewFakeSharedInformerFactory returns a new factory
-func NewFakeSharedInformerFactory(kubeClient kubernetes.Interface, namespace string) *fakeSharedInformerFactory {
+func NewFakeSharedInformerFactory(kubeClient kubernetes.Interface, namespace string) *SharedInformerFactory {
 	f := kubeinformers.NewFilteredSharedInformerFactory(kubeClient, time.Minute*5, namespace, nil)
-	factory := &fakeSharedInformerFactory{SharedInformerFactory: f}
+	factory := &SharedInformerFactory{SharedInformerFactory: f}
 	return factory
 }
 
 // AddFakeClusterRoleInformer adds a dummy informer that returns items from clusterRoleIndexer
-func (f *fakeSharedInformerFactory) AddFakeClusterRoleInformer(clusterRoleIndexer cache.Indexer) {
+func (f *SharedInformerFactory) AddFakeClusterRoleInformer(clusterRoleIndexer cache.Indexer) {
 	f.InformerFor(&rbacv1.ClusterRole{}, func(fakeKubeClient kubernetes.Interface, resync time.Duration) cache.SharedIndexInformer {
 		return &dummySharedIndexInformer{indexer: clusterRoleIndexer}
 	})
 }
 
 // AddFakeClusterRoleBindingInformer adds a dummy informer that returns items from clusterRoleBindingIndexer
-func (f *fakeSharedInformerFactory) AddFakeClusterRoleBindingInformer(clusterRoleBindingIndexer cache.Indexer) {
+func (f *SharedInformerFactory) AddFakeClusterRoleBindingInformer(clusterRoleBindingIndexer cache.Indexer) {
 	f.InformerFor(&rbacv1.ClusterRoleBinding{}, func(fakeKubeClient kubernetes.Interface, resync time.Duration) cache.SharedIndexInformer {
 		return &dummySharedIndexInformer{indexer: clusterRoleBindingIndexer}
 	})

--- a/api/pkg/controller/rbac/fake/informer_factory.go
+++ b/api/pkg/controller/rbac/fake/informer_factory.go
@@ -1,0 +1,75 @@
+package fake
+
+import (
+	"time"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type fakeSharedInformerFactory struct {
+	kubeinformers.SharedInformerFactory
+}
+
+// NewFakeSharedInformerFactory returns a new factory
+func NewFakeSharedInformerFactory(kubeClient kubernetes.Interface, namespace string) *fakeSharedInformerFactory {
+	f := kubeinformers.NewFilteredSharedInformerFactory(kubeClient, time.Minute*5, namespace, nil)
+	factory := &fakeSharedInformerFactory{SharedInformerFactory: f}
+	return factory
+}
+
+// AddFakeClusterRoleInformer adds a dummy informer that returns items from clusterRoleIndexer
+func (f *fakeSharedInformerFactory) AddFakeClusterRoleInformer(clusterRoleIndexer cache.Indexer) {
+	f.InformerFor(&rbacv1.ClusterRole{}, func(fakeKubeClient kubernetes.Interface, resync time.Duration) cache.SharedIndexInformer {
+		return &dummySharedIndexInformer{indexer: clusterRoleIndexer}
+	})
+}
+
+// AddFakeClusterRoleBindingInformer adds a dummy informer that returns items from clusterRoleBindingIndexer
+func (f *fakeSharedInformerFactory) AddFakeClusterRoleBindingInformer(clusterRoleBindingIndexer cache.Indexer) {
+	f.InformerFor(&rbacv1.ClusterRoleBinding{}, func(fakeKubeClient kubernetes.Interface, resync time.Duration) cache.SharedIndexInformer {
+		return &dummySharedIndexInformer{indexer: clusterRoleBindingIndexer}
+	})
+}
+
+type dummySharedIndexInformer struct {
+	indexer cache.Indexer
+}
+
+func (i *dummySharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	panic("implement me")
+}
+
+func (i *dummySharedIndexInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	panic("implement me")
+}
+
+func (i *dummySharedIndexInformer) GetStore() cache.Store {
+	panic("implement me")
+}
+
+func (i *dummySharedIndexInformer) GetController() cache.Controller {
+	panic("implement me")
+}
+
+func (i *dummySharedIndexInformer) Run(stopCh <-chan struct{}) {
+	panic("implement me")
+}
+
+func (i *dummySharedIndexInformer) HasSynced() bool {
+	panic("implement me")
+}
+
+func (i *dummySharedIndexInformer) LastSyncResourceVersion() string {
+	panic("implement me")
+}
+
+func (i *dummySharedIndexInformer) AddIndexers(indexers cache.Indexers) error {
+	panic("implement me")
+}
+
+func (i *dummySharedIndexInformer) GetIndexer() cache.Indexer {
+	return i.indexer
+}

--- a/api/pkg/controller/rbac/informer_provider.go
+++ b/api/pkg/controller/rbac/informer_provider.go
@@ -1,0 +1,79 @@
+package rbac
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+// InformerProvider allows for storing shared informer factories for the given namespaces
+// additionally it provides method for starting and waiting for all registered factories
+type InformerProvider interface {
+	// KubeInformerFactoryFor registeres a shared informer factory for the given namespace
+	KubeInformerFactoryFor(namespace string) kubeinformers.SharedInformerFactory
+	// StartInformers starts all registered factories
+	StartInformers(stopCh <-chan struct{})
+	// WaitForCachesToSync waits until caches from all factories are synced
+	WaitForCachesToSync(stopCh <-chan struct{}) error
+}
+
+// informerProvider simply holds namespaced factories
+type informerProvider struct {
+	kubeClient    kubernetes.Interface
+	kubeInformers map[string]kubeinformers.SharedInformerFactory
+
+	resync  time.Duration
+	lock    *sync.Mutex
+	started bool
+}
+
+// NewInformerProvider creates a new provider that
+func NewInformerProvider(kubeClient kubernetes.Interface, resync time.Duration) *informerProvider {
+	return &informerProvider{kubeClient: kubeClient, resync: resync, kubeInformers: map[string]kubeinformers.SharedInformerFactory{}, lock: &sync.Mutex{}}
+}
+
+// KubeInformerFactoryFor registeres a shared informer factory for the given namespace
+func (p *informerProvider) KubeInformerFactoryFor(namespace string) kubeinformers.SharedInformerFactory {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if informer, ok := p.kubeInformers[namespace]; ok {
+		return informer
+	}
+
+	if p.started {
+		// this is a programmer error
+		panic("Please register a factory before starting the provider call to StartInformers method")
+	}
+
+	p.kubeInformers[namespace] = kubeinformers.NewFilteredSharedInformerFactory(p.kubeClient, p.resync, namespace, nil)
+	return p.kubeInformers[namespace]
+}
+
+// StartInformers starts all registered factories
+func (p *informerProvider) StartInformers(stopCh <-chan struct{}) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	for _, informer := range p.kubeInformers {
+		informer.Start(stopCh)
+	}
+	p.started = true
+}
+
+// WaitForCachesToSync waits until caches from all factories are synced
+func (p *informerProvider) WaitForCachesToSync(stopCh <-chan struct{}) error {
+	for _, informer := range p.kubeInformers {
+		infKubeSyncStatus := informer.WaitForCacheSync(stopCh)
+		for informerType, informerSynced := range infKubeSyncStatus {
+			if !informerSynced {
+				return fmt.Errorf("Unable to sync caches for for informer %v", informerType)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/pkg/controller/rbac/informer_provider.go
+++ b/api/pkg/controller/rbac/informer_provider.go
@@ -12,7 +12,7 @@ import (
 // InformerProvider allows for storing shared informer factories for the given namespaces
 // additionally it provides method for starting and waiting for all registered factories
 type InformerProvider interface {
-	// KubeInformerFactoryFor registeres a shared informer factory for the given namespace
+	// KubeInformerFactoryFor registers a shared informer factory for the given namespace
 	KubeInformerFactoryFor(namespace string) kubeinformers.SharedInformerFactory
 	// StartInformers starts all registered factories
 	StartInformers(stopCh <-chan struct{})
@@ -20,8 +20,8 @@ type InformerProvider interface {
 	WaitForCachesToSync(stopCh <-chan struct{}) error
 }
 
-// informerProvider simply holds namespaced factories
-type informerProvider struct {
+// InformerProviderImpl simply holds namespaced factories
+type InformerProviderImpl struct {
 	kubeClient    kubernetes.Interface
 	kubeInformers map[string]kubeinformers.SharedInformerFactory
 
@@ -31,12 +31,12 @@ type informerProvider struct {
 }
 
 // NewInformerProvider creates a new provider that
-func NewInformerProvider(kubeClient kubernetes.Interface, resync time.Duration) *informerProvider {
-	return &informerProvider{kubeClient: kubeClient, resync: resync, kubeInformers: map[string]kubeinformers.SharedInformerFactory{}, lock: &sync.Mutex{}}
+func NewInformerProvider(kubeClient kubernetes.Interface, resync time.Duration) *InformerProviderImpl {
+	return &InformerProviderImpl{kubeClient: kubeClient, resync: resync, kubeInformers: map[string]kubeinformers.SharedInformerFactory{}, lock: &sync.Mutex{}}
 }
 
-// KubeInformerFactoryFor registeres a shared informer factory for the given namespace
-func (p *informerProvider) KubeInformerFactoryFor(namespace string) kubeinformers.SharedInformerFactory {
+// KubeInformerFactoryFor registers a shared informer factory for the given namespace
+func (p *InformerProviderImpl) KubeInformerFactoryFor(namespace string) kubeinformers.SharedInformerFactory {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -54,7 +54,7 @@ func (p *informerProvider) KubeInformerFactoryFor(namespace string) kubeinformer
 }
 
 // StartInformers starts all registered factories
-func (p *informerProvider) StartInformers(stopCh <-chan struct{}) {
+func (p *InformerProviderImpl) StartInformers(stopCh <-chan struct{}) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -65,7 +65,7 @@ func (p *informerProvider) StartInformers(stopCh <-chan struct{}) {
 }
 
 // WaitForCachesToSync waits until caches from all factories are synced
-func (p *informerProvider) WaitForCachesToSync(stopCh <-chan struct{}) error {
+func (p *InformerProviderImpl) WaitForCachesToSync(stopCh <-chan struct{}) error {
 	for _, informer := range p.kubeInformers {
 		infKubeSyncStatus := informer.WaitForCacheSync(stopCh)
 		for informerType, informerSynced := range infKubeSyncStatus {

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -348,6 +348,10 @@ type projectResourceQueueItem struct {
 	clusterProvider *ClusterProvider
 }
 
+func (i *projectResourceQueueItem) String() string {
+	return i.metaObject.GetName()
+}
+
 func (c *Controller) informerIndexerFor(sharedInformers kubermaticsharedinformers.SharedInformerFactory, gvr schema.GroupVersionResource, kind string, clusterProvider *ClusterProvider) (cache.Controller, cache.Indexer, error) {
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {

--- a/api/pkg/controller/rbac/sync_project.go
+++ b/api/pkg/controller/rbac/sync_project.go
@@ -47,10 +47,10 @@ func (c *Controller) sync(key string) error {
 	if err = c.ensureProjectOwner(project); err != nil {
 		return fmt.Errorf("failed to ensure that the project owner exists in the owners group: %v", err)
 	}
-	if err = c.ensureClusterRBACRoleForNamedResource(project.Name, kubermaticv1.ProjectResourceName, kubermaticv1.ProjectKindName, project.GetObjectMeta(), c.masterClusterProvider.kubeClient, c.masterClusterProvider.rbacClusterRoleLister); err != nil {
+	if err = c.ensureClusterRBACRoleForNamedResource(project.Name, kubermaticv1.ProjectResourceName, kubermaticv1.ProjectKindName, project.GetObjectMeta(), c.masterClusterProvider.kubeClient, c.masterClusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoles().Lister()); err != nil {
 		return fmt.Errorf("failed to ensure that the RBAC Role for the project exists: %v", err)
 	}
-	if err = c.ensureClusterRBACRoleBindingForNamedResource(project.Name, kubermaticv1.ProjectResourceName, kubermaticv1.ProjectKindName, project.GetObjectMeta(), c.masterClusterProvider.kubeClient, c.masterClusterProvider.rbacClusterRoleBindingLister); err != nil {
+	if err = c.ensureClusterRBACRoleBindingForNamedResource(project.Name, kubermaticv1.ProjectResourceName, kubermaticv1.ProjectKindName, project.GetObjectMeta(), c.masterClusterProvider.kubeClient, c.masterClusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoleBindings().Lister()); err != nil {
 		return fmt.Errorf("failed to ensure that the RBAC RoleBinding for the project exists: %v", err)
 	}
 	if err = c.ensureClusterRBACRoleForResources(); err != nil {
@@ -149,13 +149,13 @@ func (c *Controller) ensureClusterRBACRoleForResources() error {
 			if projectResource.destination == destinationSeed {
 				for _, seedClusterProvider := range c.seedClusterProviders {
 					seedClusterRESTClient := seedClusterProvider.kubeClient
-					err := ensureClusterRBACRoleForResource(seedClusterRESTClient, groupPrefix, projectResource.gvr.Resource, projectResource.kind, seedClusterProvider.rbacClusterRoleLister)
+					err := ensureClusterRBACRoleForResource(seedClusterRESTClient, groupPrefix, projectResource.gvr.Resource, projectResource.kind, seedClusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoles().Lister())
 					if err != nil {
 						return err
 					}
 				}
 			} else {
-				err := ensureClusterRBACRoleForResource(c.masterClusterProvider.kubeClient, groupPrefix, projectResource.gvr.Resource, projectResource.kind, c.masterClusterProvider.rbacClusterRoleLister)
+				err := ensureClusterRBACRoleForResource(c.masterClusterProvider.kubeClient, groupPrefix, projectResource.gvr.Resource, projectResource.kind, c.masterClusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoles().Lister())
 				if err != nil {
 					return err
 				}
@@ -179,13 +179,13 @@ func (c *Controller) ensureClusterRBACRoleBindingForResources(projectName string
 			if projectResource.destination == destinationSeed {
 				for _, seedClusterProvider := range c.seedClusterProviders {
 					seedClusterRESTClient := seedClusterProvider.kubeClient
-					err := ensureClusterRBACRoleBindingForResource(seedClusterRESTClient, groupName, projectResource.gvr.Resource, seedClusterProvider.rbacClusterRoleBindingLister)
+					err := ensureClusterRBACRoleBindingForResource(seedClusterRESTClient, groupName, projectResource.gvr.Resource, seedClusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoleBindings().Lister())
 					if err != nil {
 						return err
 					}
 				}
 			} else {
-				err := ensureClusterRBACRoleBindingForResource(c.masterClusterProvider.kubeClient, groupName, projectResource.gvr.Resource, c.masterClusterProvider.rbacClusterRoleBindingLister)
+				err := ensureClusterRBACRoleBindingForResource(c.masterClusterProvider.kubeClient, groupName, projectResource.gvr.Resource, c.masterClusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoleBindings().Lister())
 				if err != nil {
 					return err
 				}

--- a/api/pkg/controller/rbac/sync_resource.go
+++ b/api/pkg/controller/rbac/sync_resource.go
@@ -40,11 +40,11 @@ func (c *Controller) syncProjectResource(item *projectResourceQueueItem) error {
 		return fmt.Errorf("unable to find owing project for the object name = %s, gvr = %s", item.metaObject.GetName(), item.gvr.String())
 	}
 
-	if err := c.ensureClusterRBACRoleForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.rbacClusterRoleLister); err != nil {
+	if err := c.ensureClusterRBACRoleForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoles().Lister()); err != nil {
 		err = fmt.Errorf("failed to sync cluster RBAC Role for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
 		return err
 	}
-	err := c.ensureClusterRBACRoleBindingForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.rbacClusterRoleBindingLister)
+	err := c.ensureClusterRBACRoleBindingForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoleBindings().Lister())
 	if err != nil {
 		err = fmt.Errorf("failed to sync cluster RBAC Role Binding for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: The provider simply holds shared informer factories for the given namespace. The provider enables us to watch resources that are inside a namespace.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #2927 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
