### PR TITLE
Fix mutatingWebhookConfiguration idempotency

### DIFF
--- a/api/hack/run-userclustercontroller.sh
+++ b/api/hack/run-userclustercontroller.sh
@@ -14,7 +14,7 @@ kubectl get secret admin-kubeconfig -o go-template='{{ index .data "kubeconfig" 
   | base64 -d > ${KUBECONFIG_USERCLUSTER_CONTROLLER}
 
 CA_CERT_USERCLUSTER_CONTROLLER=$(mktemp)
-kubectl -n get secret ca -o json | jq -r '.data["ca.crt"]' | base64 -d > ${CA_CERT_USERCLUSTER_CONTROLLER}
+kubectl get secret ca -o json | jq -r '.data["ca.crt"]' | base64 -d > ${CA_CERT_USERCLUSTER_CONTROLLER}
 
 CLUSTER_NAME=$(kubectl get secret admin-kubeconfig -o go-template='{{ .metadata.namespace }}'|sed 's/cluster-//g')
 ARGS=""

--- a/api/pkg/controller/usercluster/resources/machine-controller/webhook.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/webhook.go
@@ -20,49 +20,41 @@ func MutatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace str
 			failurePolicy := admissionregistrationv1beta1.Fail
 			mdURL := fmt.Sprintf("https://%s.%s.svc.cluster.local./machinedeployments", resources.MachineControllerWebhookServiceName, namespace)
 			mURL := fmt.Sprintf("https://%s.%s.svc.cluster.local./machines", resources.MachineControllerWebhookServiceName, namespace)
-			sideEffectClass := admissionregistrationv1beta1.SideEffectClassNone
 
-			mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1beta1.Webhook{
-				{
-					Name:              fmt.Sprintf("%s-machinedeployments", resources.MachineControllerMutatingWebhookConfigurationName),
-					NamespaceSelector: &metav1.LabelSelector{},
-					FailurePolicy:     &failurePolicy,
-					SideEffects:       &sideEffectClass,
-					Rules: []admissionregistrationv1beta1.RuleWithOperations{
-						{
-							Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
-							Rule: admissionregistrationv1beta1.Rule{
-								APIGroups:   []string{clusterAPIGroup},
-								APIVersions: []string{clusterAPIVersion},
-								Resources:   []string{"machinedeployments"},
-							},
-						},
-					},
-					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-						URL:      &mdURL,
-						CABundle: certutil.EncodeCertPEM(caCert),
-					},
+			if len(mutatingWebhookConfiguration.Webhooks) != 2 {
+				mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1beta1.Webhook{{}, {}}
+			}
+
+			mutatingWebhookConfiguration.Webhooks[0].Name = fmt.Sprintf("%s-machinedeployments", resources.MachineControllerMutatingWebhookConfigurationName)
+			mutatingWebhookConfiguration.Webhooks[0].NamespaceSelector = &metav1.LabelSelector{}
+			mutatingWebhookConfiguration.Webhooks[0].FailurePolicy = &failurePolicy
+			mutatingWebhookConfiguration.Webhooks[0].Rules = []admissionregistrationv1beta1.RuleWithOperations{{
+				Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
+				Rule: admissionregistrationv1beta1.Rule{
+					APIGroups:   []string{clusterAPIGroup},
+					APIVersions: []string{clusterAPIVersion},
+					Resources:   []string{"machinedeployments"},
 				},
-				{
-					Name:              fmt.Sprintf("%s-machines", resources.MachineControllerMutatingWebhookConfigurationName),
-					NamespaceSelector: &metav1.LabelSelector{},
-					FailurePolicy:     &failurePolicy,
-					SideEffects:       &sideEffectClass,
-					Rules: []admissionregistrationv1beta1.RuleWithOperations{
-						{
-							Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
-							Rule: admissionregistrationv1beta1.Rule{
-								APIGroups:   []string{clusterAPIGroup},
-								APIVersions: []string{clusterAPIVersion},
-								Resources:   []string{"machines"},
-							},
-						},
-					},
-					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-						URL:      &mURL,
-						CABundle: certutil.EncodeCertPEM(caCert),
-					},
+			}}
+			mutatingWebhookConfiguration.Webhooks[0].ClientConfig = admissionregistrationv1beta1.WebhookClientConfig{
+				URL:      &mdURL,
+				CABundle: certutil.EncodeCertPEM(caCert),
+			}
+
+			mutatingWebhookConfiguration.Webhooks[1].Name = fmt.Sprintf("%s-machines", resources.MachineControllerMutatingWebhookConfigurationName)
+			mutatingWebhookConfiguration.Webhooks[1].NamespaceSelector = &metav1.LabelSelector{}
+			mutatingWebhookConfiguration.Webhooks[1].FailurePolicy = &failurePolicy
+			mutatingWebhookConfiguration.Webhooks[1].Rules = []admissionregistrationv1beta1.RuleWithOperations{{
+				Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
+				Rule: admissionregistrationv1beta1.Rule{
+					APIGroups:   []string{clusterAPIGroup},
+					APIVersions: []string{clusterAPIVersion},
+					Resources:   []string{"machines"},
 				},
+			}}
+			mutatingWebhookConfiguration.Webhooks[1].ClientConfig = admissionregistrationv1beta1.WebhookClientConfig{
+				URL:      &mURL,
+				CABundle: certutil.EncodeCertPEM(caCert),
 			}
 
 			return mutatingWebhookConfiguration, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the MutatingWebhookConfiguration management to be idempotent on both Kubernetes and openshift. Previously, Openshift yielded a lot of

```
I0402 17:39:34.178086    4966 ensure.go:156] Updated *v1beta1.MutatingWebhookConfiguration machine-controller.kubermatic.io in Namespace 
I0402 17:39:34.184356    4966 compare.go:30] Object *v1beta1.MutatingWebhookConfiguration /machine-controller.kubermatic.io differs from the one, generated: [Webhooks.slice[0].SideEffects: v1beta1.SideEffectClass != <nil pointer> Webhooks.slice[1].SideEffects: v1beta1.SideEffectClass != <nil pointer>]
```

Presumably because the `SideEffects` field doesn't exist in the apiserver version used by Openshift 3.10

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
