### PR TITLE
Fluentbit glog Parser

### DIFF
--- a/config/cert-manager/templates/ca-sync-job.yaml
+++ b/config/cert-manager/templates/ca-sync-job.yaml
@@ -8,6 +8,8 @@ spec:
     metadata:
       labels:
         app: ca-helper
+      annotations:
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: ca-sync
       restartPolicy: OnFailure

--- a/config/cert-manager/templates/cert-manager-deployment.yaml
+++ b/config/cert-manager/templates/cert-manager-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       annotations:
         kubermatic/scrape: "true"
         kubermatic/scrape_port: "9402"
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: cert-manager
       {{- if .Values.certManager.securityContext.enabled }}

--- a/config/cert-manager/templates/webhook-deployment.yaml
+++ b/config/cert-manager/templates/webhook-deployment.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: webhook
+      annotations:
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: webhook
       {{- if .Values.certManager.tolerations }}

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -16,6 +16,7 @@ spec:
         checksum/datecenters: {{ include (print $.Template.BasePath "/datacenter-yaml-secret.yaml") . | sha256sum }}
         checksum/kubeconfig: {{ include (print $.Template.BasePath "/kubeconfig-secret.yaml") . | sha256sum }}
         checksum/master-files: {{ include (print $.Template.BasePath "/master-files-secret.yaml") . | sha256sum }}
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: kubermatic
       containers:

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -22,6 +22,7 @@ spec:
         {{- if .Values.kubermatic.clusterNamespacePrometheus.scrapingConfigs }}
         checksum/prometheus-scraping-configs: {{ include (print $.Template.BasePath "/clusterns-prometheus-scraping-configs-configmap.yaml") . | sha256sum }}
         {{- end }}
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: kubermatic
       initContainers:

--- a/config/kubermatic/templates/rbac-generator-dep.yaml
+++ b/config/kubermatic/templates/rbac-generator-dep.yaml
@@ -18,6 +18,7 @@ spec:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '8085'
         checksum/kubeconfig: {{ include (print $.Template.BasePath "/kubeconfig-secret.yaml") . | sha256sum }}
+        fluentbit.io/parser: glog
     spec:
       initContainers:
       - name: projects-migrator

--- a/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
+++ b/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
@@ -12,6 +12,7 @@ spec:
         app: vpa-admission-controller
       annotations:
         checksum/tls: {{ include (print $.Template.BasePath "/vpa-tls.yaml") . | sha256sum }}
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: vpa-admission-controller
       containers:

--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         app: vpa-recommender
+      annotations:
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: vpa-recommender
       containers:

--- a/config/kubermatic/templates/vpa-updater-deployment.yaml
+++ b/config/kubermatic/templates/vpa-updater-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         app: vpa-updater
+      annotations:
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: vpa-updater
       containers:

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -38,6 +38,7 @@ data:
         Match               kube.*
         Kube_URL            https://kubernetes.default.svc.cluster.local:443
         Merge_Log           On
+        Merge_Log_Trim      On
         K8S-Logging.Parser  On
         Annotations         Off
 
@@ -96,3 +97,11 @@ data:
         Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
         Time_Key    time
         Time_Format %b %d %H:%M:%S
+
+    [PARSER]
+        Name        glog
+        Format      regex
+        Regex       (?<level>[A-Z])(?<time>[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)\s+(?<thread>[0-9]+)\s+(?<file>[^:]+):(?<line>[0-9]+)\]\s*(?<message>.*)$
+        Time_Key    time
+        Time_Format %m%d %H:%M:%S.%L
+        Types       thread:integer line:integer

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -76,10 +76,16 @@ data:
         Time_Format %d/%b/%Y:%H:%M:%S %z
 
     [PARSER]
-        Name   json
-        Format json
-        Time_Key time
+        Name        json
+        Format      json
+        Time_Key    time
         Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name        json_iso
+        Format      json
+        Time_Key    time
+        Time_Format %Y-%m-%dT:%H:%M:%S%z
 
     [PARSER]
         Name        docker

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
         Name              tail
         Tag               kube.*
         Path              /var/log/containers/*.log
-        Parser            docker
+        Parser            {{ .Values.logging.fluentbit.configuration.containerRuntimeParser }}
         DB                /var/log/flb_kube.db
         Mem_Buf_Limit     5MB
         Skip_Long_Lines   On
@@ -92,6 +92,22 @@ data:
         Decode_Field_As   escaped    log
 
     [PARSER]
+        Name        containerd
+        Format      regex
+        Regex       ^(?<time>[A-Z0-9.:-]+) (?<stream>[a-z0-9]+) (?<tags>[A-Z:]+)\s*(?<log>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+
+    # Legacy format before tags were introduced, see
+    # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-cri-logging.md
+    [PARSER]
+        Name        containerd3
+        Format      regex
+        Regex       ^(?<time>[A-Z0-9.:-]+) (?<stream>[a-z0-9]+)\s*(?<log>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+
+    [PARSER]
         Name        syslog
         Format      regex
         Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
@@ -101,7 +117,7 @@ data:
     [PARSER]
         Name        glog
         Format      regex
-        Regex       (?<level>[A-Z])(?<time>[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)\s+(?<thread>[0-9]+)\s+(?<file>[^:]+):(?<line>[0-9]+)\]\s*(?<message>.*)$
+        Regex       ^(?<level>[A-Z])(?<time>[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)\s+(?<thread>[0-9]+)\s+(?<file>[^:]+):(?<line>[0-9]+)\]\s*(?<message>.*)$
         Time_Key    time
         Time_Format %m%d %H:%M:%S.%L
         Types       thread:integer line:integer

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -2,7 +2,7 @@ logging:
   fluentbit:
     image:
       repository: fluent/fluent-bit
-      tag: 1.0.3
+      tag: 1.0.4
       pullPolicy: "IfNotPresent"
     configuration:
       outputs:

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -5,6 +5,7 @@ logging:
       tag: 1.0.4
       pullPolicy: "IfNotPresent"
     configuration:
+      containerRuntimeParser: docker
       outputs:
         - |
           Name            es

--- a/config/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/config/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: kube-state-metrics
+      annotations:
+        fluentbit.io/parser: glog
     spec:
       serviceAccountName: kube-state-metrics
       containers:

--- a/config/s3-exporter/templates/deployment.yaml
+++ b/config/s3-exporter/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       annotations:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '9340'
+        fluentbit.io/parser: glog
     spec:
       serviceAccount: s3-exporter
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new parser for glog outputs, so we can more easily filter by warnings, errors, files etc. in Kibana.

Note that the documentation on Fluentbit is not really all that clear and that the regex is applied to *everything* it reads from the container runtime's logs. I.e. you are not just matching against

    E0308 11:31:46.678784       1 reflector.go:205] a lot of text here

but instead the whole, raw line from the file:

    2019-03-08T11:31:46.679082406Z stderr F E0308 11:31:46.678784       1 reflector.go:205] a lot of text here

This is why the regex is not anchored at the beginning and we allow for the timestamp and other junk to preceed our glog format.

cc @mrIncompetent 

**Release note**:
```release-note
NONE
```
