### PR TITLE
Dashboard/Prometheus cleanup/update

### DIFF
--- a/config/monitoring/grafana/.helmignore
+++ b/config/monitoring/grafana/.helmignore
@@ -1,1 +1,1 @@
-jsonnet/
+dashboards/*.sh

--- a/config/monitoring/grafana/dashboards/cleanup.sh
+++ b/config/monitoring/grafana/dashboards/cleanup.sh
@@ -15,9 +15,16 @@ for dashboard in */*.json; do
     jq '(.links) = []' | \
     jq '(.refresh) = "<< refresh | default `30s` | toJson >>"' | \
     jq '(.time.from) = "<< defaultRange | toJson >>"' | \
+    jq '(.editable) = "<< editable | default false | toJson >>"' | \
+    jq '(.panels[] | select(.type!="row") | .editable) = "<< editable | default false | toJson >>"' | \
+    jq '(.panels[] | select(.type!="row") | .transparent) = "<< transparentPanels | default true | toJson >>"' | \
+    jq '(.panels[] | select(.type!="row") | .timeRegions) = []' | \
+    jq '(.hideControls) = "<< hideControls | default false | toJson >>"' | \
     jq '(.time.to) = "now"' | \
     jq '(.timezone) = ""' | \
     jq '(.graphTooltip) = 1' | \
+    jq 'del(.id)' | \
+    jq 'del(.iteration)' | \
     jq --sort-keys '.' > "$tmpfile"
 
   mv "$tmpfile" "$dashboard"

--- a/config/monitoring/grafana/dashboards/kubermatic/machine-controller.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/machine-controller.json
@@ -58,6 +58,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Machines",
       "tooltip": {
@@ -147,6 +148,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Workers",
       "tooltip": {
@@ -236,6 +238,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Nodes",
       "tooltip": {
@@ -325,6 +328,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "5min Error Rate",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubermatic/nginx.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/nginx.json
@@ -6,7 +6,6 @@
   "gnetId": null,
   "graphTooltip": 1,
   "hideControls": "<< hideControls | default false | toJson >>",
-  "iteration": 1534359654832,
   "links": [],
   "panels": [
     {
@@ -79,6 +78,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Controller Request Volume",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -163,6 +163,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Controller Connections",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -246,6 +247,7 @@
         }
       ],
       "thresholds": "95, 99, 99.5",
+      "timeRegions": [],
       "title": "Controller Success Rate (non-4|5xx responses)",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -331,6 +333,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Config Reloads",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -416,6 +419,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Last Config Failed",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -501,6 +505,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network I/O pressure",
       "tooltip": {
@@ -605,6 +610,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Average Memory Usage",
       "tooltip": {
@@ -714,6 +720,7 @@
         }
       ],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Average CPU Usage",
       "tooltip": {
@@ -970,6 +977,7 @@
         }
       ],
       "timeFrom": null,
+      "timeRegions": [],
       "title": "Ingress Percentile Response Times and Transfer Rates",
       "transform": "table",
       "transparent": "<< transparentPanels | default true | toJson >>",
@@ -1052,6 +1060,7 @@
           "step": 1
         }
       ],
+      "timeRegions": [],
       "title": "Ingress Certificate Expiry",
       "transform": "timeseries_aggregations",
       "transparent": "<< transparentPanels | default true | toJson >>",

--- a/config/monitoring/grafana/dashboards/kubernetes/etcd-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/etcd-overview.json
@@ -7,7 +7,6 @@
   "gnetId": null,
   "graphTooltip": 1,
   "hideControls": "<< hideControls | default false | toJson >>",
