### PR TITLE
removes a redundant field from resourcesToProcess struct

### DIFF
--- a/api/pkg/controller/rbac/rbac_resource_controller.go
+++ b/api/pkg/controller/rbac/rbac_resource_controller.go
@@ -29,10 +29,8 @@ type resourcesController struct {
 }
 
 type resourceToProcess struct {
-	gvr  schema.GroupVersionResource
-	kind string
-	// rm since ns is in metaObject
-	namespace       string
+	gvr             schema.GroupVersionResource
+	kind            string
 	metaObject      metav1.Object
 	clusterProvider *ClusterProvider
 }
@@ -124,7 +122,6 @@ func (c *resourcesController) processProjectResourcesNextItem() bool {
 	processingItem := &resourceToProcess{
 		gvr:             qItem.gvr,
 		kind:            qItem.kind,
-		namespace:       resMeta.GetNamespace(),
 		clusterProvider: qItem.clusterProvider,
 		metaObject:      resMeta,
 	}

--- a/api/pkg/controller/rbac/sync_resource.go
+++ b/api/pkg/controller/rbac/sync_resource.go
@@ -41,7 +41,7 @@ func (c *resourcesController) syncProjectResource(item *resourceToProcess) error
 		return fmt.Errorf("unable to find owing project for the object name = %s, gvr = %s", item.metaObject.GetName(), item.gvr.String())
 	}
 
-	if len(item.namespace) == 0 {
+	if len(item.metaObject.GetNamespace()) == 0 {
 		if err := ensureClusterRBACRoleForNamedResource(projectName, item.gvr.Resource, item.kind, item.metaObject, item.clusterProvider.kubeClient, item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(metav1.NamespaceAll).Rbac().V1().ClusterRoles().Lister()); err != nil {
 			return fmt.Errorf("failed to sync RBAC ClusterRole for %s resource for %s cluster provider, due to = %v", item.gvr.String(), item.clusterProvider.providerName, err)
 		}
@@ -54,23 +54,23 @@ func (c *resourcesController) syncProjectResource(item *resourceToProcess) error
 	err := c.ensureRBACRoleForNamedResource(projectName,
 		item.gvr,
 		item.kind,
-		item.namespace,
+		item.metaObject.GetNamespace(),
 		item.metaObject,
 		item.clusterProvider.kubeClient,
-		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().Roles().Lister().Roles(item.namespace))
+		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.metaObject.GetNamespace()).Rbac().V1().Roles().Lister().Roles(item.metaObject.GetNamespace()))
 	if err != nil {
-		return fmt.Errorf("failed to sync RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
+		return fmt.Errorf("failed to sync RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.metaObject.GetNamespace(), err)
 	}
 
 	err = c.ensureRBACRoleBindingForNamedResource(projectName,
 		item.gvr,
 		item.kind,
-		item.namespace,
+		item.metaObject.GetNamespace(),
 		item.metaObject,
 		item.clusterProvider.kubeClient,
-		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.namespace).Rbac().V1().RoleBindings().Lister().RoleBindings(item.namespace))
+		item.clusterProvider.kubeInformerProvider.KubeInformerFactoryFor(item.metaObject.GetNamespace()).Rbac().V1().RoleBindings().Lister().RoleBindings(item.metaObject.GetNamespace()))
 	if err != nil {
-		return fmt.Errorf("failed to sync RBAC RoleBinding for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.namespace, err)
+		return fmt.Errorf("failed to sync RBAC RoleBinding for %s resource for %s cluster provider in namespace %s, due to = %v", item.gvr.String(), item.clusterProvider.providerName, item.metaObject.GetNamespace(), err)
 	}
 
 	return nil

--- a/api/pkg/controller/rbac/sync_resource_test.go
+++ b/api/pkg/controller/rbac/sync_resource_test.go
@@ -617,12 +617,12 @@ func TestSyncProjectResourcesNamespaced(t *testing.T) {
 					Version:  k8scorev1.SchemeGroupVersion.Version,
 					Resource: "secrets",
 				},
-				kind:      "Secret",
-				namespace: "sa-secrets",
+				kind: "Secret",
 				metaObject: &k8scorev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "abcd",
-						UID:  types.UID("abcdID"),
+						Name:      "abcd",
+						Namespace: "sa-secrets",
+						UID:       types.UID("abcdID"),
 						Labels: map[string]string{
 							kubermaticv1.ProjectIDLabelKey: "thunderball",
 						},


### PR DESCRIPTION
**What this PR does / why we need it**: simply removes a redundant field from resourcesToProcess struct

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
