### PR TITLE
move core reconciling functions into own subpackage

### DIFF
--- a/api/codegen/reconcile/main.go
+++ b/api/codegen/reconcile/main.go
@@ -120,7 +120,7 @@ var (
 		"namedReconcileFunc": namedReconcileFunc,
 	}
 	reconcileAllTemplate = template.Must(template.New("").Funcs(reconcileAllTplFuncs).Funcs(sprig.TxtFuncMap()).Parse(`// This file is generated. DO NOT EDIT.
-package resources
+package reconciling
 
 import (
 	"fmt"

--- a/api/hack/update-codegen.sh
+++ b/api/hack/update-codegen.sh
@@ -26,4 +26,4 @@ GOPATH=$(go env GOPATH) $(go env GOPATH)/bin/deepcopy-gen \
 
 rm /tmp/headerfile
 
-go generate pkg/resources/ensure.go
+go generate pkg/resources/reconciling/ensure.go

--- a/api/pkg/controller/cluster/launching.go
+++ b/api/pkg/controller/cluster/launching.go
@@ -8,6 +8,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/openvpn"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,7 +68,7 @@ func (cc *Controller) launchingCreateOpenVPNClientCertificates(c *kubermaticv1.C
 		return fmt.Errorf("failed to build Secret: %v", err)
 	}
 
-	if equal := resources.DeepEqual(existing, secret); equal {
+	if equal := reconciling.DeepEqual(existing, secret); equal {
 		return nil
 	}
 

--- a/api/pkg/controller/openshift/resources/apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/apiserver_deployment.go
@@ -9,6 +9,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/etcd"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,8 +40,8 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the API server deployment
-func APIDeploymentCreator(ctx context.Context, data openshiftData) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return ApiserverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 
 			dep.Name = ApiserverDeploymentName

--- a/api/pkg/controller/openshift/resources/controller_manager_deployment.go
+++ b/api/pkg/controller/openshift/resources/controller_manager_deployment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/cloudconfig"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,8 +36,8 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the controller manager deployment
-func ControllerManagerDeploymentCreator(ctx context.Context, data openshiftData) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func ControllerManagerDeploymentCreator(ctx context.Context, data openshiftData) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return ControllerManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.ControllerManagerDeploymentName
 			dep.Labels = resources.BaseAppLabel(ControllerManagerDeploymentName, nil)

--- a/api/pkg/controller/openshift/resources/controlplane_configmap.go
+++ b/api/pkg/controller/openshift/resources/controlplane_configmap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/etcd"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -22,8 +23,8 @@ const (
 	openshiftContolPlaneConfigKeyName      = "master-config.yaml"
 )
 
-func OpenshiftAPIServerConfigMapCreator(ctx context.Context, data openshiftData) resources.NamedConfigMapCreatorGetter {
-	return func() (string, resources.ConfigMapCreator) {
+func OpenshiftAPIServerConfigMapCreator(ctx context.Context, data openshiftData) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
 		return openshiftAPIServerConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			if cm.Data == nil {
 				cm.Data = map[string]string{}
@@ -42,8 +43,8 @@ func OpenshiftAPIServerConfigMapCreator(ctx context.Context, data openshiftData)
 	}
 }
 
-func OpenshiftControllerMangerConfigMapCreator(ctx context.Context, data openshiftData) resources.NamedConfigMapCreatorGetter {
-	return func() (string, resources.ConfigMapCreator) {
+func OpenshiftControllerMangerConfigMapCreator(ctx context.Context, data openshiftData) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
 		return openshiftControllerMangerConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			if cm.Data == nil {
 				cm.Data = map[string]string{}

--- a/api/pkg/controller/openshift/resources/external_x509_kubeconfig.go
+++ b/api/pkg/controller/openshift/resources/external_x509_kubeconfig.go
@@ -3,15 +3,16 @@ package resources
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const ExternalX509KubeconfigName = "kubermatic-cluster-admin-secret"
 
-func ExternalX509KubeconfigCreator(data openshiftData) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func ExternalX509KubeconfigCreator(data openshiftData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return ExternalX509KubeconfigName, func(secret *corev1.Secret) (*corev1.Secret, error) {
 			b := secret.Data[resources.KubeconfigSecretKey]
 			ca, err := data.GetRootCA()

--- a/api/pkg/controller/openshift/resources/loopback_kubeconfig.go
+++ b/api/pkg/controller/openshift/resources/loopback_kubeconfig.go
@@ -7,6 +7,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	"github.com/golang/glog"
 
@@ -24,8 +25,8 @@ type loopbackKubeconfigCreatorData interface {
 // GetLoopbackKubeconfigCreator is a function to return a secret generator to create a kubeconfig which must only by the openshift-apiserver itself as it uses 127.0.0.1 as address
 // It is required because the Apiserver tries to talk to itself before it is ready, hence it
 // doesn't appear as valid endpoint on the service
-func GetLoopbackKubeconfigCreator(ctx context.Context, data loopbackKubeconfigCreatorData) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func GetLoopbackKubeconfigCreator(ctx context.Context, data loopbackKubeconfigCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return apiserverLoopbackKubeconfigName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
 				se.Data = map[string][]byte{}

--- a/api/pkg/controller/openshift/resources/machinecontroller.go
+++ b/api/pkg/controller/openshift/resources/machinecontroller.go
@@ -3,30 +3,30 @@ package resources
 import (
 	"fmt"
 
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroller"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 )
 
 const machineControllerImage = "quay.io/kubermatic/machine-controller-private:8936af2a674563e8350ee2084546d40b71c665ea-dirty"
 
-func MachineController(osData openshiftData) resources.NamedDeploymentCreatorGetter {
+func MachineController(osData openshiftData) reconciling.NamedDeploymentCreatorGetter {
 	name, creator := machinecontroller.DeploymentCreator(osData)()
-	return func() (string, resources.DeploymentCreator) {
+	return func() (string, reconciling.DeploymentCreator) {
 		return name, deploymentImageAddingWrapper(creator, "machine-controller", machineControllerImage)
 	}
 }
 
-func MachineControllerWebhook(osData openshiftData) resources.NamedDeploymentCreatorGetter {
+func MachineControllerWebhook(osData openshiftData) reconciling.NamedDeploymentCreatorGetter {
 
 	name, creator := machinecontroller.WebhookDeploymentCreator(osData)()
-	return func() (string, resources.DeploymentCreator) {
+	return func() (string, reconciling.DeploymentCreator) {
 		return name, deploymentImageAddingWrapper(creator, "machine-controller", machineControllerImage)
 	}
 }
 
-func deploymentImageAddingWrapper(creator resources.DeploymentCreator, containerName, image string) resources.DeploymentCreator {
+func deploymentImageAddingWrapper(creator reconciling.DeploymentCreator, containerName, image string) reconciling.DeploymentCreator {
 
 	return func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 		d, err := creator(d)

--- a/api/pkg/controller/openshift/resources/machinecontroller_rbac.go
+++ b/api/pkg/controller/openshift/resources/machinecontroller_rbac.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -13,7 +14,7 @@ const (
 	openshiftInfraNamespaceName      = "openshift-infra"
 )
 
-func MachineControllerRole() (types.NamespacedName, resources.RoleCreator) {
+func MachineControllerRole() (types.NamespacedName, reconciling.RoleCreator) {
 	return types.NamespacedName{Namespace: openshiftInfraNamespaceName, Name: machineControllerRoleName},
 		func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Rules = []rbacv1.PolicyRule{
@@ -33,7 +34,7 @@ func MachineControllerRole() (types.NamespacedName, resources.RoleCreator) {
 		}
 }
 
-func MachineControllerRoleBinding() (types.NamespacedName, resources.RoleBindingCreator) {
+func MachineControllerRoleBinding() (types.NamespacedName, reconciling.RoleBindingCreator) {
 	return types.NamespacedName{Namespace: openshiftInfraNamespaceName, Name: machineControllerRoleBindingName},
 		func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			rb.RoleRef = rbacv1.RoleRef{

--- a/api/pkg/controller/openshift/resources/service_signer_ca.go
+++ b/api/pkg/controller/openshift/resources/service_signer_ca.go
@@ -1,16 +1,16 @@
 package resources
 
 import (
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 )
 
 const ServiceSignerCASecretName = "service-signer-ca"
 
 // ServiceSignerCA is Openshift-specific CA used to create serving certs for workloads on-demand
 // See https://github.com/openshift/openshift-docs/pull/2324/files
-func ServiceSignerCA() resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func ServiceSignerCA() reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return ServiceSignerCASecretName, certificates.GetCACreator("service-signer-ca")
 	}
 }

--- a/api/pkg/controller/openshift/resources/tokenserviceaccount.go
+++ b/api/pkg/controller/openshift/resources/tokenserviceaccount.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -17,7 +17,7 @@ const (
 
 // TokenOwnerServiceAccount is the ServiceAccount that owns the secret which we put onto the
 // kubeconfig that is in the seed
-func TokenOwnerServiceAccount(_ context.Context) (string, resources.ServiceAccountCreator) {
+func TokenOwnerServiceAccount(_ context.Context) (string, reconciling.ServiceAccountCreator) {
 	return tokenOwnerServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
 		return sa, nil
 	}
@@ -25,7 +25,7 @@ func TokenOwnerServiceAccount(_ context.Context) (string, resources.ServiceAccou
 
 // TokenOwnerServiceAccountClusterRoleBinding is the clusterrolebinding that gives the TokenOwnerServiceAccount
 // admin powers
-func TokenOwnerServiceAccountClusterRoleBinding(_ context.Context) (string, resources.ClusterRoleBindingCreator) {
+func TokenOwnerServiceAccountClusterRoleBinding(_ context.Context) (string, reconciling.ClusterRoleBindingCreator) {
 	return tokenOwnerServiceAccountBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 		crb.Subjects = []rbacv1.Subject{
 			{

--- a/api/pkg/controller/usercluster/reconciler.go
+++ b/api/pkg/controller/usercluster/reconciler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/scheduler"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/user-auth"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -119,11 +120,11 @@ func (r *reconciler) ensureAPIServices(ctx context.Context) error {
 }
 
 func (r *reconciler) reconcileServiceAcconts(ctx context.Context) error {
-	creators := []resources.NamedServiceAccountCreatorGetter{
+	creators := []reconciling.NamedServiceAccountCreatorGetter{
 		userauth.ServiceAccountCreator(),
 	}
 
-	if err := resources.ReconcileServiceAccounts(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", metav1.NamespaceSystem, err)
 	}
 	return nil
@@ -131,30 +132,30 @@ func (r *reconciler) reconcileServiceAcconts(ctx context.Context) error {
 
 func (r *reconciler) reconcileRoles(ctx context.Context) error {
 	// kube-system
-	creators := []resources.NamedRoleCreatorGetter{
+	creators := []reconciling.NamedRoleCreatorGetter{
 		machinecontroller.KubeSystemRoleCreator(),
 	}
 
-	if err := resources.ReconcileRoles(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileRoles(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %v", metav1.NamespaceSystem, err)
 	}
 
 	// kube-public
-	creators = []resources.NamedRoleCreatorGetter{
+	creators = []reconciling.NamedRoleCreatorGetter{
 		machinecontroller.ClusterInfoReaderRoleCreator(),
 		machinecontroller.KubePublicRoleCreator(),
 	}
 
-	if err := resources.ReconcileRoles(creators, metav1.NamespacePublic, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileRoles(creators, metav1.NamespacePublic, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %v", metav1.NamespacePublic, err)
 	}
 
 	// default
-	creators = []resources.NamedRoleCreatorGetter{
+	creators = []reconciling.NamedRoleCreatorGetter{
 		machinecontroller.EndpointReaderRoleCreator(),
 	}
 
-	if err := resources.ReconcileRoles(creators, metav1.NamespaceDefault, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileRoles(creators, metav1.NamespaceDefault, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %v", metav1.NamespaceDefault, err)
 	}
 
@@ -163,30 +164,30 @@ func (r *reconciler) reconcileRoles(ctx context.Context) error {
 
 func (r *reconciler) reconcileRoleBindings(ctx context.Context) error {
 	// kube-system
-	creators := []resources.NamedRoleBindingCreatorGetter{
+	creators := []reconciling.NamedRoleBindingCreatorGetter{
 		machinecontroller.KubeSystemRoleBindingCreator(),
 		metricsserver.RolebindingAuthReaderCreator(),
 		scheduler.RoleBindingAuthDelegator(),
 		controllermanager.RoleBindingAuthDelegator(),
 	}
-	if err := resources.ReconcileRoleBindings(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileRoleBindings(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in kube-system Namespace: %v", err)
 	}
 
 	// kube-public
-	creators = []resources.NamedRoleBindingCreatorGetter{
+	creators = []reconciling.NamedRoleBindingCreatorGetter{
 		machinecontroller.KubePublicRoleBindingCreator(),
 		machinecontroller.ClusterInfoAnonymousRoleBindingCreator(),
 	}
-	if err := resources.ReconcileRoleBindings(creators, metav1.NamespacePublic, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileRoleBindings(creators, metav1.NamespacePublic, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in kube-public Namespace: %v", err)
 	}
 
 	// Default
-	creators = []resources.NamedRoleBindingCreatorGetter{
+	creators = []reconciling.NamedRoleBindingCreatorGetter{
 		machinecontroller.DefaultRoleBindingCreator(),
 	}
-	if err := resources.ReconcileRoleBindings(creators, metav1.NamespaceDefault, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileRoleBindings(creators, metav1.NamespaceDefault, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in default Namespace: %v", err)
 	}
 
@@ -194,7 +195,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context) error {
 }
 
 func (r *reconciler) reconcileClusterRoles(ctx context.Context) error {
-	creators := []resources.NamedClusterRoleCreatorGetter{
+	creators := []reconciling.NamedClusterRoleCreatorGetter{
 		kubestatemetrics.ClusterRoleCreator(),
 		prometheus.ClusterRoleCreator(),
 		machinecontroller.ClusterRoleCreator(),
@@ -202,14 +203,14 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context) error {
 		metricsserver.ClusterRoleCreator(),
 	}
 
-	if err := resources.ReconcileClusterRoles(creators, "", r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileClusterRoles(creators, "", r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoles: %v", err)
 	}
 	return nil
 }
 
 func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context) error {
-	creators := []resources.NamedClusterRoleBindingCreatorGetter{
+	creators := []reconciling.NamedClusterRoleBindingCreatorGetter{
 		userauth.ClusterRoleBindingCreator(),
 		kubestatemetrics.ClusterRoleBindingCreator(),
 		prometheus.ClusterRoleBindingCreator(),
@@ -223,62 +224,62 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context) error {
 		controllermanager.ClusterRoleBindingAuthDelegator(),
 	}
 
-	if err := resources.ReconcileClusterRoleBindings(creators, "", r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileClusterRoleBindings(creators, "", r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoleBindings: %v", err)
 	}
 	return nil
 }
 
 func (r *reconciler) reconcileCRDs(ctx context.Context) error {
-	creators := []resources.NamedCustomResourceDefinitionCreatorGetter{
+	creators := []reconciling.NamedCustomResourceDefinitionCreatorGetter{
 		machinecontroller.MachineCRDCreator(),
 		machinecontroller.MachineSetCRDCreator(),
 		machinecontroller.MachineDeploymentCRDCreator(),
 		machinecontroller.ClusterCRDCreator(),
 	}
 
-	if err := resources.ReconcileCustomResourceDefinitions(creators, "", r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileCustomResourceDefinitions(creators, "", r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile CustomResourceDefinitions: %v", err)
 	}
 	return nil
 }
 
 func (r *reconciler) reconcileMutatingWebhookConfigurations(ctx context.Context) error {
-	creators := []resources.NamedMutatingWebhookConfigurationCreatorGetter{
+	creators := []reconciling.NamedMutatingWebhookConfigurationCreatorGetter{
 		machinecontroller.MutatingwebhookConfigurationCreator(r.caCert, r.namespace),
 	}
 
-	if err := resources.ReconcileMutatingWebhookConfigurations(creators, "", r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileMutatingWebhookConfigurations(creators, "", r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile MutatingWebhookConfigurations: %v", err)
 	}
 	return nil
 }
 
 func (r *reconciler) reconcileServices(ctx context.Context) error {
-	creators := []resources.NamedServiceCreatorGetter{
+	creators := []reconciling.NamedServiceCreatorGetter{
 		metricsserver.ExternalNameServiceCreator(r.namespace),
 	}
 
-	if err := resources.ReconcileServices(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileServices(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile Services in kube-system namespace: %v", err)
 	}
 	return nil
 }
 
 func (r *reconciler) reconcileConfigMaps(ctx context.Context) error {
-	creators := []resources.NamedConfigMapCreatorGetter{
+	creators := []reconciling.NamedConfigMapCreatorGetter{
 		machinecontroller.ClusterInfoConfigMapCreator(r.clusterURL.String(), r.caCert),
 	}
 
-	if err := resources.ReconcileConfigMaps(creators, metav1.NamespacePublic, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileConfigMaps(creators, metav1.NamespacePublic, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps in kube-public namespace: %v", err)
 	}
 
-	creators = []resources.NamedConfigMapCreatorGetter{
+	creators = []reconciling.NamedConfigMapCreatorGetter{
 		openvpn.ClientConfigConfigMapCreator(r.clusterURL.Hostname(), r.openvpnServerPort),
 	}
 
-	if err := resources.ReconcileConfigMaps(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
+	if err := reconciling.ReconcileConfigMaps(creators, metav1.NamespaceSystem, r.Client, r.cache); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps in kube-system namespace: %v", err)
 	}
 	return nil

--- a/api/pkg/controller/usercluster/resources/controller-manager/rbac.go
+++ b/api/pkg/controller/usercluster/resources/controller-manager/rbac.go
@@ -2,14 +2,15 @@ package controllermanager
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 )
 
 // RoleBindingAuthDelegator creates the RoleBinding which is needed for extension apiserver which do auth delegation
-func RoleBindingAuthDelegator() resources.NamedRoleBindingCreatorGetter {
+func RoleBindingAuthDelegator() reconciling.NamedRoleBindingCreatorGetter {
 	return resources.RoleBindingAuthenticationReaderCreator("system:kube-controller-manager")
 }
 
 // ClusterRoleBindingAuthDelegator creates the ClusterRoleBinding which is needed for extension apiserver which do auth delegation
-func ClusterRoleBindingAuthDelegator() resources.NamedClusterRoleBindingCreatorGetter {
+func ClusterRoleBindingAuthDelegator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return resources.ClusterRoleBindingAuthDelegatorCreator("system:kube-controller-manager")
 }

--- a/api/pkg/controller/usercluster/resources/dnat-controller/clusterrole.go
+++ b/api/pkg/controller/usercluster/resources/dnat-controller/clusterrole.go
@@ -2,13 +2,14 @@ package dnatcontroller
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // ClusterRoleCreator returns the func to create/update the ClusterRole for the DNAT controller
-func ClusterRoleCreator() resources.NamedClusterRoleCreatorGetter {
-	return func() (string, resources.ClusterRoleCreator) {
+func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.KubeletDnatControllerClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Rules = []rbacv1.PolicyRule{
 				{

--- a/api/pkg/controller/usercluster/resources/dnat-controller/clusterrolebinding.go
+++ b/api/pkg/controller/usercluster/resources/dnat-controller/clusterrolebinding.go
@@ -2,13 +2,14 @@ package dnatcontroller
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // ClusterRoleBindingCreator returns the func to create/update the ClusterRoleBinding for the DNAT controller.
-func ClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter {
-	return func() (string, resources.ClusterRoleBindingCreator) {
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.KubeletDnatControllerClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.KubeletDnatControllerClusterRoleName,

--- a/api/pkg/controller/usercluster/resources/kube-state-metrics/clusterrole.go
+++ b/api/pkg/controller/usercluster/resources/kube-state-metrics/clusterrole.go
@@ -2,6 +2,7 @@ package kubestatemetrics
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -11,8 +12,8 @@ const (
 )
 
 // ClusterRoleCreator returns the func to create/update the ClusterRole for kube-state-metrics
-func ClusterRoleCreator() resources.NamedClusterRoleCreatorGetter {
-	return func() (string, resources.ClusterRoleCreator) {
+func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.KubeStateMetricsClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Labels = resources.BaseAppLabel(Name, nil)
 

--- a/api/pkg/controller/usercluster/resources/kube-state-metrics/clusterrolebinding.go
+++ b/api/pkg/controller/usercluster/resources/kube-state-metrics/clusterrolebinding.go
@@ -2,13 +2,14 @@ package kubestatemetrics
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // ClusterRoleBindingCreator returns a func to create/update the ClusterRoleBinding for kube-state-metrics
-func ClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter {
-	return func() (string, resources.ClusterRoleBindingCreator) {
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.KubeStateMetricsClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.Labels = resources.BaseAppLabel(Name, nil)
 

--- a/api/pkg/controller/usercluster/resources/machine-controller/cluster-info-configmap.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/cluster-info-configmap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -13,8 +14,8 @@ import (
 )
 
 // ClusterInfoConfigMapCreator returns the func to create/update the ConfigMap
-func ClusterInfoConfigMapCreator(url string, caCert *x509.Certificate) resources.NamedConfigMapCreatorGetter {
-	return func() (string, resources.ConfigMapCreator) {
+func ClusterInfoConfigMapCreator(url string, caCert *x509.Certificate) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
 		return resources.ClusterInfoConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			if cm.Data == nil {
 				cm.Data = map[string]string{}

--- a/api/pkg/controller/usercluster/resources/machine-controller/clusterrole.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/clusterrole.go
@@ -2,6 +2,7 @@ package machinecontroller
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -11,8 +12,8 @@ const (
 )
 
 // ClusterRole returns a cluster role for the machine controller (user-cluster)
-func ClusterRoleCreator() resources.NamedClusterRoleCreatorGetter {
-	return func() (string, resources.ClusterRoleCreator) {
+func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.MachineControllerClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Labels = resources.BaseAppLabel(Name, nil)
 

--- a/api/pkg/controller/usercluster/resources/machine-controller/clusterrolebinding.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/clusterrolebinding.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // ClusterRoleBinding returns a ClusterRoleBinding for the machine-controller.
-func ClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter {
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	// TemplateData actually not needed, no ownerrefs set in user-cluster
 	return createClusterRoleBindingCreator("controller",
 		resources.MachineControllerClusterRoleName, rbacv1.Subject{
@@ -20,7 +21,7 @@ func ClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter 
 }
 
 // NodeBootstrapperClusterRoleBinding returns a ClusterRoleBinding for the machine-controller.
-func NodeBootstrapperClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter {
+func NodeBootstrapperClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return createClusterRoleBindingCreator("kubelet-bootstrap",
 		"system:node-bootstrapper", rbacv1.Subject{
 			Kind:     "Group",
@@ -30,7 +31,7 @@ func NodeBootstrapperClusterRoleBindingCreator() resources.NamedClusterRoleBindi
 }
 
 // NodeSignerClusterRoleBindingCreator returns a ClusterRoleBinding for the machine-controller.
-func NodeSignerClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter {
+func NodeSignerClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return createClusterRoleBindingCreator("node-signer",
 		"system:certificates.k8s.io:certificatesigningrequests:nodeclient", rbacv1.Subject{
 			Kind:     "Group",
@@ -39,8 +40,8 @@ func NodeSignerClusterRoleBindingCreator() resources.NamedClusterRoleBindingCrea
 		})
 }
 
-func createClusterRoleBindingCreator(crbSuffix, cRoleRef string, subj rbacv1.Subject) resources.NamedClusterRoleBindingCreatorGetter {
-	return func() (string, resources.ClusterRoleBindingCreator) {
+func createClusterRoleBindingCreator(crbSuffix, cRoleRef string, subj rbacv1.Subject) reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return fmt.Sprintf("%s:%s", resources.MachineControllerClusterRoleBindingName, crbSuffix), func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.Labels = resources.BaseAppLabel(Name, nil)
 

--- a/api/pkg/controller/usercluster/resources/machine-controller/crds.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/crds.go
@@ -2,6 +2,7 @@ package machinecontroller
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
@@ -12,8 +13,8 @@ const (
 )
 
 // MachineCRD returns the machine CRD definition
-func MachineCRDCreator() resources.NamedCustomResourceDefinitionCreatorGetter {
-	return func() (string, resources.CustomResourceDefinitionCreator) {
+func MachineCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
+	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.MachineCRDName, func(crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 			crd.Spec.Group = clusterAPIGroup
 			crd.Spec.Version = clusterAPIVersion
@@ -31,8 +32,8 @@ func MachineCRDCreator() resources.NamedCustomResourceDefinitionCreatorGetter {
 }
 
 // MachineSetCRD returns the machineset CRD definition
-func MachineSetCRDCreator() resources.NamedCustomResourceDefinitionCreatorGetter {
-	return func() (string, resources.CustomResourceDefinitionCreator) {
+func MachineSetCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
+	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.MachineSetCRDName, func(crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 			crd.Spec.Group = clusterAPIGroup
 			crd.Spec.Version = clusterAPIVersion
@@ -50,8 +51,8 @@ func MachineSetCRDCreator() resources.NamedCustomResourceDefinitionCreatorGetter
 }
 
 // MachineDeploymentCRD returns the machinedeployments CRD definition
-func MachineDeploymentCRDCreator() resources.NamedCustomResourceDefinitionCreatorGetter {
-	return func() (string, resources.CustomResourceDefinitionCreator) {
+func MachineDeploymentCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
+	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.MachineDeploymentCRDName, func(crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 			crd.Spec.Group = clusterAPIGroup
 			crd.Spec.Version = clusterAPIVersion
@@ -69,8 +70,8 @@ func MachineDeploymentCRDCreator() resources.NamedCustomResourceDefinitionCreato
 }
 
 // ClusterCRD returns the cluster crd definition
-func ClusterCRDCreator() resources.NamedCustomResourceDefinitionCreatorGetter {
-	return func() (string, resources.CustomResourceDefinitionCreator) {
+func ClusterCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
+	return func() (string, reconciling.CustomResourceDefinitionCreator) {
 		return resources.ClusterCRDName, func(crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 			crd.Spec.Group = clusterAPIGroup
 			crd.Spec.Version = clusterAPIVersion

--- a/api/pkg/controller/usercluster/resources/machine-controller/role.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/role.go
@@ -3,14 +3,15 @@ package machinecontroller
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroller"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // KubeSystemRoleCreator returns the func to create/update the Role for the machine controller to allow reading secrets
-func KubeSystemRoleCreator() resources.NamedRoleCreatorGetter {
-	return func() (string, resources.RoleCreator) {
+func KubeSystemRoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
 		return resources.MachineControllerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Name = resources.MachineControllerRoleName
 			r.Namespace = metav1.NamespaceSystem
@@ -45,8 +46,8 @@ func KubeSystemRoleCreator() resources.NamedRoleCreatorGetter {
 }
 
 // EndpointReaderRoleCreator returns the func to create/update the Role for the machine controller to allow reading the kubernetes api endpoints
-func EndpointReaderRoleCreator() resources.NamedRoleCreatorGetter {
-	return func() (string, resources.RoleCreator) {
+func EndpointReaderRoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
 		return resources.MachineControllerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Name = resources.MachineControllerRoleName
 			r.Namespace = metav1.NamespaceDefault
@@ -70,8 +71,8 @@ func EndpointReaderRoleCreator() resources.NamedRoleCreatorGetter {
 
 // ClusterInfoReaderRoleCreator returns the func to create/update the Role for the machine controller to allow
 // the kubelet & kubeadm to read the cluster-info reading the cluster-info ConfigMap without authentication.
-func ClusterInfoReaderRoleCreator() resources.NamedRoleCreatorGetter {
-	return func() (string, resources.RoleCreator) {
+func ClusterInfoReaderRoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
 		return resources.ClusterInfoReaderRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Name = resources.ClusterInfoReaderRoleName
 			r.Namespace = metav1.NamespacePublic
@@ -92,8 +93,8 @@ func ClusterInfoReaderRoleCreator() resources.NamedRoleCreatorGetter {
 
 // KubePublicRoleCreator returns the func to create/update the Role for the machine controller to allow
 // reading all configmaps in kube-public.
-func KubePublicRoleCreator() resources.NamedRoleCreatorGetter {
-	return func() (string, resources.RoleCreator) {
+func KubePublicRoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
 		return resources.MachineControllerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Name = resources.MachineControllerRoleName
 			r.Namespace = metav1.NamespacePublic

--- a/api/pkg/controller/usercluster/resources/machine-controller/rolebinding.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/rolebinding.go
@@ -3,29 +3,30 @@ package machinecontroller
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroller"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DefaultRoleBindingCreator returns the func to create/update the RoleBinding for the machine-controller.
-func DefaultRoleBindingCreator() resources.NamedRoleBindingCreatorGetter {
+func DefaultRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
 	// RoleBindingDataProvider actually not needed, no ownerrefs set in user-cluster
 	return RoleBindingCreator()
 }
 
 // KubeSystemRoleBinding returns the RoleBinding for the machine-controller in kube-system ns.
-func KubeSystemRoleBindingCreator() resources.NamedRoleBindingCreatorGetter {
+func KubeSystemRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
 	return RoleBindingCreator()
 }
 
 // KubePublicRoleBinding returns the RoleBinding for the machine-controller in kube-public ns.
-func KubePublicRoleBindingCreator() resources.NamedRoleBindingCreatorGetter {
+func KubePublicRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
 	return RoleBindingCreator()
 }
 
-func RoleBindingCreator() resources.NamedRoleBindingCreatorGetter {
-	return func() (string, resources.RoleBindingCreator) {
+func RoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
 		return resources.MachineControllerRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			rb.Labels = resources.BaseAppLabel(machinecontroller.Name, nil)
 
@@ -47,8 +48,8 @@ func RoleBindingCreator() resources.NamedRoleBindingCreatorGetter {
 }
 
 // ClusterInfoAnonymousRoleBindingCreator returns a func to create/update the RoleBinding to allow anonymous access to the cluster-info ConfigMap
-func ClusterInfoAnonymousRoleBindingCreator() resources.NamedRoleBindingCreatorGetter {
-	return func() (string, resources.RoleBindingCreator) {
+func ClusterInfoAnonymousRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
 		return resources.ClusterInfoAnonymousRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			rb.Namespace = metav1.NamespacePublic
 

--- a/api/pkg/controller/usercluster/resources/machine-controller/webhook.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/webhook.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	"k8s.io/api/admissionregistration/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -13,8 +14,8 @@ import (
 )
 
 // MutatingwebhookConfigurationCreator returns the MutatingwebhookConfiguration for the machine controler
-func MutatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace string) resources.NamedMutatingWebhookConfigurationCreatorGetter {
-	return func() (string, resources.MutatingWebhookConfigurationCreator) {
+func MutatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace string) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
+	return func() (string, reconciling.MutatingWebhookConfigurationCreator) {
 		return resources.MachineControllerMutatingWebhookConfigurationName, func(mutatingWebhookConfiguration *v1beta1.MutatingWebhookConfiguration) (*v1beta1.MutatingWebhookConfiguration, error) {
 			failurePolicy := admissionregistrationv1beta1.Fail
 			mdURL := fmt.Sprintf("https://%s.%s.svc.cluster.local./machinedeployments", resources.MachineControllerWebhookServiceName, namespace)

--- a/api/pkg/controller/usercluster/resources/metrics-server/clusterrole.go
+++ b/api/pkg/controller/usercluster/resources/metrics-server/clusterrole.go
@@ -2,13 +2,14 @@ package metricsserver
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // ClusterRole returns a cluster role for the metrics server
-func ClusterRoleCreator() resources.NamedClusterRoleCreatorGetter {
-	return func() (string, resources.ClusterRoleCreator) {
+func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.MetricsServerClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Labels = resources.BaseAppLabel(Name, nil)
 

--- a/api/pkg/controller/usercluster/resources/metrics-server/clusterrolebinding.go
+++ b/api/pkg/controller/usercluster/resources/metrics-server/clusterrolebinding.go
@@ -2,13 +2,14 @@ package metricsserver
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // ClusterRoleBindingResourceReaderCreator returns the ClusterRoleBinding required for the metrics server to read all required resources
-func ClusterRoleBindingResourceReaderCreator() resources.NamedClusterRoleBindingCreatorGetter {
-	return func() (string, resources.ClusterRoleBindingCreator) {
+func ClusterRoleBindingResourceReaderCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.MetricsServerResourceReaderClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.Labels = resources.BaseAppLabel(Name, nil)
 
@@ -31,6 +32,6 @@ func ClusterRoleBindingResourceReaderCreator() resources.NamedClusterRoleBinding
 }
 
 // ClusterRoleBindingAuthDelegatorCreator returns the ClusterRoleBinding required for the metrics server to create token review requests
-func ClusterRoleBindingAuthDelegatorCreator() resources.NamedClusterRoleBindingCreatorGetter {
+func ClusterRoleBindingAuthDelegatorCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return resources.ClusterRoleBindingAuthDelegatorCreator(resources.MetricsServerCertUsername)
 }

--- a/api/pkg/controller/usercluster/resources/metrics-server/external-name-service.go
+++ b/api/pkg/controller/usercluster/resources/metrics-server/external-name-service.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ExternalNameServiceCreator returns the function to reconcile the metrics server service
-func ExternalNameServiceCreator(namespace string) resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func ExternalNameServiceCreator(namespace string) reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return resources.MetricsServerExternalNameServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Namespace = metav1.NamespaceSystem
 			se.Labels = resources.BaseAppLabel(Name, nil)

--- a/api/pkg/controller/usercluster/resources/metrics-server/rolebinding.go
+++ b/api/pkg/controller/usercluster/resources/metrics-server/rolebinding.go
@@ -2,13 +2,14 @@ package metricsserver
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // RolebindingAuthReaderCreator returns a func to create/update the RoleBinding used by the metrics-server to get access to the token subject review API
-func RolebindingAuthReaderCreator() resources.NamedRoleBindingCreatorGetter {
-	return func() (string, resources.RoleBindingCreator) {
+func RolebindingAuthReaderCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
 		return resources.MetricsServerAuthReaderRoleName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			rb.Labels = resources.BaseAppLabel(Name, nil)
 

--- a/api/pkg/controller/usercluster/resources/openvpn/configmap.go
+++ b/api/pkg/controller/usercluster/resources/openvpn/configmap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	v1 "k8s.io/api/core/v1"
 )
@@ -13,8 +14,8 @@ const (
 )
 
 // ClientConfigConfigMapCreator returns a ConfigMap containing the config for the OpenVPN client. It lives inside the user-cluster
-func ClientConfigConfigMapCreator(hostname string, serverPort int) resources.NamedConfigMapCreatorGetter {
-	return func() (string, resources.ConfigMapCreator) {
+func ClientConfigConfigMapCreator(hostname string, serverPort int) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
 		return resources.OpenVPNClientConfigConfigMapName, func(cm *v1.ConfigMap) (*v1.ConfigMap, error) {
 			if cm.Data == nil {
 				cm.Data = map[string]string{}

--- a/api/pkg/controller/usercluster/resources/prometheus/clusterrole.go
+++ b/api/pkg/controller/usercluster/resources/prometheus/clusterrole.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -11,8 +12,8 @@ const (
 )
 
 // ClusterRoleCreator returns the func to create/update the ClusterRole for Prometheus
-func ClusterRoleCreator() resources.NamedClusterRoleCreatorGetter {
-	return func() (string, resources.ClusterRoleCreator) {
+func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.PrometheusClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Labels = resources.BaseAppLabel(Name, nil)
 

--- a/api/pkg/controller/usercluster/resources/prometheus/clusterrolebinding.go
+++ b/api/pkg/controller/usercluster/resources/prometheus/clusterrolebinding.go
@@ -2,13 +2,14 @@ package prometheus
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // ClusterRoleBindingCreator returns a func to create/update the ClusterRoleBinding for Prometheus
-func ClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter {
-	return func() (string, resources.ClusterRoleBindingCreator) {
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.PrometheusClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.Labels = resources.BaseAppLabel(Name, nil)
 

--- a/api/pkg/controller/usercluster/resources/scheduler/rbac.go
+++ b/api/pkg/controller/usercluster/resources/scheduler/rbac.go
@@ -2,14 +2,15 @@ package scheduler
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 )
 
 // RoleBindingAuthDelegator creates the RoleBinding which is needed for extension apiserver which do auth delegation
-func RoleBindingAuthDelegator() resources.NamedRoleBindingCreatorGetter {
+func RoleBindingAuthDelegator() reconciling.NamedRoleBindingCreatorGetter {
 	return resources.RoleBindingAuthenticationReaderCreator("system:kube-scheduler")
 }
 
 // ClusterRoleBindingAuthDelegatorCreator creates the ClusterRoleBinding which is needed for extension apiserver which do auth delegation
-func ClusterRoleBindingAuthDelegatorCreator() resources.NamedClusterRoleBindingCreatorGetter {
+func ClusterRoleBindingAuthDelegatorCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return resources.ClusterRoleBindingAuthDelegatorCreator("system:kube-scheduler")
 }

--- a/api/pkg/controller/usercluster/resources/user-auth/auth.go
+++ b/api/pkg/controller/usercluster/resources/user-auth/auth.go
@@ -1,7 +1,7 @@
 package userauth
 
 import (
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -13,8 +13,8 @@ const (
 )
 
 // ServiceAccountCreator returns a func to create/update the ServiceAccount used by the cluster user
-func ServiceAccountCreator() resources.NamedServiceAccountCreatorGetter {
-	return func() (string, resources.ServiceAccountCreator) {
+func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
 		return ServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
 			return sa, nil
 		}
@@ -22,8 +22,8 @@ func ServiceAccountCreator() resources.NamedServiceAccountCreatorGetter {
 }
 
 // ClusterRoleBindingCreator returns a func to create/update the ClusterRoleBinding which will give the "external-admin-user" full admin access
-func ClusterRoleBindingCreator() resources.NamedClusterRoleBindingCreatorGetter {
-	return func() (string, resources.ClusterRoleBindingCreator) {
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return "external-admin-user", func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     "cluster-admin",

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -8,6 +8,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/etcd"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,8 +38,8 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the API server deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data resources.DeploymentDataProvider) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.ApiserverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			var enableDexCA bool
 			if len(data.OIDCCAFile()) > 0 {

--- a/api/pkg/resources/apiserver/dex_ca_certificate.go
+++ b/api/pkg/resources/apiserver/dex_ca_certificate.go
@@ -3,11 +3,12 @@ package apiserver
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 )
 
 // DexCACertificateCreator returns a function to create/update the secret with the certificate for TLS verification against dex
-func DexCACertificateCreator(data resources.SecretDataProvider) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func DexCACertificateCreator(data resources.SecretDataProvider) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.DexCASecretName, certificates.GetDexCACreator(
 			resources.DexCAFileName,
 			data.GetDexCA,

--- a/api/pkg/resources/apiserver/etcd-client-certificate.go
+++ b/api/pkg/resources/apiserver/etcd-client-certificate.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 )
 
 type etcdClientCertificateCreatorData interface {
@@ -11,7 +12,7 @@ type etcdClientCertificateCreatorData interface {
 }
 
 // EtcdClientCertificateCreator returns a function to create/update the secret with the client certificate for authenticating against etcd
-func EtcdClientCertificateCreator(data etcdClientCertificateCreatorData) resources.NamedSecretCreatorGetter {
+func EtcdClientCertificateCreator(data etcdClientCertificateCreatorData) reconciling.NamedSecretCreatorGetter {
 	return certificates.GetClientCertificateCreator(
 		resources.ApiserverEtcdClientCertificateSecretName,
 		"apiserver",

--- a/api/pkg/resources/apiserver/frontproxy-client-certificate.go
+++ b/api/pkg/resources/apiserver/frontproxy-client-certificate.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 )
 
 type frontProxyClientCertificateCreatorData interface {
@@ -11,7 +12,7 @@ type frontProxyClientCertificateCreatorData interface {
 }
 
 // FrontProxyClientCertificateCreator returns a function to create/update the secret with the client certificate for authenticating against extension apiserver
-func FrontProxyClientCertificateCreator(data frontProxyClientCertificateCreatorData) resources.NamedSecretCreatorGetter {
+func FrontProxyClientCertificateCreator(data frontProxyClientCertificateCreatorData) reconciling.NamedSecretCreatorGetter {
 	return certificates.GetClientCertificateCreator(
 		resources.ApiserverFrontProxyClientCertificateSecretName,
 		"apiserver-aggregator",

--- a/api/pkg/resources/apiserver/kubelet-client-certificate.go
+++ b/api/pkg/resources/apiserver/kubelet-client-certificate.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 )
 
 type kubeletClientCertificateCreatorData interface {
@@ -11,7 +12,7 @@ type kubeletClientCertificateCreatorData interface {
 }
 
 // KubeletClientCertificateCreator returns a function to create/update a secret with the client certificate for the apiserver -> kubelet connection.
-func KubeletClientCertificateCreator(data kubeletClientCertificateCreatorData) resources.NamedSecretCreatorGetter {
+func KubeletClientCertificateCreator(data kubeletClientCertificateCreatorData) reconciling.NamedSecretCreatorGetter {
 	return certificates.GetClientCertificateCreator(
 		resources.KubeletClientCertificatesSecretName,
 		"kube-apiserver-kubelet-client",

--- a/api/pkg/resources/apiserver/pdb.go
+++ b/api/pkg/resources/apiserver/pdb.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -9,8 +10,8 @@ import (
 )
 
 // PodDisruptionBudgetCreator returns a func to create/update the apiserver PodDisruptionBudget
-func PodDisruptionBudgetCreator() resources.NamedPodDisruptionBudgetCreatorGetter {
-	return func() (string, resources.PodDisruptionBudgetCreator) {
+func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGetter {
+	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return resources.ApiserverPodDisruptionBudgetName, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
 			maxUnavailable := intstr.FromInt(1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{

--- a/api/pkg/resources/apiserver/service-account-key.go
+++ b/api/pkg/resources/apiserver/service-account-key.go
@@ -7,13 +7,14 @@ import (
 	"encoding/pem"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
 // ServiceAccountKeyCreator returns a function to create/update a secret with the ServiceAccount key
-func ServiceAccountKeyCreator() resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func ServiceAccountKeyCreator() reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.ServiceAccountKeySecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if _, exists := se.Data[resources.ServiceAccountKeySecretKey]; exists {
 				return se, nil

--- a/api/pkg/resources/apiserver/service.go
+++ b/api/pkg/resources/apiserver/service.go
@@ -2,14 +2,15 @@ package apiserver
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // InternalServiceCreator returns the function to reconcile the internal API server service
-func InternalServiceCreator() resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func InternalServiceCreator() reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return resources.ApiserverInternalServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.ApiserverInternalServiceName
 			se.Labels = resources.BaseAppLabel(name, nil)
@@ -32,8 +33,8 @@ func InternalServiceCreator() resources.NamedServiceCreatorGetter {
 }
 
 // ExternalServiceCreator returns the function to reconcile the external API server service
-func ExternalServiceCreator() resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func ExternalServiceCreator() reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return resources.ApiserverExternalServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.ApiserverExternalServiceName
 			se.Annotations = map[string]string{

--- a/api/pkg/resources/apiserver/tls-serving-certificate.go
+++ b/api/pkg/resources/apiserver/tls-serving-certificate.go
@@ -9,6 +9,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	certutil "k8s.io/client-go/util/cert"
@@ -20,8 +21,8 @@ type tlsServingCertCreatorData interface {
 }
 
 // TLSServingCertificateCreator returns a function to create/update the secret with the apiserver tls certificate used to serve https
-func TLSServingCertificateCreator(data tlsServingCertCreatorData) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func TLSServingCertificateCreator(data tlsServingCertCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.ApiserverTLSSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
 				se.Data = map[string][]byte{}

--- a/api/pkg/resources/apiserver/token-users.go
+++ b/api/pkg/resources/apiserver/token-users.go
@@ -5,13 +5,14 @@ import (
 	"encoding/csv"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
 // TokenUsers returns a secret containing the tokens csv
-func TokenUsersCreator(data resources.SecretDataProvider) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func TokenUsersCreator(data resources.SecretDataProvider) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.TokensSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
 				se.Data = map[string][]byte{}

--- a/api/pkg/resources/auth-delegation.go
+++ b/api/pkg/resources/auth-delegation.go
@@ -1,12 +1,14 @@
 package resources
 
 import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // RoleBindingAuthenticationReaderCreator returns a function to create the RoleBinding which is needed for extension apiserver which do auth delegation
-func RoleBindingAuthenticationReaderCreator(username string) NamedRoleBindingCreatorGetter {
-	return func() (string, RoleBindingCreator) {
+func RoleBindingAuthenticationReaderCreator(username string) reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
 		return username + "-authentication-reader", func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			rb.RoleRef = rbacv1.RoleRef{
 				Name:     "extension-apiserver-authentication-reader",
@@ -26,8 +28,8 @@ func RoleBindingAuthenticationReaderCreator(username string) NamedRoleBindingCre
 }
 
 // ClusterRoleBindingAuthDelegatorCreator returns a function to create the ClusterRoleBinding which is needed for extension apiserver which do auth delegation
-func ClusterRoleBindingAuthDelegatorCreator(username string) NamedClusterRoleBindingCreatorGetter {
-	return func() (string, ClusterRoleBindingCreator) {
+func ClusterRoleBindingAuthDelegatorCreator(username string) reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return username + "-auth-delegator", func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     "system:auth-delegator",

--- a/api/pkg/resources/certificates/client-certificate.go
+++ b/api/pkg/resources/certificates/client-certificate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	certutil "k8s.io/client-go/util/cert"
@@ -13,8 +14,8 @@ import (
 type caGetter func() (*triple.KeyPair, error)
 
 // GetClientCertificateCreator is a generic function to return a secret generator to create a client certificate signed by the cluster CA
-func GetClientCertificateCreator(name, commonName string, organizations []string, dataCertKey, dataKeyKey string, getCA caGetter) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func GetClientCertificateCreator(name, commonName string, organizations []string, dataCertKey, dataKeyKey string, getCA caGetter) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return name, func(se *corev1.Secret) (*corev1.Secret, error) {
 			// TODO: Remove this after the backup controller has been adapter to the new reconciling behaviour
 			if se == nil {

--- a/api/pkg/resources/certificates/dex-ca.go
+++ b/api/pkg/resources/certificates/dex-ca.go
@@ -5,7 +5,7 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -13,7 +13,7 @@ import (
 type dexCAGetter func() ([]*x509.Certificate, error)
 
 // GetDexCACreator returns a function to create a secret containing a CA bundle with the specified name
-func GetDexCACreator(dataCAKey string, getCA dexCAGetter) resources.SecretCreator {
+func GetDexCACreator(dataCAKey string, getCA dexCAGetter) reconciling.SecretCreator {
 	return func(se *corev1.Secret) (*corev1.Secret, error) {
 		ca, err := getCA()
 		if err != nil {

--- a/api/pkg/resources/certificates/ecdsa.go
+++ b/api/pkg/resources/certificates/ecdsa.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	certutil "k8s.io/client-go/util/cert"
@@ -26,7 +27,7 @@ type ecdsaCAGetter func() (*resources.ECDSAKeyPair, error)
 
 // GetECDSAClientCertificateCreator is a generic function to return a secret generator to create a client certificate
 // signed by the cert returned by the passed getCA func. The resulting secret has no ownerRef
-func GetECDSAClientCertificateCreator(name, commonName string, organizations []string, dataCertKey, dataKeyKey string, getCA ecdsaCAGetter) resources.SecretCreator {
+func GetECDSAClientCertificateCreator(name, commonName string, organizations []string, dataCertKey, dataKeyKey string, getCA ecdsaCAGetter) reconciling.SecretCreator {
 	return func(se *corev1.Secret) (*corev1.Secret, error) {
 		ca, err := getCA()
 		if err != nil {

--- a/api/pkg/resources/certificates/root-ca.go
+++ b/api/pkg/resources/certificates/root-ca.go
@@ -6,13 +6,14 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	certutil "k8s.io/client-go/util/cert"
 )
 
 // GetCACreator returns a function to create a secret containing a CA with the specified name
-func GetCACreator(commonName string) resources.SecretCreator {
+func GetCACreator(commonName string) reconciling.SecretCreator {
 	return func(se *corev1.Secret) (*corev1.Secret, error) {
 		if se.Data == nil {
 			se.Data = map[string][]byte{}
@@ -39,15 +40,15 @@ type caCreatorData interface {
 }
 
 // RootCACreator returns a function to create a secret with the root ca
-func RootCACreator(data caCreatorData) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func RootCACreator(data caCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.CASecretName, GetCACreator(fmt.Sprintf("root-ca.%s", data.Cluster().Address.ExternalName))
 	}
 }
 
 // FrontProxyCACreator returns a function to create a secret with front proxy ca
-func FrontProxyCACreator() resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func FrontProxyCACreator() reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.FrontProxyCASecretName, GetCACreator("front-proxy-ca")
 	}
 }

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -7,6 +7,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack"
@@ -25,8 +26,8 @@ type configMapCreatorData interface {
 }
 
 // ConfigMapCreator returns a function to create the ConfigMap containing the cloud-config
-func ConfigMapCreator(data configMapCreatorData) resources.NamedConfigMapCreatorGetter {
-	return func() (string, resources.ConfigMapCreator) {
+func ConfigMapCreator(data configMapCreatorData) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
 		return resources.CloudConfigConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			if cm.Data == nil {
 				cm.Data = map[string]string{}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/cloudconfig"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,8 +36,8 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the controller manager deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data resources.DeploymentDataProvider) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.ControllerManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.ControllerManagerDeploymentName
 			dep.Labels = resources.BaseAppLabel(name, nil)

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -5,6 +5,7 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,8 +29,8 @@ var (
 )
 
 // ServiceCreator returns the function to reconcile the DNS service
-func ServiceCreator() resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func ServiceCreator() reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return resources.DNSResolverServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.DNSResolverServiceName
 			se.Spec.Selector = resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil)
@@ -48,8 +49,8 @@ func ServiceCreator() resources.NamedServiceCreatorGetter {
 }
 
 // DeploymentCreator returns the function to create and update the DNS resolver deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data resources.DeploymentDataProvider) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.DNSResolverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.DNSResolverDeploymentName
 			dep.Labels = resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil)
@@ -171,8 +172,8 @@ type configMapCreatorData interface {
 }
 
 // ConfigMapCreator returns a ConfigMap containing the cloud-config for the supplied data
-func ConfigMapCreator(data configMapCreatorData) resources.NamedConfigMapCreatorGetter {
-	return func() (string, resources.ConfigMapCreator) {
+func ConfigMapCreator(data configMapCreatorData) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
 		return resources.DNSResolverConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			dnsIP, err := resources.UserClusterDNSResolverIP(data.Cluster())
 			if err != nil {

--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/sprig"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -15,8 +16,8 @@ import (
 )
 
 // CronJobCreator returns the func to create/update the etcd defragger cronjob
-func CronJobCreator(data *resources.TemplateData) resources.NamedCronJobCreatorGetter {
-	return func() (string, resources.CronJobCreator) {
+func CronJobCreator(data *resources.TemplateData) reconciling.NamedCronJobCreatorGetter {
+	return func() (string, reconciling.CronJobCreator) {
 		return resources.EtcdDefragCronJobName, func(job *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
 			command, err := defraggerCommand(data)
 			if err != nil {

--- a/api/pkg/resources/etcd/etcdservices.go
+++ b/api/pkg/resources/etcd/etcdservices.go
@@ -5,6 +5,8 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -16,8 +18,8 @@ type serviceCreatorData interface {
 }
 
 // ServiceCreator returns the function to reconcile the etcd service
-func ServiceCreator(data serviceCreatorData) resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func ServiceCreator(data serviceCreatorData) reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return resources.EtcdServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.EtcdServiceName
 			se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}

--- a/api/pkg/resources/etcd/pdb.go
+++ b/api/pkg/resources/etcd/pdb.go
@@ -2,15 +2,16 @@ package etcd
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // PodDisruptionBudgetCreator returns a func to create/update the etcd PodDisruptionBudget
-func PodDisruptionBudgetCreator(data *resources.TemplateData) resources.NamedPodDisruptionBudgetCreatorGetter {
-	return func() (string, resources.PodDisruptionBudgetCreator) {
+func PodDisruptionBudgetCreator(data *resources.TemplateData) reconciling.NamedPodDisruptionBudgetCreatorGetter {
+	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return resources.EtcdPodDisruptionBudgetName, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
 			minAvailable := intstr.FromInt((resources.EtcdClusterSize / 2) + 1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -6,8 +6,10 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
+
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,8 +39,8 @@ const (
 )
 
 // StatefulSetCreator returns the function to reconcile the etcd StatefulSet
-func StatefulSetCreator(data *resources.TemplateData) resources.NamedStatefulSetCreatorGetter {
-	return func() (string, resources.StatefulSetCreator) {
+func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulSetCreatorGetter {
+	return func() (string, reconciling.StatefulSetCreator) {
 		return resources.EtcdStatefulSetName, func(set *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 			set.Name = resources.EtcdStatefulSetName
 

--- a/api/pkg/resources/etcd/tls-serving-certificate.go
+++ b/api/pkg/resources/etcd/tls-serving-certificate.go
@@ -8,6 +8,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	certutil "k8s.io/client-go/util/cert"
@@ -19,8 +20,8 @@ type tlsCertificateCreatorData interface {
 }
 
 // TLSCertificateCreator returns a function to create/update the secret with the etcd tls certificate
-func TLSCertificateCreator(data tlsCertificateCreatorData) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func TLSCertificateCreator(data tlsCertificateCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.EtcdTLSCertificateSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			ca, err := data.GetRootCA()
 			if err != nil {

--- a/api/pkg/resources/imagepullsecret.go
+++ b/api/pkg/resources/imagepullsecret.go
@@ -1,12 +1,14 @@
 package resources
 
 import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 // ImagePullSecretCreator returns a creator function to create a ImagePullSecret
-func ImagePullSecretCreator(dockerPullConfigJSON []byte) NamedSecretCreatorGetter {
-	return func() (string, SecretCreator) {
+func ImagePullSecretCreator(dockerPullConfigJSON []byte) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return ImagePullSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			se.Type = corev1.SecretTypeDockerConfigJson
 

--- a/api/pkg/resources/kubeconfig.go
+++ b/api/pkg/resources/kubeconfig.go
@@ -7,6 +7,7 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	"github.com/golang/glog"
 
@@ -23,8 +24,8 @@ type adminKubeconfigCreatorData interface {
 }
 
 // AdminKubeconfigCreator returns a function to create/update the secret with the admin kubeconfig
-func AdminKubeconfigCreator(data adminKubeconfigCreatorData, modifier ...func(*clientcmdapi.Config)) NamedSecretCreatorGetter {
-	return func() (string, SecretCreator) {
+func AdminKubeconfigCreator(data adminKubeconfigCreatorData, modifier ...func(*clientcmdapi.Config)) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return AdminKubeconfigSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
 				se.Data = map[string][]byte{}
@@ -65,8 +66,8 @@ type internalKubeconfigCreatorData interface {
 }
 
 // GetInternalKubeconfigCreator is a generic function to return a secret generator to create a kubeconfig which must only be used within the seed-cluster as it uses the ClusterIP of the apiserver.
-func GetInternalKubeconfigCreator(name, commonName string, organizations []string, data internalKubeconfigCreatorData) NamedSecretCreatorGetter {
-	return func() (string, SecretCreator) {
+func GetInternalKubeconfigCreator(name, commonName string, organizations []string, data internalKubeconfigCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return name, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
 				se.Data = map[string][]byte{}

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -3,9 +3,10 @@ package kubestatemetrics
 import (
 	"fmt"
 
-	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
-
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -32,8 +33,8 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the kube-state-metrics deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data resources.DeploymentDataProvider) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.KubeStateMetricsDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.KubeStateMetricsDeploymentName
 			dep.Labels = resources.BaseAppLabel(name, nil)

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,8 +46,8 @@ type machinecontrollerData interface {
 }
 
 // DeploymentCreator returns the function to create and update the machine controller deployment
-func DeploymentCreator(data machinecontrollerData) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data machinecontrollerData) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.MachineControllerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.MachineControllerDeploymentName
 			dep.Labels = resources.BaseAppLabel(Name, nil)

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,8 +31,8 @@ var (
 )
 
 // WebhookDeploymentCreator returns the function to create and update the machine controller webhook deployment
-func WebhookDeploymentCreator(data machinecontrollerData) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.MachineControllerWebhookDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.MachineControllerWebhookDeploymentName
 			dep.Labels = resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil)
@@ -130,8 +131,8 @@ func WebhookDeploymentCreator(data machinecontrollerData) resources.NamedDeploym
 }
 
 // ServiceCreator returns the function to reconcile the DNS service
-func ServiceCreator() resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func ServiceCreator() reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return resources.MachineControllerWebhookServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.MachineControllerWebhookServiceName
 			se.Labels = resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil)
@@ -172,8 +173,8 @@ type tlsServingCertCreatorData interface {
 }
 
 // TLSServingCertificateCreator returns a function to create/update the secret with the machine-controller-webhook tls certificate
-func TLSServingCertificateCreator(data tlsServingCertCreatorData) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func TLSServingCertificateCreator(data tlsServingCertCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.MachineControllerWebhookServingCertSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
 				se.Data = map[string][]byte{}

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -34,8 +35,8 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the metrics server deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data resources.DeploymentDataProvider) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.MetricsServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.MetricsServerDeploymentName
 			dep.Labels = resources.BaseAppLabel(name, nil)

--- a/api/pkg/resources/metrics-server/pdb.go
+++ b/api/pkg/resources/metrics-server/pdb.go
@@ -2,6 +2,7 @@ package metricsserver
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,8 +10,8 @@ import (
 )
 
 // PodDisruptionBudgetCreator returns a func to create/update the metrics-server PodDisruptionBudget
-func PodDisruptionBudgetCreator() resources.NamedPodDisruptionBudgetCreatorGetter {
-	return func() (string, resources.PodDisruptionBudgetCreator) {
+func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGetter {
+	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return resources.MetricsServerPodDisruptionBudgetName, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
 			maxUnavailable := intstr.FromInt(1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{

--- a/api/pkg/resources/metrics-server/service.go
+++ b/api/pkg/resources/metrics-server/service.go
@@ -2,14 +2,15 @@ package metricsserver
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ServiceCreator returns the function to reconcile the seed cluster internal metrics-server service
-func ServiceCreator() resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func ServiceCreator() reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return resources.MetricsServerServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.MetricsServerServiceName
 			labels := resources.BaseAppLabel(name, nil)

--- a/api/pkg/resources/openvpn/configmap.go
+++ b/api/pkg/resources/openvpn/configmap.go
@@ -7,6 +7,7 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -17,8 +18,8 @@ type serverClientConfigsData interface {
 }
 
 // ServerClientConfigsConfigMapCreator returns a ConfigMap containing the ClientConfig for the OpenVPN server. It lives inside the seed-cluster
-func ServerClientConfigsConfigMapCreator(data serverClientConfigsData) resources.NamedConfigMapCreatorGetter {
-	return func() (string, resources.ConfigMapCreator) {
+func ServerClientConfigsConfigMapCreator(data serverClientConfigsData) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
 		return resources.OpenVPNClientConfigsConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			cm.Labels = resources.BaseAppLabel(name, nil)
 

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,8 +43,8 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the openvpn server deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data resources.DeploymentDataProvider) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.OpenVPNServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.OpenVPNServerDeploymentName
 			dep.Labels = resources.BaseAppLabel(name, nil)

--- a/api/pkg/resources/openvpn/internal-client-certificate.go
+++ b/api/pkg/resources/openvpn/internal-client-certificate.go
@@ -3,6 +3,7 @@ package openvpn
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 )
 
 type internalClientCertificateCreatorData interface {
@@ -10,8 +11,8 @@ type internalClientCertificateCreatorData interface {
 }
 
 // InternalClientCertificateCreator returns a function to create/update the secret with a client certificate for the openvpn clients in the seed cluster.
-func InternalClientCertificateCreator(data internalClientCertificateCreatorData) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func InternalClientCertificateCreator(data internalClientCertificateCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.OpenVPNClientCertificatesSecretName, certificates.GetECDSAClientCertificateCreator(
 			resources.OpenVPNClientCertificatesSecretName,
 			"internal-client",
@@ -25,7 +26,7 @@ func InternalClientCertificateCreator(data internalClientCertificateCreatorData)
 
 // UserClusterClientCertificateCreator returns a function to create/update the secret with the client certificate for the openvpn client in the user
 // cluster
-func UserClusterClientCertificateCreator(ca *resources.ECDSAKeyPair) resources.SecretCreator {
+func UserClusterClientCertificateCreator(ca *resources.ECDSAKeyPair) reconciling.SecretCreator {
 	return certificates.GetECDSAClientCertificateCreator(
 		resources.OpenVPNClientCertificatesSecretName,
 		"user-cluster-client",

--- a/api/pkg/resources/openvpn/server-certificate.go
+++ b/api/pkg/resources/openvpn/server-certificate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	certutil "k8s.io/client-go/util/cert"
@@ -16,8 +17,8 @@ type tlsServingCertCreatorData interface {
 }
 
 // TLSServingCertificateCreator returns a function to create/update a secret with the openvpn server tls certificate
-func TLSServingCertificateCreator(data tlsServingCertCreatorData) resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func TLSServingCertificateCreator(data tlsServingCertCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.OpenVPNServerCertificatesSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
 				se.Data = map[string][]byte{}
@@ -56,8 +57,8 @@ func TLSServingCertificateCreator(data tlsServingCertCreatorData) resources.Name
 }
 
 // CACreator returns a function to create the ECDSA-based CA to be used for OpenVPN
-func CACreator() resources.NamedSecretCreatorGetter {
-	return func() (string, resources.SecretCreator) {
+func CACreator() reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
 		return resources.OpenVPNCASecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
 			if se.Data == nil {
 				se.Data = map[string][]byte{}

--- a/api/pkg/resources/openvpn/service.go
+++ b/api/pkg/resources/openvpn/service.go
@@ -2,14 +2,15 @@ package openvpn
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ServiceCreator returns the function to reconcile the external OpenVPN service
-func ServiceCreator() resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func ServiceCreator() reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return resources.OpenVPNServerServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.OpenVPNServerServiceName
 			se.Labels = resources.BaseAppLabel(name, nil)

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Masterminds/sprig"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -19,8 +20,8 @@ type promTplModel struct {
 }
 
 // ConfigMapCreator returns a ConfigMapCreator containing the prometheus config for the supplied data
-func ConfigMapCreator(data resources.ConfigMapDataProvider) resources.NamedConfigMapCreatorGetter {
-	return func() (string, resources.ConfigMapCreator) {
+func ConfigMapCreator(data resources.ConfigMapDataProvider) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
 		return resources.PrometheusConfigConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			if cm.Data == nil {
 				cm.Data = map[string]string{}

--- a/api/pkg/resources/prometheus/federation_service.go
+++ b/api/pkg/resources/prometheus/federation_service.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,8 +10,8 @@ import (
 )
 
 // ServiceCreator returns the function to reconcile the prometheus service used for federation
-func ServiceCreator(data resources.ServiceDataProvider) resources.NamedServiceCreatorGetter {
-	return func() (string, resources.ServiceCreator) {
+func ServiceCreator(data resources.ServiceDataProvider) reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
 		return name, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = name
 			se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}

--- a/api/pkg/resources/prometheus/role.go
+++ b/api/pkg/resources/prometheus/role.go
@@ -2,13 +2,14 @@ package prometheus
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // RoleCreator returns the func to create/update the role for Prometheus
-func RoleCreator() resources.NamedRoleCreatorGetter {
-	return func() (string, resources.RoleCreator) {
+func RoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
 		return resources.PrometheusRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Labels = resources.BaseAppLabel(name, nil)
 

--- a/api/pkg/resources/prometheus/rolebinding.go
+++ b/api/pkg/resources/prometheus/rolebinding.go
@@ -2,13 +2,14 @@ package prometheus
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 // RoleBindingCreator returns the func to create/update the RoleBinding for Prometheus
-func RoleBindingCreator(clusterNamespace string) resources.NamedRoleBindingCreatorGetter {
-	return func() (string, resources.RoleBindingCreator) {
+func RoleBindingCreator(clusterNamespace string) reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
 		return resources.PrometheusRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			rb.Labels = resources.BaseAppLabel(name, nil)
 

--- a/api/pkg/resources/prometheus/serviceaccount.go
+++ b/api/pkg/resources/prometheus/serviceaccount.go
@@ -2,13 +2,14 @@ package prometheus
 
 import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
 // ServiceAccountCreator returns a func to create/update the ServiceAccount used by Prometheus.
-func ServiceAccountCreator() resources.NamedServiceAccountCreatorGetter {
-	return func() (string, resources.ServiceAccountCreator) {
+func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
 		return resources.PrometheusServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
 			return sa, nil
 		}

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,8 +36,8 @@ var (
 )
 
 // StatefulSetCreator returns the function to reconcile the Prometheus StatefulSet
-func StatefulSetCreator(data *resources.TemplateData) resources.NamedStatefulSetCreatorGetter {
-	return func() (string, resources.StatefulSetCreator) {
+func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulSetCreatorGetter {
+	return func() (string, reconciling.StatefulSetCreator) {
 		return resources.PrometheusStatefulSetName, func(existing *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 			var set *appsv1.StatefulSet
 			if existing != nil {

--- a/api/pkg/resources/reconciling/compare.go
+++ b/api/pkg/resources/reconciling/compare.go
@@ -1,4 +1,4 @@
-package resources
+package reconciling
 
 import (
 	"github.com/go-test/deep"

--- a/api/pkg/resources/reconciling/ensure.go
+++ b/api/pkg/resources/reconciling/ensure.go
@@ -1,4 +1,4 @@
-package resources
+package reconciling
 
 import (
 	"context"
@@ -10,10 +10,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//go:generate go run ../../codegen/reconcile/main.go
+//go:generate go run ../../../codegen/reconcile/main.go
+
+// ObjectCreator defines an interface to create/update a runtime.Object
+type ObjectCreator = func(existing runtime.Object) (runtime.Object, error)
+
+// ObjectModifier is a wrapper function which modifies the object which gets returned by the passed in ObjectCreator
+type ObjectModifier func(create ObjectCreator) ObjectCreator
 
 func createWithNamespace(rawcreate ObjectCreator, namespace string) ObjectCreator {
 	return func(existing runtime.Object) (runtime.Object, error) {

--- a/api/pkg/resources/reconciling/ensure_test.go
+++ b/api/pkg/resources/reconciling/ensure_test.go
@@ -1,4 +1,4 @@
-package resources
+package reconciling
 
 import (
 	"context"

--- a/api/pkg/resources/reconciling/wrapper.go
+++ b/api/pkg/resources/reconciling/wrapper.go
@@ -1,4 +1,4 @@
-package resources
+package reconciling
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/api/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/api/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -1,5 +1,5 @@
 // This file is generated. DO NOT EDIT.
-package resources
+package reconciling
 
 import (
 	"fmt"

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	certutil "k8s.io/client-go/util/cert"
@@ -337,12 +336,6 @@ type CRDCreateor = func(version semver.Semver, existing *apiextensionsv1beta1.Cu
 
 // APIServiceCreator defines an interface to create/update APIService's
 type APIServiceCreator = func(existing *apiregistrationv1beta1.APIService) (*apiregistrationv1beta1.APIService, error)
-
-// ObjectCreator defines an interface to create/update a runtime.Object
-type ObjectCreator = func(existing runtime.Object) (runtime.Object, error)
-
-// ObjectModifier is a wrapper function which modifies the object which gets returned by the passed in ObjectCreator
-type ObjectModifier func(create ObjectCreator) ObjectCreator
 
 // GetClusterApiserverAddress returns the apiserver address for the given Cluster
 func GetClusterApiserverAddress(cluster *kubermaticv1.Cluster, lister corev1lister.ServiceLister) (string, error) {

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
@@ -35,8 +36,8 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the scheduler deployment
-func DeploymentCreator(data resources.DeploymentDataProvider) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data resources.DeploymentDataProvider) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.SchedulerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.SchedulerDeploymentName
 			dep.Labels = resources.BaseAppLabel(name, nil)

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machine"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	ksemver "github.com/kubermatic/kubermatic/api/pkg/semver"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 
@@ -528,7 +529,7 @@ func TestLoadFiles(t *testing.T) {
 				kubeInformerFactory.Start(wait.NeverStop)
 				kubeInformerFactory.WaitForCacheSync(wait.NeverStop)
 
-				var deploymentCreators []resources.NamedDeploymentCreatorGetter
+				var deploymentCreators []reconciling.NamedDeploymentCreatorGetter
 				deploymentCreators = append(deploymentCreators, clustercontroller.GetDeploymentCreators(data)...)
 				deploymentCreators = append(deploymentCreators, monitoringcontroller.GetDeploymentCreators(data)...)
 				for _, create := range deploymentCreators {
@@ -549,7 +550,7 @@ func TestLoadFiles(t *testing.T) {
 					checkTestResult(t, fixturePath, res)
 				}
 
-				var namedConfigMapCreatorGetters []resources.NamedConfigMapCreatorGetter
+				var namedConfigMapCreatorGetters []reconciling.NamedConfigMapCreatorGetter
 				namedConfigMapCreatorGetters = append(namedConfigMapCreatorGetters, clustercontroller.GetConfigMapCreators(data)...)
 				namedConfigMapCreatorGetters = append(namedConfigMapCreatorGetters, monitoringcontroller.GetConfigMapCreators(data)...)
 				for _, namedGetter := range namedConfigMapCreatorGetters {
@@ -563,7 +564,7 @@ func TestLoadFiles(t *testing.T) {
 					checkTestResult(t, fixturePath, res)
 				}
 
-				var serviceCreators []resources.NamedServiceCreatorGetter
+				var serviceCreators []reconciling.NamedServiceCreatorGetter
 				serviceCreators = append(serviceCreators, clustercontroller.GetServiceCreators(data)...)
 				for _, creatorGetter := range serviceCreators {
 					_, create := creatorGetter()
@@ -576,7 +577,7 @@ func TestLoadFiles(t *testing.T) {
 					checkTestResult(t, fixturePath, res)
 				}
 
-				var statefulSetCreators []resources.NamedStatefulSetCreatorGetter
+				var statefulSetCreators []reconciling.NamedStatefulSetCreatorGetter
 				statefulSetCreators = append(statefulSetCreators, clustercontroller.GetStatefulSetCreators(data)...)
 				statefulSetCreators = append(statefulSetCreators, monitoringcontroller.GetStatefulSetCreators(data)...)
 				for _, creatorGetter := range statefulSetCreators {

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -8,6 +8,7 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -46,8 +47,8 @@ type userclusterControllerData interface {
 }
 
 // DeploymentCreator returns the function to create and update the user cluster controller deployment
-func DeploymentCreator(data userclusterControllerData, openshift bool) resources.NamedDeploymentCreatorGetter {
-	return func() (string, resources.DeploymentCreator) {
+func DeploymentCreator(data userclusterControllerData, openshift bool) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
 		return resources.UserClusterControllerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.UserClusterControllerDeploymentName
 			dep.Labels = resources.BaseAppLabel(name, nil)

--- a/api/pkg/resources/vpa.go
+++ b/api/pkg/resources/vpa.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"fmt"
 
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,7 +17,7 @@ import (
 	ctrlruntimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
-func getVPACreatorForPodTemplate(name string, pod corev1.PodSpec, controllerRef metav1.OwnerReference) NamedVerticalPodAutoscalerCreatorGetter {
+func getVPACreatorForPodTemplate(name string, pod corev1.PodSpec, controllerRef metav1.OwnerReference) reconciling.NamedVerticalPodAutoscalerCreatorGetter {
 	var containerPolicies []autoscalingv1beta2.ContainerResourcePolicy
 	for _, container := range pod.Containers {
 		containerPolicies = append(containerPolicies, autoscalingv1beta2.ContainerResourcePolicy{
@@ -26,7 +27,7 @@ func getVPACreatorForPodTemplate(name string, pod corev1.PodSpec, controllerRef 
 		})
 	}
 
-	return func() (string, VerticalPodAutoscalerCreator) {
+	return func() (string, reconciling.VerticalPodAutoscalerCreator) {
 		return name, func(vpa *autoscalingv1beta2.VerticalPodAutoscaler) (*autoscalingv1beta2.VerticalPodAutoscaler, error) {
 			updateMode := autoscalingv1beta2.UpdateModeAuto
 			// We're doing this as we don't want to use the Cluster object as owner.
@@ -54,8 +55,8 @@ func getVPACreatorForPodTemplate(name string, pod corev1.PodSpec, controllerRef 
 // If creator functions for VPA's for Deployments should be returned, a deployment store must be passed in. Otherwise a StatefulSet store.
 // All resources must exist in the specified namespace.
 // The VPA resource will have the same selector as the Deployment/StatefulSet. The pod container limits will be set as VPA limits.
-func getVerticalPodAutoscalersForResource(names []string, namespace string, store cache.Store) ([]NamedVerticalPodAutoscalerCreatorGetter, error) {
-	var creators []NamedVerticalPodAutoscalerCreatorGetter
+func getVerticalPodAutoscalersForResource(names []string, namespace string, store cache.Store) ([]reconciling.NamedVerticalPodAutoscalerCreatorGetter, error) {
+	var creators []reconciling.NamedVerticalPodAutoscalerCreatorGetter
 	for _, name := range names {
 		name := name
 		key := fmt.Sprintf("%s/%s", namespace, name)
@@ -92,7 +93,7 @@ func getVerticalPodAutoscalersForResource(names []string, namespace string, stor
 // GetVerticalPodAutoscalersForAll will return functions to create VPA resource for all supplied Deployments and StatefulSets.
 // All resources must exist in the specified namespace.
 // The VPA resource will have the same selector as the Deployment/StatefulSet. The pod container limits will be set as VPA limits.
-func GetVerticalPodAutoscalersForAll(deploymentNames, statefulSetNames []string, namespace string, dynamicCache ctrlruntimecache.Cache) ([]NamedVerticalPodAutoscalerCreatorGetter, error) {
+func GetVerticalPodAutoscalersForAll(deploymentNames, statefulSetNames []string, namespace string, dynamicCache ctrlruntimecache.Cache) ([]reconciling.NamedVerticalPodAutoscalerCreatorGetter, error) {
 	deploymentStore, err := informer.GetSyncedStoreFromDynamicFactory(dynamicCache, &appsv1.Deployment{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Deployment store: %v", err)

--- a/docs/resource-handling.md
+++ b/docs/resource-handling.md
@@ -259,7 +259,7 @@ Extend the `Resources` slice with the additional item in the [code](https://gith
 
 Run the code generation from the repository root:
 ```bash
-go generate api/pkg/resources/ensure.go
+go generate api/pkg/resources/reconciling/ensure.go
 ```
 
 See [here](#example-namedsecretcreator-implementation) on how to use the generated functions.


### PR DESCRIPTION
**What this PR does / why we need it**:
Move core reconciling functions into own subpackage.

This is mostly to avoid potential cyclic dependencies (Which i ran into)

**Release note**:
```release-note
NONE
```
