### PR TITLE
add service account binding controller

### DIFF
--- a/api/cmd/rbac-generator/main.go
+++ b/api/cmd/rbac-generator/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	rbaccontroller "github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac/service-account"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -190,6 +191,9 @@ func main() {
 			}
 
 			if err := rbaccontroller.Add(mgr); err != nil {
+				return err
+			}
+			if err := serviceaccount.Add(mgr); err != nil {
 				return err
 			}
 

--- a/api/pkg/controller/rbac/service-account/service_account_binding_controller.go
+++ b/api/pkg/controller/rbac/service-account/service_account_binding_controller.go
@@ -104,11 +104,11 @@ func (r *reconcileServiceAccountProjectBinding) ensureServiceAccountProjectBindi
 		if err := r.createBinding(sa, projectName); err != nil {
 			return err
 		}
-		// remove labelGroup from sa
-		delete(sa.Labels, labelGroup)
-		if err := r.Update(r.ctx, sa); err != nil {
-			return err
-		}
+	}
+	// remove labelGroup from sa
+	delete(sa.Labels, labelGroup)
+	if err := r.Update(r.ctx, sa); err != nil {
+		return err
 	}
 	return nil
 }

--- a/api/pkg/controller/rbac/service-account/service_account_binding_controller.go
+++ b/api/pkg/controller/rbac/service-account/service_account_binding_controller.go
@@ -106,10 +106,13 @@ func (r *reconcileServiceAccountProjectBinding) ensureServiceAccountProjectBindi
 		}
 	}
 	// remove labelGroup from sa
