### PR TITLE
Add uccm healthchecks

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -687,6 +687,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:b669bf7ea147e4d75e097e89f45c1e7de52e79dc913bbbae94b79177f7b075b6"
+  name = "github.com/heptiolabs/healthcheck"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "6ff867650f40c632367411120275478876202233"
+
+[[projects]]
   digest = "1:0e6ba0b7d6e399fcfd307379c02fc5cb703a72632dd3f4f219e8a0b6301a1625"
   name = "github.com/hetznercloud/hcloud-go"
   packages = [
@@ -1888,6 +1896,7 @@
     "github.com/gorilla/handlers",
     "github.com/gorilla/mux",
     "github.com/gorilla/securecookie",
+    "github.com/heptiolabs/healthcheck",
     "github.com/hetznercloud/hcloud-go/hcloud",
     "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws",
     "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure",

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -131,7 +131,7 @@ required = [
   name = "sigs.k8s.io/controller-runtime"
   version = "v0.1.10"
 
-[[constraint]]
+[[override]]
   name = "github.com/prometheus/client_golang"
   version = "v0.9.2"
 
@@ -192,3 +192,7 @@ required = [
 [[constraint]]
   name = "github.com/envoyproxy/go-control-plane"
   version = "v0.6.3"
+
+[[constraint]]
+  name = "github.com/heptiolabs/healthcheck"
+  branch = "master"

--- a/api/pkg/controller/cluster/health.go
+++ b/api/pkg/controller/cluster/health.go
@@ -20,11 +20,12 @@ func (cc *Controller) clusterHealth(c *kubermaticv1.Cluster) (*kubermaticv1.Clus
 	}
 
 	healthMapping := map[string]*depInfo{
-		resources.ApiserverDeploymentName:         {healthy: &health.Apiserver, minReady: 1},
-		resources.ControllerManagerDeploymentName: {healthy: &health.Controller, minReady: 1},
-		resources.SchedulerDeploymentName:         {healthy: &health.Scheduler, minReady: 1},
-		resources.MachineControllerDeploymentName: {healthy: &health.MachineController, minReady: 1},
-		resources.OpenVPNServerDeploymentName:     {healthy: &health.OpenVPN, minReady: 1},
+		resources.ApiserverDeploymentName:             {healthy: &health.Apiserver, minReady: 1},
+		resources.ControllerManagerDeploymentName:     {healthy: &health.Controller, minReady: 1},
+		resources.SchedulerDeploymentName:             {healthy: &health.Scheduler, minReady: 1},
+		resources.MachineControllerDeploymentName:     {healthy: &health.MachineController, minReady: 1},
+		resources.OpenVPNServerDeploymentName:         {healthy: &health.OpenVPN, minReady: 1},
+		resources.UserClusterControllerDeploymentName: {healthy: &health.UserClusterControllerManager, minReady: 1},
 	}
 
 	for name := range healthMapping {

--- a/api/pkg/controller/usercluster/controller.go
+++ b/api/pkg/controller/usercluster/controller.go
@@ -38,10 +38,10 @@ func Add(mgr manager.Manager, openshift bool, registerReconciledCheck func(name 
 		return err
 	}
 
-	// A very simple but limited way to express the successful reconciling to the seed cluster
-	registerReconciledCheck(fmt.Sprintf("%s-%s", controllerName, "reconciling_successfully"), func() error {
-		if !reconcile.reconcilingSuccessfully {
-			return errors.New("last reconcile failed or did not happen yet")
+	// A very simple but limited way to express the first successful reconciling to the seed cluster
+	registerReconciledCheck(fmt.Sprintf("%s-%s", controllerName, "reconciled_successfully_once"), func() error {
+		if !reconcile.reconciledSuccessfullyOnce {
+			return errors.New("no successful reconciliation so far")
 		}
 		return nil
 	})
@@ -52,18 +52,17 @@ func Add(mgr manager.Manager, openshift bool, registerReconciledCheck func(name 
 // reconcileUserCluster reconciles objects in the user cluster
 type reconciler struct {
 	client.Client
-	openshift               bool
-	cache                   cache.Cache
-	reconcilingSuccessfully bool
+	openshift                  bool
+	cache                      cache.Cache
+	reconciledSuccessfullyOnce bool
 }
 
 // Reconcile makes changes in response to objects in the user cluster.
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	if err := r.reconcile(context.TODO()); err != nil {
-		r.reconcilingSuccessfully = false
 		return reconcile.Result{}, err
 	}
-	r.reconcilingSuccessfully = true
 
+	r.reconciledSuccessfullyOnce = true
 	return reconcile.Result{}, nil
 }

--- a/api/pkg/controller/usercluster/controller.go
+++ b/api/pkg/controller/usercluster/controller.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 
 	"github.com/heptiolabs/healthcheck"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -13,9 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 )
 
 const (

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	corev1 "k8s.io/api/core/v1"
@@ -334,13 +335,14 @@ type OpenstackCloudSpec struct {
 
 // ClusterHealthStatus stores health information of the components of a cluster.
 type ClusterHealthStatus struct {
-	Apiserver                   bool `json:"apiserver"`
-	Scheduler                   bool `json:"scheduler"`
-	Controller                  bool `json:"controller"`
-	MachineController           bool `json:"machineController"`
-	Etcd                        bool `json:"etcd"`
-	OpenVPN                     bool `json:"openvpn"`
-	CloudProviderInfrastructure bool `json:"cloudProviderInfrastructure"`
+	Apiserver                    bool `json:"apiserver"`
+	Scheduler                    bool `json:"scheduler"`
+	Controller                   bool `json:"controller"`
+	MachineController            bool `json:"machineController"`
+	Etcd                         bool `json:"etcd"`
+	OpenVPN                      bool `json:"openvpn"`
+	CloudProviderInfrastructure  bool `json:"cloudProviderInfrastructure"`
+	UserClusterControllerManager bool `json:"userClusterControllerManager"`
 }
 
 // AllHealthy returns if all components are healthy

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -352,7 +352,8 @@ func (h *ClusterHealthStatus) AllHealthy() bool {
 		h.Controller &&
 		h.Apiserver &&
 		h.Scheduler &&
-		h.CloudProviderInfrastructure
+		h.CloudProviderInfrastructure &&
+		h.UserClusterControllerManager
 }
 
 // MarshalJSON adds base64 json encoding to the Bytes type.

--- a/api/pkg/handler/v1/node/node_test.go
+++ b/api/pkg/handler/v1/node/node_test.go
@@ -1260,12 +1260,13 @@ func genTestCluster(isControllerReady bool) *kubermaticv1.Cluster {
 	cluster.Status = kubermaticv1.ClusterStatus{
 		Health: kubermaticv1.ClusterHealth{
 			ClusterHealthStatus: kubermaticv1.ClusterHealthStatus{
-				Apiserver:                   true,
-				Scheduler:                   true,
-				Controller:                  isControllerReady,
-				MachineController:           true,
-				Etcd:                        true,
-				CloudProviderInfrastructure: true,
+				Apiserver:                    true,
+				Scheduler:                    true,
+				Controller:                   isControllerReady,
+				MachineController:            true,
+				Etcd:                         true,
+				CloudProviderInfrastructure:  true,
+				UserClusterControllerManager: true,
 			},
 		},
 	}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -29,8 +29,10 @@ spec:
       - args:
         - -kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - -internal-address
+        - -metrics-listen-address
         - 0.0.0.0:8085
+        - -health-listen-address
+        - 0.0.0.0:8086
         - -logtostderr
         - -v
         - "2"
@@ -41,6 +43,15 @@ spec:
         image: 'quay.io/kubermatic/api:'
         imagePullPolicy: IfNotPresent
         name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 500m

--- a/api/vendor/github.com/heptiolabs/healthcheck/LICENSE
+++ b/api/vendor/github.com/heptiolabs/healthcheck/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/api/vendor/github.com/heptiolabs/healthcheck/async.go
+++ b/api/vendor/github.com/heptiolabs/healthcheck/async.go
@@ -1,0 +1,85 @@
+// Copyright 2017 by the contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrNoData is returned if the first call of an Async() wrapped Check has not
+// yet returned.
+var ErrNoData = errors.New("no data yet")
+
+// Async converts a Check into an asynchronous check that runs in a background
+// goroutine at a fixed interval. The check is called at a fixed rate, not with
+// a fixed delay between invocations. If your check takes longer than the
+// interval to execute, the next execution will happen immediately.
+//
+// Note: if you need to clean up the background goroutine, use AsyncWithContext().
+func Async(check Check, interval time.Duration) Check {
+	return AsyncWithContext(context.Background(), check, interval)
+}
+
+// AsyncWithContext converts a Check into an asynchronous check that runs in a
+// background goroutine at a fixed interval. The check is called at a fixed
+// rate, not with a fixed delay between invocations. If your check takes longer
+// than the interval to execute, the next execution will happen immediately.
+//
+// Note: if you don't need to cancel execution (because this runs forever), use Async()
+func AsyncWithContext(ctx context.Context, check Check, interval time.Duration) Check {
+	// create a chan that will buffer the most recent check result
+	result := make(chan error, 1)
+
+	// fill it with ErrNoData so we'll start in an initially failing state
+	// (we don't want to be ready/live until we've actually executed the check
+	// once, but that might be slow).
+	result <- ErrNoData
+
+	// make a wrapper that runs the check, and swaps out the current head of
+	// the channel with the latest result
+	update := func() {
+		err := check()
+		<-result
+		result <- err
+	}
+
+	// spawn a background goroutine to run the check
+	go func() {
+		// call once right away (time.Tick() doesn't always tick immediately
+		// but we want an initial result as soon as possible)
+		update()
+
+		// loop forever or until the context is canceled
+		ticker := time.Tick(interval)
+		for {
+			select {
+			case <-ticker:
+				update()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// return a Check function that closes over our result and mutex
+	return func() error {
+		// peek at the head of the channel, then put it back
+		err := <-result
+		result <- err
+		return err
+	}
+}

--- a/api/vendor/github.com/heptiolabs/healthcheck/checks.go
+++ b/api/vendor/github.com/heptiolabs/healthcheck/checks.go
@@ -1,0 +1,104 @@
+// Copyright 2017 by the contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+// TCPDialCheck returns a Check that checks TCP connectivity to the provided
+// endpoint.
+func TCPDialCheck(addr string, timeout time.Duration) Check {
+	return func() error {
+		conn, err := net.DialTimeout("tcp", addr, timeout)
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}
+}
+
+// HTTPGetCheck returns a Check that performs an HTTP GET request against the
+// specified URL. The check fails if the response times out or returns a non-200
+// status code.
+func HTTPGetCheck(url string, timeout time.Duration) Check {
+	client := http.Client{
+		Timeout: timeout,
+		// never follow redirects
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	return func() error {
+		resp, err := client.Get(url)
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("returned status %d", resp.StatusCode)
+		}
+		return nil
+	}
+}
+
+// DatabasePingCheck returns a Check that validates connectivity to a
+// database/sql.DB using Ping().
+func DatabasePingCheck(database *sql.DB, timeout time.Duration) Check {
+	return func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		if database == nil {
+			return fmt.Errorf("database is nil")
+		}
+		return database.PingContext(ctx)
+	}
+}
+
+// DNSResolveCheck returns a Check that makes sure the provided host can resolve
+// to at least one IP address within the specified timeout.
+func DNSResolveCheck(host string, timeout time.Duration) Check {
+	resolver := net.Resolver{}
+	return func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		addrs, err := resolver.LookupHost(ctx, host)
+		if err != nil {
+			return err
+		}
+		if len(addrs) < 1 {
+			return fmt.Errorf("could not resolve host")
+		}
+		return nil
+	}
+}
+
+// GoroutineCountCheck returns a Check that fails if too many goroutines are
+// running (which could indicate a resource leak).
+func GoroutineCountCheck(threshold int) Check {
+	return func() error {
+		count := runtime.NumGoroutine()
+		if count > threshold {
+			return fmt.Errorf("too many goroutines (%d > %d)", count, threshold)
+		}
+		return nil
+	}
+}

--- a/api/vendor/github.com/heptiolabs/healthcheck/doc.go
+++ b/api/vendor/github.com/heptiolabs/healthcheck/doc.go
@@ -1,0 +1,24 @@
+// Copyright 2017 by the contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package healthcheck helps you implement Kubernetes liveness and readiness checks
+for your application. It supports synchronous and asynchronous (background)
+checks. It can optionally report each check's status as a set of Prometheus
+gauge metrics for cluster-wide monitoring and alerting.
+
+It also includes a small library of generic checks for DNS, TCP, and HTTP
+reachability as well as Goroutine usage.
+*/
+package healthcheck

--- a/api/vendor/github.com/heptiolabs/healthcheck/handler.go
+++ b/api/vendor/github.com/heptiolabs/healthcheck/handler.go
@@ -1,0 +1,103 @@
+// Copyright 2017 by the contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+)
+
+// basicHandler is a basic Handler implementation.
+type basicHandler struct {
+	http.ServeMux
+	checksMutex     sync.RWMutex
+	livenessChecks  map[string]Check
+	readinessChecks map[string]Check
+}
+
+// NewHandler creates a new basic Handler
+func NewHandler() Handler {
+	h := &basicHandler{
+		livenessChecks:  make(map[string]Check),
+		readinessChecks: make(map[string]Check),
+	}
+	h.Handle("/live", http.HandlerFunc(h.LiveEndpoint))
+	h.Handle("/ready", http.HandlerFunc(h.ReadyEndpoint))
+	return h
+}
+
+func (s *basicHandler) LiveEndpoint(w http.ResponseWriter, r *http.Request) {
+	s.handle(w, r, s.livenessChecks)
+}
+
+func (s *basicHandler) ReadyEndpoint(w http.ResponseWriter, r *http.Request) {
+	s.handle(w, r, s.readinessChecks, s.livenessChecks)
+}
+
+func (s *basicHandler) AddLivenessCheck(name string, check Check) {
+	s.checksMutex.Lock()
+	defer s.checksMutex.Unlock()
+	s.livenessChecks[name] = check
+}
+
+func (s *basicHandler) AddReadinessCheck(name string, check Check) {
+	s.checksMutex.Lock()
+	defer s.checksMutex.Unlock()
+	s.readinessChecks[name] = check
+}
+
+func (s *basicHandler) collectChecks(checks map[string]Check, resultsOut map[string]string, statusOut *int) {
+	s.checksMutex.RLock()
+	defer s.checksMutex.RUnlock()
+	for name, check := range checks {
+		if err := check(); err != nil {
+			*statusOut = http.StatusServiceUnavailable
+			resultsOut[name] = err.Error()
+		} else {
+			resultsOut[name] = "OK"
+		}
+	}
+}
+
+func (s *basicHandler) handle(w http.ResponseWriter, r *http.Request, checks ...map[string]Check) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	checkResults := make(map[string]string)
+	status := http.StatusOK
+	for _, checks := range checks {
+		s.collectChecks(checks, checkResults, &status)
+	}
+
+	// write out the response code and content type header
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+
+	// unless ?full=1, return an empty body. Kubernetes only cares about the
+	// HTTP status code, so we won't waste bytes on the full body.
+	if r.URL.Query().Get("full") != "1" {
+		w.Write([]byte("{}\n"))
+		return
+	}
+
+	// otherwise, write the JSON body ignoring any encoding errors (which
+	// shouldn't really be possible since we're encoding a map[string]string).
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "    ")
+	encoder.Encode(checkResults)
+}

--- a/api/vendor/github.com/heptiolabs/healthcheck/metrics_handler.go
+++ b/api/vendor/github.com/heptiolabs/healthcheck/metrics_handler.go
@@ -1,0 +1,76 @@
+// Copyright 2017 by the contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metricsHandler struct {
+	handler   Handler
+	registry  prometheus.Registerer
+	namespace string
+}
+
+// NewMetricsHandler returns a healthcheck Handler that also exposes metrics
+// into the provided Prometheus registry.
+func NewMetricsHandler(registry prometheus.Registerer, namespace string) Handler {
+	return &metricsHandler{
+		handler:   NewHandler(),
+		registry:  registry,
+		namespace: namespace,
+	}
+}
+
+func (h *metricsHandler) AddLivenessCheck(name string, check Check) {
+	h.handler.AddLivenessCheck(name, h.wrap(name, check))
+}
+
+func (h *metricsHandler) AddReadinessCheck(name string, check Check) {
+	h.handler.AddReadinessCheck(name, h.wrap(name, check))
+}
+
+func (h *metricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.handler.ServeHTTP(w, r)
+}
+
+func (h *metricsHandler) LiveEndpoint(w http.ResponseWriter, r *http.Request) {
+	h.handler.LiveEndpoint(w, r)
+}
+
+func (h *metricsHandler) ReadyEndpoint(w http.ResponseWriter, r *http.Request) {
+	h.handler.ReadyEndpoint(w, r)
+}
+
+func (h *metricsHandler) wrap(name string, check Check) Check {
+	h.registry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace:   h.namespace,
+			Subsystem:   "healthcheck",
+			Name:        "status",
+			Help:        "Current check status (0 indicates success, 1 indicates failure)",
+			ConstLabels: prometheus.Labels{"check": name},
+		},
+		func() float64 {
+			if check() == nil {
+				return 0
+			}
+			return 1
+		},
+	))
+	return check
+}

--- a/api/vendor/github.com/heptiolabs/healthcheck/timeout.go
+++ b/api/vendor/github.com/heptiolabs/healthcheck/timeout.go
@@ -1,0 +1,52 @@
+// Copyright 2017 by the contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"fmt"
+	"time"
+)
+
+// TimeoutError is the error returned when a Timeout-wrapped Check takes too long
+type timeoutError time.Duration
+
+func (e timeoutError) Error() string {
+	return fmt.Sprintf("timed out after %s", time.Duration(e).String())
+}
+
+// Timeout returns whether this error is a timeout (always true for timeoutError)
+func (e timeoutError) Timeout() bool {
+	return true
+}
+
+// Temporary returns whether this error is temporary (always true for timeoutError)
+func (e timeoutError) Temporary() bool {
+	return true
+}
+
+// Timeout adds a timeout to a Check. If the underlying check takes longer than
+// the timeout, it returns an error.
+func Timeout(check Check, timeout time.Duration) Check {
+	return func() error {
+		c := make(chan error, 1)
+		go func() { c <- check() }()
+		select {
+		case err := <-c:
+			return err
+		case <-time.After(timeout):
+			return timeoutError(timeout)
+		}
+	}
+}

--- a/api/vendor/github.com/heptiolabs/healthcheck/types.go
+++ b/api/vendor/github.com/heptiolabs/healthcheck/types.go
@@ -1,0 +1,52 @@
+// Copyright 2017 by the contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"net/http"
+)
+
+// Check is a health/readiness check.
+type Check func() error
+
+// Handler is an http.Handler with additional methods that register health and
+// readiness checks. It handles handle "/live" and "/ready" HTTP
+// endpoints.
+type Handler interface {
+	// The Handler is an http.Handler, so it can be exposed directly and handle
+	// /live and /ready endpoints.
+	http.Handler
+
+	// AddLivenessCheck adds a check that indicates that this instance of the
+	// application should be destroyed or restarted. A failed liveness check
+	// indicates that this instance is unhealthy, not some upstream dependency.
+	// Every liveness check is also included as a readiness check.
+	AddLivenessCheck(name string, check Check)
+
+	// AddReadinessCheck adds a check that indicates that this instance of the
+	// application is currently unable to serve requests because of an upstream
+	// or some transient failure. If a readiness check fails, this instance
+	// should no longer receiver requests, but should not be restarted or
+	// destroyed.
+	AddReadinessCheck(name string, check Check)
+
+	// LiveEndpoint is the HTTP handler for just the /live endpoint, which is
+	// useful if you need to attach it into your own HTTP handler tree.
+	LiveEndpoint(http.ResponseWriter, *http.Request)
+
+	// ReadyEndpoint is the HTTP handler for just the /ready endpoint, which is
+	// useful if you need to attach it into your own HTTP handler tree.
+	ReadyEndpoint(http.ResponseWriter, *http.Request)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This introduces (Potentially misuses) readiness probes to the user cluster controllers.
The main purpose for those is to communicate the "reconciling state" back to the seed cluster.

When adding the corresponding ReadinessProbes to the UCCM deployment, we now have a way to identify if relevant user cluster controllers finished reconciling at least once (Creating relevant RBAC rules, CRD's, etc.).
This works because the cluster controller waits for all pods to reach the "Ready" phase.

The reason why i currently wrote this is mainly because its really simple and even works when we extend the UCCM to reconcile more resources.
For example:
In the next version we extend the UCCM to reconcile more RBAC resources, which are required by the api+dashboard. 
When using a ConfigMap as checkpoint file, we now would need to introduce a new checkpoint for the new RBAC resources.
With the readiness probe we don't have to extend anything as it only turns ready when the reconciling has finished at least once (Which implies the new resources have been created).

Fixes #3019

**Release note**:
```release-note
NONE
```
