### PR TITLE
fix Prometheus backup

### DIFF
--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
         backup.ark.heptio.com/backup-volumes: prometheus-backup
         pre.hook.backup.ark.heptio.com/container: backup
         pre.hook.backup.ark.heptio.com/timeout: 30m
-        pre.hook.backup.ark.heptio.com/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot && rsync --archive /prometheus/snapshots/*/ /backup"]'
+        pre.hook.backup.ark.heptio.com/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
         {{- end }}
     spec:
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
We often run into issues when creating a Prometheus snapshot. The HTTP call responds with

    {"status":"error","errorType":"internal","error":"create snapshot: snapshot head block: write compaction: found chunk with minTime: 1553171533343 maxTime: 1553173843343 outside of compacted minTime: 1553169600000 maxTime: 1553173840566"}

This has been reported in https://github.com/prometheus/prometheus/issues/5105 and a PR exists since February, but has not yet been merged. The issue mentioned above mentions a workaround that would allow us to create snapshots, even thought they might miss the last few hours of data.

Missing the last few hours of data is better than not having snapshot at all. Until the PR is merged, this is a good bandaid.

**Release note**:
```release-note
improve Prometheus backups in high traffic environments
```