-	delete(sa.Labels, labelGroup)
-	if err := r.Update(r.ctx, sa); err != nil {
-		return err
+	if _, ok := sa.Labels[labelGroup]; ok {
+		delete(sa.Labels, labelGroup)
+		if err := r.Update(r.ctx, sa); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 

--- a/api/pkg/controller/rbac/service-account/service_account_binding_controller.go
+++ b/api/pkg/controller/rbac/service-account/service_account_binding_controller.go
@@ -1,0 +1,138 @@
+package serviceaccount
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	controllerName = "kubermatic_serviceaccount_projectbinding_controller"
+
+	labelGroup = "group"
+)
+
+func Add(mgr manager.Manager) error {
+	r := &reconcileServiceAccountProjectBinding{Client: mgr.GetClient(), ctx: context.TODO()}
+	// Create a new controller
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to User
+	err = c.Watch(&source.Kind{Type: &kubermaticv1.User{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// reconcileServiceAccountProjectBinding reconciles User objects
+type reconcileServiceAccountProjectBinding struct {
+	ctx context.Context
+	client.Client
+}
+
+func (r *reconcileServiceAccountProjectBinding) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	resourceName := request.Name
+	if !strings.HasPrefix(resourceName, "serviceaccount") {
+		return reconcile.Result{}, nil
+	}
+
+	return reconcile.Result{}, r.ensureServiceAccountProjectBinding(resourceName)
+}
+
+func (r *reconcileServiceAccountProjectBinding) ensureServiceAccountProjectBinding(saName string) error {
+	glog.V(4).Infof("Reconciling SA binding for %s", saName)
+
+	sa := &kubermaticv1.User{}
+	if err := r.Get(r.ctx, client.ObjectKey{Namespace: metav1.NamespaceAll, Name: saName}, sa); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	// get project name from Owner Reference or from label
+	projectName := ""
+	for _, owner := range sa.GetOwnerReferences() {
+		if owner.APIVersion == kubermaticv1.SchemeGroupVersion.String() && owner.Kind == kubermaticv1.ProjectKindName &&
+			len(owner.Name) > 0 && len(owner.UID) > 0 {
+			projectName = owner.Name
+			break
+		}
+	}
+	if len(projectName) == 0 {
+		projectName = sa.GetLabels()[kubermaticv1.ProjectIDLabelKey]
+	}
+
+	if len(projectName) == 0 {
+		return fmt.Errorf("unable to find owing project for the service account = %s", sa.Name)
+	}
+
+	project := &kubermaticv1.Project{}
+	if err := r.Get(r.ctx, client.ObjectKey{Namespace: metav1.NamespaceAll, Name: projectName}, project); err != nil {
+		return err
+	}
+
+	binding := &kubermaticv1.UserProjectBinding{}
+	bindingName := genBindingName(projectName, sa.Spec.ID)
+	if err := r.Get(r.ctx, client.ObjectKey{Namespace: metav1.NamespaceAll, Name: bindingName}, binding); err != nil {
+		if kerrors.IsNotFound(err) {
+			return r.createBinding(sa, project)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (r *reconcileServiceAccountProjectBinding) createBinding(user *kubermaticv1.User, project *kubermaticv1.Project) error {
+	group, ok := user.Labels[labelGroup]
+	if !ok {
+		return fmt.Errorf("label %s not found", labelGroup)
+	}
+	binding := &kubermaticv1.UserProjectBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+					Kind:       kubermaticv1.UserKindName,
+					UID:        user.GetUID(),
+					Name:       user.Name,
+				},
+			},
+			Name:   genBindingName(project.Name, user.Spec.ID),
+			Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: project.Name},
+		},
+		Spec: kubermaticv1.UserProjectBindingSpec{
+			ProjectID: project.Name,
+			UserEmail: user.Spec.Email,
+			Group:     group,
+		},
+	}
+
+	if err := r.Create(r.ctx, binding); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func genBindingName(projectName, userID string) string {
+	return fmt.Sprintf("sa-%s-%s", projectName, userID)
+}

--- a/api/pkg/controller/rbac/service-account/service_account_binding_test.go
+++ b/api/pkg/controller/rbac/service-account/service_account_binding_test.go
@@ -1,0 +1,92 @@
+package serviceaccount
+
+import (
+	"context"
+	"testing"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestCreateBinding(t *testing.T) {
+
+	tests := []struct {
+		name                      string
+		saName                    string
+		existingKubermaticObjects []runtime.Object
+		expectedBindingName       string
+		expectedBinding           *kubermaticv1.UserProjectBinding
+	}{
+		{
+			name:   "scenario 1: this test creates binding for service account",
+			saName: "serviceaccount-abcd",
+			existingKubermaticObjects: []runtime.Object{
+				test.GenDefaultProject(),
+				test.GenServiceAccount("abcd", "test", "editors", "my-first-project-ID"),
+			},
+			expectedBindingName: "sa-my-first-project-ID-abcd",
+			expectedBinding: &kubermaticv1.UserProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+							Kind:       kubermaticv1.UserKindName,
+							UID:        "",
+							Name:       "serviceaccount-abcd",
+						},
+					},
+					Name:   "sa-my-first-project-ID-abcd",
+					Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: "my-first-project-ID"},
+				},
+				Spec: kubermaticv1.UserProjectBindingSpec{
+					ProjectID: "my-first-project-ID",
+					UserEmail: "serviceaccount-abcd@sa.kubermatic.io",
+					Group:     "editors",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup the test scenario
+
+			scheme := scheme.Scheme
+			if err := kubermaticv1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			kubermaticFakeClient := fake.NewFakeClientWithScheme(scheme, test.existingKubermaticObjects...)
+
+			// act
+			target := reconcileServiceAccountProjectBinding{ctx: context.TODO(), Client: kubermaticFakeClient}
+
+			_, err := target.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: test.saName}})
+
+			// validate
+			if err != nil {
+				t.Fatal(err)
+			}
+			binding := &kubermaticv1.UserProjectBinding{}
+			err = kubermaticFakeClient.Get(target.ctx, controllerclient.ObjectKey{Name: test.expectedBindingName}, binding)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !equality.Semantic.DeepEqual(binding, test.expectedBinding) {
+				t.Fatalf("%v", diff.ObjectDiff(binding, test.expectedBinding))
+			}
+
+		})
+	}
+}

