### PR TITLE
adds RBAC for named resources in a namespace for RBAC Controller

### DIFF
--- a/api/pkg/controller/rbac/mapper.go
+++ b/api/pkg/controller/rbac/mapper.go
@@ -291,7 +291,7 @@ func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, er
 	}
 	// special case - editors are not allowed to interact with members of a project (UserProjectBinding)
 	if strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == kubermaticv1.UserProjectBindingKind {
-		return []string{}, nil
+		return nil, nil
 	}
 
 	// editors of a named resource
@@ -304,7 +304,7 @@ func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, er
 	// viewers of a named resource
 	// special case - viewers are not allowed to interact with members of a project (UserProjectBinding)
 	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) && resourceKind == kubermaticv1.UserProjectBindingKind {
-		return []string{}, nil
+		return nil, nil
 
 	}
 	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) {
@@ -312,7 +312,7 @@ func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, er
 	}
 
 	// unknown group passed
-	return []string{}, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s", groupName)
+	return nil, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s", groupName)
 }
 
 // generateVerbsForResource generates verbs for a resource for example "cluster"
@@ -323,7 +323,7 @@ func generateVerbsForResource(groupName, resourceKind string) ([]string, error) 
 	if strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == kubermaticv1.UserProjectBindingKind {
 		return []string{"create"}, nil
 	} else if resourceKind == kubermaticv1.UserProjectBindingKind {
-		return []string{}, nil
+		return nil, nil
 	}
 
 	// verbs for owners and editors
@@ -337,11 +337,11 @@ func generateVerbsForResource(groupName, resourceKind string) ([]string, error) 
 	//
 	// viewers cannot create resources
 	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) {
-		return []string{}, nil
+		return nil, nil
 	}
 
 	// unknown group passed
-	return []string{}, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s", groupName)
+	return nil, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s", groupName)
 }
 
 func generateVerbsForNamespacedResource(groupName, resourceKind, namespace string) ([]string, error) {
@@ -352,12 +352,12 @@ func generateVerbsForNamespacedResource(groupName, resourceKind, namespace strin
 		if strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind {
 			return []string{"create"}, nil
 		} else if resourceKind == secretV1Kind {
-			return []string{}, nil
+			return nil, nil
 		}
 	}
 
 	// unknown group passed
-	return []string{}, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s, namespace = %s", groupName, namespace)
+	return nil, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s, namespace = %s", groupName, namespace)
 }
 
 // generateVerbsForNamedResourceInNamespace generates a set of verbs for a named resource in a given namespace
@@ -370,10 +370,10 @@ func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace
 		if strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind {
 			return []string{"get", "update", "delete"}, nil
 		} else if resourceKind == secretV1Kind {
-			return []string{}, nil
+			return nil, nil
 		}
 	}
 
 	// unknown group passed
-	return []string{}, fmt.Errorf("unable to generate verbs for group = %s, kind = %s, namespace = %s", groupName, resourceKind, namespace)
+	return nil, fmt.Errorf("unable to generate verbs for group = %s, kind = %s, namespace = %s", groupName, resourceKind, namespace)
 }

--- a/api/pkg/controller/rbac/mapper.go
+++ b/api/pkg/controller/rbac/mapper.go
@@ -211,6 +211,67 @@ func generateRBACRoleForResource(groupName, policyResource, policyAPIGroups, kin
 	return role, nil
 }
 
