### PR TITLE
Add Velero Helm Chart

### DIFF
--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,0 +1,3 @@
+description: A Helm chart for Heptio Velero
+name: velero
+version: 0.11.0

--- a/config/backup/velero/schedules/daily-logging.yaml
+++ b/config/backup/velero/schedules/daily-logging.yaml
@@ -1,0 +1,10 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: daily-logging
+spec:
+  schedule: "0 1 * * *"
+  template:
+    includedNamespaces:
+    - logging
+    ttl: 168h # 7 days

--- a/config/backup/velero/schedules/daily-minio.yaml
+++ b/config/backup/velero/schedules/daily-minio.yaml
@@ -1,0 +1,10 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: daily-minio
+spec:
+  schedule: "0 1 * * *"
+  template:
+    includedNamespaces:
+    - minio
+    ttl: 168h # 7 days

--- a/config/backup/velero/schedules/daily-monitoring.yaml
+++ b/config/backup/velero/schedules/daily-monitoring.yaml
@@ -1,0 +1,10 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: daily-monitoring
+spec:
+  schedule: "0 1 * * *"
+  template:
+    includedNamespaces:
+    - monitoring
+    ttl: 168h # 7 days

--- a/config/backup/velero/templates/config.yaml
+++ b/config/backup/velero/templates/config.yaml
@@ -1,0 +1,8 @@
+{{ range $name, $config := .Values.velero.backupStorageLocations }}
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: {{ $name }}
+spec:
+{{ $config | toYaml | indent 2 }}
+{{ end }}

--- a/config/backup/velero/templates/customresourcedefinitions.yaml
+++ b/config/backup/velero/templates/customresourcedefinitions.yaml
@@ -1,0 +1,185 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backups
+    kind: Backup
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: schedules.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: schedules
+    kind: Schedule
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: restores
+    kind: Restore
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: downloadrequests.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: downloadrequests
+    kind: DownloadRequest
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: deletebackuprequests.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: deletebackuprequests
+    kind: DeleteBackupRequest
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podvolumebackups.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: podvolumebackups
+    kind: PodVolumeBackup
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podvolumerestores.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: podvolumerestores
+    kind: PodVolumeRestore
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resticrepositories.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: resticrepositories
+    kind: ResticRepository
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backupstoragelocations.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backupstoragelocations
+    kind: BackupStorageLocation
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotlocations.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: volumesnapshotlocations
+    kind: VolumeSnapshotLocation
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serverstatusrequests.velero.io
+  labels:
+    component: velero
+  annotations:
+    'helm.sh/hook': crd-install
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: serverstatusrequests
+    kind: ServerStatusRequest

--- a/config/backup/velero/templates/daemonset.yaml
+++ b/config/backup/velero/templates/daemonset.yaml
@@ -31,8 +31,8 @@ spec:
 
         {{- if .Values.velero.credentials.azure }}
         envFrom:
-          - secretRef:
-              name: azure-credentials
+        - secretRef:
+            name: azure-credentials
         {{- end }}
 
         env:

