### PR TITLE
Use autodetection for openstack bs version

### DIFF
--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -100,7 +100,7 @@ func CloudConfig(cluster *kubermaticv1.Cluster, dc *provider.DatacenterMeta) (cl
 				Region:     dc.Spec.Openstack.Region,
 			},
 			BlockStorage: openstack.BlockStorageOpts{
-				BSVersion:       "v2",
+				BSVersion:       "auto",
 				TrustDevicePath: false,
 				IgnoreVolumeAZ:  dc.Spec.Openstack.IgnoreVolumeAZ,
 			},

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-cloud-config.yaml
@@ -18,7 +18,7 @@ data:
     [BlockStorage]
     ignore-volume-az  = true
     trust-device-path = false
-    bs-version        = "v2"
+    bs-version        = "auto"
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-cloud-config.yaml
@@ -19,7 +19,7 @@ data:
     [BlockStorage]
     ignore-volume-az  = true
     trust-device-path = false
-    bs-version        = "v2"
+    bs-version        = "auto"
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-cloud-config.yaml
@@ -18,7 +18,7 @@ data:
     [BlockStorage]
     ignore-volume-az  = true
     trust-device-path = false
-    bs-version        = "v2"
+    bs-version        = "auto"
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-cloud-config.yaml
@@ -19,7 +19,7 @@ data:
     [BlockStorage]
     ignore-volume-az  = true
     trust-device-path = false
-    bs-version        = "v2"
+    bs-version        = "auto"
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-cloud-config.yaml
@@ -19,7 +19,7 @@ data:
     [BlockStorage]
     ignore-volume-az  = true
     trust-device-path = false
-    bs-version        = "v2"
+    bs-version        = "auto"
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-cloud-config.yaml
@@ -19,7 +19,7 @@ data:
     [BlockStorage]
     ignore-volume-az  = true
     trust-device-path = false
-    bs-version        = "v2"
+    bs-version        = "auto"
   fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the automatic detection of the BlockStorage API version for OpenStack clusters according to https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage

Blocked by https://github.com/kubermatic/machine-controller/pull/480

**Release note**:
```release-note
Enable automatic detection of the OpenStack BlockStorage API version within the cloud config
```