+// generateRBACRoleNamedResource generates Role for a named resource.
+// named resources have its rules set to a resource with the given name for example:
+// the following rule allows reading a ConfigMap named “my-config”
+//  rules:
+//   - apiGroups: [""]
+//   resources: ["configmaps"]
+//   resourceNames: ["my-config"]
+//   verbs: ["get"]
+//
+// Note that for some kinds we don't want to generate Role in that case a nil cluster resource will be returned without an error
+func generateRBACRoleNamedResource(kind, groupName, policyResource, policyAPIGroups, policyResourceName string, namespace string, oRef metav1.OwnerReference) (*rbacv1.Role, error) {
+	verbs, err := generateVerbsForNamedResourceInNamespace(groupName, kind, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if len(verbs) == 0 {
+		return nil, nil
+	}
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            generateRBACRoleNameForNamedResource(kind, policyResourceName, groupName),
+			OwnerReferences: []metav1.OwnerReference{oRef},
+			Namespace:       namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{policyAPIGroups},
+				Resources:     []string{policyResource},
+				ResourceNames: []string{policyResourceName},
+				Verbs:         verbs,
+			},
+		},
+	}
+	return role, nil
+}
+
+// generateRBACRoleBindingNamedResource generates RoleBiding for the given group
+// that will be bound to the corresponding Role
+func generateRBACRoleBindingNamedResource(kind, resourceName, groupName, namespace string, oRef metav1.OwnerReference) *rbacv1.RoleBinding {
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            generateRBACRoleNameForNamedResource(kind, resourceName, groupName),
+			OwnerReferences: []metav1.OwnerReference{oRef},
+			Namespace:       namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "Group",
+				Name:     groupName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     generateRBACRoleNameForNamedResource(kind, resourceName, groupName),
+		},
+	}
+	return binding
+}
+
 // generateVerbsForNamedResource generates a set of verbs for a named resource
 // for example a "cluster" named "beefy-john"
 func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, error) {
@@ -284,7 +345,7 @@ func generateVerbsForResource(groupName, resourceKind string) ([]string, error) 
 }
 
 func generateVerbsForNamespacedResource(groupName, resourceKind, namespace string) ([]string, error) {
-	// special case - only the owners of a project can manipulate secrets in "sa-secrets" namespace
+	// special case - only the owners of a project can create secrets in "sa-secrets" namespace
 	//
 	if namespace == "sa-secrets" {
 		secretV1Kind := "Secret"
@@ -297,4 +358,22 @@ func generateVerbsForNamespacedResource(groupName, resourceKind, namespace strin
 
 	// unknown group passed
 	return []string{}, fmt.Errorf("unable to generate verbs, unknown group name passed in = %s, namespace = %s", groupName, namespace)
+}
+
+// generateVerbsForNamedResourceInNamespace generates a set of verbs for a named resource in a given namespace
+// for example a "cluster" named "beefy-john"
+func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace string) ([]string, error) {
+	// special case - only the owners of a project can manipulate secrets in "sa-secrets" namespace
+	//
+	if namespace == "sa-secrets" {
+		secretV1Kind := "Secret"
+		if strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind {
+			return []string{"get", "update", "delete"}, nil
+		} else if resourceKind == secretV1Kind {
+			return []string{}, nil
+		}
+	}
+
+	// unknown group passed
+	return []string{}, fmt.Errorf("unable to generate verbs for group = %s, kind = %s, namespace = %s", groupName, resourceKind, namespace)
 }

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -287,6 +287,7 @@ const projectResourcesResyncTime time.Duration = 5 * time.Minute
 type projectResourceQueueItem struct {
 	gvr             schema.GroupVersionResource
 	kind            string
+	namespace       string
 	metaObject      metav1.Object
 	clusterProvider *ClusterProvider
 }

--- a/api/pkg/controller/rbac/sync_resource.go
+++ b/api/pkg/controller/rbac/sync_resource.go
@@ -43,14 +43,12 @@ func (c *Controller) syncProjectResource(item *projectResourceQueueItem) error {
 
 	if len(item.namespace) == 0 {
 		if err := c.ensureClusterRBACRoleForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoles().Lister()); err != nil {
-			err = fmt.Errorf("failed to sync RBAC ClusterRole for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
-			return err
+			return fmt.Errorf("failed to sync RBAC ClusterRole for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
 		}
-		err := c.ensureClusterRBACRoleBindingForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoleBindings().Lister())
-		if err != nil {
-			err = fmt.Errorf("failed to sync RBAC ClusterRoleBinding for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
+		if err := c.ensureClusterRBACRoleBindingForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoleBindings().Lister()); err != nil {
+			return fmt.Errorf("failed to sync RBAC ClusterRoleBinding for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
 		}
-		return err
+		return nil
 	}
 
 	err := c.ensureRBACRoleForNamedResource(projectName,


### PR DESCRIPTION
**What this PR does / why we need it**: this pull changes the controller to also monitor and generated Roles/Bindings for named resources in a namespace. This helps to handle "only the project's owners can manipulate "abc" secret in "sa-secrets" namespace" scenario.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #2927 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
changes RBAC generator controller to also  monitor and generate Roles/Bindings for named resources in a namespace
```
