### PR TITLE
allow to re-enable the Grafana login form

### DIFF
--- a/config/monitoring/grafana/config/grafana.ini
+++ b/config/monitoring/grafana/config/grafana.ini
@@ -3,7 +3,7 @@ admin_password = {{ .Values.grafana.password | b64dec }}
 admin_user = {{ .Values.grafana.user | b64dec }}
 
 [auth]
-disable_login_form = true
+disable_login_form = {{ .Values.grafana.provisioning.configuration.disable_login_form }}
 
 [auth.basic]
 enabled = false

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -43,6 +43,11 @@ grafana:
       # to add and edit the dashboards
       auto_assign_org_role: Viewer
 
+      # Set this to false if you do not have an identity-aware proxy
+      # in front of Grafana and would still like to login with the
+      # credentials defined above.
+      disable_login_form: true
+
   # If you manage your dashboards via your own configmaps,
   # you can add them here to have them automatically be
   # mounted in Grafana. For each volume, specify either a


### PR DESCRIPTION
**What this PR does / why we need it**:
In some situations we do not have Keycloak in front of cluster services and would still like to allow customers to login manually, i.e. when port-forwarding to Grafana for debugging cluster issues. This change makes it possible to have a plain ol' login form.

**Release note**:
```release-note
NONE
```
