### PR TITLE
Move control plane version param from request body to path

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2709,11 +2709,9 @@
         "operationId": "getNodeUpgrades",
         "parameters": [
           {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/MasterVersion"
-            }
+            "type": "string",
+            "name": "ControlPlaneVersion",
+            "in": "query"
           }
         ],
         "responses": {

--- a/api/pkg/handler/v1/cluster/upgrade_test.go
+++ b/api/pkg/handler/v1/cluster/upgrade_test.go
@@ -412,7 +412,7 @@ func TestGetNodeUpgrades(t *testing.T) {
 	}{
 		{
 			name:                "only the same major version and no more than 2 minor versions behind the control plane",
-			controlPlaneVersion: `{"version": "1.6.0"}`,
+			controlPlaneVersion: "1.6.0",
 			apiUser:             *test.GenDefaultAPIUser(),
 			existingUpdates: []*version.MasterUpdate{
 				{
@@ -488,7 +488,7 @@ func TestGetNodeUpgrades(t *testing.T) {
 	}
 	for _, testStruct := range tests {
 		t.Run(testStruct.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/v1/upgrades/node", strings.NewReader(testStruct.controlPlaneVersion))
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/upgrades/node?control_plane_version=%s", testStruct.controlPlaneVersion), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(testStruct.apiUser, []runtime.Object{}, nil,
 				testStruct.existingVersions, testStruct.existingUpdates, hack.NewTestRouting)


### PR DESCRIPTION
**What this PR does / why we need it**: Moves control plane version param from request body to path. It should be done like this as it is GET request and it is better to keep request body empty. Related to https://github.com/kubermatic/kubermatic/issues/2866#issuecomment-473343107.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
