### PR TITLE
keep node names when scraping node-exporters

### DIFF
--- a/config/monitoring/prometheus/config/scraping/pods.yaml
+++ b/config/monitoring/prometheus/config/scraping/pods.yaml
@@ -31,3 +31,9 @@ relabel_configs:
   target_label: pod
   replacement: $1
   action: replace
+# put the node name on node-exporter metrics
+- source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_node_name]
+  action: replace
+  regex: node-exporter;(.+)
+  replacement: $1
+  target_label: node_name


### PR DESCRIPTION
**What this PR does / why we need it**: 
Up until now, when we wanted to see node metrics, we had to select the node-exporter instances, i.e. the pod IPs. This is both unintuitive and instable, as pods get rescheduled and get new IPs over time. This is especially true in environments with preemtible nodes.

Some systems (like kube-prometheus) try to *sometimes* fix this by joining with pod info metrics to get the node names, but only do so in a few places.

It seems much, much easier to just keep the node name from Prometheus' service discovery attached to the node-exporter pods and then use that label, instead of the `instance` label, to build alerts and dashboards around it.

After this change, we have to rethink/build a bunch of dashboards, but at least they will make sense from then on.

**Release note**:
```release-note
NONE
```
