### PR TITLE
make node-exporter not listen on 0.0.0.0 anymore

### DIFF
--- a/config/monitoring/node-exporter/templates/daemonset.yaml
+++ b/config/monitoring/node-exporter/templates/daemonset.yaml
@@ -2,6 +2,10 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: node-exporter
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/version: '{{ .Values.nodeExporter.image.tag }}'
+    app.kubernetes.io/managed-by: helm
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -12,20 +16,19 @@ spec:
         app: node-exporter
       annotations:
         kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '9100'
+        kubermatic/scrape_port: '9123'
     spec:
       hostNetwork: true
       hostPID: true
+      serviceAccountName: node-exporter
       containers:
       - name: node-exporter
         image: "{{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag}}"
         args:
         - "--path.procfs=/host/proc"
         - "--path.sysfs=/host/sys"
-        ports:
-        - containerPort: 9100
-          hostPort: 9100
-          name: scrape
+        - "--path.rootfs=/host/root"
+        - "--web.listen-address=127.0.0.1:9123"
         resources:
 {{ toYaml .Values.nodeExporter.resources | indent 10 }}
         volumeMounts:
@@ -35,9 +38,33 @@ spec:
         - name: sys
           readOnly: true
           mountPath: /host/sys
+        - name: root
+          readOnly: true
+          mountPath: /host/root
+          mountPropagation: HostToContainer
+      - name: kube-rbac-proxy
+        image: "{{ .Values.nodeExporter.rbacProxy.image.repository }}:{{ .Values.nodeExporter.rbacProxy.image.tag}}"
+        args:
+        - "--logtostderr"
+        - "--secure-listen-address=$(IP):9123"
+        - "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+        - "--upstream=http://127.0.0.1:9123/"
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        ports:
+        - containerPort: 9123
+          hostPort: 9123
+          name: https
+        resources:
+{{ toYaml .Values.nodeExporter.rbacProxy.resources | indent 10 }}
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - name: proc
         hostPath:
@@ -45,3 +72,9 @@ spec:
       - name: sys
         hostPath:
           path: /sys
+      - name: root
+        hostPath:
+          path: /
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534

--- a/config/monitoring/node-exporter/templates/daemonset.yaml
+++ b/config/monitoring/node-exporter/templates/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
         app: node-exporter
       annotations:
         kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '9123'
+        kubermatic/scrape_port: '9100'
     spec:
       hostNetwork: true
       hostPID: true
@@ -28,7 +28,7 @@ spec:
         - "--path.procfs=/host/proc"
         - "--path.sysfs=/host/sys"
         - "--path.rootfs=/host/root"
-        - "--web.listen-address=127.0.0.1:9123"
+        - "--web.listen-address=127.0.0.1:9100"
         resources:
 {{ toYaml .Values.nodeExporter.resources | indent 10 }}
         volumeMounts:
@@ -46,17 +46,17 @@ spec:
         image: "{{ .Values.nodeExporter.rbacProxy.image.repository }}:{{ .Values.nodeExporter.rbacProxy.image.tag}}"
         args:
         - "--logtostderr"
-        - "--secure-listen-address=$(IP):9123"
+        - "--secure-listen-address=$(IP):9100"
         - "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
-        - "--upstream=http://127.0.0.1:9123/"
+        - "--upstream=http://127.0.0.1:9100/"
         env:
         - name: IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
         ports:
-        - containerPort: 9123
-          hostPort: 9123
+        - containerPort: 9100
+          hostPort: 9100
           name: https
         resources:
 {{ toYaml .Values.nodeExporter.rbacProxy.resources | indent 10 }}

--- a/config/monitoring/node-exporter/templates/rbac.yaml
+++ b/config/monitoring/node-exporter/templates/rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-exporter
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-exporter
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-exporter
+subjects:
+- kind: ServiceAccount
+  name: node-exporter
+  namespace: {{ .Release.Namespace }}

--- a/config/monitoring/node-exporter/templates/service.yaml
+++ b/config/monitoring/node-exporter/templates/service.yaml
@@ -5,11 +5,10 @@ metadata:
   labels:
     app: node-exporter
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
-  - name: http
-    port: 9100
-    protocol: TCP
+  - name: https
+    port: 9123
+    targetPort: https
   selector:
     app: node-exporter

--- a/config/monitoring/node-exporter/templates/service.yaml
+++ b/config/monitoring/node-exporter/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   clusterIP: None
   ports:
   - name: https
-    port: 9123
+    port: 9100
     targetPort: https
   selector:
     app: node-exporter

--- a/config/monitoring/node-exporter/values.yaml
+++ b/config/monitoring/node-exporter/values.yaml
@@ -9,3 +9,15 @@ nodeExporter:
     limits:
       cpu: 200m
       memory: 48Mi
+
+  rbacProxy:
+    image:
+      repository: quay.io/coreos/kube-rbac-proxy
+      tag: v0.4.1
+    resources:
+      requests:
+        cpu: 10m
+        memory: 24Mi
+      limits:
+        cpu: 20m
+        memory: 48Mi

--- a/config/monitoring/prometheus/config/scraping/node-exporter.yaml
+++ b/config/monitoring/prometheus/config/scraping/node-exporter.yaml
@@ -1,15 +1,16 @@
-job_name: 'pods'
+job_name: node-exporter
+scheme: https
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  insecure_skip_verify: true
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 kubernetes_sd_configs:
 - role: pod
 relabel_configs:
-# drop everything within test clusters
-- source_labels: [__meta_kubernetes_namespace]
-  regex: prow-kubermatic-.*
-  action: drop
-# drop node-exporters, as they need HTTPS scraping with credentials
+# only keep node-exporters
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
-  regex: monitoring;node-exporter
-  action: drop
+  regex: node-exporter-beta;node-exporter
+  action: keep
 - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape]
   action: keep
   regex: true
@@ -34,3 +35,9 @@ relabel_configs:
   target_label: pod
   replacement: $1
   action: replace
+# put the node name on node-exporter metrics
+- source_labels: [__meta_kubernetes_pod_node_name]
+  action: replace
+  regex: (.+)
+  replacement: $1
+  target_label: node_name


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a longstanding issue where the node-exporter was listening on all interfaces on the host network, effectively making its metrics endpoint public to the world.

This PR changes it so that an authentication proxy is sitting in front of it, most of which is adapted from the prometheus-operator.

**Which issue(s) this PR fixes**:
Fixes #3015

**Release note**:
```release-note
node-exporter is not exposed on all host interfaces anymore
```
