### PR TITLE
Define resource requests/limits for Helm charts

### DIFF
--- a/config/backup/ark/templates/daemonset.yaml
+++ b/config/backup/ark/templates/daemonset.yaml
@@ -61,6 +61,8 @@ spec:
             - name: gcp-credentials
               mountPath: /credentials/gcp
           {{- end }}
+          resources:
+{{ toYaml .Values.ark.resources.arkRestic | indent 12 }}
       volumes:
         - name: host-pods
           hostPath:

--- a/config/backup/ark/templates/deployment.yaml
+++ b/config/backup/ark/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
             - name: metrics
               containerPort: 8085
               protocol: TCP
+          resources:
+{{ toYaml .Values.ark.resources.ark | indent 12 }}
       volumes:
         - name: plugins
           emptyDir: {}

--- a/config/backup/ark/values.yaml
+++ b/config/backup/ark/values.yaml
@@ -7,6 +7,23 @@ ark:
     tag: v0.10.0
     pullPolicy: IfNotPresent
 
+  resources:
+    ark:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 100Mi
+    arkRestic:
+      requests:
+        cpu: 10m
+        memory: 30Mi
+      limits:
+        cpu: 200m
+        # during backups memory usage can spike, see https://github.com/restic/restic/issues/979
+        memory: 1Gi
+
   # CLI flags to pass to ark server; note that the two flags
   # `default-backup-storage-location` and `default-volume-snapshot-locations`
   # are automatically set via the ark-config Helm chart's
@@ -16,7 +33,7 @@ ark:
     - --backup-sync-period=1m
 
   # whether or not to create a restic daemonset
-  # restic: true
+  restic: true
 
   # configure the credentials used to make snapshots (when using
   # persistentVolumeProvider) and to store backups; you can enable

--- a/config/cert-manager/templates/ca-sync-cronjob.yaml
+++ b/config/cert-manager/templates/ca-sync-cronjob.yaml
@@ -28,12 +28,7 @@ spec:
             - name: config
               mountPath: /config
             resources:
-              requests:
-                cpu: 10m
-                memory: 32Mi
-              limits:
-                cpu: 100m
-                memory: 128Mi
+{{ toYaml .Values.certManager.resources.caSync | indent 14 }}
           volumes:
           - name: config
             configMap:

--- a/config/cert-manager/templates/ca-sync-job.yaml
+++ b/config/cert-manager/templates/ca-sync-job.yaml
@@ -23,12 +23,7 @@ spec:
         - name: config
           mountPath: /config
         resources:
-          requests:
-            cpu: 10m
-            memory: 32Mi
-          limits:
-            cpu: 100m
-            memory: 128Mi
+{{ toYaml .Values.certManager.resources.caSync | indent 10 }}
       volumes:
       - name: config
         configMap:

--- a/config/cert-manager/templates/cert-manager-deployment.yaml
+++ b/config/cert-manager/templates/cert-manager-deployment.yaml
@@ -60,3 +60,5 @@ spec:
           ports:
           - name: metrics
             containerPort: 9402
+          resources:
+{{ toYaml .Values.certManager.resources.certManager | indent 12 }}

--- a/config/cert-manager/templates/webhook-deployment.yaml
+++ b/config/cert-manager/templates/webhook-deployment.yaml
@@ -42,6 +42,8 @@ spec:
           volumeMounts:
           - name: certs
             mountPath: /certs
+          resources:
+{{ toYaml .Values.certManager.resources.webhook | indent 12 }}
       volumes:
       - name: certs
         secret:

--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -31,3 +31,26 @@ certManager:
   #  - operator: Exists
   #nodeSelector: |
   #  node-role.kubernetes.io/master: ""
+
+  resources:
+    certManager:
+      requests:
+        cpu: 10m
+        memory: 30Mi
+      limits:
+        cpu: 30m
+        memory: 50Mi
+    caSync:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    webhook:
+      requests:
+        cpu: 10m
+        memory: 30Mi
+      limits:
+        cpu: 30m
+        memory: 30Mi

--- a/config/iap/templates/deployments.yaml
+++ b/config/iap/templates/deployments.yaml
@@ -50,10 +50,8 @@ spec:
             port: http
           initialDelaySeconds: 3
           timeoutSeconds: 2
