### PR TITLE
define a dedicated time series in prometheus for the VPA

### DIFF
--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           "--v", "4",
           "--storage", "prometheus",
           "--prometheus-address","http://prometheus-kubermatic.monitoring.svc.cluster.local:9090",
-          "--prometheus-cadvisor-job-name", "cadvisor",
+          "--prometheus-cadvisor-job-name", "cadvisor-vpa",
           "--recommendation-margin-fraction", "0",
         ]
         resources:

--- a/config/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
+++ b/config/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
@@ -4,13 +4,13 @@ groups:
   rules:
   - expr: |
       label_replace(
-        sum(container_cpu_usage_seconds_total{job="cadvisor", pod_name=~".+"}) by (pod_name, namespace, name),
+        sum(container_cpu_usage_seconds_total{job="cadvisor", pod_name=~".+", name!="POD", name!=""}) by (pod_name, namespace, name),
         "job", "cadvisor-vpa", "", ""
       )
     record: container_cpu_usage_seconds_total
   - expr: |
       label_replace(
-        sum(container_memory_usage_bytes{job="cadvisor", pod_name=~".+"}) by (pod_name, namespace, name),
+        sum(container_memory_usage_bytes{job="cadvisor", pod_name=~".+", name!="POD", name!=""}) by (pod_name, namespace, name),
         "job", "cadvisor-vpa", "", ""
       )
     record: container_memory_usage_bytes

--- a/config/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
+++ b/config/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
@@ -1,0 +1,16 @@
+# This file has been generated, do not edit.
+groups:
+- name: vertical-pod-autoscaler
+  rules:
+  - expr: |
+      label_replace(
+        sum(container_cpu_usage_seconds_total{job="cadvisor", pod_name=~".+"}) by (pod_name, namespace, name),
+        "job", "cadvisor-vpa", "", ""
+      )
+    record: container_cpu_usage_seconds_total
+  - expr: |
+      label_replace(
+        sum(container_memory_usage_bytes{job="cadvisor", pod_name=~".+"}) by (pod_name, namespace, name),
+        "job", "cadvisor-vpa", "", ""
+      )
+    record: container_memory_usage_bytes

--- a/config/monitoring/prometheus/rules/src/general/vertical-pod-autoscaler.yaml
+++ b/config/monitoring/prometheus/rules/src/general/vertical-pod-autoscaler.yaml
@@ -1,0 +1,23 @@
+groups:
+- name: vertical-pod-autoscaler
+  rules:
+
+  # These rules provide metrics to be consumed by Kubernetes' VPA. The VPA only needs a tiny fraction
+  # of the labels available on the container_* metrics, so we reduce them with the inner query to
+  # only contain pod_name, namespace and name.
+  # Because the VPA does not allow to change the metric name it queries, but only the job selector,
+  # we "cheat" by re-using the same metric name and injecting a custom job ("cadvisor-vpa") label.
+
+  - record: container_cpu_usage_seconds_total
+    expr: |
+      label_replace(
+        sum(container_cpu_usage_seconds_total{job="cadvisor", pod_name=~".+"}) by (pod_name, namespace, name),
+        "job", "cadvisor-vpa", "", ""
+      )
+
+  - record: container_memory_usage_bytes
+    expr: |
+      label_replace(
+        sum(container_memory_usage_bytes{job="cadvisor", pod_name=~".+"}) by (pod_name, namespace, name),
+        "job", "cadvisor-vpa", "", ""
+      )

--- a/config/monitoring/prometheus/rules/src/general/vertical-pod-autoscaler.yaml
+++ b/config/monitoring/prometheus/rules/src/general/vertical-pod-autoscaler.yaml
@@ -11,13 +11,13 @@ groups:
   - record: container_cpu_usage_seconds_total
     expr: |
       label_replace(
-        sum(container_cpu_usage_seconds_total{job="cadvisor", pod_name=~".+"}) by (pod_name, namespace, name),
+        sum(container_cpu_usage_seconds_total{job="cadvisor", pod_name=~".+", name!="POD", name!=""}) by (pod_name, namespace, name),
         "job", "cadvisor-vpa", "", ""
       )
 
   - record: container_memory_usage_bytes
     expr: |
       label_replace(
-        sum(container_memory_usage_bytes{job="cadvisor", pod_name=~".+"}) by (pod_name, namespace, name),
+        sum(container_memory_usage_bytes{job="cadvisor", pod_name=~".+", name!="POD", name!=""}) by (pod_name, namespace, name),
         "job", "cadvisor-vpa", "", ""
       )


### PR DESCRIPTION
**What this PR does / why we need it**:
As the comment in the rule files indicates, the VPA is *always* fetching the predetermined `container_*` metrics. The only thing we can change is the job label.

In the default metrics, we have lots and lots of metrics that we do not need:

```
container_cpu_usage_seconds_total{
  beta_kubernetes_io_arch="amd64",
  beta_kubernetes_io_fluentd_ds_ready="true",
  beta_kubernetes_io_instance_type="n1-standard-2",
  beta_kubernetes_io_masq_agent_ds_ready="true",
  beta_kubernetes_io_os="linux",
  cloud_google_com_gke_nodepool="preemtible",
  cloud_google_com_gke_os_distribution="cos",
  cloud_google_com_gke_preemptible="true",
  container_name="POD",
  cpu="total",
  failure_domain_beta_kubernetes_io_region="europe-west3",
  failure_domain_beta_kubernetes_io_zone="europe-west3-c",
  id="/kubepods/burstable/pod37745faa-506e-11e9-9ea9-42010a9c0125/8074d9e1579d7760a12ce9fd4a959018eb0e64c46e824a05f957aca9da28e77d",
  image="k8s.gcr.io/pause:3.1",
  instance="gke-kubermatic-dev-preemtible-73c91f1f-zhth",
  job="cadvisor",
  kubernetes_io_hostname="gke-kubermatic-dev-preemtible-73c91f1f-zhth",
  name="k8s_POD_alertmanager-kubermatic-0_monitoring_37745faa-506e-11e9-9ea9-42010a9c0125_0",
  namespace="monitoring",
  pod_name="alertmanager-kubermatic-0",
  projectcalico_org_ds_ready="true"
}
```

The VPA only cares for pod_name, namespace and name. All other labels are junk and are needlessly transferred from Prometheus, JSON-decoded, put into Go maps and then ignored.

This PR prepares a special version of the required metrics with only the required labels *and a new job label*, so that we have to transfer less data and can hopefully reduce the VPA's memory consumption a bit.

In my local tests (and judging from only 2h worth of data), this reduced the memory usage by roughly 5-10MB per hour. I expect this to be more noticable when we use the default time range (8 days).

The reason for choosing this "hack" is that Henrik apparently already suggested to the VPA people to make the metric name configurable, so that we could have used a nice recording rule with a dedicated metric, like `pod_name:container_bla_bla:sum`. But they rejected the idea.

---

If you compare our recording rule to the query of the [VPA @ v0.4.0](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-0.4.0/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go#L186), you will notice that ours restrict the data with `name!="POD", name!=""`. This is because in 0.4.0, there is a bug where metrics without the name label are rejected, stopping the entire VPA from working properly. In the [current master branch](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go#L190-L192), the query has been changed to this.

cc @mrIncompetent 

**Release note**:
```release-note
NONE
```
