### PR TITLE
pass whole object for project update

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -256,10 +256,11 @@
             "required": true
           },
           {
-            "type": "string",
-            "x-go-name": "Name",
-            "name": "name",
-            "in": "query"
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
           }
         ],
         "responses": {

--- a/api/pkg/handler/v1/project/project.go
+++ b/api/pkg/handler/v1/project/project.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
@@ -235,10 +236,10 @@ type updateRq struct {
 func (r updateRq) validate() error {
 
 	if len(r.ProjectID) == 0 {
-		return errors.NewBadRequest("the id of the project cannot be empty")
+		return fmt.Errorf("the id of the project cannot be empty")
 	}
 	if len(r.Body.Name) == 0 {
-		return errors.NewBadRequest("the name of the project cannot be empty")
+		return fmt.Errorf("the name of the project cannot be empty")
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: change UpdateEdpoint for the project to pass the whole object

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3087 

```release-note
NONE
```
