### PR TITLE
moves ssh.go files to v1/ssh pkg

### DIFF
--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -8,11 +8,13 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/cluster"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/dc"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/project"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/ssh"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/user"
 )
 
@@ -304,8 +306,8 @@ func (r Routing) listSSHKeys() http.Handler {
 			r.oidcAuthenticator.Verifier(),
 			middleware.UserSaver(r.userProvider),
 			middleware.UserInfo(r.userProjectMapper),
-		)(listSSHKeyEndpoint(r.sshKeyProvider, r.projectProvider)),
-		decodeListSSHKeyReq,
+		)(ssh.ListEndpoint(r.sshKeyProvider, r.projectProvider)),
+		ssh.DecodeListReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,
 	)
@@ -332,8 +334,8 @@ func (r Routing) createSSHKey() http.Handler {
 			r.oidcAuthenticator.Verifier(),
 			middleware.UserSaver(r.userProvider),
 			middleware.UserInfo(r.userProjectMapper),
-		)(createSSHKeyEndpoint(r.sshKeyProvider, r.projectProvider)),
-		decodeCreateSSHKeyReq,
+		)(ssh.CreateEndpoint(r.sshKeyProvider, r.projectProvider)),
+		ssh.DecodeCreateReq,
 		setStatusCreatedHeader(EncodeJSON),
 		r.defaultServerOptions()...,
 	)
@@ -357,8 +359,8 @@ func (r Routing) deleteSSHKey() http.Handler {
 			r.oidcAuthenticator.Verifier(),
 			middleware.UserSaver(r.userProvider),
 			middleware.UserInfo(r.userProjectMapper),
-		)(deleteSSHKeyEndpoint(r.sshKeyProvider, r.projectProvider)),
-		decodeDeleteSSHKeyReq,
+		)(ssh.DeleteEndpoint(r.sshKeyProvider, r.projectProvider)),
+		ssh.DecodeDeleteReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,
 	)
@@ -618,7 +620,7 @@ func (r Routing) getKubermaticVersion() http.Handler {
 		endpoint.Chain(
 			r.oidcAuthenticator.Verifier(),
 			middleware.UserSaver(r.userProvider),
-		)(getKubermaticVersion()),
+		)(v1.GetKubermaticVersion()),
 		decodeEmptyReq,
 		EncodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/handler/v1/ssh/ssh.go
+++ b/api/pkg/handler/v1/ssh/ssh.go
@@ -1,4 +1,4 @@
-package handler
+package ssh
 
 import (
 	"context"
@@ -16,9 +16,9 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
-func createSSHKeyEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
+func CreateEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req, ok := request.(CreateSSHKeyReq)
+		req, ok := request.(CreateReq)
 		if !ok {
 			return nil, errors.NewBadRequest("invalid request")
 		}
@@ -56,9 +56,9 @@ func createSSHKeyEndpoint(keyProvider provider.SSHKeyProvider, projectProvider p
 	}
 }
 
-func deleteSSHKeyEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
+func DeleteEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req, ok := request.(DeleteSSHKeyReq)
+		req, ok := request.(DeleteReq)
 		if !ok {
 			return nil, errors.NewBadRequest("invalid request")
 		}
@@ -76,9 +76,9 @@ func deleteSSHKeyEndpoint(keyProvider provider.SSHKeyProvider, projectProvider p
 	}
 }
 
-func listSSHKeyEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
+func ListEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req, ok := request.(ListSSHKeyReq)
+		req, ok := request.(ListReq)
 		if !ok {
 			return nil, errors.NewBadRequest("invalid request")
 		}
@@ -103,30 +103,30 @@ func listSSHKeyEndpoint(keyProvider provider.SSHKeyProvider, projectProvider pro
 	}
 }
 
-// ListSSHKeyReq defined HTTP request for listSHHKeys endpoint
+// ListReq defined HTTP request for listSHHKeys endpoint
 // swagger:parameters listSSHKeys
-type ListSSHKeyReq struct {
+type ListReq struct {
 	common.ProjectReq
 }
 
-func decodeListSSHKeyReq(c context.Context, r *http.Request) (interface{}, error) {
+func DecodeListReq(c context.Context, r *http.Request) (interface{}, error) {
 	req, err := common.DecodeProjectRequest(c, r)
 	if err != nil {
 		return nil, nil
 	}
-	return ListSSHKeyReq{ProjectReq: req.(common.ProjectReq)}, err
+	return ListReq{ProjectReq: req.(common.ProjectReq)}, err
 }
 
-// DeleteSSHKeyReq defines HTTP request for deleteSSHKey endpoint
+// DeleteReq defines HTTP request for deleteSSHKey endpoint
 // swagger:parameters deleteSSHKey
-type DeleteSSHKeyReq struct {
+type DeleteReq struct {
 	common.ProjectReq
 	// in: path
 	SSHKeyID string `json:"key_id"`
 }
 
-func decodeDeleteSSHKeyReq(c context.Context, r *http.Request) (interface{}, error) {
-	var req DeleteSSHKeyReq
+func DecodeDeleteReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req DeleteReq
 
 	dcr, err := common.DecodeProjectRequest(c, r)
 	if err != nil {
@@ -143,16 +143,16 @@ func decodeDeleteSSHKeyReq(c context.Context, r *http.Request) (interface{}, err
 	return req, nil
 }
 
-// CreateSSHKeyReq represent a request for specific data to create a new SSH key
+// CreateReq represent a request for specific data to create a new SSH key
 // swagger:parameters createSSHKey
-type CreateSSHKeyReq struct {
+type CreateReq struct {
 	common.ProjectReq
 	// swagger:ignore
 	Key apiv1.SSHKey `json:"-"`
 }
 
-func decodeCreateSSHKeyReq(c context.Context, r *http.Request) (interface{}, error) {
-	var req CreateSSHKeyReq
+func DecodeCreateReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req CreateReq
 
 	dcr, err := common.DecodeProjectRequest(c, r)
 	if err != nil {

--- a/api/pkg/handler/v1/ssh/ssh_test.go
+++ b/api/pkg/handler/v1/ssh/ssh_test.go
@@ -1,22 +1,22 @@
-package handler_test
+package ssh_test
 
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	clienttesting "k8s.io/client-go/testing"
-
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
 )
 
 func TestDeleteSSHKey(t *testing.T) {

--- a/api/pkg/handler/v1/version.go
+++ b/api/pkg/handler/v1/version.go
@@ -1,4 +1,4 @@
-package handler
+package v1
 
 import (
 	"context"
@@ -8,13 +8,13 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 )
 
-// getKubermaticVersion returns the versions of running Kubermatic components.
+// GetKubermaticVersion returns the versions of running Kubermatic components.
 //
 // At this time we're only interested in the version of the API server,
 // since it knows its own version and can answer the endpoint promptly.
 //
 // This version string is constructed with `git describe` and embedded in the binary during build.
-func getKubermaticVersion() endpoint.Endpoint {
+func GetKubermaticVersion() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		versions := apiv1.KubermaticVersions{API: resources.KUBERMATICGITTAG}
 		return versions, nil

--- a/api/pkg/handler/v1/version_test.go
+++ b/api/pkg/handler/v1/version_test.go
@@ -1,4 +1,4 @@
-package handler_test
+package v1_test
 
 import (
 	"encoding/json"


### PR DESCRIPTION
**What this PR does / why we need it**: simply moves `ssh.go` to `v1/ssh` package.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