-{{- if $.Values.iap.resources }}
         resources:
 {{ toYaml $.Values.iap.resources | indent 10 }}
-{{- end }}
         volumeMounts:
         - name: config
           mountPath: /config

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -61,10 +61,10 @@ iap:
     tag: v2.3.0
     pullPolicy: IfNotPresent
 
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 10m
-    #   memory: 64Mi
+  resources:
+    requests:
+      cpu: 10m
+      memory: 25Mi
+    limits:
+      cpu: 100m
+      memory: 50Mi

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -66,12 +66,7 @@ spec:
               mountPath: "/opt/master-files/"
               readOnly: true
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "100m"
-            limits:
-              memory: "128Mi"
-              cpu: "250m"
+{{ toYaml .Values.kubermatic.api.resources | indent 12 }}
       imagePullSecrets:
         - name: dockercfg
       tolerations:

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -143,12 +143,7 @@ spec:
               readOnly: true
             {{- end }}
           resources:
-            requests:
-              memory: "256Mi"
-              cpu: "200m"
-            limits:
-              memory: "512Mi"
-              cpu: "500m"
+{{ toYaml .Values.kubermatic.controller.resources | indent 12 }}
       imagePullSecrets:
         - name: dockercfg
       tolerations:

--- a/config/kubermatic/templates/kubermatic-ui-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-ui-dep.yaml
@@ -17,13 +17,6 @@ spec:
         - name: webserver
           image: '{{ .Values.kubermatic.ui.image.repository }}:{{ .Values.kubermatic.ui.image.tag }}'
           imagePullPolicy: {{ .Values.kubermatic.ui.image.pullPolicy }}
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "100m"
-            limits:
-              memory: "128Mi"
-              cpu: "250m"
           ports:
             - name: http
               containerPort: 8080
@@ -31,6 +24,8 @@ spec:
             - name: config
               mountPath: "/dist/config/"
               readOnly: true
+          resources:
+{{ toYaml .Values.kubermatic.ui.resources | indent 12 }}
       imagePullSecrets:
         - name: dockercfg
       tolerations:

--- a/config/kubermatic/templates/rbac-generator-dep.yaml
+++ b/config/kubermatic/templates/rbac-generator-dep.yaml
@@ -56,12 +56,7 @@ spec:
             mountPath: "/opt/.kube/"
             readOnly: true
         resources:
-          requests:
-            memory: "64Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
-            cpu: "200m"
+{{ toYaml .Values.kubermatic.rbac.resources | indent 10 }}
       imagePullSecrets:
         - name: dockercfg
       volumes:

--- a/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
+++ b/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
@@ -33,12 +33,7 @@ spec:
             mountPath: "/etc/tls-certs"
             readOnly: true
         resources:
-          limits:
-            cpu: 200m
-            memory: 500Mi
-          requests:
-            cpu: 50m
-            memory: 200Mi
+{{ toYaml .Values.kubermatic.vpa.admissioncontroller.resources | indent 10 }}
         ports:
         - containerPort: 8000
       volumes:

--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -36,12 +36,7 @@ spec:
           "--recommendation-margin-fraction", "0",
         ]
         resources:
-          limits:
-            cpu: 200m
-            memory: 1000Mi
-          requests:
-            cpu: 50m
-            memory: 500Mi
+{{ toYaml .Values.kubermatic.vpa.recommender.resources | indent 10 }}
         ports:
         - containerPort: 8080
         {{ end }}

--- a/config/kubermatic/templates/vpa-updater-deployment.yaml
+++ b/config/kubermatic/templates/vpa-updater-deployment.yaml
@@ -32,12 +32,7 @@ spec:
           "--logtostderr",
         ]
         resources:
-          limits:
-            cpu: 200m
-            memory: 1000Mi
-          requests:
-            cpu: 50m
-            memory: 500Mi
+{{ toYaml .Values.kubermatic.vpa.updater.resources | indent 10 }}
         ports:
         - containerPort: 8080
 {{ end }}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -113,11 +113,11 @@ kubermatic:
       }
     resources:
       requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
         cpu: 100m
         memory: 64Mi
