### PR TITLE
teaches RBAC generator how to monitor secrets in sa-secrets ns

### DIFF
--- a/api/pkg/controller/rbac/cluster_provider.go
+++ b/api/pkg/controller/rbac/cluster_provider.go
@@ -49,7 +49,7 @@ func NewClusterProvider(providerName string, kubeClient kubernetes.Interface, ku
 	}
 
 	// registering Listers for RBAC Cluster Roles and Bindings
-	glog.V(6).Infof("registering ClusterRoles and ClusterRoleBindings informers in all namespaces for provider %s", providerName)
+	glog.V(4).Infof("registering ClusterRoles and ClusterRoleBindings informers in all namespaces for provider %s", providerName)
 	_ = cp.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoles().Lister()
 	_ = cp.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoleBindings().Lister()
 

--- a/api/pkg/controller/rbac/mapper.go
+++ b/api/pkg/controller/rbac/mapper.go
@@ -377,3 +377,21 @@ func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace
 	// unknown group passed
 	return nil, fmt.Errorf("unable to generate verbs for group = %s, kind = %s, namespace = %s", groupName, resourceKind, namespace)
 }
+
+// generateVerbsForNamedResourceInNamespace generates a set of verbs for a named resource in a given namespace
+// for example a "cluster" named "beefy-john"
+func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace string) ([]string, error) {
+	// special case - only the owners of a project can manipulate secrets in "sa-secrets" namespace
+	//
+	if namespace == "sa-secrets" {
+		secretV1Kind := "Secret"
+		if strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind {
+			return []string{"get", "update", "delete"}, nil
+		} else if resourceKind == secretV1Kind {
+			return []string{}, nil
+		}
+	}
+
+	// unknown group passed
+	return []string{}, fmt.Errorf("unable to generate verbs for group = %s, kind = %s, namespace = %s", groupName, resourceKind, namespace)
+}

--- a/api/pkg/controller/rbac/mapper.go
+++ b/api/pkg/controller/rbac/mapper.go
@@ -377,21 +377,3 @@ func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace
 	// unknown group passed
 	return nil, fmt.Errorf("unable to generate verbs for group = %s, kind = %s, namespace = %s", groupName, resourceKind, namespace)
 }
-
-// generateVerbsForNamedResourceInNamespace generates a set of verbs for a named resource in a given namespace
-// for example a "cluster" named "beefy-john"
-func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace string) ([]string, error) {
-	// special case - only the owners of a project can manipulate secrets in "sa-secrets" namespace
-	//
-	if namespace == "sa-secrets" {
-		secretV1Kind := "Secret"
-		if strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == secretV1Kind {
-			return []string{"get", "update", "delete"}, nil
-		} else if resourceKind == secretV1Kind {
-			return []string{}, nil
-		}
-	}
-
-	// unknown group passed
-	return []string{}, fmt.Errorf("unable to generate verbs for group = %s, kind = %s, namespace = %s", groupName, resourceKind, namespace)
-}

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -74,7 +74,8 @@ type projectResource struct {
 	destination string
 	namespace   string
 
-	//
+	// shouldEnqueue is a convenience function that is called right before
+	// the object is added to the queue. This is your last chance to say "no"
 	shouldEnqueue func(obj metav1.Object) bool
 }
 

--- a/api/pkg/controller/rbac/sync_project.go
+++ b/api/pkg/controller/rbac/sync_project.go
@@ -214,7 +214,7 @@ func ensureClusterRBACRoleForResource(kubeClient kubernetes.Interface, groupName
 		return err
 	}
 	if generatedClusterRole == nil {
-		glog.V(5).Infof("skipping ClusterRole generation because the resource for group \"%s\" and resource \"%s\" will not be created", groupName, resource)
+		glog.V(6).Infof("skipping ClusterRole generation because the resource for group %q and resource %q will not be created", groupName, resource)
 		return nil
 	}
 	sharedExistingClusterRole, err := rbacLister.Get(generatedClusterRole.Name)
@@ -323,7 +323,7 @@ func ensureRBACRoleForResource(kubeClient kubernetes.Interface, groupName string
 		return err
 	}
 	if generatedRole == nil {
-		glog.V(5).Infof("skipping Role generation because the resource for group %q and resource %q in namespace %q will not be created", groupName, gvr.Resource, namespace)
+		glog.V(6).Infof("skipping Role generation because the resource for group %q and resource %q in namespace %q will not be created", groupName, gvr.Resource, namespace)
 		return nil
 	}
 	sharedExistingRole, err := rbacLister.Get(generatedRole.Name)
@@ -592,7 +592,7 @@ func shouldSkipClusterRBACRoleBindingFor(groupName, policyResource, policyAPIGro
 		return false, err
 	}
 	if generatedClusterRole == nil {
-		glog.V(5).Infof("skipping operation on ClusterRoleBinding because corresponding ClusterRole was not(will not be) created for group %q and %q resource for project %q", groupName, policyResource, projectName)
+		glog.V(6).Infof("skipping operation on ClusterRoleBinding because corresponding ClusterRole was not(will not be) created for group %q and %q resource for project %q", groupName, policyResource, projectName)
 		return true, nil
 	}
 	return false, nil
@@ -608,7 +608,7 @@ func shouldSkipRBACRoleBindingFor(groupName, policyResource, policyAPIGroups, pr
 		return false, err
 	}
 	if generatedRole == nil {
-		glog.V(5).Infof("skipping operation on RoleBinding because corresponding Role was not(will not be) created for group %q and %q resource for project %q in namespace %q", groupName, policyResource, projectName, namespace)
+		glog.V(6).Infof("skipping operation on RoleBinding because corresponding Role was not(will not be) created for group %q and %q resource for project %q in namespace %q", groupName, policyResource, projectName, namespace)
 		return true, nil
 	}
 	return false, nil

