### PR TITLE
skip nodeport proxy deployment for CI

### DIFF
--- a/api/hack/ci/ci-deploy-ci-kubermatic-io.sh
+++ b/api/hack/ci/ci-deploy-ci-kubermatic-io.sh
@@ -37,5 +37,5 @@ vault kv get -field=values.yaml dev/seed-clusters/ci.kubermatic.io > ${VALUES_FI
 echodate "Successfully got secrets for dev from Vault"
 
 echodate "Deploying Kubermatic to ci.kubermatic.io"
-./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+DEPLOY_NODEPORT_PROXY=false ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
 echodate "Successfully deployed Kubermatic to ci.kubermatic.io"

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -20,6 +20,7 @@ if [[ "${1}" = "master" ]]; then
 else
   MASTER_FLAG="--set=kubermatic.isMaster=false"
 fi
+DEPLOY_NODEPORT_PROXY=${DEPLOY_NODEPORT_PROXY:-true}
 
 cd "$(dirname "$0")/../../"
 
@@ -47,7 +48,10 @@ if [[ "${1}" = "master" ]]; then
 fi
 
 deploy "minio" "minio" ./config/minio/
-deploy "nodeport-proxy" "nodeport-proxy" ./config/nodeport-proxy/
+# The NodePort proxy is only relevant in cloud environments (Where LB services can be used)
+if [[ "${DEPLOY_NODEPORT_PROXY}" = true ]]; then
+  deploy "nodeport-proxy" "nodeport-proxy" ./config/nodeport-proxy/
+fi
 
 #Monitoring
 deploy "prometheus" "monitoring" ./config/monitoring/prometheus/


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip nodeport proxy deployment for CI

**Release note**:
```release-note
NONE
```
