### PR TITLE
Add more information to events

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3788,10 +3788,8 @@
           "type": "string",
           "x-go-name": "ID"
         },
-        "involvedObjectName": {
-          "description": "The object name that those events are about.",
-          "type": "string",
-          "x-go-name": "InvolvedObjectName"
+        "involvedObject": {
+          "$ref": "#/definitions/ObjectReference"
         },
         "lastTimestamp": {
           "description": "The time at which the most recent occurrence of this event was recorded.",
@@ -4458,6 +4456,28 @@
           "description": "Name represents human readable name for the resource",
           "type": "string",
           "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "ObjectReference": {
+      "type": "object",
+      "title": "ObjectReference contains basic information about referred object.",
+      "properties": {
+        "kind": {
+          "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\n+optional",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
+        "name": {
+          "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\n+optional",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "namespace": {
+          "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/\n+optional",
+          "type": "string",
+          "x-go-name": "Namespace"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -732,15 +732,15 @@ type ObjectReference struct {
 	// Kind of the referent.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
 	// +optional
-	Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
+	Kind string `json:"kind,omitempty"`
 	// Namespace of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 	// +optional
-	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
+	Namespace string `json:"namespace,omitempty"`
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	// +optional
-	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
+	Name string `json:"name,omitempty"`
 }
 
 // KubermaticVersions describes the versions of running Kubermatic components.

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/Masterminds/semver"
+
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	ksemver "github.com/kubermatic/kubermatic/api/pkg/semver"
 
@@ -715,8 +716,8 @@ type Event struct {
 	// Type of this event (i.e. normal or warning). New types could be added in the future.
 	Type string `json:"type,omitempty"`
 
-	// The object name that those events are about.
-	InvolvedObjectName string `json:"involvedObjectName"`
+	// The object reference that those events are about.
+	InvolvedObject ObjectReference `json:"involvedObject"`
 
 	// The time at which the most recent occurrence of this event was recorded.
 	// swagger:strfmt date-time
@@ -724,6 +725,22 @@ type Event struct {
 
 	// The number of times this event has occurred.
 	Count int32 `json:"count,omitempty"`
+}
+
+// ObjectReference contains basic information about referred object.
+type ObjectReference struct {
+	// Kind of the referent.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+	// +optional
+	Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
+	// Namespace of the referent.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+	// +optional
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
+	// Name of the referent.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +optional
+	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
 }
 
 // KubermaticVersions describes the versions of running Kubermatic components.

--- a/api/pkg/handler/v1/common/conversion.go
+++ b/api/pkg/handler/v1/common/conversion.go
@@ -34,11 +34,15 @@ func ConvertInternalEventToExternal(event corev1.Event) apiv1.Event {
 			Name:              event.ObjectMeta.Name,
 			CreationTimestamp: apiv1.NewTime(event.ObjectMeta.CreationTimestamp.Time),
 		},
-		Message:            event.Message,
-		Type:               event.Type,
-		InvolvedObjectName: event.InvolvedObject.Name,
-		LastTimestamp:      apiv1.NewTime(event.LastTimestamp.Time),
-		Count:              event.Count,
+		Message: event.Message,
+		Type:    event.Type,
+		InvolvedObject: apiv1.ObjectReference{
+			Name:      event.InvolvedObject.Name,
+			Namespace: event.InvolvedObject.Namespace,
+			Kind:      event.InvolvedObject.Kind,
+		},
+		LastTimestamp: apiv1.NewTime(event.LastTimestamp.Time),
+		Count:         event.Count,
 	}
 	return result
 }

--- a/api/pkg/handler/v1/node/node_test.go
+++ b/api/pkg/handler/v1/node/node_test.go
@@ -926,7 +926,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObjectName":"testMachine","lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObjectName":"testMachine","lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
 		},
 		// scenario 2
 		{
@@ -948,7 +948,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObjectName":"testMachine","lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
 		},
 		// scenario 3
 		{
@@ -970,7 +970,7 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started"),
 				genTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed"),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObjectName":"testMachine","lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds more information to events, i.e. `Namespace` and `Kind` of an involved object.

Sample API response:
```json
[
  {
    "id": "af8a6c61-59d8-11e9-b670-5a7d004a539b",
    "name": "romantic-franklin-56f66b56fb-vdt4r.15937294eed8bfd8",
    "creationTimestamp": "2019-04-08T08:31:20Z",
    "message": "Successfully created instance",
    "type": "Normal",
    "involvedObject": {
      "kind": "Machine",
      "namespace": "kube-system",
      "name": "romantic-franklin-56f66b56fb-vdt4r"
    },
    "lastTimestamp": "2019-04-08T08:31:20Z",
    "count": 1
  },
  {
    "id": "b0599e76-59d8-11e9-b670-5a7d004a539b",
    "name": "romantic-franklin-56f66b56fb-vdt4r.159372954453515c",
    "creationTimestamp": "2019-04-08T08:31:21Z",
    "message": "Found instance at cloud provider, addresses: [159.89.28.143 10.135.111.31]",
    "type": "Normal",
    "involvedObject": {
      "kind": "Machine",
      "namespace": "kube-system",
      "name": "romantic-franklin-56f66b56fb-vdt4r"
    },
    "lastTimestamp": "2019-04-08T08:34:53Z",
    "count": 12
  }
]
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3140 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```