### PR TITLE
Do Openshift address reconciliation in Openshift controller

### DIFF
--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -117,10 +117,12 @@ func createOpenshiftController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.mgr,
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.runOptions.workerName,
+		ctrlCtx.runOptions.dc,
 		ctrlCtx.dcs,
 		ctrlCtx.runOptions.overwriteRegistry,
 		ctrlCtx.runOptions.nodeAccessNetwork,
 		ctrlCtx.dockerPullConfigJSON,
+		ctrlCtx.runOptions.externalURL,
 		openshiftcontroller.OIDCConfig{
 			CAFile:       ctrlCtx.runOptions.oidcCAFile,
 			ClientID:     ctrlCtx.runOptions.oidcIssuerClientID,

--- a/api/pkg/controller/cluster/address.go
+++ b/api/pkg/controller/cluster/address.go
@@ -2,43 +2,13 @@ package cluster
 
 import (
 	"context"
-	"fmt"
-	"net"
 
 	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/types"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/kubernetes"
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/address"
 )
-
-func getExternalIPv4(hostname string) (string, error) {
-	resolvedIPs, err := net.LookupIP(hostname)
-	if err != nil {
-		return "", fmt.Errorf("failed to lookup ip for %s: %v", hostname, err)
-	}
-	ipList := sets.NewString()
-	for _, ip := range resolvedIPs {
-		if ip.To4() != nil {
-			ipList.Insert(ip.String())
-		}
-	}
-	ips := ipList.List()
-	if len(ips) == 0 {
-		return "", fmt.Errorf("no ip addresses found for %s: %v", hostname, err)
-	}
-
-	//Just one ipv4
-	if len(ips) > 1 {
-		glog.V(6).Infof("lookup of %s returned multiple ipv4 addresses (%v). Picking the first one after sorting: %s", hostname, ips, ips[0])
-	}
-	return ips[0], nil
-}
 
 // syncAddress will set the all address relevant fields on the cluster
 func (r *Reconciler) syncAddress(ctx context.Context, cluster *kubermaticv1.Cluster) error {
@@ -55,61 +25,18 @@ func (r *Reconciler) syncAddress(ctx context.Context, cluster *kubermaticv1.Clus
 		glog.V(4).Infof("Created admin token for cluster %s", cluster.Name)
 	}
 
-	nodeDc, found := r.dcs[cluster.Spec.Cloud.DatacenterName]
-	if !found {
-		return fmt.Errorf("unknown node dataceter set '%s'", cluster.Spec.Cloud.DatacenterName)
-	}
-	seedDCName := r.dc
-	if nodeDc.SeedDNSOverwrite != nil && *nodeDc.SeedDNSOverwrite != "" {
-		seedDCName = *nodeDc.SeedDNSOverwrite
-	}
-
-	externalName := fmt.Sprintf("%s.%s.%s", cluster.Name, seedDCName, r.externalURL)
-	if cluster.Address.ExternalName != externalName {
-		err = r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-			c.Address.ExternalName = externalName
-		})
-		if err != nil {
-			return err
-		}
-		glog.V(4).Infof("Set external name for cluster %s to '%s'", cluster.Name, cluster.Address.ExternalName)
-	}
-
-	// Always lookup IP address, c case it changes (IP's on AWS LB's change)
-	ip, err := getExternalIPv4(cluster.Address.ExternalName)
+	modifiers, err := address.SyncClusterAddress(ctx, cluster, r.Client, r.externalURL, r.dc, r.dcs)
 	if err != nil {
 		return err
 	}
-	if cluster.Address.IP != ip {
-		err = r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-			c.Address.IP = ip
-		})
-		if err != nil {
+	if len(modifiers) > 0 {
+		if err := r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
+			for _, modifier := range modifiers {
+				modifier(c)
+			}
+		}); err != nil {
 			return err
 		}
-		glog.V(4).Infof("Set IP for cluster %s to '%s'", cluster.Name, cluster.Address.IP)
-	}
-
-	// We fetch the Apiserver service as its a NodePort and we'll take the first NodePort (so far we only have one)
-	service := &corev1.Service{}
-	serviceKey := types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.ApiserverExternalServiceName}
-	if err := r.Get(ctx, serviceKey, service); err != nil {
-		if errors.IsNotFound(err) {
-			glog.V(6).Infof("Skipping URL setting for cluster %s as no external apiserver service exists yet. Will retry later", cluster.Name)
-			return nil
-		}
-		return err
-	}
-
-	url := fmt.Sprintf("https://%s:%d", cluster.Address.ExternalName, int(service.Spec.Ports[0].NodePort))
-	if cluster.Address.URL != url {
-		err = r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-			c.Address.URL = url
-		})
-		if err != nil {
-			return err
-		}
-		glog.V(4).Infof("Set URL for cluster %s to '%s'", cluster.Name, cluster.Address.URL)
 	}
 
 	return nil

