### PR TITLE
RBAC controller monitors ServiceAccount resources

### DIFF
--- a/api/pkg/controller/rbac/mapper.go
+++ b/api/pkg/controller/rbac/mapper.go
@@ -293,6 +293,10 @@ func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, er
 	if strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == kubermaticv1.UserProjectBindingKind {
 		return nil, nil
 	}
+	// special case - editors are not allowed to interact with service accounts (User)
+	if strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == kubermaticv1.UserKindName {
+		return nil, nil
+	}
 
 	// editors of a named resource
 	if strings.HasPrefix(groupName, EditorGroupNamePrefix) {
@@ -305,7 +309,10 @@ func generateVerbsForNamedResource(groupName, resourceKind string) ([]string, er
 	// special case - viewers are not allowed to interact with members of a project (UserProjectBinding)
 	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) && resourceKind == kubermaticv1.UserProjectBindingKind {
 		return nil, nil
-
+	}
+	// special case - viewers are not allowed to interact with service accounts (User)
+	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) && resourceKind == kubermaticv1.UserKindName {
+		return nil, nil
 	}
 	if strings.HasPrefix(groupName, ViewerGroupNamePrefix) {
 		return []string{"get"}, nil
@@ -323,6 +330,14 @@ func generateVerbsForResource(groupName, resourceKind string) ([]string, error) 
 	if strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == kubermaticv1.UserProjectBindingKind {
 		return []string{"create"}, nil
 	} else if resourceKind == kubermaticv1.UserProjectBindingKind {
+		return nil, nil
+	}
+
+	// special case - only the owners of a project can create service account (aka. users)
+	//
+	if strings.HasPrefix(groupName, OwnerGroupNamePrefix) && resourceKind == kubermaticv1.UserKindName {
+		return []string{"create"}, nil
+	} else if resourceKind == kubermaticv1.UserKindName {
 		return nil, nil
 	}
 

--- a/api/pkg/controller/rbac/mapper_test.go
+++ b/api/pkg/controller/rbac/mapper_test.go
@@ -61,6 +61,18 @@ func TestGenerateVerbsForNamedResources(t *testing.T) {
 			expectedVerbs: []string{},
 			resourceKind:  "UserProjectBinding",
 		},
+		{
+			name:          "scenario 8: viewers of a project cannot interact with ServiceAccount (User) named resource",
+			groupName:     "viewers-projectID",
+			expectedVerbs: []string{},
+			resourceKind:  "User",
+		},
+		{
+			name:          "scenario 8: editors of a project cannot interact with ServiceAccount (User) named resource",
+			groupName:     "editors-projectID",
+			expectedVerbs: []string{},
+			resourceKind:  "User",
+		},
 	}
 
 	for _, test := range tests {
@@ -125,6 +137,24 @@ func TestGenerateVerbsForResources(t *testing.T) {
 			groupName:     "viewers-projectID",
 			expectedVerbs: []string{},
 			resourceKind:  "UserProjectBinding",
+		},
+		{
+			name:          "scenario 8: only the owners can create ServiceAccounts (aka. User) resources",
+			groupName:     "owners-projectID",
+			expectedVerbs: []string{"create"},
+			resourceKind:  "User",
+		},
+		{
+			name:          "scenario 9: the editors cannot create ServiceAccounts (aka. User) resources",
+			groupName:     "editors-projectID",
+			expectedVerbs: []string{},
+			resourceKind:  "User",
+		},
+		{
+			name:          "scenario 10: the viewers cannot create ServiceAccounts (aka. User) resources",
+			groupName:     "viewers-projectID",
+			expectedVerbs: []string{},
+			resourceKind:  "User",
 		},
 	}
 

--- a/api/pkg/controller/rbac/rbac_controller.go
+++ b/api/pkg/controller/rbac/rbac_controller.go
@@ -178,6 +178,19 @@ func New(metrics *Metrics, allClusterProviders []*ClusterProvider) (*Controller,
 				return !strings.HasPrefix(obj.GetName(), "default")
 			},
 		},
+
+		{
+			gvr: schema.GroupVersionResource{
+				Group:    kubermaticv1.GroupName,
+				Version:  kubermaticv1.GroupVersion,
+				Resource: kubermaticv1.UserResourceName,
+			},
+			kind: kubermaticv1.UserKindName,
+			shouldEnqueue: func(obj metav1.Object) bool {
+				// do not reconcile resources without "serviceaccount" prefix
+				return strings.HasPrefix(obj.GetName(), "serviceaccount")
+			},
+		},
 	}
 
 	for _, clusterProvider := range allClusterProviders {


### PR DESCRIPTION
**What this PR does / why we need it**: the controller generates RBAC for ServiceAccount (aka. User) resources. At the moment only the owners can create and manipulate SA (mapper.go).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2932 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
RBAC generator controller adds RBAC Roles/Bindings for ServiceAccount resources.
```
