### PR TITLE
Add metrics server entry

### DIFF
--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-dns-resolver.yaml
@@ -5,6 +5,11 @@ data:
         forward . /etc/resolv.conf
         errors
     }
+    # Required as we cannot use the trailing dot inside the externalName sevice which is located inside the user cluster
+    metrics-server.cluster-de-test-01.svc.cluster.local {
+        forward . /etc/resolv.conf
+        errors
+    }
     cluster.local {
         forward . 10.10.10.10
         errors


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a static entry for the metrics-server DNS name which gets used from the API server.

The API server does a call to `https://metrics-server.cluster-xxxxxxx.cluster.local:443` which might get forwarded to the user cluster DNS resolver.
We cannot use a trailing dot as its not allowed by the validation.

**Release note**:
```release-note
NONE
```
