### PR TITLE
fix ark-config forgetting to define VolumeSnapshotLocations

### DIFF
--- a/config/backup/ark-config/templates/config.yaml
+++ b/config/backup/ark-config/templates/config.yaml
@@ -1,6 +1,17 @@
 {{ range $name, $config := .Values.ark.backupStorageLocations }}
+---
 apiVersion: ark.heptio.com/v1
 kind: BackupStorageLocation
+metadata:
+  name: {{ $name }}
+spec:
+{{ $config | toYaml | indent 2 }}
+{{ end }}
+
+{{ range $name, $config := .Values.ark.volumeSnapshotLocations }}
+---
+apiVersion: ark.heptio.com/v1
+kind: VolumeSnapshotLocation
 metadata:
   name: {{ $name }}
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
For some reason I forgot to actually put the configured VSL into the manifests.

**Release note**:
```release-note
fix VolumeSnapshotLocations for Ark configuration
```
