### PR TITLE
set dummy IPAM data on cluster for fixture tests

### DIFF
--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -35,7 +35,7 @@ spec:
         - -v
         - "4"
         - --ipam-controller-network
-        - ',,'
+        - 192.168.1.1/24,192.168.1.1,8.8.8.8
         command:
         - /usr/local/bin/user-cluster-controller-manager
         image: 'quay.io/kubermatic/api:'

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -213,7 +213,13 @@ func TestLoadFiles(t *testing.T) {
 							DNSDomain: "cluster.local",
 						},
 						MachineNetworks: []kubermaticv1.MachineNetworkingConfig{
-							{},
+							{
+								CIDR: "192.168.1.1/24",
+								DNSServers: []string{
+									"8.8.8.8",
+								},
+								Gateway: "192.168.1.1",
+							},
 						},
 					},
 					Address: kubermaticv1.ClusterAddress{


### PR DESCRIPTION
**What this PR does / why we need it**:
Aet dummy IPAM data on cluster for fixture tests.

**Release note**:
```release-note
NONE
```