-      limits:
-        cpu: 250m
-        memory: 128Mi
   rbac:
     replicas: 1
     image:
@@ -126,11 +126,11 @@ kubermatic:
       pullPolicy: IfNotPresent
     resources:
       requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
         cpu: 100m
         memory: 64Mi
-      limits:
-        cpu: 200m
-        memory: 256Mi
   storeContainer: |
     command:
     - /bin/sh

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -117,7 +117,7 @@ kubermatic:
         memory: 32Mi
       limits:
         cpu: 100m
-        memory: 64Mi
+        memory: 32Mi
   rbac:
     replicas: 1
     image:
@@ -209,10 +209,10 @@ kubermatic:
       resources:
         requests:
           cpu: 50m
-          memory: 500Mi
+          memory: 32Mi
         limits:
           cpu: 200m
-          memory: 1000Mi
+          memory: 128Mi
 
     recommender:
       image:
@@ -233,7 +233,7 @@ kubermatic:
       resources:
         requests:
           cpu: 50m
-          memory: 200Mi
+          memory: 32Mi
         limits:
           cpu: 200m
-          memory: 500Mi
+          memory: 128Mi

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -31,6 +31,7 @@ kubermatic:
   etcd:
     # PV size for the etcd StatefulSet of new clusters
     diskSize: "5Gi"
+
   controller:
     # Available feature gates:
     # - OpenIDAuthPlugin
@@ -76,12 +77,26 @@ kubermatic:
           repository: "quay.io/kubermatic/openshift-addons"
           tag: "v0.4"
           pullPolicy: "IfNotPresent"
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
   api:
     replicas: 2
     image:
       repository: "quay.io/kubermatic/api"
       tag: "__KUBERMATIC_TAG__"
       pullPolicy: "IfNotPresent"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 128Mi
   ui:
     replicas: 2
     image:
@@ -96,12 +111,26 @@ kubermatic:
         "show_terms_of_service": false,
         "cleanup_cluster": false
       }
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 128Mi
   rbac:
     replicas: 1
     image:
-      repository: "quay.io/kubermatic/api"
-      tag: "__KUBERMATIC_TAG__"
-      pullPolicy: "IfNotPresent"
+      repository: quay.io/kubermatic/api
+      tag: __KUBERMATIC_TAG__
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
   storeContainer: |
     command:
     - /bin/sh
@@ -146,6 +175,8 @@ kubermatic:
         secretKeyRef:
           name: s3-credentials
           key: SECRET_ACCESS_KEY
+
+  clusterNamespacePrometheus: {}
 #  clusterNamespacePrometheus:
 #    disableDefaultScrapingConfigs: true
 #    scrapingConfigs:
@@ -169,17 +200,40 @@ kubermatic:
 #          for: 10m
 #          labels:
 #            severity: warning
-  clusterNamespacePrometheus: {}
+
   vpa:
     updater:
       image:
         repository: k8s.gcr.io/vpa-updater
         tag: 0.4.0
+      resources:
+        requests:
+          cpu: 50m
+          memory: 500Mi
+        limits:
+          cpu: 200m
+          memory: 1000Mi
+
     recommender:
       image:
         repository: k8s.gcr.io/vpa-recommender
         tag: 0.4.0
+      resources:
+        requests:
+          cpu: 50m
+          memory: 500Mi
+        limits:
+          cpu: 200m
+          memory: 1000Mi
+
     admissioncontroller:
       image:
         repository: k8s.gcr.io/vpa-admission-controller
         tag: 0.4.0
+      resources:
+        requests:
+          cpu: 50m
+          memory: 200Mi
+        limits:
+          cpu: 200m
+          memory: 500Mi

--- a/config/logging/elasticsearch/templates/cerebro-dep.yaml
+++ b/config/logging/elasticsearch/templates/cerebro-dep.yaml
@@ -36,9 +36,7 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 10
         resources:
-          requests:
-            cpu: 50m
-            memory: 400Mi
+{{ toYaml .Values.logging.elasticsearch.cerebro.resources | indent 10 }}
         volumeMounts:
           - name: config
             mountPath: /cerebro

--- a/config/logging/elasticsearch/templates/es-data-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-data-stateful.yaml
@@ -101,9 +101,7 @@ spec:
                   - /bin/bash
                   - /post-start.sh
           resources:
