### PR TITLE
fix kibana to match new elasticsearch chart

### DIFF
--- a/config/logging/kibana/templates/deployment.yaml
+++ b/config/logging/kibana/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         k8s-app: kibana-logging
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       containers:

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -1,8 +1,8 @@
 logging:
   kibana:
     image:
-      repository: docker.elastic.co/kibana/kibana
-      tag: "6.5.1"
+      repository: docker.elastic.co/kibana/kibana-oss
+      tag: "6.6.2"
       pullPolicy: IfNotPresent
     resources:
       requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
After updating Elasticsearch recently, we also must use a matching OSS image for Kibana or it will fail because no _xpack index has been setup.

**Release note**:
```release-note
NONE
```
