### PR TITLE
add Status for ServiceAccount

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -4817,6 +4817,11 @@
           "description": "Name represents human readable name for the resource",
           "type": "string",
           "x-go-name": "Name"
+        },
+        "status": {
+          "description": "Status describes three stages of ServiceAccount life including Active, Inactive and Terminating",
+          "type": "string",
+          "x-go-name": "Status"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -181,10 +181,24 @@ type ProjectGroup struct {
 	GroupPrefix string `json:"group"`
 }
 
+// These are the valid statuses of a ServiceAccount.
+const (
+	// ServiceAccountActive means the ServiceAccount is available for use in the system
+	ServiceAccountActive string = "Active"
+
+	// ServiceAccountInactive means the ServiceAccount is inactive and requires further initialization
+	ServiceAccountInactive string = "Inactive"
+
+	// ServiceAccountTerminating means the ServiceAccount is undergoing graceful termination
+	ServiceAccountTerminating string = "Terminating"
+)
+
 // ServiceAccount represent an API service account
 // swagger:model ServiceAccount
 type ServiceAccount struct {
 	ObjectMeta
+	// Status describes three stages of ServiceAccount life including Active, Inactive and Terminating
+	Status string `json:"status"`
 	// Group that a service account belongs to
 	Group string `json:"group"`
 }

--- a/api/pkg/handler/v1/serviceaccount/sa.go
+++ b/api/pkg/handler/v1/serviceaccount/sa.go
@@ -106,6 +106,14 @@ func convertInternalServiceAccountToExternal(internal *kubermaticapiv1.User) *ap
 			Name:              internal.Spec.Name,
 			CreationTimestamp: apiv1.NewTime(internal.CreationTimestamp.Time),
 		},
-		Group: internal.Labels[sa.ServiceAccountLabelGroup],
+		Group:  internal.Labels[sa.ServiceAccountLabelGroup],
+		Status: getStatus(internal),
 	}
+}
+
+func getStatus(serviceAccount *kubermaticapiv1.User) string {
+	if _, ok := serviceAccount.Labels[sa.ServiceAccountLabelGroup]; ok {
+		return apiv1.ServiceAccountInactive
+	}
+	return apiv1.ServiceAccountActive
 }

--- a/api/pkg/handler/v1/serviceaccount/sa_test.go
+++ b/api/pkg/handler/v1/serviceaccount/sa_test.go
@@ -130,6 +130,9 @@ func TestCreateServiceAccountProject(t *testing.T) {
 				if sa.Name != tc.expectedSAName {
 					t.Fatalf("expected name %s got %s", tc.expectedSAName, sa.Name)
 				}
+				if sa.Status != apiv1.ServiceAccountInactive {
+					t.Fatalf("expected Inactive state got %s", sa.Status)
+				}
 
 				expectedSA, err := client.FakeKubermaticClient.KubermaticV1().Users().Get(sa.ID, metav1.GetOptions{})
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: Service Account extended for Status

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3057

```release-note
NONE
```
