### PR TITLE
update VPA to 0.5.0

### DIFF
--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -18,6 +18,8 @@ spec:
         app: vpa-recommender
       annotations:
         fluentbit.io/parser: glog
+        kubermatic/scrape: 'true'
+        kubermatic/scrape_port: '8942'
     spec:
       serviceAccountName: vpa-recommender
       containers:
@@ -33,10 +35,14 @@ spec:
           "--storage", "prometheus",
           "--prometheus-address","http://prometheus-kubermatic.monitoring.svc.cluster.local:9090",
           "--prometheus-cadvisor-job-name", "cadvisor-vpa",
+          "--metric-for-pod-labels", "kube_pod_labels",
+          "--pod-namespace-label", "namespace",
+          "--pod-name-label", "pod",
+          "--pod-label-prefix", "label_",
           "--recommendation-margin-fraction", "0",
         ]
         resources:
 {{ toYaml .Values.kubermatic.vpa.recommender.resources | indent 10 }}
         ports:
-        - containerPort: 8080
+        - containerPort: 8942
         {{ end }}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -206,7 +206,7 @@ kubermatic:
     updater:
       image:
         repository: k8s.gcr.io/vpa-updater
-        tag: 0.4.0
+        tag: 0.5.0
       resources:
         requests:
           cpu: 50m
@@ -218,19 +218,19 @@ kubermatic:
     recommender:
       image:
         repository: k8s.gcr.io/vpa-recommender
-        tag: 0.4.0
+        tag: 0.5.0
       resources:
         requests:
           cpu: 50m
-          memory: 500Mi
+          memory: 1000Mi
         limits:
           cpu: 200m
-          memory: 1000Mi
+          memory: 3000Mi
 
     admissioncontroller:
       image:
         repository: k8s.gcr.io/vpa-admission-controller
-        tag: 0.4.0
+        tag: 0.5.0
       resources:
         requests:
           cpu: 50m

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -222,7 +222,7 @@ kubermatic:
       resources:
         requests:
           cpu: 50m
-          memory: 1000Mi
+          memory: 500Mi
         limits:
           cpu: 200m
           memory: 3000Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the VPA to 0.5 and makes it so that Prometheus can scrape it. The update has no effect on the memory usage when it starts up, unfortunately.

In addition to the update, this now also configures the VPA correctly to fetch the pod labels, because there is no `up{job="kubernetes-pods"}` metric in our seeds.

**Release note**:
```release-note
update Vertical Pod Autoscaler to 0.5
```