-            requests:
-              cpu: 200m
-              memory: 1500Mi
+{{ toYaml .Values.logging.elasticsearch.resources.data | indent 12 }}
           volumeMounts:
             - name: storage
               mountPath: /usr/share/elasticsearch/data

--- a/config/logging/elasticsearch/templates/es-master-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-master-stateful.yaml
@@ -103,9 +103,7 @@ spec:
                 - /bin/bash
                 - /post-start.sh
           resources:
-            requests:
-              cpu: 75m
-              memory: 350Mi
+{{ toYaml .Values.logging.elasticsearch.resources.master | indent 12 }}
           volumeMounts:
             - name: storage
               mountPath: /usr/share/elasticsearch/data

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -51,5 +51,9 @@ logging:
       deploy: false
       resources:
         requests:
-          cpu: 50m
+          cpu: 100m
           memory: 400Mi
+        limits:
+          cpu: 200m
+          # memory usage spikes when starting
+          memory: 800Mi

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -8,6 +8,15 @@ logging:
       repository: docker.elastic.co/elasticsearch/elasticsearch
       tag: "6.5.1"
       pullPolicy: IfNotPresent
+    resources:
+      data:
+        requests:
+          cpu: 200m
+          memory: 1500Mi
+      master:
+        requests:
+          cpu: 75m
+          memory: 350Mi
     curator:
       # Amount of days after which the indicies should be killed
       interval: 5
@@ -27,16 +36,20 @@ logging:
         pullPolicy: IfNotPresent
       all: true
       indices: false
-      resources: {}
-        # requests:
-        #   cpu: 100m
-        #   memory: 128Mi
-        # limits:
-        #   cpu: 100m
-        #   memory: 128Mi
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
     cerebro:
       image:
         repository: yannart/cerebro
         tag: "0.8.1"
         pullPolicy: IfNotPresent
       deploy: false
+      resources:
+        requests:
+          cpu: 50m
+          memory: 400Mi

--- a/config/logging/fluentbit/templates/fluent-bit-ds.yaml
+++ b/config/logging/fluentbit/templates/fluent-bit-ds.yaml
@@ -40,6 +40,8 @@ spec:
           readOnly: true
         - name: fluent-bit-config
           mountPath: /fluent-bit/etc/
+        resources:
+{{ toYaml .Values.logging.fluentbit.resources | indent 10 }}
       terminationGracePeriodSeconds: 10
       volumes:
       - name: varlog

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -14,3 +14,10 @@ logging:
           Port            ${FLUENT_ELASTICSEARCH_PORT}
           Logstash_Format On
           Retry_Limit     False
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 30m
+        memory: 24Mi

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -17,7 +17,7 @@ logging:
     resources:
       requests:
         cpu: 10m
-        memory: 16Mi
+        memory: 24Mi
       limits:
         cpu: 30m
-        memory: 24Mi
+        memory: 32Mi

--- a/config/logging/kibana/templates/deployment.yaml
+++ b/config/logging/kibana/templates/deployment.yaml
@@ -23,12 +23,7 @@ spec:
         image: '{{ .Values.logging.kibana.image.repository }}:{{ .Values.logging.kibana.image.tag }}'
         imagePullPolicy: {{ .Values.logging.kibana.image.pullPolicy }}
         resources:
-          # need more cpu upon initialization, therefore burstable class
-          limits:
-            cpu: 1000m
-          requests:
-            cpu: 100m
-            memory: 400Mi
+{{ toYaml .Values.logging.kibana.resources | indent 10 }}
         env:
           - name: ELASTICSEARCH_URL
             value: http://es-data:9200

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -7,7 +7,8 @@ logging:
     resources:
       requests:
         cpu: 100m
-        memory: 400Mi
+        memory: 450Mi
       limits:
         # need more cpu upon initialization, therefore burstable class
         cpu: 1000m
+        memory: 600Mi

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -3,4 +3,11 @@ logging:
     image:
       repository: docker.elastic.co/kibana/kibana
       tag: "6.5.1"
-      pullPolicy: "IfNotPresent"
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 400Mi
+      limits:
+        # need more cpu upon initialization, therefore burstable class
+        cpu: 1000m

