### PR TITLE
make addon controller respect cluster pause

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -270,6 +270,10 @@ func (c *Controller) sync(key string) error {
 		return nil
 	}
 
+	if cluster.Spec.Pause {
+		return nil
+	}
+
 	// When the apiserver is not healthy, we must skip it
 	if !cluster.Status.Health.Apiserver {
 		glog.V(6).Infof("API server of cluster %s is not running - not processing the addon", cluster.Name)

--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -270,7 +270,9 @@ func (c *Controller) sync(key string) error {
 		return nil
 	}
 
+	// If a cluster has the pause flag set, every processing should be skipped
 	if cluster.Spec.Pause {
+		glog.V(6).Infof("skipping paused cluster %s", key)
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make addon controller respect cluster pause.

**Release note**:
```release-note
Addon controller now respects the pause flag on a cluster
```
