### PR TITLE
fix node resources dashboard

### DIFF
--- a/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
@@ -797,14 +797,14 @@
       "dashes": false,
       "datasource": "$datasource",
       "editable": "<< editable | default false | toJson >>",
-      "fill": 10,
+      "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
         "y": 33
       },
-      "id": 8,
+      "id": 14,
       "legend": {
         "avg": false,
         "current": false,
@@ -815,24 +815,24 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 0,
+      "linewidth": 1,
       "links": [],
-      "nullPointMode": "null as zero",
+      "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node=~\"$nodes\"} - node_filesystem_avail_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node=~\"$nodes\"}) by (device,pod,namespace)) by (pod,namespace)\n/ scalar(sum(max(node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node=~\"$nodes\"}) by (device,pod,namespace)))\n* on (namespace, pod) group_left (node) node_namespace_pod:kube_pod_info:\n",
+          "expr": "(\n  sum(node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node_name=~\"$nodes\"}) by (node_name) -\n  sum(node_filesystem_avail_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node_name=~\"$nodes\"}) by (node_name)\n) / sum(node_filesystem_size_bytes{fstype=~\"ext[234]|btrfs|xfs|zfs\",node_name=~\"$nodes\"}) by (node_name)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
-          "legendFormat": "{{node}}",
+          "legendFormat": "{{node_name}}",
           "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
           "refId": "A",
           "step": 10
@@ -859,11 +859,12 @@
       },
       "yaxes": [
         {
+          "decimals": 1,
           "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": 1,
-          "min": 0,
+          "max": null,
+          "min": null,
           "show": true
         },
         {

--- a/config/monitoring/prometheus/rules/general-node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-node-exporter.yaml
@@ -33,6 +33,13 @@ groups:
       node:node_num_cpu:sum
     record: 'node:node_cpu_saturation_load1:'
   - expr: |
+      node:node_cpu_utilisation:avg1m
+        *
+      node:node_num_cpu:sum
+        /
+      scalar(sum(node:node_num_cpu:sum))
+    record: node:cluster_cpu_utilisation:ratio
+  - expr: |
       1 -
       sum(node_memory_MemFree_bytes{app="node-exporter"} + node_memory_Cached_bytes{app="node-exporter"} + node_memory_Buffers_bytes{app="node-exporter"})
       /
@@ -88,6 +95,11 @@ groups:
           node_namespace_pod:kube_pod_info:
       )
     record: node:node_memory_swap_io_bytes:sum_rate
+  - expr: |
+      (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
+      /
+      scalar(sum(node:node_memory_bytes_total:sum))
+    record: node:cluster_memory_utilisation:ratio
   - expr: |
       avg(irate(node_disk_io_time_seconds_total{app="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]))
     record: :node_disk_utilisation:avg_irate

--- a/config/monitoring/prometheus/rules/src/general/node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/node-exporter.yaml
@@ -36,6 +36,14 @@ groups:
       /
       node:node_num_cpu:sum
 
+  - record: node:cluster_cpu_utilisation:ratio
+    expr: |
+      node:node_cpu_utilisation:avg1m
+        *
+      node:node_num_cpu:sum
+        /
+      scalar(sum(node:node_num_cpu:sum))
+
   - record: ':node_memory_utilisation:'
     expr: |
       1 -
@@ -99,6 +107,12 @@ groups:
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
       )
+
+  - record: node:cluster_memory_utilisation:ratio
+    expr: |
+      (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
+      /
+      scalar(sum(node:node_memory_bytes_total:sum))
 
   - record: :node_disk_utilisation:avg_irate
     expr: |


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds two missing recording rules and fixes the disk overview chart because we now have the node name available directly and do not need the old, complicated metric merge logic anymore. Also the old chart was unreadable and would have annoyed customers because it was stacking and limited to 100% -- meaning if three disks are at 40%, they would destroy the chart.

**Release note**:
```release-note
NONE
```