--- a/api/pkg/controller/rbac/sync_resource.go
+++ b/api/pkg/controller/rbac/sync_resource.go
@@ -58,6 +58,31 @@ func (c *Controller) syncProjectResource(item *projectResourceQueueItem) error {
 		item.metaObject,
 		item.clusterProvider.kubeClient,
 		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().Roles().Lister().Roles(item.namespace))
+		if err != nil {
+		return fmt.Errorf("failed to sync RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
+		}
+
+	err = c.ensureRBACRoleBindingForNamedResource(projectName,
+		item.gvr,
+		item.kind,
+		item.namespace,
+		item.metaObject,
+		item.clusterProvider.kubeClient,
+		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().RoleBindings().Lister().RoleBindings(item.namespace))
+	if err != nil {
+		return fmt.Errorf("failed to sync RBAC RoleBinding for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
+	}
+
+	return nil
+	}
+
+	err := c.ensureRBACRoleForNamedResource(projectName,
+		item.gvr,
+		item.kind,
+		item.namespace,
+		item.metaObject,
+		item.clusterProvider.kubeClient,
+		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().Roles().Lister().Roles(item.namespace))
 	if err != nil {
 		return fmt.Errorf("failed to sync RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
 	}

--- a/api/pkg/controller/rbac/sync_resource.go
+++ b/api/pkg/controller/rbac/sync_resource.go
@@ -58,30 +58,6 @@ func (c *Controller) syncProjectResource(item *projectResourceQueueItem) error {
 		item.metaObject,
 		item.clusterProvider.kubeClient,
 		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().Roles().Lister().Roles(item.namespace))
-		return fmt.Errorf("failed to sync RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
-		}
-
-	err = c.ensureRBACRoleBindingForNamedResource(projectName,
-		item.gvr,
-		item.kind,
-		item.namespace,
-		item.metaObject,
-		item.clusterProvider.kubeClient,
-		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().RoleBindings().Lister().RoleBindings(item.namespace))
-	if err != nil {
-		return fmt.Errorf("failed to sync RBAC RoleBinding for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
-	}
-
-	return nil
-	}
-
-	err := c.ensureRBACRoleForNamedResource(projectName,
-		item.gvr,
-		item.kind,
-		item.namespace,
-		item.metaObject,
-		item.clusterProvider.kubeClient,
-		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().Roles().Lister().Roles(item.namespace))
 	if err != nil {
 		return fmt.Errorf("failed to sync RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
 	}

--- a/api/pkg/controller/rbac/sync_resource.go
+++ b/api/pkg/controller/rbac/sync_resource.go
@@ -58,7 +58,6 @@ func (c *Controller) syncProjectResource(item *projectResourceQueueItem) error {
 		item.metaObject,
 		item.clusterProvider.kubeClient,
 		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().Roles().Lister().Roles(item.namespace))
-		if err != nil {
 		return fmt.Errorf("failed to sync RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
 		}
 
@@ -108,7 +107,7 @@ func (c *Controller) ensureClusterRBACRoleForNamedResource(projectName string, o
 			return err
 		}
 		if skip {
-			glog.V(5).Infof("skipping ClusterRole generation for named resource for group \"%s\" and resource \"%s\"", groupPrefix, objectResource)
+			glog.V(6).Infof("skipping ClusterRole generation for named resource for group \"%s\" and resource \"%s\"", groupPrefix, objectResource)
 			continue
 		}
 		sharedExistingRole, err := rbacClusterRoleLister.Get(generatedRole.Name)
@@ -146,7 +145,7 @@ func (c *Controller) ensureClusterRBACRoleBindingForNamedResource(projectName st
 			return err
 		}
 		if skip {
-			glog.V(5).Infof("skipping operation on ClusterRoleBinding because corresponding ClusterRole was not(will not be) created for group %q and %q resource for project %q", groupPrefix, objectResource, projectName)
+			glog.V(6).Infof("skipping operation on ClusterRoleBinding because corresponding ClusterRole was not(will not be) created for group %q and %q resource for project %q", groupPrefix, objectResource, projectName)
 			continue
 		}
 
@@ -220,7 +219,7 @@ func (c *Controller) ensureRBACRoleForNamedResource(projectName string, objectGV
 			return err
 		}
 		if skip {
-			glog.V(5).Infof("skipping Role generation for named resource for group %q and resource %q in namespace %q", groupPrefix, objectGVR.Resource, namespace)
+			glog.V(6).Infof("skipping Role generation for named resource for group %q and resource %q in namespace %q", groupPrefix, objectGVR.Resource, namespace)
 			continue
 		}
 		sharedExistingRole, err := rbacRoleLister.Get(generatedRole.Name)
@@ -258,7 +257,7 @@ func (c *Controller) ensureRBACRoleBindingForNamedResource(projectName string, o
 			return err
 		}
 		if skip {
-			glog.V(5).Infof("skipping operation on RoleBinding because corresponding Role was not(will not be) created for group %q and %q resource for project %q in namespace %q", groupPrefix, objectGVR.Resource, projectName, namespace)
+			glog.V(6).Infof("skipping operation on RoleBinding because corresponding Role was not(will not be) created for group %q and %q resource for project %q in namespace %q", groupPrefix, objectGVR.Resource, projectName, namespace)
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**: this pull only adds a definition for a new resource to the controller. The hard work was introduced in #2975 , #2988 and #3000.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2927 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
 RBAC generator monitors secrets resources in sa-secrets namespace. 
```
