### PR TITLE
remove unused and broken symlink

### DIFF
--- a/api/hack/ci-deploy-ci-kubermatic-io.sh
+++ b/api/hack/ci-deploy-ci-kubermatic-io.sh
@@ -1,1 +1,0 @@
-ci/ci-deploy-ci-kubermatic-io.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove unused and broken symlink. 
Unused when https://github.com/kubermatic/infra/pull/246 got merged.

**Release note**:
```release-note
NONE
```
