### PR TITLE
Notify the API caller which cluster upgrades are restricted by kubelet versions 

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3916,6 +3916,11 @@
           "type": "boolean",
           "x-go-name": "Default"
         },
+        "restrictedByKubeletVersion": {
+          "description": "If true, then given version control plane version is not compatible\nwith one of the kubelets inside cluster and shouldn't be used.",
+          "type": "boolean",
+          "x-go-name": "RestrictedByKubeletVersion"
+        },
         "version": {
           "$ref": "#/definitions/Version"
         }

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -265,6 +265,10 @@ type VSphereNetwork struct {
 type MasterVersion struct {
 	Version *semver.Version `json:"version"`
 	Default bool            `json:"default,omitempty"`
+
+	// If true, then given version control plane version is not compatible
+	// with one of the kubelets inside cluster and shouldn't be used.
+	RestrictedByKubeletVersion bool `json:"restrictedByKubeletVersion,omitempty"`
 }
 
 // Cluster defines the cluster resource

--- a/api/pkg/handler/upgrade_test.go
+++ b/api/pkg/handler/upgrade_test.go
@@ -26,16 +26,21 @@ import (
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-func TestGetClusterUpgradesV1(t *testing.T) {
+func TestGetClusterUpgrades(t *testing.T) {
 	t.Parallel()
+
+	mdWithOldKubelet := genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil)
+	mdWithOldKubelet.Spec.Template.Spec.Versions.Kubelet = "v1.4.0"
+
 	tests := []struct {
-		name                   string
-		cluster                *kubermaticv1.Cluster
-		existingKubermaticObjs []runtime.Object
-		apiUser                apiv1.User
-		versions               []*version.MasterVersion
-		updates                []*version.MasterUpdate
-		wantUpdates            []*apiv1.MasterVersion
+		name                       string
+		cluster                    *kubermaticv1.Cluster
+		existingKubermaticObjs     []runtime.Object
+		existingMachineDeployments []*clusterv1alpha1.MachineDeployment
+		apiUser                    apiv1.User
+		versions                   []*version.MasterVersion
+		updates                    []*version.MasterUpdate
+		wantUpdates                []*apiv1.MasterVersion
 	}{
 		{
 			name: "upgrade available",
@@ -46,14 +51,60 @@ func TestGetClusterUpgradesV1(t *testing.T) {
 				},
 				Spec: kubermaticv1.ClusterSpec{Version: *ksemver.NewSemverOrDie("1.6.0")},
 			},
-			existingKubermaticObjs: test.GenDefaultKubermaticObjects(),
-			apiUser:                *test.GenDefaultAPIUser(),
+			existingKubermaticObjs:     test.GenDefaultKubermaticObjects(),
+			existingMachineDeployments: []*clusterv1alpha1.MachineDeployment{},
+			apiUser:                    *test.GenDefaultAPIUser(),
 			wantUpdates: []*apiv1.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.1"),
 				},
 				{
 					Version: semver.MustParse("1.7.0"),
+				},
+			},
+			versions: []*version.MasterVersion{
+				{
+					Version: semver.MustParse("1.6.0"),
+				},
+				{
+					Version: semver.MustParse("1.6.1"),
+				},
+				{
+					Version: semver.MustParse("1.7.0"),
+				},
+			},
+			updates: []*version.MasterUpdate{
+				{
+					From:      "1.6.0",
+					To:        "1.6.1",
+					Automatic: false,
+				},
+				{
+					From:      "1.6.x",
+					To:        "1.7.0",
+					Automatic: false,
+				},
+			},
+		},
+		{
+			name: "upgrade available but restricted by kubelet versions",
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"user": test.UserName},
+				},
+				Spec: kubermaticv1.ClusterSpec{Version: *ksemver.NewSemverOrDie("1.6.0")},
+			},
+			existingKubermaticObjs:     test.GenDefaultKubermaticObjects(),
+			existingMachineDeployments: []*clusterv1alpha1.MachineDeployment{mdWithOldKubelet},
+			apiUser:                    *test.GenDefaultAPIUser(),
+			wantUpdates: []*apiv1.MasterVersion{
+				{
+					Version: semver.MustParse("1.6.1"),
+				},
+				{
+					Version:                    semver.MustParse("1.7.0"),
+					RestrictedByKubeletVersion: true,
 				},
 			},
 			versions: []*version.MasterVersion{
@@ -89,9 +140,10 @@ func TestGetClusterUpgradesV1(t *testing.T) {
 				},
 				Spec: kubermaticv1.ClusterSpec{Version: *ksemver.NewSemverOrDie("1.6.0")},
 			},
-			existingKubermaticObjs: test.GenDefaultKubermaticObjects(),
-			apiUser:                *test.GenDefaultAPIUser(),
-			wantUpdates:            []*apiv1.MasterVersion{},
+			existingKubermaticObjs:     test.GenDefaultKubermaticObjects(),
+			existingMachineDeployments: []*clusterv1alpha1.MachineDeployment{},
+			apiUser:                    *test.GenDefaultAPIUser(),
+			wantUpdates:                []*apiv1.MasterVersion{},
 			versions: []*version.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.0"),
@@ -106,7 +158,12 @@ func TestGetClusterUpgradesV1(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{testStruct.cluster}
 			kubermaticObj = append(kubermaticObj, testStruct.existingKubermaticObjs...)
-			ep, err := test.CreateTestEndpoint(testStruct.apiUser, []runtime.Object{}, kubermaticObj, testStruct.versions, testStruct.updates, hack.NewTestRouting)
+			machineObj := []runtime.Object{}
+			for _, existingMachineDeployment := range testStruct.existingMachineDeployments {
+				machineObj = append(machineObj, existingMachineDeployment)
+			}
+
+			ep, _, err := test.CreateTestEndpointAndGetClients(testStruct.apiUser, nil, []runtime.Object{}, machineObj, kubermaticObj, testStruct.versions, testStruct.updates, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create testStruct endpoint due to %v", err)
 			}

--- a/api/pkg/version/manager.go
+++ b/api/pkg/version/manager.go
@@ -23,10 +23,6 @@ type Manager struct {
 type MasterVersion struct {
 	Version *semver.Version `json:"version"`
 	Default bool            `json:"default"`
-
-	// If true, then given version control plane version is not compatible
-	// with one of the kubelets inside cluster and shouldn't be used.
-	RestrictedByKubeletVersion bool `json:"restrictedByKubeletVersion"`
 }
 
 // MasterUpdate represents an update option for K8s master components

--- a/api/pkg/version/manager.go
+++ b/api/pkg/version/manager.go
@@ -23,6 +23,10 @@ type Manager struct {
 type MasterVersion struct {
 	Version *semver.Version `json:"version"`
 	Default bool            `json:"default"`
+
+	// If true, then given version control plane version is not compatible
+	// with one of the kubelets inside cluster and shouldn't be used.
+	RestrictedByKubeletVersion bool `json:"restrictedByKubeletVersion"`
 }
 
 // MasterUpdate represents an update option for K8s master components


### PR DESCRIPTION
**What this PR does / why we need it**: Notifies the API caller which cluster upgrades are restricted by kubelet versions .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes #2541.

**Special notes for your reviewer**: n/a

**Documentation**: n/a
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Mark cluster upgrades as restricted if kubelet version is incompatible.
```
