### PR TITLE
new endpoint to get a list of service accounts

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2071,6 +2071,45 @@
       }
     },
     "/api/v1/projects/{project_id}/serviceaccounts": {
+      "get": {
+        "description": "List Service Accounts for the given project",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "serviceaccounts"
+        ],
+        "operationId": "listServiceAccounts",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ServiceAccount",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ServiceAccount"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      },
       "post": {
         "description": "Adds the given service account to the given project",
         "consumes": [

--- a/api/pkg/handler/test/fake_wrapper.go
+++ b/api/pkg/handler/test/fake_wrapper.go
@@ -164,3 +164,33 @@ func (k ProjectV1SliceWrapper) EqualOrDie(expected ProjectV1SliceWrapper, t *tes
 		t.Errorf("actual slice is different that the expected one. Diff: %v", diff)
 	}
 }
+
+// NewServiceAccountV1SliceWrapper wraps []apiv1.ServiceAccount
+// to provide convenient methods for tests
+type NewServiceAccountV1SliceWrapper []apiv1.ServiceAccount
+
+// Sort sorts the collection by name
+func (k NewServiceAccountV1SliceWrapper) Sort() {
+	sort.Slice(k, func(i, j int) bool {
+		return k[i].Name > (k[j].Name)
+	})
+}
+
+// DecodeOrDie reads and decodes json data from the reader
+func (k *NewServiceAccountV1SliceWrapper) DecodeOrDie(r io.Reader, t *testing.T) *NewServiceAccountV1SliceWrapper {
+	t.Helper()
+	dec := json.NewDecoder(r)
+	err := dec.Decode(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+// EqualOrDie compares whether expected collection is equal to the actual one
+func (k NewServiceAccountV1SliceWrapper) EqualOrDie(expected NewServiceAccountV1SliceWrapper, t *testing.T) {
+	t.Helper()
+	if diff := deep.Equal(k, expected); diff != nil {
+		t.Errorf("actual slice is different that the expected one. Diff: %v", diff)
+	}
+}

--- a/api/pkg/handler/v1/common/request.go
+++ b/api/pkg/handler/v1/common/request.go
@@ -31,7 +31,7 @@ type ProjectIDGetter interface {
 }
 
 // GetProjectRq defines HTTP request for getProject endpoint
-// swagger:parameters getProject getUsersForProject listClustersForProject
+// swagger:parameters getProject getUsersForProject listClustersForProject listServiceAccounts
 type GetProjectRq struct {
 	ProjectReq
 }

--- a/api/pkg/handler/v1/serviceaccount/sa.go
+++ b/api/pkg/handler/v1/serviceaccount/sa.go
@@ -85,9 +85,9 @@ func ListEndpoint(projectProvider provider.ProjectProvider, serviceAccountProvid
 		var errorList []string
 		response := make([]*apiv1.ServiceAccount, 0)
 		for _, sa := range saList {
-			internalSA := convertInternalServiceAccountToExternal(sa)
-			if apiv1.ServiceAccountInactive == internalSA.Status {
-				response = append(response, internalSA)
+			externalSA := convertInternalServiceAccountToExternal(sa)
+			if apiv1.ServiceAccountInactive == externalSA.Status {
+				response = append(response, externalSA)
 				continue
 			}
 
@@ -95,8 +95,8 @@ func ListEndpoint(projectProvider provider.ProjectProvider, serviceAccountProvid
 			if err != nil {
 				errorList = append(errorList, err.Error())
 			} else {
-				internalSA.Group = group
-				response = append(response, internalSA)
+				externalSA.Group = group
+				response = append(response, externalSA)
 			}
 		}
 		if len(errorList) > 0 {

--- a/api/pkg/handler/v1/serviceaccount/sa.go
+++ b/api/pkg/handler/v1/serviceaccount/sa.go
@@ -59,6 +59,54 @@ func CreateEndpoint(projectProvider provider.ProjectProvider, serviceAccountProv
 	}
 }
 
+// ListEndpoint returns service accounts of the given project
+func ListEndpoint(projectProvider provider.ProjectProvider, serviceAccountProvider provider.ServiceAccountProvider, memberMapper provider.ProjectMemberMapper) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		req, ok := request.(common.GetProjectRq)
+		if !ok {
+			return nil, errors.NewBadRequest("invalid request")
+		}
+
+		if len(req.ProjectID) == 0 {
+			return nil, errors.NewBadRequest("the name of the project cannot be empty")
+		}
+
+		project, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		saList, err := serviceAccountProvider.List(userInfo, project, nil)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		var errorList []string
+		response := make([]*apiv1.ServiceAccount, 0)
+		for _, sa := range saList {
+			internalSA := convertInternalServiceAccountToExternal(sa)
+			if apiv1.ServiceAccountInactive == internalSA.Status {
+				response = append(response, internalSA)
+				continue
+			}
+
+			group, err := memberMapper.MapUserToGroup(sa.Spec.Email, project.Name)
+			if err != nil {
+				errorList = append(errorList, err.Error())
+			} else {
+				internalSA.Group = group
+				response = append(response, internalSA)
+			}
+		}
+		if len(errorList) > 0 {
+			return response, errors.NewWithDetails(http.StatusInternalServerError, "failed to get some service accounts, please examine details field for more info", errorList)
+		}
+
+		return response, nil
+	}
+}
+
 // addReq defines HTTP request for addServiceAccountToProject
 // swagger:parameters addServiceAccountToProject
 type addReq struct {

--- a/api/pkg/handler/v1/serviceaccount/sa_test.go
+++ b/api/pkg/handler/v1/serviceaccount/sa_test.go
@@ -149,3 +149,128 @@ func TestCreateServiceAccountProject(t *testing.T) {
 		})
 	}
 }
+
+func TestList(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name                   string
+		expectedSA             []apiv1.ServiceAccount
+		expectedError          string
+		projectToSync          string
+		httpStatus             int
+		existingAPIUser        apiv1.User
+		existingKubermaticObjs []runtime.Object
+	}{
+		{
+			name:          "scenario 1: list active service accounts",
+			projectToSync: "plan9-ID",
+			httpStatus:    http.StatusOK,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "editors"),
+				test.GenBinding("plan9-ID", "serviceaccount-3@sa.kubermatic.io", "viewers"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				genActiveServiceAccount("1", "test-1", "editors", "plan9-ID"),
+				genActiveServiceAccount("2", "test-2", "editors", "test-ID"),
+				genActiveServiceAccount("3", "test-3", "viewers", "plan9-ID"),
+			},
+			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
+			expectedSA: []apiv1.ServiceAccount{
+				{
+					ObjectMeta: apiv1.ObjectMeta{
+						ID:   "serviceaccount-1",
+						Name: "test-1",
+					},
+					Group:  "editors-plan9-ID",
+					Status: "Active",
+				},
+				{
+					ObjectMeta: apiv1.ObjectMeta{
+						ID:   "serviceaccount-3",
+						Name: "test-3",
+					},
+					Group:  "viewers-plan9-ID",
+					Status: "Active",
+				},
+			},
+		},
+		{
+			name:          "scenario 2: list active 'test-3' and inactive 'test-1' service accounts",
+			projectToSync: "plan9-ID",
+			httpStatus:    http.StatusOK,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-3@sa.kubermatic.io", "viewers"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				test.GenServiceAccount("1", "test-1", "editors", "plan9-ID"),
+				test.GenServiceAccount("2", "test-2", "editors", "test-ID"),
+				genActiveServiceAccount("3", "test-3", "viewers", "plan9-ID"),
+			},
+			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
+			expectedSA: []apiv1.ServiceAccount{
+				{
+					ObjectMeta: apiv1.ObjectMeta{
+						ID:   "serviceaccount-1",
+						Name: "test-1",
+					},
+					Group:  "editors-plan9-ID",
+					Status: "Inactive",
+				},
+				{
+					ObjectMeta: apiv1.ObjectMeta{
+						ID:   "serviceaccount-3",
+						Name: "test-3",
+					},
+					Group:  "viewers-plan9-ID",
+					Status: "Active",
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts", tc.projectToSync), nil)
+			res := httptest.NewRecorder()
+
+			ep, _, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, tc.existingKubermaticObjs, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.httpStatus {
+				t.Fatalf("expected HTTP status code %d, got %d: %s", tc.httpStatus, res.Code, res.Body.String())
+			}
+
+			if tc.httpStatus == http.StatusOK {
+				actualSA := test.NewServiceAccountV1SliceWrapper{}
+				actualSA.DecodeOrDie(res.Body, t).Sort()
+
+				wrappedExpectedSA := test.NewServiceAccountV1SliceWrapper(tc.expectedSA)
+				wrappedExpectedSA.Sort()
+
+				actualSA.EqualOrDie(wrappedExpectedSA, t)
+
+			} else {
+				test.CompareWithResult(t, res, tc.expectedError)
+			}
+
+		})
+	}
+}
+
+func genActiveServiceAccount(id, name, group, projectName string) *kubermaticapiv1.User {
+	serviceAccount := test.GenServiceAccount(id, name, group, projectName)
+	serviceAccount.Labels = map[string]string{}
+	return serviceAccount
+}


### PR DESCRIPTION
**What this PR does / why we need it**: new endpoint to get a list of service accounts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3045

```release-note
a new endpoint for getting ServiceAccounts for projects: 'GET /api/v1/projects/{project_id}/serviceaccounts'
```
