### PR TITLE
fix typo

### DIFF
--- a/config/monitoring/prometheus/config/scraping/node-exporter.yaml
+++ b/config/monitoring/prometheus/config/scraping/node-exporter.yaml
@@ -9,7 +9,7 @@ kubernetes_sd_configs:
 relabel_configs:
 # only keep node-exporters
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
-  regex: node-exporter-beta;node-exporter
+  regex: monitoring;node-exporter
   action: keep
 - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape]
   action: keep


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix leftover from testing the previous node-exporter PR.

**Release note**:
```release-note
NONE
```