--- a/api/pkg/controller/rbac/sync_project_binding_controller.go
+++ b/api/pkg/controller/rbac/sync_project_binding_controller.go
@@ -162,16 +162,9 @@ func (r *reconcileSyncProjectBinding) userForBinding(projectBinding *kubermaticv
 }
 
 func (r *reconcileSyncProjectBinding) getProjectForBinding(projectBinding *kubermaticv1.UserProjectBinding) (*kubermaticv1.Project, error) {
-	for _, ref := range projectBinding.OwnerReferences {
-		if ref.Kind == kubermaticv1.ProjectKindName {
-			var err error
-			projectFromCache := &kubermaticv1.Project{}
-			if err = r.Get(r.ctx, client.ObjectKey{Namespace: metav1.NamespaceAll, Name: ref.Name}, projectFromCache); err != nil {
-				return nil, err
-			}
-			return projectFromCache, nil
-		}
+	projectFromCache := &kubermaticv1.Project{}
+	if err := r.Get(r.ctx, client.ObjectKey{Namespace: metav1.NamespaceAll, Name: projectBinding.Spec.ProjectID}, projectFromCache); err != nil {
+		return nil, err
 	}
-
-	return nil, fmt.Errorf("the given project binding %s doesn't have associated project", projectBinding.Name)
+	return projectFromCache, nil
 }

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -294,6 +294,29 @@ func GenUser(id, name, email string) *kubermaticapiv1.User {
 	}
 }
 
+// GenServiceAccount generates a Service Account resource
+func GenServiceAccount(id, name, group, projectName string) *kubermaticapiv1.User {
+	return &kubermaticapiv1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"group": group},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
+					Kind:       kubermaticapiv1.ProjectKindName,
+					Name:       projectName,
+					UID:        types.UID(id),
+				},
+			},
+			Name: fmt.Sprintf("serviceaccount-%s", id),
+		},
+		Spec: kubermaticapiv1.UserSpec{
+			Name:  name,
+			ID:    id,
+			Email: fmt.Sprintf("serviceaccount-%s@sa.kubermatic.io", id),
+		},
+	}
+}
+
 // GenAPIUser generates a API user
 func GenAPIUser(name, email string) *apiv1.User {
 	usr := GenUser("", name, email)

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -296,25 +296,21 @@ func GenUser(id, name, email string) *kubermaticapiv1.User {
 
 // GenServiceAccount generates a Service Account resource
 func GenServiceAccount(id, name, group, projectName string) *kubermaticapiv1.User {
-	return &kubermaticapiv1.User{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{"group": group},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
-					Kind:       kubermaticapiv1.ProjectKindName,
-					Name:       projectName,
-					UID:        types.UID(id),
-				},
-			},
-			Name: fmt.Sprintf("serviceaccount-%s", id),
-		},
-		Spec: kubermaticapiv1.UserSpec{
-			Name:  name,
-			ID:    id,
-			Email: fmt.Sprintf("serviceaccount-%s@sa.kubermatic.io", id),
+	user := GenUser(id, name, fmt.Sprintf("serviceaccount-%s@sa.kubermatic.io", id))
+	user.Labels = map[string]string{"group": group}
+	user.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
+			Kind:       kubermaticapiv1.ProjectKindName,
+			Name:       projectName,
+			UID:        types.UID(id),
 		},
 	}
+	user.Spec.ID = id
+	user.Name = fmt.Sprintf("serviceaccount-%s", id)
+	user.UID = ""
+
+	return user
 }
 
 // GenAPIUser generates a API user


### PR DESCRIPTION
**What this PR does / why we need it**: new controller watches SA objects and creates binding to the project.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2932

```release-note
add service account binding controller
```
