### PR TITLE
add admin user serviceaccount reconciling

### DIFF
--- a/api/pkg/controller/usercluster/controller.go
+++ b/api/pkg/controller/usercluster/controller.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/heptiolabs/healthcheck"
 
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -17,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 )
 
 const (
@@ -36,6 +38,14 @@ func Add(mgr manager.Manager, openshift bool, registerReconciledCheck func(name 
 	}
 
 	if err = c.Watch(&source.Kind{Type: &rbacv1.Role{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
+	if err = c.Watch(&source.Kind{Type: &corev1.ServiceAccount{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
+	if err = c.Watch(&source.Kind{Type: &corev1.ServiceAccount{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
 

--- a/api/pkg/controller/usercluster/resources/user-auth/auth.go
+++ b/api/pkg/controller/usercluster/resources/user-auth/auth.go
@@ -1,0 +1,43 @@
+package userauth
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ServiceAccountName = "external-admin-user"
+)
+
+// ServiceAccountCreator returns a func to create/update the ServiceAccount used by the cluster user
+func ServiceAccountCreator() resources.NamedServiceAccountCreatorGetter {
+	return func() (string, resources.ServiceAccountCreator) {
+		return ServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			return sa, nil
+		}
+	}
+}
+
+// ClusterRoleBindingCreator returns a func to create/update the ClusterRoleBinding which will give the "external-admin-user" full admin access
+func ClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, resources.ClusterRoleBindingCreator) {
+		return "external-admin-user", func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.RoleRef = rbacv1.RoleRef{
+				Name:     "cluster-admin",
+				Kind:     "ClusterRole",
+				APIGroup: rbacv1.GroupName,
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      ServiceAccountName,
+					Namespace: metav1.NamespaceSystem,
+				},
+			}
+			return crb, nil
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the first step to replace the static tokens file with ServiceAccounts.
Goal is to align the admin auth handling for Kubernetes & OpenShift clusters.

**Release note**:
```release-note
NONE
```
