### PR TITLE
Add latest tag to API docker image

### DIFF
--- a/api/hack/ci/ci-deploy-dev-cloud.sh
+++ b/api/hack/ci/ci-deploy-dev-cloud.sh
@@ -16,7 +16,7 @@ time make -C api build
 echodate "Successfully finished building binaries"
 
 echodate "Building and pushing quay images"
-retry 5 ./api/hack/push_image.sh $GIT_HEAD_HASH $(git tag -l --points-at HEAD)
+retry 5 ./api/hack/push_image.sh $GIT_HEAD_HASH $(git tag -l --points-at HEAD) "latest"
 echodate "Sucessfully finished building and pushing quay images"
 
 echodate "Getting secrets from Vault"


### PR DESCRIPTION
**What this PR does / why we need it**:
As we need access to latest API image for Dashboard e2e tests, I'd like to add latest tag that will be updated with every build.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