--- a/config/backup/velero/templates/daemonset.yaml
+++ b/config/backup/velero/templates/daemonset.yaml
@@ -1,0 +1,96 @@
+{{ if .Values.velero.restic }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: restic
+  labels:
+    app.kubernetes.io/name: restic
+    app.kubernetes.io/version: '{{ .Values.velero.image.tag }}'
+    app.kubernetes.io/managed-by: helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: restic
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: restic
+    spec:
+      containers:
+      - name: restic
+        image: '{{ .Values.velero.image.repository }}:{{ .Values.velero.image.tag }}'
+        imagePullPolicy: {{ .Values.velero.image.pullPolicy }}
+
+        command:
+        - /velero
+        args:
+        - restic
+        - server
+
+        {{- if .Values.velero.credentials.azure }}
+        envFrom:
+          - secretRef:
+              name: azure-credentials
+        {{- end }}
+
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: VELERO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: VELERO_SCRATCH_DIR
+          value: /scratch
+        {{- if .Values.velero.credentials.aws }}
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /credentials/aws/creds
+        {{- end }}
+        {{- if .Values.velero.credentials.gcp }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /credentials/gcp/creds
+        {{- end }}
+
+        volumeMounts:
+        - name: host-pods
+          mountPath: /host_pods
+          mountPropagation: HostToContainer
+        - name: scratch
+          mountPath: /scratch
+        {{- if .Values.velero.credentials.aws }}
+        - name: aws-credentials
+          mountPath: /credentials/aws
+        {{- end }}
+        {{- if .Values.velero.credentials.gcp }}
+        - name: gcp-credentials
+          mountPath: /credentials/gcp
+        {{- end }}
+
+        resources:
+{{ toYaml .Values.velero.resources.restic | indent 10 }}
+
+      volumes:
+      - name: host-pods
+        hostPath:
+          path: /var/lib/kubelet/pods
+      - name: scratch
+        emptyDir: {}
+      {{- if .Values.velero.credentials.aws }}
+      - name: aws-credentials
+        secret:
+          secretName: aws-credentials
+      {{- end }}
+      {{- if .Values.velero.credentials.gcp }}
+      - name: gcp-credentials
+        secret:
+          secretName: gcp-credentials
+      {{- end }}
+
+      serviceAccountName: velero
+      securityContext:
+        runAsUser: 0
+{{ end }}

--- a/config/backup/velero/templates/deployment.yaml
+++ b/config/backup/velero/templates/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/version: '{{ .Values.velero.image.tag }}'
+    app.kubernetes.io/managed-by: helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: velero
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: velero
+      annotations:
+        kubermatic/scrape: "true"
+        kubermatic/scrape_port: "8085"
+{{- with .Values.velero.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: velero
+        image: '{{ .Values.velero.image.repository }}:{{ .Values.velero.image.tag }}'
+        imagePullPolicy: {{ .Values.velero.image.pullPolicy }}
+
+        command:
+        - /velero
+        args:
+        - server
+        {{- range .Values.velero.serverFlags }}
+        - '{{ . }}'
+        {{- end }}
+        {{- with .Values.velero.defaultBackupStorageLocation }}
+        - '--default-backup-storage-location={{ . }}'
+        {{- end }}
+        {{- with .Values.velero.defaultVolumeSnapshotLocations }}
+        - '--default-volume-snapshot-locations={{ . | join "," }}'
+        {{- end }}
+
+        {{- if .Values.velero.credentials.azure }}
+        envFrom:
+        - secretRef:
+            name: azure-credentials
+        {{- end }}
+
+        env:
+        - name: VELERO_SCRATCH_DIR
+          value: /scratch
+        {{- if .Values.velero.credentials.aws }}
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /credentials/aws/creds
+        {{- end }}
+        {{- if .Values.velero.credentials.gcp }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /credentials/gcp/creds
+        {{- end }}
+
+        volumeMounts:
+        - name: plugins
+          mountPath: /plugins
+        - name: scratch
+          mountPath: /scratch
+        {{- if .Values.velero.credentials.aws }}
+        - name: aws-credentials
+          mountPath: /credentials/aws
+        {{- end }}
+        {{- if .Values.velero.credentials.gcp }}
+        - name: gcp-credentials
+          mountPath: /credentials/gcp
+        {{- end }}
+
+        ports:
+        - name: metrics
+          containerPort: 8085
+          protocol: TCP
+
+        resources:
+{{ toYaml .Values.velero.resources.velero | indent 10 }}
+
+      volumes:
+      - name: plugins
+        emptyDir: {}
+      - name: scratch
+        emptyDir: {}
+      {{- if .Values.velero.credentials.aws }}
+      - name: aws-credentials
+        secret:
+          secretName: aws-credentials
+      {{- end }}
+      {{- if .Values.velero.credentials.gcp }}
+      - name: gcp-credentials
+        secret:
+          secretName: gcp-credentials
+      {{- end }}
+
+      serviceAccountName: velero
+      nodeSelector:
+{{ toYaml .Values.velero.nodeSelector | indent 8 }}
+      tolerations:
+{{ toYaml .Values.velero.tolerations | indent 8 }}

--- a/config/backup/velero/templates/rbac.yaml
+++ b/config/backup/velero/templates/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: velero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: velero
+  namespace: {{ .Release.Namespace }}

--- a/config/backup/velero/templates/schedules.yaml
+++ b/config/backup/velero/templates/schedules.yaml
@@ -1,0 +1,8 @@
+{{- with .Values.velero.schedulesPath }}
+apiVersion: v1
+kind: List
+items:
+{{- range $filename, $content := $.Files.Glob . }}
+- {{ $.Files.Get $filename | fromYaml | toJson }}
+{{- end }}
+{{- end }}

--- a/config/backup/velero/templates/secrets.yaml
+++ b/config/backup/velero/templates/secrets.yaml
@@ -1,0 +1,52 @@
+{{- with .Values.velero.credentials }}
+{{- with .restic }}
+{{- with .password }}
+---
+# This secret contains the password with which restic is encrypting all
+# the backups. It must be called "velero-restic-credentials" and contain
+# the key "repository-password".
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-restic-credentials
+type: Opaque
+data:
+  repository-password: {{ . | b64enc | quote }}
+{{- end }}
+{{- end }}
+
+{{- with .aws }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+type: Opaque
+data:
+  creds: {{ (printf "[default]\naws_access_key_id=%s\naws_secret_access_key=%s\n" .accessKey .secretKey) | b64enc | quote }}
+{{- end }}
+
+{{- with .gcp }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-credentials
+type: Opaque
+data:
+  creds: {{ .serviceKey | b64enc | quote }}
+{{- end }}
+
+{{- with .azure }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-credentials
+type: Opaque
+data:
+{{- range $key, $value := . }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/config/backup/velero/templates/serviceaccount.yaml
+++ b/config/backup/velero/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: velero

--- a/config/backup/velero/values.yaml
+++ b/config/backup/velero/values.yaml
@@ -1,0 +1,90 @@
+velero:
+  # the Docker image for Velero;
+  # if you are using restic, make sure to use an official image
+  # that also contains the restic binary
+  image:
+    repository: gcr.io/heptio-images/velero
+    tag: v0.11.0
+    pullPolicy: IfNotPresent
+
+  resources:
+    velero:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 100Mi
+    restic:
+      requests:
+        cpu: 10m
+        memory: 30Mi
+      limits:
+        cpu: 200m
+        # during backups memory usage can spike, see https://github.com/restic/restic/issues/979
+        memory: 1Gi
+
+  # CLI flags to pass to velero server; note that the two flags
+  # `default-backup-storage-location` and `default-volume-snapshot-locations`
+  # are automatically set via the configuration below
+  serverFlags:
+  - --metrics-address=:8085
+  - --backup-sync-period=1m
+
+  # whether or not to create a restic daemonset
+  restic: true
+
+  # configure the credentials used to make snapshots (when using
+  # persistentVolumeProvider) and to store backups; you can enable
+  # multiple credentials, if for some reason you run on GCP and
+  # still want to make restic snapshots to be stored in AWS S3.
+  credentials: {}
+    #aws:
+    #  accessKey: ...
+    #  secretKey: ...
+    #gcp:
+    #  serviceKey: '{...}'
+    #azure:
+    #  AZURE_SUBSCRIPTION_ID: ...
+    #  AZURE_TENANT_ID: ...
+    #  AZURE_RESOURCE_GROUP: ...
+    #  AZURE_CLIENT_ID: ...
+    #  AZURE_CLIENT_SECRET: ...
+    #  AZURE_STORAGE_ACCOUNT_ID: ...
+    #  AZURE_STORAGE_KEY: ...
+    #restic:
+    #  password: averysecurepassword
+
+  # define one of your backupStorageLocations as the default
+  #defaultBackupStorageLocation: aws
+
+  # see https://heptio.github.io/velero/v0.11.0/api-types/backupstoragelocation.html
+  #backupStorageLocations:
+  #  aws:
+  #    provider: aws
+  #    objectStorage:
+  #      bucket: myclusterbackups
+  #    config:
+  #      region: eu-west-1
+
+  # optionally define some of your volumeSnapshotLocations as the default;
+  # each element in the list must be a string of the form "provider:location"
+  #defaultVolumeSnapshotLocations:
+  #  - aws:aws
+
+  # see https://heptio.github.io/velero/v0.11.0/api-types/volumesnapshotlocation.html
+  #volumeSnapshotLocations:
+  #  aws:
+  #    provider: aws
+  #    config:
+  #      region: eu-west-1
+
+  # glob expressions to find schedule defitions
+  schedulesPath: schedules/*
+
+  # Only kube2iam: change the AWS_ACCOUNT_ID and HEPTIO_VELERO_ROLE_NAME
+  podAnnotations: {}
+  # iam.amazonaws.com/role: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<HEPTIO_VELERO_ROLE_NAME>
+
+  tolerations: []
+  nodeSelector: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
It's time to pull the bandaid and start joining the ark->velero name change. Ultimately, we want to remove the ark and ark-config charts. For Velero, I have merged the two charts because we can make use of the crd-install Helm hook.

**Release note**:
```release-note
update from Ark 0.10 to Velero 0.11
```