--- a/config/minio/templates/deployment.yaml
+++ b/config/minio/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: storage
           mountPath: "/storage"
         resources:
-{{ toYaml .Values.minio.resources | indent 10 }}
+{{ toYaml .Values.minio.resources.minio | indent 10 }}
 
       {{- if .Values.minio.backups }}
       - name: backup
@@ -67,6 +67,8 @@ spec:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
+        resources:
+{{ toYaml .Values.minio.resources.backup | indent 10 }}
       {{- end }}
       volumes:
       - name: storage

--- a/config/minio/templates/deployment.yaml
+++ b/config/minio/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         volumeMounts:
         - name: storage
           mountPath: "/storage"
+        resources:
+{{ toYaml .Values.minio.resources | indent 10 }}
+
       {{- if .Values.minio.backups }}
       - name: backup
         image: alpine:3.7

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -21,7 +21,7 @@ minio:
         memory: 32Mi
       limits:
         cpu: 100m
-        memory: 128Mi
+        memory: 512Mi
     backup:
       requests:
         cpu: 50m

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -15,9 +15,17 @@ minio:
   #storageClass: hdd
 
   resources:
-    requests:
-      cpu: 10m
-      memory: 32Mi
-    limits:
-      cpu: 100m
-      memory: 128Mi
+    minio:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    backup:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        cpu: 500m
+        memory: 1500Mi

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -13,3 +13,11 @@ minio:
   # you cannot change this later on without purging the
   # chart and losing data.
   #storageClass: hdd
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -63,8 +63,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-          requests:
-            memory: 200Mi
+{{ toYaml .Values.alertmanager.resources.alertmanager | indent 10 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -80,9 +79,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: config-reloader
         resources:
-          limits:
-            cpu: 5m
-            memory: 10Mi
+{{ toYaml .Values.alertmanager.resources.reloader | indent 10 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -72,12 +72,12 @@ spec:
         - mountPath: /alertmanager
           name: alertmanager-kubermatic-db
           subPath: alertmanager-db
-      - args:
+      - name: reloader
+        image: jimmidyson/configmap-reload
+        imagePullPolicy: IfNotPresent
+        args:
         - -webhook-url=http://localhost:9093/-/reload
         - -volume-dir=/etc/alertmanager/config
-        image: quay.io/coreos/configmap-reload:v0.0.1
-        imagePullPolicy: IfNotPresent
-        name: config-reloader
         resources:
 {{ toYaml .Values.alertmanager.resources.reloader | indent 10 }}
         terminationMessagePath: /dev/termination-log

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -12,3 +12,18 @@ alertmanager:
       slack_configs:
       - channel: '#alerting'
         send_resolved: true
+  resources:
+    alertmanager:
+      requests:
+        cpu: 20m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+    reloader:
+      requests:
+        cpu: 5m
+        memory: 10Mi
+      limits:
+        cpu: 5m
+        memory: 10Mi

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -23,7 +23,7 @@ alertmanager:
     reloader:
       requests:
         cpu: 5m
-        memory: 10Mi
+        memory: 24Mi
       limits:
         cpu: 5m
-        memory: 10Mi
+        memory: 32Mi

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -19,7 +19,7 @@ alertmanager:
         memory: 32Mi
       limits:
         cpu: 100m
-        memory: 64Mi
+        memory: 48Mi
     reloader:
       requests:
         cpu: 5m

--- a/config/monitoring/blackbox-exporter/values.yaml
+++ b/config/monitoring/blackbox-exporter/values.yaml
@@ -7,12 +7,12 @@ blackboxExporter:
   containers:
     blackboxExporter:
       resources:
-        limits:
-          cpu: 100m
-          memory: 50Mi
         requests:
           cpu: 20m
-          memory: 25Mi
+          memory: 24Mi
+        limits:
+          cpu: 100m
+          memory: 32Mi
 
   modules:
     # A module that requires HTTPS and HTTP 2xx codes on its targets.

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         - containerPort: 3000
           name: http
         resources:
-          limits:
-            cpu: 200m
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+{{ toYaml .Values.grafana.resources | indent 10 }}
         volumeMounts:
         - mountPath: /var/lib/grafana
           name: grafana-storage

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -9,10 +9,10 @@ grafana:
   resources:
     requests:
       cpu: 100m
-      memory: 50Mi
+      memory: 48Mi
     limits:
       cpu: 200m
-      memory: 100Mi
+      memory: 128Mi
 
   # Control where the provisioning files are located.
   # If you want to *not* use the predefined ones, this

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -1,9 +1,18 @@
 grafana:
   user: YWRtaW4= # admin
   password: bG9vZHNlMTIz # loodse123
+
   image:
     repository: grafana/grafana
     tag: 5.4.3
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 50Mi
+    limits:
+      cpu: 200m
+      memory: 100Mi
 
   # Control where the provisioning files are located.
   # If you want to *not* use the predefined ones, this

--- a/config/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/config/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -29,15 +29,13 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
+        resources:
+{{ toYaml .Values.kubeStateMetrics.resources | indent 10 }}
+
       - name: addon-resizer
         image: {{ .Values.kubeStateMetrics.resizer.image.repository }}:{{ .Values.kubeStateMetrics.resizer.image.tag }}
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 30Mi
+{{ toYaml .Values.kubeStateMetrics.resizer.resources | indent 10 }}
         env:
           - name: MY_POD_NAME
             valueFrom:

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -2,7 +2,21 @@ kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
     tag: v1.5.0
+  resources:
+    requests:
+      cpu: 50m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
   resizer:
     image:
       repository: k8s.gcr.io/addon-resizer
       tag: '1.7'
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 48Mi

--- a/config/monitoring/node-exporter/templates/daemonset.yaml
+++ b/config/monitoring/node-exporter/templates/daemonset.yaml
@@ -27,12 +27,7 @@ spec:
           hostPort: 9100
           name: scrape
         resources:
-          requests:
-            memory: 30Mi
-            cpu: 100m
-          limits:
-            memory: 50Mi
-            cpu: 200m
+{{ toYaml .Values.nodeExporter.resources | indent 10 }}
         volumeMounts:
         - name: proc
           readOnly:  true

--- a/config/monitoring/node-exporter/values.yaml
+++ b/config/monitoring/node-exporter/values.yaml
@@ -8,4 +8,4 @@ nodeExporter:
       memory: 24Mi
     limits:
       cpu: 200m
-      memory: 50Mi
+      memory: 48Mi

--- a/config/monitoring/node-exporter/values.yaml
+++ b/config/monitoring/node-exporter/values.yaml
@@ -2,3 +2,10 @@ nodeExporter:
   image:
     repository: quay.io/prometheus/node-exporter
     tag: v0.17.0
+  resources:
+    requests:
+      cpu: 50m
+      memory: 24Mi
+    limits:
+      cpu: 200m
+      memory: 50Mi

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -120,6 +120,8 @@ spec:
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
+        resources:
+{{ toYaml .Values.prometheus.containers.backup.resources | indent 10 }}
       {{- end }}
       serviceAccountName: prometheus-kubermatic
       securityContext:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -76,17 +76,23 @@ prometheus:
   #  mountPath: /initech/recordings
   #  secretName: initech-recording-rules-secret
 
-  # For larger deployments it can make sense to increase the CPU/memory
-  # limits accordingly.
   containers:
     prometheus:
       resources:
         requests:
-          cpu: 500m
-          memory: 512Mi
-        limits:
           cpu: 1
           memory: 2Gi
+        limits:
+          cpu: 2
+          memory: 10Gi
+    backup:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 10Gi
     reloader:
       resources:
         requests:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -81,17 +81,17 @@ prometheus:
   containers:
     prometheus:
       resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
         limits:
           cpu: 1
           memory: 2Gi
-        requests:
-          cpu: 100m
-          memory: 512Mi
     reloader:
       resources:
-        limits:
-          cpu: 100m
-          memory: 64Mi
         requests:
           cpu: 25m
           memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 32Mi

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -90,8 +90,8 @@ prometheus:
     reloader:
       resources:
         requests:
-          cpu: 25m
-          memory: 16Mi
+          cpu: 5m
+          memory: 24Mi
         limits:
-          cpu: 100m
+          cpu: 5m
           memory: 32Mi

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -105,3 +105,6 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          resources:
+{{ toYaml .Values.nginx.resources | indent 12 }}
+

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -12,3 +12,10 @@ nginx:
     tag: 0.22.0
   config: {}
 #    load-balance: "least_conn"
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi

--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
         - containerPort: 8001
           name: grpc
           protocol: TCP
+        resources:
+{{ toYaml .Values.nodePortPoxy.resources.envoyManager | indent 10 }}
       - name: envoy
         command:
         - /usr/local/bin/envoy
@@ -78,6 +80,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/envoy
           name: envoy-config
+        resources:
+{{ toYaml .Values.nodePortPoxy.resources.envoy | indent 10 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -125,5 +129,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        resources:
+{{ toYaml .Values.nodePortPoxy.resources.lbUpdater | indent 10 }}
       imagePullSecrets:
       - name: quay

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -7,3 +7,25 @@ nodePortPoxy:
   image:
     repository: "quay.io/kubermatic/nodeport-proxy"
     tag: "v2.0.0"
+  resources:
+    envoy:
+      requests:
+        cpu: 10m
+        memory: 24Mi
+      limits:
+        cpu: 20m
+        memory: 48Mi
+    envoyManager:
+      requests:
+        cpu: 10m
+        memory: 24Mi
+      limits:
+        cpu: 20m
+        memory: 48Mi
+    lbUpdater:
+      requests:
+        cpu: 10m
+        memory: 24Mi
+      limits:
+        cpu: 10m
+        memory: 24Mi

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -11,21 +11,21 @@ nodePortPoxy:
     envoy:
       requests:
         cpu: 10m
-        memory: 24Mi
+        memory: 32Mi
       limits:
         cpu: 20m
-        memory: 48Mi
+        memory: 64Mi
     envoyManager:
       requests:
         cpu: 10m
-        memory: 24Mi
+        memory: 32Mi
       limits:
         cpu: 20m
         memory: 48Mi
     lbUpdater:
       requests:
         cpu: 10m
-        memory: 24Mi
+        memory: 32Mi
       limits:
         cpu: 10m
-        memory: 24Mi
+        memory: 32Mi

--- a/config/oauth/templates/dex-dep.yaml
+++ b/config/oauth/templates/dex-dep.yaml
@@ -30,6 +30,8 @@ spec:
           readOnly: true
 {{ if .Values.dex.grpc }}{{ toYaml .Values.dex.grpc.certMount | trim | indent 8 }}
 {{- end }}
+        resources:
+{{ toYaml .Values.dex.resources | indent 10 }}
       volumes:
       - name: config
         configMap:

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -34,3 +34,10 @@ dex:
 #    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
 #    username: "admin"
 #    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+  resources:
+    requests:
+      cpu: 10m
+      memory: 128Mi
+    limits:
+      cpu: 50m
+      memory: 200Mi

--- a/config/s3-exporter/templates/deployment.yaml
+++ b/config/s3-exporter/templates/deployment.yaml
@@ -41,3 +41,5 @@ spec:
             - -access-key-id=$(ACCESS_KEY_ID)
             - -secret-access-key=$(SECRET_ACCESS_KEY)
             - -bucket={{ .Values.s3Exporter.bucket }}
+          resources:
+{{ toYaml .Values.s3Exporter.resources | indent 12 }}

--- a/config/s3-exporter/values.yaml
+++ b/config/s3-exporter/values.yaml
@@ -4,3 +4,10 @@ s3Exporter:
     tag: v0.3
   endpoint: http://minio.minio.svc.cluster.local:9000
   bucket: kubermatic-etcd-backups
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 30m
+      memory: 24Mi

--- a/config/s3-exporter/values.yaml
+++ b/config/s3-exporter/values.yaml
@@ -7,7 +7,7 @@ s3Exporter:
   resources:
     requests:
       cpu: 10m
-      memory: 16Mi
+      memory: 24Mi
     limits:
       cpu: 30m
-      memory: 24Mi
+      memory: 32Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
This defines resources constraints for all of our Helm charts based on their current usage on the dev cluster. In many cases they are probably a bit high, but we can correct this later.

**Release note**:
```release-note
Helm charts define configurable resource constraints
```