--- a/api/pkg/controller/cluster/address_test.go
+++ b/api/pkg/controller/cluster/address_test.go
@@ -7,6 +7,7 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/address"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,7 +21,7 @@ import (
 // - 2001:16B8:6844:D700:A1B9:D94B:FDC3:1C33
 func TestGetExternalIPv4(t *testing.T) {
 	const testDomain = "dns-test.kubermatic.io"
-	ip, err := getExternalIPv4(testDomain)
+	ip, err := address.GetExternalIPv4(testDomain)
 	if err != nil {
 		t.Fatalf("failed to get the external IPv4 address for %s: %v", testDomain, err)
 	}

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -25,8 +25,10 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 	}
 
 	// Set the hostname & url
-	if err := r.syncAddress(ctx, cluster); err != nil {
-		return nil, err
+	if cluster.Annotations["kubermatic.io/openshift"] == "" {
+		if err := r.syncAddress(ctx, cluster); err != nil {
+			return nil, err
+		}
 	}
 
 	// Set default network configuration

--- a/api/pkg/resources/address/address.go
+++ b/api/pkg/resources/address/address.go
@@ -1,0 +1,101 @@
+package address
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/golang/glog"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func SyncClusterAddress(ctx context.Context,
+	cluster *kubermaticv1.Cluster,
+	client ctrlruntimeclient.Client,
+	externalURL, seedDCName string,
+	nodeDCs map[string]provider.DatacenterMeta) ([]func(*kubermaticv1.Cluster), error) {
+
+	var modifiers []func(*kubermaticv1.Cluster)
+
+	nodeDc, found := nodeDCs[cluster.Spec.Cloud.DatacenterName]
+	if !found {
+		return nil, fmt.Errorf("unknown node dataceter set '%s'", cluster.Spec.Cloud.DatacenterName)
+	}
+	if nodeDc.SeedDNSOverwrite != nil && *nodeDc.SeedDNSOverwrite != "" {
+		seedDCName = *nodeDc.SeedDNSOverwrite
+	}
+
+	externalName := fmt.Sprintf("%s.%s.%s", cluster.Name, seedDCName, externalURL)
+	if cluster.Address.ExternalName != externalName {
+		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
+			c.Address.ExternalName = externalName
+		})
+		glog.V(4).Infof("Set external name for cluster %s to %q", cluster.Name, externalName)
+	}
+
+	// Always lookup IP address, in case it changes (IP's on AWS LB's change)
+	ip, err := GetExternalIPv4(externalName)
+	if err != nil {
+		return nil, err
+	}
+	if cluster.Address.IP != ip {
+		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
+			c.Address.IP = ip
+		})
+		glog.V(4).Infof("Set IP for cluster %s to '%s'", cluster.Name, ip)
+	}
+
+	// We fetch the Apiserver service as its a NodePort and we'll take the first NodePort (so far we only have one)
+	service := &corev1.Service{}
+	serviceKey := types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.ApiserverExternalServiceName}
+	if err := client.Get(ctx, serviceKey, service); err != nil {
+		if kerrors.IsNotFound(err) {
+			glog.V(6).Infof("Skipping URL setting for cluster %s as no external apiserver service exists yet. Will retry later", cluster.Name)
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	url := fmt.Sprintf("https://%s:%d", externalName, int(service.Spec.Ports[0].NodePort))
+	if cluster.Address.URL != url {
+		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
+			c.Address.URL = url
+		})
+		glog.V(4).Infof("Set URL for cluster %s to '%s'", cluster.Name, url)
+	}
+
+	return modifiers, nil
+}
+
+// GetExternalIPv4 returns the the first IPv4 address for the given hostname or an error
+func GetExternalIPv4(hostname string) (string, error) {
+	resolvedIPs, err := net.LookupIP(hostname)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup ip for %s: %v", hostname, err)
+	}
+	ipList := sets.NewString()
+	for _, ip := range resolvedIPs {
+		if ip.To4() != nil {
+			ipList.Insert(ip.String())
+		}
+	}
+	ips := ipList.List()
+	if len(ips) == 0 {
+		return "", fmt.Errorf("no ip addresses found for %s: %v", hostname, err)
+	}
+
+	//Just one ipv4
+	if len(ips) > 1 {
+		glog.V(6).Infof("lookup of %s returned multiple ipv4 addresses (%v). Picking the first one after sorting: %s", hostname, ips, ips[0])
+	}
+	return ips[0], nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Does the Openshift address reconciliation in the Openshift controller. As a sideeffect, this avoids writing a defunct token into Openshift Cluster CRs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