-  "iteration": 1534515683711,
   "links": [],
   "panels": [
     {
@@ -74,6 +73,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage",
       "tooltip": {
@@ -120,7 +120,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 0,
       "gridPos": {
@@ -165,6 +165,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Resident Memory",
       "tooltip": {
@@ -211,7 +212,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 0,
       "gridPos": {
@@ -256,6 +257,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Open File Descriptors",
       "tooltip": {
@@ -302,7 +304,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 0,
       "gridPos": {
@@ -347,6 +349,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Cluster Members",
       "tooltip": {
@@ -408,7 +411,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "decimals": null,
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 0,
       "grid": {},
@@ -455,6 +458,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Database Size",
       "tooltip": {
@@ -499,7 +503,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 0,
       "grid": {},
@@ -555,6 +559,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Sync Duration",
       "tooltip": {
@@ -612,7 +617,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -657,6 +662,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Client Traffic In",
       "tooltip": {
@@ -703,7 +709,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -748,6 +754,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Client Traffic Out",
       "tooltip": {
@@ -794,7 +801,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 0,
       "gridPos": {
@@ -839,6 +846,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Peer Traffic In",
       "tooltip": {
@@ -886,7 +894,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "decimals": null,
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 0,
       "grid": {},
@@ -933,6 +941,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Peer Traffic Out",
       "tooltip": {
@@ -990,7 +999,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -1035,6 +1044,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Transactions",
       "tooltip": {
@@ -1081,7 +1091,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -1126,6 +1136,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "PUT Requests",
       "tooltip": {
@@ -1172,7 +1183,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -1217,6 +1228,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "RANGE Requests",
       "tooltip": {
@@ -1263,7 +1275,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -1308,6 +1320,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "DELETE Requests",
       "tooltip": {
@@ -1354,7 +1367,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -1399,6 +1412,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Keys",
       "tooltip": {
@@ -1445,7 +1459,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -1490,6 +1504,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Reads",
       "tooltip": {
@@ -1536,7 +1551,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -1581,6 +1596,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Writes",
       "tooltip": {
@@ -1627,7 +1643,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 5,
       "gridPos": {
@@ -1672,6 +1688,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Expires",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubernetes/etcd.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/etcd.json
@@ -7,7 +7,6 @@
   "gnetId": null,
   "graphTooltip": 1,
   "hideControls": "<< hideControls | default false | toJson >>",
-  "iteration": 1534505906124,
   "links": [],
   "panels": [
     {
@@ -97,6 +96,7 @@
         }
       ],
       "thresholds": "1,2",
+      "timeRegions": [],
       "title": "Up",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -161,6 +161,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage",
       "tooltip": {
@@ -252,6 +253,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Resident Memory",
       "tooltip": {
@@ -343,6 +345,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Open File Descriptors",
       "tooltip": {
@@ -450,6 +453,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Database Size",
       "tooltip": {
@@ -550,6 +554,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Sync Duration",
       "tooltip": {
@@ -652,6 +657,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Client Traffic In",
       "tooltip": {
@@ -743,6 +749,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Client Traffic Out",
       "tooltip": {
@@ -834,6 +841,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Peer Traffic In",
       "tooltip": {
@@ -928,6 +936,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Peer Traffic Out",
       "tooltip": {
@@ -1043,6 +1052,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Raft Proposals",
       "tooltip": {
@@ -1137,6 +1147,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Leader Elections Per Day",
       "tooltip": {
@@ -1241,6 +1252,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Transactions",
       "tooltip": {
@@ -1332,6 +1344,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "PUT Requests",
       "tooltip": {
@@ -1423,6 +1436,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "RANGE Requests",
       "tooltip": {
@@ -1514,6 +1528,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "DELETE Requests",
       "tooltip": {
@@ -1605,6 +1620,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Keys",
       "tooltip": {
@@ -1696,6 +1712,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Reads",
       "tooltip": {
@@ -1787,6 +1804,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Writes",
       "tooltip": {
@@ -1878,6 +1896,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Expires",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
@@ -29,7 +29,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -47,7 +47,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 0,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -56,11 +56,11 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node:node_cpu_utilisation:avg1m{node=~\"$node\"}",
+          "expr": "node:cluster_cpu_utilisation:ratio{node=~\"$nodes\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
@@ -90,11 +90,10 @@
       },
       "yaxes": [
         {
-          "decimals": 1,
           "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": null,
+          "max": 1,
           "min": 0,
           "show": true
         },
@@ -119,7 +118,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -137,7 +136,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 0,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -146,11 +145,11 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node:node_cpu_saturation_load1:{node=~\"$node\"}",
+          "expr": "node:node_cpu_saturation_load1:{node=~\"$nodes\"} / scalar(sum(min(kube_pod_info) by (node)))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
@@ -180,11 +179,10 @@
       },
       "yaxes": [
         {
-          "decimals": 0,
-          "format": "none",
+          "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": null,
+          "max": 1,
           "min": 0,
           "show": true
         },
@@ -223,7 +221,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -241,7 +239,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 0,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -250,11 +248,11 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node:node_memory_utilisation:ratio{node=~\"$node\"}",
+          "expr": "node:cluster_memory_utilisation:ratio{node=~\"$nodes\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
@@ -284,11 +282,10 @@
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": null,
+          "max": 1,
           "min": 0,
           "show": true
         },
@@ -313,7 +310,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -331,7 +328,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 0,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -340,11 +337,11 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node:node_memory_swap_io_bytes:sum_rate{node=~\"$node\"}",
+          "expr": "node:node_memory_swap_io_bytes:sum_rate{node=~\"$nodes\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
@@ -416,7 +413,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -434,7 +431,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 0,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -443,11 +440,11 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node:node_disk_utilisation:avg_irate{node=~\"$node\"}",
+          "expr": "node:node_disk_utilisation:avg_irate{node=~\"$nodes\"} / scalar(:kube_pod_info_node_count:)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
@@ -460,7 +457,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Disk I/O Utilisation",
+      "title": "Disk IO Utilisation",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -477,11 +474,10 @@
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": null,
+          "max": 1,
           "min": 0,
           "show": true
         },
@@ -506,7 +502,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -524,7 +520,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 0,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -533,11 +529,11 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node:node_disk_saturation:avg_irate{node=~\"$node\"}",
+          "expr": "node:node_disk_saturation:avg_irate{node=~\"$nodes\"} / scalar(:kube_pod_info_node_count:)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
@@ -567,11 +563,10 @@
       },
       "yaxes": [
         {
-          "decimals": 1,
           "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": null,
+          "max": 1,
           "min": 0,
           "show": true
         },
@@ -610,7 +605,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -628,7 +623,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 0,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -637,11 +632,11 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node:node_net_utilisation:sum_irate{node=~\"$node\"}",
+          "expr": "node:node_net_utilisation:sum_irate{node=~\"$nodes\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
@@ -730,7 +725,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node:node_net_saturation:sum_irate{node=~\"$node\"}",
+          "expr": "node:node_net_saturation:sum_irate{node=~\"$nodes\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
@@ -802,7 +797,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 7,
         "w": 24,
@@ -820,7 +815,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 0,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -829,12 +824,13 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(node_filesystem_size_bytes{fstype=~\"ext[24]\"} - node_filesystem_avail_bytes{fstype=~\"ext[24]\"}) by (device,pod,namespace)) by (pod,namespace) / scalar(sum(max(node_filesystem_size_bytes{fstype=~\"ext[24]\"}) by (device,pod,namespace))) * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{node=~\"$node\"}",
+          "expr": "sum(max(node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node=~\"$nodes\"} - node_filesystem_avail_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node=~\"$nodes\"}) by (device,pod,namespace)) by (pod,namespace)\n/ scalar(sum(max(node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node=~\"$nodes\"}) by (device,pod,namespace)))\n* on (namespace, pod) group_left (node) node_namespace_pod:kube_pod_info:\n",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 2,
           "legendFormat": "{{node}}",
           "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
@@ -863,11 +859,10 @@
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": null,
+          "max": 1,
           "min": 0,
           "show": true
         },
@@ -904,21 +899,24 @@
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
-        "label": "Node",
+        "label": "Nodes",
         "multi": true,
-        "name": "node",
+        "name": "nodes",
         "options": [],
         "query": "label_values(kube_node_info, node)",
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
@@ -71,6 +71,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Utilisation",
       "tooltip": {
@@ -160,6 +161,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Saturation (Load1)",
       "tooltip": {
@@ -263,6 +265,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Utilisation",
       "tooltip": {
@@ -352,6 +355,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Saturation (Swap I/O)",
       "tooltip": {
@@ -454,6 +458,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk I/O Utilisation",
       "tooltip": {
@@ -543,6 +548,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk IO Saturation",
       "tooltip": {
@@ -646,6 +652,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Net Utilisation (Transmitted)",
       "tooltip": {
@@ -734,6 +741,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Net Saturation (Dropped)",
       "tooltip": {
@@ -836,6 +844,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Capacity",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
@@ -2,11 +2,10 @@
   "annotations": {
     "list": []
   },
-  "editable": "<< editable | toJson >>",
+  "editable": "<< editable | default false | toJson >>",
   "gnetId": null,
   "graphTooltip": 1,
   "hideControls": "<< hideControls | default false | toJson >>",
-  "iteration": 1540473940956,
   "links": [],
   "panels": [
     {
@@ -19,7 +18,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -63,6 +62,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "System load",
       "tooltip": {
@@ -70,7 +70,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -108,7 +108,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -155,6 +155,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Utilizaion",
       "tooltip": {
@@ -162,7 +163,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -205,7 +206,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -249,6 +250,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Used",
       "tooltip": {
@@ -256,7 +258,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -294,7 +296,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -337,6 +339,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk I/O Time",
       "tooltip": {
@@ -344,7 +347,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -382,7 +385,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -435,6 +438,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Read",
       "tooltip": {
@@ -442,7 +446,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -480,7 +484,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -532,6 +536,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Written",
       "tooltip": {
@@ -539,7 +544,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -577,7 +582,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -621,6 +626,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network Received",
       "tooltip": {
@@ -628,7 +634,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -666,7 +672,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -709,6 +715,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network Sent",
       "tooltip": {
@@ -716,7 +723,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
@@ -9,100 +9,6 @@
   "links": [],
   "panels": [
     {
-      "aliasColors": {
-        "load 15m": "#bf1b00",
-        "load 1m": "#eab839",
-        "load 5m": "#ef843c"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeat": null,
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "avg by (instance) (node_load5{app=\"node-exporter\", instance=~\"$instance\"})",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "System load",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": "<< transparentPanels | default true | toJson >>",
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -111,12 +17,12 @@
       "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
+        "h": 7,
+        "w": 20,
+        "x": 0,
         "y": 0
       },
-      "id": 4,
+      "id": 2,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -139,17 +45,16 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeat": null,
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (instance) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=~\"$instance\"}[5m]) * 100)",
+          "expr": "avg by (node_name) (sum by (node_name) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node_name }}",
           "refId": "A"
         }
       ],
@@ -157,7 +62,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CPU Utilizaion",
+      "title": "Average CPU Utilization",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -177,16 +82,16 @@
           "format": "percent",
           "label": null,
           "logBase": 1,
-          "max": 100,
-          "min": 0,
+          "max": null,
+          "min": "0",
           "show": true
         },
         {
           "format": "percent",
           "label": null,
           "logBase": 1,
-          "max": 100,
-          "min": 0,
+          "max": null,
+          "min": null,
           "show": false
         }
       ],
@@ -194,6 +99,89 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 17,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg (sum by (node_name) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "80, 90",
+      "timeRegions": [],
+      "title": "Total CPU Usage",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
     },
     {
       "aliasColors": {
@@ -209,10 +197,10 @@
       "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 7,
+        "w": 20,
         "x": 0,
-        "y": 8
+        "y": 7
       },
       "id": 6,
       "legend": {
@@ -241,10 +229,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (\n  node_memory_MemTotal_bytes{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_MemFree_bytes{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_Buffers_bytes{app=\"node-exporter\", instance=~\"$instance\"}\n  - node_memory_Cached_bytes{app=\"node-exporter\", instance=~\"$instance\"}\n)\n",
+          "expr": "max by (node_name) (\n  node_memory_MemTotal_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n  - node_memory_MemFree_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n  - node_memory_Buffers_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n  - node_memory_Cached_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n)\n",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
+          "legendFormat": "{{ node_name }}",
           "refId": "A"
         }
       ],
@@ -273,7 +261,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -291,192 +279,87 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
+        "h": 7,
+        "w": 4,
+        "x": 20,
+        "y": 7
       },
-      "id": 12,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
+      "id": 18,
+      "interval": null,
       "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      "mappingType": 1,
+      "mappingTypes": [
         {
-          "expr": "max by (instance) (rate(node_disk_io_time_seconds_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Disk I/O Time",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": "<< transparentPanels | default true | toJson >>",
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "name": "value to text",
+          "value": 1
         },
         {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
+          "name": "range to text",
+          "value": 2
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "id": 8,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeat": null,
-      "seriesOverrides": [
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
         {
-          "alias": "read",
-          "yaxis": 1
-        },
-        {
-          "alias": "written",
-          "transform": "negative-Y"
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
         }
       ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
       "targets": [
         {
-          "expr": "max by (instance) (rate(node_disk_read_bytes_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
+          "expr": "max(\n  (\n    sum(\n      node_memory_MemTotal_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n    - node_memory_MemFree_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n    - node_memory_Buffers_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n    - node_memory_Cached_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n    )\n    /\n    sum(\n      node_memory_MemTotal_bytes{app=\"node-exporter\", node_name=~\"$nodes\"}\n    )\n  ) * 100)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
+      "thresholds": "80, 90",
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Disk Read",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
+      "title": "Total Memory Usage",
       "transparent": "<< transparentPanels | default true | toJson >>",
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
         {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "valueName": "current"
     },
     {
       "aliasColors": {},
@@ -487,108 +370,10 @@
       "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
-      "id": 14,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "read",
-          "yaxis": 1
-        },
-        {
-          "alias": "written",
-          "transform": "negative-Y"
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "max by (instance) (rate(node_disk_written_bytes_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Disk Written",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": "<< transparentPanels | default true | toJson >>",
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
-      "fill": 1,
-      "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 14
       },
       "id": 10,
       "legend": {
@@ -617,10 +402,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (rate(node_network_receive_bytes_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
+          "expr": "max by (node_name) (rate(node_network_receive_bytes_total{app=\"node-exporter\", node_name=~\"$nodes\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
+          "legendFormat": "{{ node_name }}",
           "refId": "A"
         }
       ],
@@ -675,10 +460,10 @@
       "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 14
       },
       "id": 13,
       "legend": {
@@ -706,10 +491,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (instance) (rate(node_network_transmit_bytes_total{app=\"node-exporter\", instance=~\"$instance\"}[2m]))",
+          "expr": "max by (node_name) (rate(node_network_transmit_bytes_total{app=\"node-exporter\", node_name=~\"$nodes\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
+          "legendFormat": "{{ node_name }}",
           "refId": "A"
         }
       ],
@@ -754,6 +539,363 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 8,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max by (node_name) (rate(node_disk_read_bytes_total{app=\"node-exporter\", node_name=~\"$nodes\"}[2m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node_name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Read",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 14,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max by (node_name) (rate(node_disk_written_bytes_total{app=\"node-exporter\", node_name=~\"$nodes\"}[2m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node_name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Written",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 12,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max by (node_name) (rate(node_disk_io_time_seconds_total{app=\"node-exporter\", node_name=~\"$nodes\"}[2m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node_name }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk I/O Time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 15,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "1 - sum by (node_name) (node_filesystem_avail_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\", node_name=~\"$nodes\"}) / sum by (node_name) (node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\", node_name=~\"$nodes\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node_name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "<< refresh | default `30s` | toJson >>",
@@ -764,6 +906,7 @@
     "list": [
       {
         "current": {
+          "selected": true,
           "text": "prometheus",
           "value": "prometheus"
         },
@@ -774,22 +917,25 @@
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
+        "definition": "label_values(node_boot_time_seconds{app=\"node-exporter\"}, node_name)",
         "hide": 0,
         "includeAll": true,
-        "label": null,
+        "label": "Nodes",
         "multi": true,
-        "name": "instance",
+        "name": "nodes",
         "options": [],
-        "query": "label_values(node_boot_time_seconds{app=\"node-exporter\"}, instance)",
+        "query": "label_values(node_boot_time_seconds{app=\"node-exporter\"}, node_name)",
         "refresh": 2,
         "regex": "",
-        "sort": 0,
+        "skipUrlSync": false,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes.json
@@ -1058,6 +1058,95 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 19,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "1 - (max by (device) (node_filesystem_avail_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",instance=\"$instance\"} / node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",instance=\"$instance\"}))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ device }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "<< refresh | default `30s` | toJson >>",

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes.json
@@ -54,21 +54,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(node_load1{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_load1{app=\"node-exporter\", node_name=\"$node\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "load 1m",
           "refId": "A"
         },
         {
-          "expr": "max(node_load5{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_load5{app=\"node-exporter\", node_name=\"$node\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "load 5m",
           "refId": "B"
         },
         {
-          "expr": "max(node_load15{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_load15{app=\"node-exporter\", node_name=\"$node\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "load 15m",
@@ -161,7 +161,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[5m]) * 100)",
+          "expr": "sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "core {{ cpu }}",
@@ -220,7 +220,7 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 19,
+        "w": 20,
         "x": 0,
         "y": 8
       },
@@ -253,7 +253,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]) * 100))",
+          "expr": "avg(sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 10,
           "legendFormat": "average",
@@ -323,8 +323,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
-        "x": 19,
+        "w": 4,
+        "x": 20,
         "y": 8
       },
       "id": 15,
@@ -364,7 +364,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg (sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]) * 100))",
+          "expr": "avg (sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"
@@ -400,7 +400,7 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 19,
+        "w": 20,
         "x": 0,
         "y": 15
       },
@@ -431,28 +431,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(\n  node_memory_MemTotal_bytes{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_MemFree_bytes{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Buffers_bytes{app=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Cached_bytes{app=\"node-exporter\", instance=\"$instance\"}\n)\n",
+          "expr": "max(\n  node_memory_MemTotal_bytes{app=\"node-exporter\", node_name=\"$node\"}\n  - node_memory_MemFree_bytes{app=\"node-exporter\", node_name=\"$node\"}\n  - node_memory_Buffers_bytes{app=\"node-exporter\", node_name=\"$node\"}\n  - node_memory_Cached_bytes{app=\"node-exporter\", node_name=\"$node\"}\n)\n",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "memory used",
           "refId": "A"
         },
         {
-          "expr": "max(node_memory_Buffers_bytes{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_memory_Buffers_bytes{app=\"node-exporter\", node_name=\"$node\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "memory buffers",
           "refId": "B"
         },
         {
-          "expr": "max(node_memory_Cached_bytes{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_memory_Cached_bytes{app=\"node-exporter\", node_name=\"$node\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "memory cached",
           "refId": "C"
         },
         {
-          "expr": "max(node_memory_MemFree_bytes{app=\"node-exporter\", instance=\"$instance\"})",
+          "expr": "max(node_memory_MemFree_bytes{app=\"node-exporter\", node_name=\"$node\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "memory free",
@@ -522,8 +522,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
-        "x": 19,
+        "w": 4,
+        "x": 20,
         "y": 15
       },
       "id": 16,
@@ -563,7 +563,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(\n  (\n    (\n      node_memory_MemTotal_bytes{app=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_MemFree_bytes{app=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Buffers_bytes{app=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Cached_bytes{app=\"node-exporter\", instance=\"$instance\"}\n    )\n    / node_memory_MemTotal_bytes{app=\"node-exporter\", instance=\"$instance\"}\n  ) * 100)",
+          "expr": "max(\n  (\n    (\n      node_memory_MemTotal_bytes{app=\"node-exporter\", node_name=\"$node\"}\n    - node_memory_MemFree_bytes{app=\"node-exporter\", node_name=\"$node\"}\n    - node_memory_Buffers_bytes{app=\"node-exporter\", node_name=\"$node\"}\n    - node_memory_Cached_bytes{app=\"node-exporter\", node_name=\"$node\"}\n    )\n    / node_memory_MemTotal_bytes{app=\"node-exporter\", node_name=\"$node\"}\n  ) * 100)",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"
@@ -600,7 +600,7 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 19,
+        "w": 20,
         "x": 0,
         "y": 22
       },
@@ -630,7 +630,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(\n  node_filesystem_files{app=\"node-exporter\", instance=\"$instance\"}\n  - node_filesystem_files_free{app=\"node-exporter\", instance=\"$instance\"}\n)",
+          "expr": "max(\n  node_filesystem_files{app=\"node-exporter\", node_name=\"$node\"}\n  - node_filesystem_files_free{app=\"node-exporter\", node_name=\"$node\"}\n)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "used",
@@ -700,8 +700,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
-        "x": 19,
+        "w": 4,
+        "x": 20,
         "y": 22
       },
       "id": 18,
@@ -741,7 +741,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(\n  (\n    (\n      node_filesystem_files{app=\"node-exporter\", instance=\"$instance\"}\n    - node_filesystem_files_free{app=\"node-exporter\", instance=\"$instance\"}\n    )\n    / node_filesystem_files{app=\"node-exporter\", instance=\"$instance\"}\n  ) * 100)",
+          "expr": "max(\n  (\n    (\n      node_filesystem_files{app=\"node-exporter\", node_name=\"$node\"}\n    - node_filesystem_files_free{app=\"node-exporter\", node_name=\"$node\"}\n    )\n    / node_filesystem_files{app=\"node-exporter\", node_name=\"$node\"}\n  ) * 100)",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"
@@ -812,14 +812,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(node_disk_read_bytes_total{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
+          "expr": "max(rate(node_disk_read_bytes_total{app=\"node-exporter\", node_name=\"$node\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "read",
           "refId": "A"
         },
         {
-          "expr": "max(rate(node_disk_written_bytes_total{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
+          "expr": "max(rate(node_disk_written_bytes_total{app=\"node-exporter\", node_name=\"$node\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "written",
@@ -914,14 +914,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(node_network_receive_bytes_total{app=\"node-exporter\", instance=\"$instance\", device!~\"lo\"}[2m]))",
+          "expr": "max(rate(node_network_receive_bytes_total{app=\"node-exporter\", node_name=\"$node\", device!~\"lo\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "received",
           "refId": "A"
         },
         {
-          "expr": "max(rate(node_network_transmit_bytes_total{app=\"node-exporter\", instance=\"$instance\", device!~\"lo\"}[2m]))",
+          "expr": "max(rate(node_network_transmit_bytes_total{app=\"node-exporter\", node_name=\"$node\", device!~\"lo\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "sent",
@@ -1010,7 +1010,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(node_disk_io_time_seconds_total{app=\"node-exporter\",  instance=\"$instance\"}[2m]))",
+          "expr": "max(rate(node_disk_io_time_seconds_total{app=\"node-exporter\",  node_name=\"$node\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "io time",
@@ -1099,7 +1099,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (max by (device) (node_filesystem_avail_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",instance=\"$instance\"} / node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",instance=\"$instance\"}))",
+          "expr": "1 - (max by (device) (node_filesystem_avail_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\", node_name=\"$node\"} / node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\", node_name=\"$node\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ device }}",
@@ -1157,6 +1157,7 @@
     "list": [
       {
         "current": {
+          "selected": true,
           "text": "prometheus",
           "value": "prometheus"
         },
@@ -1174,18 +1175,18 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
-        "definition": "",
+        "definition": "label_values(node_boot_time_seconds, node_name)",
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Node",
         "multi": false,
-        "name": "instance",
+        "name": "node",
         "options": [],
-        "query": "label_values(node_boot_time_seconds{app=\"node-exporter\"}, instance)",
+        "query": "label_values(node_boot_time_seconds, node_name)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes.json
@@ -2,26 +2,24 @@
   "annotations": {
     "list": []
   },
-  "editable": "<< editable | toJson >>",
+  "editable": "<< editable | default false | toJson >>",
   "gnetId": null,
   "graphTooltip": 1,
   "hideControls": "<< hideControls | default false | toJson >>",
-  "id": 6,
-  "iteration": 1540470554249,
   "links": [],
   "panels": [
     {
       "aliasColors": {
-        "load 15m": "#bf1b00",
-        "load 1m": "#eab839",
-        "load 5m": "#ef843c"
+        "load 15m": "#ffffffff",
+        "load 1m": "#e24d42",
+        "load 5m": "#e5ac0e"
       },
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
-      "fill": 10,
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -29,6 +27,7 @@
         "y": 0
       },
       "id": 2,
+      "interval": "",
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -51,7 +50,7 @@
       "repeat": null,
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -78,6 +77,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "System load",
       "tooltip": {
@@ -85,7 +85,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -123,7 +123,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -161,23 +161,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]) * 100)",
+          "expr": "sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[5m]) * 100)",
           "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ cpu }}",
+          "intervalFactor": 2,
+          "legendFormat": "core {{ cpu }}",
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "CPU Utilizaion",
+      "title": "CPU Utilization per Core",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -210,6 +211,181 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 19,
+        "x": 0,
+        "y": 8
+      },
+      "id": 13,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]) * 100))",
+          "format": "time_series",
+          "intervalFactor": 10,
+          "legendFormat": "average",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average CPU Utilization",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": 100,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": 100,
+          "min": 0,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 19,
+        "y": 8
+      },
+      "id": 15,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg (sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]) * 100))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "80, 90",
+      "timeRegions": [],
+      "title": "Current CPU Usage",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
       "aliasColors": {
         "memory buffers": "#eab839",
         "memory cached": "#82b5d8",
@@ -220,13 +396,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 7,
+        "w": 19,
         "x": 0,
-        "y": 8
+        "y": 15
       },
       "id": 6,
       "legend": {
@@ -285,6 +461,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Usage",
       "tooltip": {
@@ -292,7 +469,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -325,20 +502,109 @@
       }
     },
     {
-      "aliasColors": {},
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 19,
+        "y": 15
+      },
+      "id": 16,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "max(\n  (\n    (\n      node_memory_MemTotal_bytes{app=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_MemFree_bytes{app=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Buffers_bytes{app=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Cached_bytes{app=\"node-exporter\", instance=\"$instance\"}\n    )\n    / node_memory_MemTotal_bytes{app=\"node-exporter\", instance=\"$instance\"}\n  ) * 100)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "80, 90",
+      "timeRegions": [],
+      "title": "Current Memory Usage",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {
+        "memory buffers": "#eab839",
+        "memory cached": "#82b5d8",
+        "memory free": "#629e51",
+        "memory used": "#ea6460",
+        "used": "#e0752d"
+      },
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
+        "h": 7,
+        "w": 19,
+        "x": 0,
+        "y": 22
       },
-      "id": 10,
+      "id": 17,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -358,42 +624,30 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeat": null,
-      "seriesOverrides": [
-        {
-          "alias": "sent",
-          "transform": "negative-Y"
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(node_network_receive_bytes_total{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
+          "expr": "max(\n  node_filesystem_files{app=\"node-exporter\", instance=\"$instance\"}\n  - node_filesystem_files_free{app=\"node-exporter\", instance=\"$instance\"}\n)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "received",
+          "legendFormat": "used",
           "refId": "A"
-        },
-        {
-          "expr": "max(rate(node_network_transmit_bytes_total{app=\"node-exporter\", instance=\"$instance\"}[2m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "sent",
-          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Network Traffic",
+      "title": "Inode Usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -404,7 +658,7 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -426,18 +680,101 @@
       }
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 19,
+        "y": 22
+      },
+      "id": 18,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "max(\n  (\n    (\n      node_filesystem_files{app=\"node-exporter\", instance=\"$instance\"}\n    - node_filesystem_files_free{app=\"node-exporter\", instance=\"$instance\"}\n    )\n    / node_filesystem_files{app=\"node-exporter\", instance=\"$instance\"}\n  ) * 100)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "80, 90",
+      "timeRegions": [],
+      "title": "Current Inode Usage",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 29
       },
       "id": 8,
       "legend": {
@@ -491,6 +828,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk I/O",
       "tooltip": {
@@ -498,7 +836,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -536,13 +874,115 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 29
+      },
+      "id": 10,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [
+        {
+          "alias": "sent",
+          "transform": "negative-Y"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(node_network_receive_bytes_total{app=\"node-exporter\", instance=\"$instance\", device!~\"lo\"}[2m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "received",
+          "refId": "A"
+        },
+        {
+          "expr": "max(rate(node_network_transmit_bytes_total{app=\"node-exporter\", instance=\"$instance\", device!~\"lo\"}[2m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "sent",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Traffic",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 37
       },
       "id": 12,
       "legend": {
@@ -579,6 +1019,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk I/O Time",
       "tooltip": {
@@ -586,7 +1027,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -637,12 +1078,14 @@
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -652,6 +1095,7 @@
         "query": "label_values(node_boot_time_seconds{app=\"node-exporter\"}, instance)",
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/pods.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/pods.json
@@ -73,6 +73,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Pod Memory",
       "tooltip": {
@@ -175,6 +176,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Container Memory",
       "tooltip": {
@@ -264,6 +266,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage",
       "tooltip": {
@@ -353,6 +356,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network I/O",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
@@ -117,6 +117,7 @@
       ],
       "thresholds": "70,80",
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Utilisation",
       "tooltip": {
@@ -256,6 +257,7 @@
       ],
       "thresholds": "70,80",
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Requests Commitment",
       "tooltip": {
@@ -395,6 +397,7 @@
       ],
       "thresholds": "70,80",
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Limits Commitment",
       "tooltip": {
@@ -534,6 +537,7 @@
       ],
       "thresholds": "70,80",
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Utilisation",
       "tooltip": {
@@ -673,6 +677,7 @@
       ],
       "thresholds": "70,80",
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Requests Commitment",
       "tooltip": {
@@ -812,6 +817,7 @@
       ],
       "thresholds": "70,80",
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Limits Commitment",
       "tooltip": {
@@ -919,6 +925,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage",
       "tooltip": {
@@ -1169,6 +1176,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Quota",
       "tooltip": {
@@ -1268,6 +1276,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Usage (w/o cache)",
       "tooltip": {
@@ -1518,6 +1527,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Requests by Namespace",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
@@ -914,7 +914,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{namespace!=\"\"}[1m])) by (namespace)",
+          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{namespace}}",
@@ -1109,10 +1109,12 @@
           "decimals": 2,
           "link": true,
           "linkTooltip": "Drill down",
-          "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell",
+          "linkUrl": "/d/f9d729354e90/resources-namespace?var-namespace=$__cell",
           "pattern": "namespace",
+          "preserveFormat": false,
+          "sanitize": false,
           "thresholds": [],
-          "type": "number",
+          "type": "string",
           "unit": "short"
         },
         {
@@ -1129,7 +1131,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace!=\"\"}[5m])) by (namespace)",
+          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1147,7 +1149,7 @@
           "step": 10
         },
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total[5m])) by (namespace) / sum(kube_pod_container_resource_requests_cpu_cores) by (namespace)",
+          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_container_resource_requests_cpu_cores) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1165,7 +1167,7 @@
           "step": 10
         },
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total[5m])) by (namespace) / sum(kube_pod_container_resource_limits_cpu_cores) by (namespace)",
+          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_container_resource_limits_cpu_cores) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1265,7 +1267,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_rss{namespace!=\"\"}) by (namespace)",
+          "expr": "sum(container_memory_rss{container_name!=\"\"}) by (namespace)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{namespace}}",
@@ -1460,10 +1462,10 @@
           "decimals": 2,
           "link": true,
           "linkTooltip": "Drill down",
-          "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell",
+          "linkUrl": "/d/f9d729354e90/resources-namespace?var-namespace=$__cell",
           "pattern": "namespace",
           "thresholds": [],
-          "type": "number",
+          "type": "string",
           "unit": "short"
         },
         {
@@ -1480,7 +1482,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(container_memory_rss{namespace!=\"\"}) by (namespace)",
+          "expr": "sum(container_memory_rss{container_name!=\"\"}) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1498,7 +1500,7 @@
           "step": 10
         },
         {
-          "expr": "sum(container_memory_rss) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes) by (namespace)",
+          "expr": "sum(container_memory_rss{container_name!=\"\"}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1516,7 +1518,7 @@
           "step": 10
         },
         {
-          "expr": "sum(container_memory_rss) by (namespace) / sum(kube_pod_container_resource_limits_memory_bytes) by (namespace)",
+          "expr": "sum(container_memory_rss{container_name!=\"\"}) by (namespace) / sum(kube_pod_container_resource_limits_memory_bytes) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1583,6 +1585,7 @@
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       }
     ]

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
@@ -60,7 +60,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[1m])) by (pod_name)",
+          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod_name)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{pod_name}}",
@@ -255,10 +255,10 @@
           "decimals": 2,
           "link": true,
           "linkTooltip": "Drill down",
-          "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell",
+          "linkUrl": "/d/0143e76b1bcb/resources-pod?var-namespace=$namespace&var-pod=$__cell",
           "pattern": "pod",
           "thresholds": [],
-          "type": "number",
+          "type": "string",
           "unit": "short"
         },
         {
@@ -275,7 +275,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[5m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -293,7 +293,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[5m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -311,7 +311,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[5m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -411,7 +411,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\"}) by (pod_name)",
+          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", container_name!=\"\"}) by (pod_name)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{pod_name}}",
@@ -599,6 +599,48 @@
           "unit": "percentunit"
         },
         {
+          "alias": "Memory Usage (RSS)",
+          "colorMode": null,
+          "colors": [],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "linkTooltip": "Drill down",
+          "linkUrl": "",
+          "pattern": "Value #F",
+          "thresholds": [],
+          "type": "number",
+          "unit": "bytes"
+        },
+        {
+          "alias": "Memory Usage (Cache)",
+          "colorMode": null,
+          "colors": [],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "linkTooltip": "Drill down",
+          "linkUrl": "",
+          "pattern": "Value #G",
+          "thresholds": [],
+          "type": "number",
+          "unit": "bytes"
+        },
+        {
+          "alias": "Memory Usage (Swap",
+          "colorMode": null,
+          "colors": [],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "linkTooltip": "Drill down",
+          "linkUrl": "",
+          "pattern": "Value #H",
+          "thresholds": [],
+          "type": "number",
+          "unit": "bytes"
+        },
+        {
           "alias": "Pod",
           "colorMode": null,
           "colors": [],
@@ -606,10 +648,10 @@
           "decimals": 2,
           "link": true,
           "linkTooltip": "Drill down",
-          "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell",
+          "linkUrl": "/d/0143e76b1bcb/resources-pod?var-namespace=$namespace&var-pod=$__cell",
           "pattern": "pod",
           "thresholds": [],
-          "type": "number",
+          "type": "string",
           "unit": "short"
         },
         {
@@ -626,7 +668,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -644,7 +686,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -662,12 +704,39 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "E",
+          "step": 10
+        },
+        {
+          "expr": "sum(label_replace(container_memory_rss{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "F",
+          "step": 10
+        },
+        {
+          "expr": "sum(label_replace(container_memory_cache{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "G",
+          "step": 10
+        },
+        {
+          "expr": "sum(label_replace(container_memory_swap{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "H",
           "step": 10
         }
       ],
@@ -729,12 +798,14 @@
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "namespace",
@@ -744,6 +815,7 @@
         "query": "label_values(kube_pod_info, namespace)",
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
@@ -5,6 +5,7 @@
   "editable": "<< editable | default false | toJson >>",
   "gnetId": null,
   "graphTooltip": 1,
+  "hideControls": "<< hideControls | default false | toJson >>",
   "links": [],
   "panels": [
     {
@@ -70,6 +71,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage",
       "tooltip": {
@@ -320,6 +322,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Quota",
       "tooltip": {
@@ -419,6 +422,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Usage",
       "tooltip": {
@@ -669,6 +673,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Quota",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
@@ -71,6 +71,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage",
       "tooltip": {
@@ -321,6 +322,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Quota",
       "tooltip": {
@@ -420,6 +422,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Usage",
       "tooltip": {
@@ -670,6 +673,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Quota",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
@@ -9,12 +9,249 @@
   "links": [],
   "panels": [
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 10,
+        "x": 0,
+        "y": 0
+      },
+      "id": 11,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "kube_pod_info{namespace=\"$namespace\",pod=\"$pod\"}",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{ created_by_kind }} {{ created_by_name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeRegions": [],
+      "title": "Created By",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [],
+      "valueName": "name"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 10,
+        "y": 0
+      },
+      "id": 9,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "kube_pod_info{namespace=\"$namespace\",pod=\"$pod\"}",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{ pod_ip }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeRegions": [],
+      "title": "Pod IP",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [],
+      "valueName": "name"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 10,
+        "x": 14,
+        "y": 0
+      },
+      "id": 10,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "kube_pod_info{namespace=\"$namespace\",pod=\"$pod\"}",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{ node }} ({{ host_ip }})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeRegions": [],
+      "title": "Scheduled on Node",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [],
+      "valueName": "name"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 4,
       "panels": [],
@@ -34,7 +271,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 4
       },
       "id": 0,
       "legend": {
@@ -60,10 +297,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}[1m])) by (container_name)",
+          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}) by (container_name)",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 2,
-          "legendFormat": "{{container_name}}",
+          "legendFormat": "{{ container_name }}",
           "legendLink": null,
           "refId": "A",
           "step": 10
@@ -117,7 +355,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 11
       },
       "id": 5,
       "panels": [],
@@ -139,7 +377,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 12
       },
       "id": 1,
       "legend": {
@@ -275,7 +513,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}[5m]), \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -293,7 +531,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=\"$pod\"}[5m]), \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod_name=\"$pod\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -311,7 +549,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=\"$pod\"}[5m]), \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod_name=\"$pod\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -365,7 +603,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 19
       },
       "id": 6,
       "panels": [],
@@ -385,7 +623,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 20
       },
       "id": 2,
       "legend": {
@@ -411,12 +649,30 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}) by (container_name)",
+          "expr": "sum(container_memory_rss{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{container_name}}",
+          "legendFormat": "{{ container_name }} (RSS)",
           "legendLink": null,
           "refId": "A",
+          "step": 10
+        },
+        {
+          "expr": "sum(container_memory_cache{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ container_name }} (Cache)",
+          "legendLink": null,
+          "refId": "B",
+          "step": 10
+        },
+        {
+          "expr": "sum(container_memory_swap{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ container_name }} (Swap)",
+          "legendLink": null,
+          "refId": "C",
           "step": 10
         }
       ],
@@ -468,7 +724,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 27
       },
       "id": 7,
       "panels": [],
@@ -490,7 +746,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 28
       },
       "id": 3,
       "legend": {
@@ -599,6 +855,48 @@
           "unit": "percentunit"
         },
         {
+          "alias": "Memory Usage (RSS)",
+          "colorMode": null,
+          "colors": [],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "linkTooltip": "Drill down",
+          "linkUrl": "",
+          "pattern": "Value #F",
+          "thresholds": [],
+          "type": "number",
+          "unit": "bytes"
+        },
+        {
+          "alias": "Memory Usage (Cache)",
+          "colorMode": null,
+          "colors": [],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "linkTooltip": "Drill down",
+          "linkUrl": "",
+          "pattern": "Value #G",
+          "thresholds": [],
+          "type": "number",
+          "unit": "bytes"
+        },
+        {
+          "alias": "Memory Usage (Swap",
+          "colorMode": null,
+          "colors": [],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "linkTooltip": "Drill down",
+          "linkUrl": "",
+          "pattern": "Value #H",
+          "thresholds": [],
+          "type": "number",
+          "unit": "bytes"
+        },
+        {
           "alias": "Container",
           "colorMode": null,
           "colors": [],
@@ -626,7 +924,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -653,7 +951,7 @@
           "step": 10
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -662,12 +960,39 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "E",
+          "step": 10
+        },
+        {
+          "expr": "sum(label_replace(container_memory_rss{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "F",
+          "step": 10
+        },
+        {
+          "expr": "sum(label_replace(container_memory_cache{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "G",
+          "step": 10
+        },
+        {
+          "expr": "sum(label_replace(container_memory_swap{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "H",
           "step": 10
         }
       ],
@@ -729,12 +1054,14 @@
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "namespace",
@@ -744,6 +1071,7 @@
         "query": "label_values(kube_pod_info, namespace)",
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -755,6 +1083,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "pod",
@@ -764,6 +1093,7 @@
         "query": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
@@ -77,6 +77,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "CPU",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -159,6 +160,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Memory",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -241,6 +243,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Network",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -324,6 +327,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Desired Replicas",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -407,6 +411,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Replicas of current version",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -490,6 +495,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Observed Generation",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -573,6 +579,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Metadata Generation",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -664,6 +671,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Replicas",
       "tooltip": {

--- a/config/monitoring/grafana/dashboards/kubernetes/volumes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/volumes.json
@@ -90,6 +90,7 @@
         }
       ],
       "thresholds": "0.7,0.9",
+      "timeRegions": [],
       "title": "Total Disk Usage",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -172,6 +173,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Total Disk Capacity",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -254,6 +256,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Total Available Disk Space",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -336,6 +339,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Total Used Disk Space",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -436,6 +440,7 @@
         }
       ],
       "thresholds": "0.7,0.9",
+      "timeRegions": [],
       "title": "Disk Usage",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -521,6 +526,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Capacity",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -589,6 +595,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Usages",
       "tooltip": {
@@ -700,6 +707,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Available",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
@@ -785,6 +793,7 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Used",
       "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",

--- a/config/monitoring/grafana/dashboards/prometheus/seed.json
+++ b/config/monitoring/grafana/dashboards/prometheus/seed.json
@@ -12,7 +12,7 @@
       "columns": [],
       "datasource": "$datasource",
       "description": "Servers which are DOWN RIGHT NOW!",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fontSize": "100%",
       "gridPos": {
         "h": 7,
@@ -83,9 +83,10 @@
         }
       ],
       "timeFrom": "1s",
+      "timeRegions": [],
       "title": "Currently Down",
       "transform": "table",
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "table"
     },
     {
@@ -99,7 +100,7 @@
       ],
       "datasource": "$datasource",
       "description": "Total number of time series in prometheus",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "format": "locale",
       "gauge": {
         "maxValue": 100,
@@ -159,8 +160,9 @@
         }
       ],
       "thresholds": "1000000,2000000",
+      "timeRegions": [],
       "title": "Total Series",
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "100%",
       "valueMaps": [
@@ -183,7 +185,7 @@
       ],
       "datasource": "$datasource",
       "decimals": null,
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "format": "locale",
       "gauge": {
         "maxValue": 100,
@@ -243,8 +245,9 @@
         }
       ],
       "thresholds": "",
+      "timeRegions": [],
       "title": "Memory Chunks",
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "100%",
       "valueMaps": [
@@ -267,7 +270,7 @@
       ],
       "datasource": "$datasource",
       "description": "The total number of rule group evaluations missed due to slow rule group evaluation.",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "format": "locale",
       "gauge": {
         "maxValue": 100,
@@ -327,8 +330,9 @@
         }
       ],
       "thresholds": "1,10",
+      "timeRegions": [],
       "title": "Missed Iterations [$interval]",
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "100%",
       "valueMaps": [
@@ -351,7 +355,7 @@
       ],
       "datasource": "$datasource",
       "description": "The total number of rule group evaluations skipped due to throttled metric storage.",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "format": "locale",
       "gauge": {
         "maxValue": 100,
@@ -411,8 +415,9 @@
         }
       ],
       "thresholds": "1,10",
+      "timeRegions": [],
       "title": "Skipped Iterations [$interval]",
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "100%",
       "valueMaps": [
@@ -435,7 +440,7 @@
       ],
       "datasource": "$datasource",
       "description": "Total number of scrapes that hit the sample limit and were rejected.",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -495,8 +500,9 @@
         }
       ],
       "thresholds": "1,10",
+      "timeRegions": [],
       "title": "Tardy Scrapes [$interval]",
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "100%",
       "valueMaps": [
@@ -519,7 +525,7 @@
       ],
       "datasource": "$datasource",
       "description": "Number of times the database failed to reload block data from disk.",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -579,8 +585,9 @@
         }
       ],
       "thresholds": "1,10",
+      "timeRegions": [],
       "title": "Reload Failures [$interval]",
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "100%",
       "valueMaps": [
@@ -603,7 +610,7 @@
       ],
       "datasource": "$datasource",
       "description": "Sum of all skipped scrapes",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -663,8 +670,9 @@
         }
       ],
       "thresholds": "1,10",
+      "timeRegions": [],
       "title": "Skipped Scrapes [$interval]",
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "100%",
       "valueMaps": [
@@ -683,7 +691,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "All non-zero failures and errors",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -877,6 +885,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Failures and Errors",
       "tooltip": {
@@ -884,7 +893,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -922,7 +931,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -965,6 +974,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Upness (stacked)",
       "tooltip": {
@@ -972,7 +982,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1011,7 +1021,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1053,6 +1063,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Storage Memory Chunks",
       "tooltip": {
@@ -1060,7 +1071,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1098,7 +1109,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1140,6 +1151,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Series Count",
       "tooltip": {
@@ -1147,7 +1159,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1185,7 +1197,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1240,6 +1252,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Series Created / Removed",
       "tooltip": {
@@ -1247,7 +1260,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1286,7 +1299,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Rate of total number of appended samples",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1328,6 +1341,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Appended Samples per Second",
       "tooltip": {
@@ -1335,7 +1349,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1374,7 +1388,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Total number of syncs that were executed on a scrape pool.",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1418,6 +1432,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Scrape Sync Total",
       "tooltip": {
@@ -1425,7 +1440,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1464,7 +1479,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Actual interval to sync the scrape pool.",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1506,6 +1521,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Target Sync",
       "tooltip": {
@@ -1513,7 +1529,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1551,7 +1567,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1593,6 +1609,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Scrape Duration",
       "tooltip": {
@@ -1600,7 +1617,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1639,7 +1656,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Total number of rejected scrapes",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1708,6 +1725,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rejected Scrapes",
       "tooltip": {
@@ -1715,7 +1733,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1755,7 +1773,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "The duration of rule group evaluations",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1797,6 +1815,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Average Rule Evaluation Duration",
       "tooltip": {
@@ -1804,7 +1823,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1842,7 +1861,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1884,6 +1903,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "HTTP Request Duration",
       "tooltip": {
@@ -1891,7 +1911,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1929,7 +1949,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1971,6 +1991,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Prometheus Engine Query Duration Seconds",
       "tooltip": {
@@ -1978,7 +1999,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2017,7 +2038,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Rule-group evaluations \n - total\n - missed due to slow rule group evaluation\n - skipped due to throttled metric storage",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -2075,6 +2096,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rule Evaluator Iterations",
       "tooltip": {
@@ -2082,7 +2104,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2120,7 +2142,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -2162,6 +2184,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Notifications Sent",
       "tooltip": {
@@ -2169,7 +2192,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2207,7 +2230,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -2249,6 +2272,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Minutes Since Successful Config Reload",
       "tooltip": {
@@ -2256,7 +2280,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2294,7 +2318,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -2336,6 +2360,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Successful Config Reload",
       "tooltip": {
@@ -2343,7 +2368,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2383,7 +2408,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "GC invocation durations",
-      "editable": "<< editable | toJson >>",
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -2425,6 +2450,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "GC Rate / 2m",
       "tooltip": {
@@ -2432,7 +2458,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | toJson >>",
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,

--- a/config/monitoring/prometheus/rules/general-kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/general-kube-state-metrics.yaml
@@ -9,9 +9,7 @@ groups:
       max(label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
     record: 'node_namespace_pod:kube_pod_info:'
   - expr: |
-      sum by (namespace) (
-        rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])
-      )
+      sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace)
     record: namespace:container_cpu_usage_seconds_total:sum_rate
   - expr: |
       sum by (namespace, pod_name, container_name) (

--- a/config/monitoring/prometheus/rules/general-node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-node-exporter.yaml
@@ -39,12 +39,6 @@ groups:
       sum(node_memory_MemTotal_bytes{app="node-exporter"})
     record: ':node_memory_utilisation:'
   - expr: |
-      sum(node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
-    record: :node_memory_MemFreeCachedBuffers:sum
-  - expr: |
-      sum(node_memory_MemTotal_bytes{app="node-exporter"})
-    record: :node_memory_MemTotal:sum
-  - expr: |
       sum by (node) (
         (node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
         * on (namespace, pod) group_left(node)
@@ -95,118 +89,57 @@ groups:
       )
     record: node:node_memory_swap_io_bytes:sum_rate
   - expr: |
-      avg(irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]))
+      avg(irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]))
     record: :node_disk_utilisation:avg_irate
   - expr: |
       avg by (node) (
-        irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m])
+        irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m])
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
     record: node:node_disk_utilisation:avg_irate
   - expr: |
-      avg(irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]))
+      avg(irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]) / 1e3)
     record: :node_disk_saturation:avg_irate
   - expr: |
       avg by (node) (
-        irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m])
+        irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]) / 1e3
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
     record: node:node_disk_saturation:avg_irate
   - expr: |
-      max by (namespace, pod, device) (
-        (node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-        /
-        node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
-      )
+      max by (namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+      - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+      / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
     record: 'node:node_filesystem_usage:'
   - expr: |
-      max by (namespace, pod, device) (
-        node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
-      )
+      max by (namespace, pod, device) (node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
     record: 'node:node_filesystem_avail:'
   - expr: |
-      sum(irate(node_network_receive_bytes_total{app="node-exporter",device="eth0"}[1m])) +
-      sum(irate(node_network_transmit_bytes_total{app="node-exporter",device="eth0"}[1m]))
+      sum(irate(node_network_receive_bytes_total{app="node-exporter",device!~"veth.+"}[1m])) +
+      sum(irate(node_network_transmit_bytes_total{app="node-exporter",device!~"veth.+"}[1m]))
     record: :node_net_utilisation:sum_irate
   - expr: |
       sum by (node) (
-        (irate(node_network_receive_bytes_total{app="node-exporter",device="eth0"}[1m]) +
-        irate(node_network_transmit_bytes_total{app="node-exporter",device="eth0"}[1m]))
+        (irate(node_network_receive_bytes_total{app="node-exporter",device!~"veth.+"}[1m]) +
+        irate(node_network_transmit_bytes_total{app="node-exporter",device!~"veth.+"}[1m]))
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
     record: node:node_net_utilisation:sum_irate
   - expr: |
-      sum(irate(node_network_receive_drop_total{app="node-exporter",device="eth0"}[1m])) +
-      sum(irate(node_network_transmit_drop_total{app="node-exporter",device="eth0"}[1m]))
+      sum(irate(node_network_receive_drop_total{app="node-exporter",device!~"veth.+"}[1m])) +
+      sum(irate(node_network_transmit_drop_total{app="node-exporter",device!~"veth.+"}[1m]))
     record: :node_net_saturation:sum_irate
   - expr: |
       sum by (node) (
-        (irate(node_network_receive_drop_total{app="node-exporter",device="eth0"}[1m]) +
-        irate(node_network_transmit_drop_total{app="node-exporter",device="eth0"}[1m]))
+        (irate(node_network_receive_drop_total{app="node-exporter",device!~"veth.+"}[1m]) +
+        irate(node_network_transmit_drop_total{app="node-exporter",device!~"veth.+"}[1m]))
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
     record: node:node_net_saturation:sum_irate
-  - expr: |
-      count by (instance) (
-        sum by (instance, cpu) (
-          node_cpu_seconds_total{app="node-exporter"}
-        )
-      )
-    record: instance:node_num_cpu:sum
-  - expr: |
-      1 - avg by (instance) (
-        rate(node_cpu_seconds_total{app="node-exporter",mode="idle"}[1m])
-      )
-    record: instance:node_cpu_utilisation:avg1m
-  - expr: |
-      sum by (instance) (node_load1{app="node-exporter"})
-      /
-      instance:node_num_cpu:sum
-    record: 'instance:node_cpu_saturation_load1:'
-  - expr: |
-      sum by (instance) (
-        node_memory_MemTotal_bytes{app="node-exporter"}
-      )
-    record: instance:node_memory_bytes_total:sum
-  - expr: |
-      1 - (
-          node_memory_MemAvailable_bytes{app="node-exporter"}
-        /
-          node_memory_MemTotal_bytes{app="node-exporter"}
-      )
-    record: instance:node_memory_utilisation:ratio
-  - expr: |
-      1e3 * sum by (instance) (
-        (rate(node_vmstat_pgpgin{app="node-exporter"}[1m])
-          + rate(node_vmstat_pgpgout{app="node-exporter"}[1m]))
-      )
-    record: instance:node_memory_swap_io_bytes:sum_rate
-  - expr: |
-      sum by (instance) (
-        irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd).+"}[1m])
-      )
-    record: instance:node_disk_utilisation:sum_irate
-  - expr: |
-      sum by (instance) (
-        irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd).+"}[1m])
-      )
-    record: instance:node_disk_saturation:sum_irate
-  - expr: |
-      sum by (instance) (
-        (irate(node_network_receive_bytes_total{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
-          irate(node_network_transmit_bytes_total{app="node-exporter",device=~"eth[0-9]+"}[1m]))
-      )
-    record: instance:node_net_utilisation:sum_irate
-  - expr: |
-      sum by (instance) (
-        (irate(node_network_receive_drop_total{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
-          irate(node_network_transmit_drop_total{app="node-exporter",device=~"eth[0-9]+"}[1m]))
-      )
-    record: instance:node_net_saturation:sum_irate
   - alert: NodeFilesystemSpaceFillingUp
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted

--- a/config/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
@@ -11,9 +11,7 @@ groups:
 
   - record: namespace:container_cpu_usage_seconds_total:sum_rate
     expr: |
-      sum by (namespace) (
-        rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])
-      )
+      sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace)
 
   - record: namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate
     expr: |

--- a/config/monitoring/prometheus/rules/src/general/node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/node-exporter.yaml
@@ -43,14 +43,6 @@ groups:
       /
       sum(node_memory_MemTotal_bytes{app="node-exporter"})
 
-  - record: :node_memory_MemFreeCachedBuffers:sum
-    expr: |
-      sum(node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
-
-  - record: :node_memory_MemTotal:sum
-    expr: |
-      sum(node_memory_MemTotal_bytes{app="node-exporter"})
-
   - record: node:node_memory_bytes_available:sum
     expr: |
       sum by (node) (
@@ -110,135 +102,64 @@ groups:
 
   - record: :node_disk_utilisation:avg_irate
     expr: |
-      avg(irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]))
+      avg(irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]))
 
   - record: node:node_disk_utilisation:avg_irate
     expr: |
       avg by (node) (
-        irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m])
+        irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m])
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
 
   - record: :node_disk_saturation:avg_irate
     expr: |
-      avg(irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]))
+      avg(irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]) / 1e3)
 
   - record: node:node_disk_saturation:avg_irate
     expr: |
       avg by (node) (
-        irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd|nvme).+"}[1m])
+        irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]) / 1e3
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
 
   - record: 'node:node_filesystem_usage:'
     expr: |
-      max by (namespace, pod, device) (
-        (node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-        /
-        node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
-      )
+      max by (namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+      - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+      / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
 
   - record: 'node:node_filesystem_avail:'
     expr: |
-      max by (namespace, pod, device) (
-        node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
-      )
+      max by (namespace, pod, device) (node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
 
   - record: :node_net_utilisation:sum_irate
     expr: |
-      sum(irate(node_network_receive_bytes_total{app="node-exporter",device="eth0"}[1m])) +
-      sum(irate(node_network_transmit_bytes_total{app="node-exporter",device="eth0"}[1m]))
+      sum(irate(node_network_receive_bytes_total{app="node-exporter",device!~"veth.+"}[1m])) +
+      sum(irate(node_network_transmit_bytes_total{app="node-exporter",device!~"veth.+"}[1m]))
 
   - record: node:node_net_utilisation:sum_irate
     expr: |
       sum by (node) (
-        (irate(node_network_receive_bytes_total{app="node-exporter",device="eth0"}[1m]) +
-        irate(node_network_transmit_bytes_total{app="node-exporter",device="eth0"}[1m]))
+        (irate(node_network_receive_bytes_total{app="node-exporter",device!~"veth.+"}[1m]) +
+        irate(node_network_transmit_bytes_total{app="node-exporter",device!~"veth.+"}[1m]))
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
       )
 
   - record: :node_net_saturation:sum_irate
     expr: |
-      sum(irate(node_network_receive_drop_total{app="node-exporter",device="eth0"}[1m])) +
-      sum(irate(node_network_transmit_drop_total{app="node-exporter",device="eth0"}[1m]))
+      sum(irate(node_network_receive_drop_total{app="node-exporter",device!~"veth.+"}[1m])) +
+      sum(irate(node_network_transmit_drop_total{app="node-exporter",device!~"veth.+"}[1m]))
 
   - record: node:node_net_saturation:sum_irate
     expr: |
       sum by (node) (
-        (irate(node_network_receive_drop_total{app="node-exporter",device="eth0"}[1m]) +
-        irate(node_network_transmit_drop_total{app="node-exporter",device="eth0"}[1m]))
+        (irate(node_network_receive_drop_total{app="node-exporter",device!~"veth.+"}[1m]) +
+        irate(node_network_transmit_drop_total{app="node-exporter",device!~"veth.+"}[1m]))
       * on (namespace, pod) group_left(node)
         node_namespace_pod:kube_pod_info:
-      )
-
-  - record: instance:node_num_cpu:sum
-    expr: |
-      count by (instance) (
-        sum by (instance, cpu) (
-          node_cpu_seconds_total{app="node-exporter"}
-        )
-      )
-
-  - record: instance:node_cpu_utilisation:avg1m
-    expr: |
-      1 - avg by (instance) (
-        rate(node_cpu_seconds_total{app="node-exporter",mode="idle"}[1m])
-      )
-
-  - record: 'instance:node_cpu_saturation_load1:'
-    expr: |
-      sum by (instance) (node_load1{app="node-exporter"})
-      /
-      instance:node_num_cpu:sum
-
-  - record: instance:node_memory_bytes_total:sum
-    expr: |
-      sum by (instance) (
-        node_memory_MemTotal_bytes{app="node-exporter"}
-      )
-
-  - record: instance:node_memory_utilisation:ratio
-    expr: |
-      1 - (
-          node_memory_MemAvailable_bytes{app="node-exporter"}
-        /
-          node_memory_MemTotal_bytes{app="node-exporter"}
-      )
-
-  - record: instance:node_memory_swap_io_bytes:sum_rate
-    expr: |
-      1e3 * sum by (instance) (
-        (rate(node_vmstat_pgpgin{app="node-exporter"}[1m])
-          + rate(node_vmstat_pgpgout{app="node-exporter"}[1m]))
-      )
-
-  - record: instance:node_disk_utilisation:sum_irate
-    expr: |
-      sum by (instance) (
-        irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"(sd|xvd).+"}[1m])
-      )
-
-  - record: instance:node_disk_saturation:sum_irate
-    expr: |
-      sum by (instance) (
-        irate(node_disk_io_time_weighted_seconds_total{app="node-exporter",device=~"(sd|xvd).+"}[1m])
-      )
-
-  - record: instance:node_net_utilisation:sum_irate
-    expr: |
-      sum by (instance) (
-        (irate(node_network_receive_bytes_total{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
-          irate(node_network_transmit_bytes_total{app="node-exporter",device=~"eth[0-9]+"}[1m]))
-      )
-
-  - record: instance:node_net_saturation:sum_irate
-    expr: |
-      sum by (instance) (
-        (irate(node_network_receive_drop_total{app="node-exporter",device=~"eth[0-9]+"}[1m]) +
-          irate(node_network_transmit_drop_total{app="node-exporter",device=~"eth[0-9]+"}[1m]))
       )
 
   ############################################################


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates our Prometheus recording rules and dashboards to the current examples from kube-prometheus (i.e. prometheus-operator). It removes a bunch of unused rules and fixes up details about the dashboards, like broken drilldown links or misused metrics.

This should be backported to 2.9.

cc @kdomanski 

**Release note**:
```release-note
update Grafana dashboards and Prometheus config to latest kube-prometheus
```
