### PR TITLE
Set oidc flag in hack script

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -159,10 +159,10 @@ func getImagesForVersion(versions []*version.MasterVersion, requestedVersion str
 }
 
 func getImagesFromCreators(templateData *resources.TemplateData) (images []string, err error) {
-	statefulsetCreators := cluster.GetStatefulSetCreators(templateData)
+	statefulsetCreators := cluster.GetStatefulSetCreators(templateData, false)
 	statefulsetCreators = append(statefulsetCreators, monitoring.GetStatefulSetCreators(templateData)...)
 
-	deploymentCreators := cluster.GetDeploymentCreators(templateData)
+	deploymentCreators := cluster.GetDeploymentCreators(templateData, false)
 	deploymentCreators = append(deploymentCreators, monitoring.GetDeploymentCreators(templateData)...)
 
 	cronjobCreators := cluster.GetCronJobCreators(templateData)
@@ -362,7 +362,6 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 		"",
 		"",
 		"",
-		false,
 	), nil
 }
 

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -69,7 +69,9 @@ func newServerRunOptions() (serverRunOptions, error) {
 }
 
 func (o serverRunOptions) validate() error {
-	// As long as OpenShift support has not reached the testing stage, we only validate those flags when the OIDC feature flag was set
+	// OpenShift always requires those flags, but as long as OpenShift support is not stable/testable
+	// we only validate them when the OIDCKubeCfgEndpoint feature flag is set (Kubernetes specific).
+	// Otherwise we force users to set those flags without any result (for Kubernetes clusters)
 	// TODO: Enforce validation as soon as OpenShift support is testable
 	if o.featureGates.Enabled(OIDCKubeCfgEndpoint) {
 		if len(o.oidcIssuerClientSecret) == 0 {

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -69,6 +69,8 @@ func newServerRunOptions() (serverRunOptions, error) {
 }
 
 func (o serverRunOptions) validate() error {
+	// As long as OpenShift support has not reached the testing stage, we only validate those flags when the OIDC feature flag was set
+	// TODO: Enforce validation as soon as OpenShift support is testable
 	if o.featureGates.Enabled(OIDCKubeCfgEndpoint) {
 		if len(o.oidcIssuerClientSecret) == 0 {
 			return fmt.Errorf("%s feature is enabled but \"oidc-client-secret\" flag was not specified", OIDCKubeCfgEndpoint)

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -157,8 +157,10 @@ func createClusterController(ctrlCtx *controllerContext) (runner, error) {
 		ctrlCtx.runOptions.oidcCAFile,
 		ctrlCtx.runOptions.oidcIssuerURL,
 		ctrlCtx.runOptions.oidcIssuerClientID,
-		ctrlCtx.runOptions.featureGates.Enabled(VerticalPodAutoscaler),
-		ctrlCtx.runOptions.featureGates.Enabled(EtcdDataCorruptionChecks),
+		cluster.Features{
+			VPA:                      ctrlCtx.runOptions.featureGates.Enabled(VerticalPodAutoscaler),
+			EtcdDataCorruptionChecks: ctrlCtx.runOptions.featureGates.Enabled(EtcdDataCorruptionChecks),
+		},
 	)
 }
 

--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -133,16 +133,6 @@ func (o controllerRunOptions) validate() error {
 		if len(o.oidcIssuerClientSecret) == 0 {
 			return fmt.Errorf("%s feature is enabled but \"oidc-issuer-client-secret\" flag was not specified", OpenIDAuthPlugin)
 		}
-
-	} else {
-		// don't pass OpenID issuer flags if OpenIDAuthPlugin disabled
-		if len(o.oidcIssuerURL) > 0 {
-			return fmt.Errorf("%s feature is disabled but \"oidc-issuer-url\" flag was specified, please remove it", OpenIDAuthPlugin)
-		}
-
-		if len(o.oidcIssuerClientID) > 0 {
-			return fmt.Errorf("%s feature is disabled but \"oidc-issuer-client-id\" flag was specified, please remove it", OpenIDAuthPlugin)
-		}
 	}
 
 	if o.masterResources == "" {

--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -27,7 +27,6 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -address=127.0.0.1:8080 \
   -oidc-url=https://dev.kubermatic.io/dex \
   -oidc-authenticator-client-id=kubermatic \
-  -oidc-issuer-url="$(vault kv get -field=oidc-issuer-url dev/seed-clusters/dev.kubermatic.io)" \
   -oidc-issuer-client-id="$(vault kv get -field=oidc-issuer-client-id dev/seed-clusters/dev.kubermatic.io)" \
   -oidc-issuer-client-secret="$(vault kv get -field=oidc-issuer-client-secret dev/seed-clusters/dev.kubermatic.io)" \
   -oidc-issuer-redirect-uri="$(vault kv get -field=oidc-issuer-redirect-uri dev/seed-clusters/dev.kubermatic.io)" \

--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -27,5 +27,10 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -address=127.0.0.1:8080 \
   -oidc-url=https://dev.kubermatic.io/dex \
   -oidc-authenticator-client-id=kubermatic \
+  -oidc-issuer-url="$(vault kv get -field=oidc-issuer-url dev/seed-clusters/dev.kubermatic.io)" \
+  -oidc-issuer-client-id="$(vault kv get -field=oidc-issuer-client-id dev/seed-clusters/dev.kubermatic.io)" \
+  -oidc-issuer-client-secret="$(vault kv get -field=oidc-issuer-client-secret dev/seed-clusters/dev.kubermatic.io)" \
+  -oidc-issuer-redirect-uri="$(vault kv get -field=oidc-issuer-redirect-uri dev/seed-clusters/dev.kubermatic.io)" \
+  -oidc-issuer-cookie-hash-key="$(vault kv get -field=oidc-issuer-cookie-hash-key dev/seed-clusters/dev.kubermatic.io)" \
   -logtostderr \
   -v=8 $@

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -27,6 +27,9 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
   -cleanup-container=../config/kubermatic/static/cleanup-container.yaml \
   -docker-pull-config-json-file=../../secrets/seed-clusters/dev.kubermatic.io/.dockerconfigjson \
   -oidc-ca-file=../../secrets/seed-clusters/dev.kubermatic.io/caBundle.pem \
+  -oidc-issuer-url=$(vault kv get -field=oidc-issuer-url dev/seed-clusters/dev.kubermatic.io) \
+  -oidc-issuer-client-id=$(vault kv get -field=oidc-issuer-client-id dev/seed-clusters/dev.kubermatic.io) \
+  -oidc-issuer-client-secret=$(vault kv get -field=oidc-issuer-client-secret dev/seed-clusters/dev.kubermatic.io) \
   -monitoring-scrape-annotation-prefix='kubermatic.io' \
   -logtostderr=1 \
   -v=6 $@ 2>&1|tee /tmp/kubermatic-controller-manager.log

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -87,7 +87,6 @@ type Reconciler struct {
 	oidcIssuerURL      string
 	oidcIssuerClientID string
 
-	// Temporary feature flags. TODO: Replace with the featureGates map
 	features Features
 }
 

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -53,6 +53,12 @@ type userClusterConnectionProvider interface {
 	GetDynamicClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
 }
 
+type Features struct {
+	VPA                          bool
+	EtcdDataCorruptionChecks     bool
+	KubernetesOIDCAuthentication bool
+}
+
 // Reconciler is a controller which is responsible for managing clusters
 type Reconciler struct {
 	ctrlruntimeclient.Client
@@ -82,8 +88,7 @@ type Reconciler struct {
 	oidcIssuerClientID string
 
 	// Temporary feature flags. TODO: Replace with the featureGates map
-	enableVPA                      bool
-	enableEtcdDataCorruptionChecks bool
+	features Features
 }
 
 // NewController creates a cluster controller.
@@ -111,9 +116,7 @@ func Add(
 	oidcCAFile string,
 	oidcIssuerURL string,
 	oidcIssuerClientID string,
-	// I would prefer to pass the whole feature gates struct but that leads to a ugly import cycle.
-	// We would first clean up the resource handling to move the data->creator handling into the controller
-	enableVPA, enableEtcdDataCorruptionChecks bool) error {
+	features Features) error {
 
 	if err := kubermaticscheme.AddToScheme(scheme.Scheme); err != nil {
 		return fmt.Errorf("failed to add kubermatic scheme: %v", err)
@@ -146,8 +149,7 @@ func Add(
 		oidcIssuerURL:      oidcIssuerURL,
 		oidcIssuerClientID: oidcIssuerClientID,
 
-		enableVPA:                      enableVPA,
-		enableEtcdDataCorruptionChecks: enableEtcdDataCorruptionChecks,
+		features: features,
 	}
 
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})

--- a/api/pkg/controller/cluster/cluster_controller_test.go
+++ b/api/pkg/controller/cluster/cluster_controller_test.go
@@ -27,15 +27,13 @@ func newTestReconciler(t *testing.T, objects []runtime.Object) *Reconciler {
 
 	dynamicClient := ctrlruntimefakeclient.NewFakeClient(objects...)
 	r := &Reconciler{
-		Client:                         dynamicClient,
-		userClusterConnProvider:        nil,
-		externalURL:                    TestExternalURL,
-		dc:                             TestDC,
-		dcs:                            dcs,
-		enableEtcdDataCorruptionChecks: true,
-		enableVPA:                      true,
-		etcdDiskSize:                   resource.MustParse("5Gi"),
-		nodeAccessNetwork:              "192.0.2.0/24",
+		Client:                  dynamicClient,
+		userClusterConnProvider: nil,
+		externalURL:             TestExternalURL,
+		dc:                      TestDC,
+		dcs:                     dcs,
+		etcdDiskSize:            resource.MustParse("5Gi"),
+		nodeAccessNetwork:       "192.0.2.0/24",
 	}
 
 	return r

--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -38,7 +38,6 @@ func (c *Controller) getClusterTemplateData(ctx context.Context, client ctrlrunt
 		"",
 		"",
 		"",
-		false,
 	), nil
 }
 

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -40,7 +40,6 @@ type TemplateData struct {
 	oidcCAFile                                       string
 	oidcIssuerURL                                    string
 	oidcIssuerClientID                               string
-	enableEtcdDataCorruptionChecks                   bool
 }
 
 // NewTemplateData returns an instance of TemplateData
@@ -61,8 +60,7 @@ func NewTemplateData(
 	inClusterPrometheusScrapingConfigsFile string,
 	oidcCAFile string,
 	oidcURL string,
-	oidcIssuerClientID string,
-	enableEtcdDataCorruptionChecks bool) *TemplateData {
+	oidcIssuerClientID string) *TemplateData {
 	return &TemplateData{
 		ctx:                                    ctx,
 		client:                                 client,
@@ -81,18 +79,12 @@ func NewTemplateData(
 		oidcCAFile:                                       oidcCAFile,
 		oidcIssuerURL:                                    oidcURL,
 		oidcIssuerClientID:                               oidcIssuerClientID,
-		enableEtcdDataCorruptionChecks:                   enableEtcdDataCorruptionChecks,
 	}
 }
 
 // GetDexCA returns the chain of public certificates of the Dex
 func (d *TemplateData) GetDexCA() ([]*x509.Certificate, error) {
 	return GetDexCAFromFile(d.oidcCAFile)
-}
-
-// OIDCAuthPluginEnabled returns flag to indicate if OpenID auth plugin enabled
-func (d *TemplateData) OIDCAuthPluginEnabled() bool {
-	return len(d.oidcIssuerURL) > 0 && len(d.oidcIssuerClientID) > 0
 }
 
 // OIDCCAFile return CA file
@@ -163,11 +155,6 @@ func (d *TemplateData) NodeAccessNetwork() string {
 // NodePortRange returns the node access network
 func (d *TemplateData) NodePortRange() string {
 	return d.nodePortRange
-}
-
-// EnableEtcdDataCorruptionChecks tells if the etcdDataCorruptionCheck feature flag has been enabled
-func (d *TemplateData) EnableEtcdDataCorruptionChecks() bool {
-	return d.enableEtcdDataCorruptionChecks
 }
 
 // GetClusterRef returns a instance of a OwnerReference for the Cluster in the TemplateData

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -38,7 +38,7 @@ const (
 )
 
 // StatefulSetCreator returns the function to reconcile the etcd StatefulSet
-func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulSetCreatorGetter {
+func StatefulSetCreator(data *resources.TemplateData, enableDataCorruptionChecks bool) reconciling.NamedStatefulSetCreatorGetter {
 	return func() (string, reconciling.StatefulSetCreator) {
 		return resources.EtcdStatefulSetName, func(set *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 			set.Name = resources.EtcdStatefulSetName
@@ -72,7 +72,7 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 				return nil, fmt.Errorf("failed to check if we need to include the etcd-operator migration code: %v", err)
 			}
 
-			etcdStartCmd, err := getEtcdCommand(data.Cluster().Name, data.Cluster().Status.NamespaceName, migrate, data.EnableEtcdDataCorruptionChecks())
+			etcdStartCmd, err := getEtcdCommand(data.Cluster().Name, data.Cluster().Status.NamespaceName, migrate, enableDataCorruptionChecks)
 			if err != nil {
 				return nil, err
 			}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -210,6 +210,14 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -210,6 +210,14 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -210,6 +210,14 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -210,6 +210,14 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -206,6 +206,14 @@ spec:
         - ExternalIP,InternalIP
         - --feature-gates
         - CustomResourceSubresources=true
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -206,6 +206,14 @@ spec:
         - ExternalIP,InternalIP
         - --feature-gates
         - CustomResourceSubresources=true
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -204,6 +204,14 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -204,6 +204,14 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -204,6 +204,14 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -204,6 +204,14 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -206,6 +206,14 @@ spec:
         - ExternalIP,InternalIP
         - --feature-gates
         - CustomResourceSubresources=true
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -206,6 +206,14 @@ spec:
         - ExternalIP,InternalIP
         - --feature-gates
         - CustomResourceSubresources=true
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -204,6 +204,14 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -204,6 +204,14 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -204,6 +204,14 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -204,6 +204,14 @@ spec:
         - X-Remote-User
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -210,6 +210,14 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -210,6 +210,14 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -210,6 +210,14 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -210,6 +210,14 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -208,6 +208,14 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
         command:
         - /hyperkube
         - apiserver

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -519,13 +519,12 @@ func TestLoadFiles(t *testing.T) {
 					false,
 					tmpFilePath,
 					"test",
-					"",
-					"",
-					false,
+					"https://dev.kubermatic.io/dex",
+					"kubermaticIssuer",
 				)
 
 				var deploymentCreators []reconciling.NamedDeploymentCreatorGetter
-				deploymentCreators = append(deploymentCreators, clustercontroller.GetDeploymentCreators(data)...)
+				deploymentCreators = append(deploymentCreators, clustercontroller.GetDeploymentCreators(data, true)...)
 				deploymentCreators = append(deploymentCreators, monitoringcontroller.GetDeploymentCreators(data)...)
 				for _, create := range deploymentCreators {
 					_, creator := create()
@@ -573,7 +572,7 @@ func TestLoadFiles(t *testing.T) {
 				}
 
 				var statefulSetCreators []reconciling.NamedStatefulSetCreatorGetter
-				statefulSetCreators = append(statefulSetCreators, clustercontroller.GetStatefulSetCreators(data)...)
+				statefulSetCreators = append(statefulSetCreators, clustercontroller.GetStatefulSetCreators(data, false)...)
 				statefulSetCreators = append(statefulSetCreators, monitoringcontroller.GetStatefulSetCreators(data)...)
 				for _, creatorGetter := range statefulSetCreators {
 					_, create := creatorGetter()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates our codebase to do certain templating based on the existence of the actual feature flag (`-features=OIDC=true`) and not on the existence of a feature based flag (`-oidc-issuer-url`).
Also this PR updates the hack scripts to contain the OIDC flags.

Fixes #3108

**Release note**:
```release-note
NONE
```
