### PR TITLE
stops listing project on an error

### DIFF
--- a/api/pkg/handler/v1/project/project.go
+++ b/api/pkg/handler/v1/project/project.go
@@ -75,13 +75,12 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 					errorList = append(errorList, err.Error())
 					continue
 				}
-				if _, errGetUnsecured := privilegedProjectProvider.GetUnsecured(mapping.Spec.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: true}); errGetUnsecured != nil {
-					if !isStatus(errGetUnsecured, http.StatusNotFound) {
-						// store original error
-						errorList = append(errorList, err.Error())
-					}
-					continue
+				_, errGetUnsecured := privilegedProjectProvider.GetUnsecured(mapping.Spec.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
+				if !isStatus(errGetUnsecured, http.StatusNotFound) {
+					// store original error
+					errorList = append(errorList, err.Error())
 				}
+				continue
 			}
 
 			projectOwners, err := getOwnersForProject(userInfo, projectInternal, memberProvider, userProvider)


### PR DESCRIPTION
**What this PR does / why we need it**: changes in this pull stop further processing in list project EP when a user doesn't belong to the given project.

**Special notes for your reviewer**: it might have caused a nil pointer exception before, as we continued processing even though a project resource had not been filled (permission denied).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
