### PR TITLE
adds TokenVerifier and TokenExtractor plugins

### DIFF
--- a/api/pkg/handler/auth/plugin.go
+++ b/api/pkg/handler/auth/plugin.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// TokenClaims holds various claims extracted from the id_token
+type TokenClaims struct {
+	Name    string
+	Email   string
+	Subject string
+	Groups  []string
+}
+
+// TokenExtractor is an interface that knows how to extract a token
+type TokenExtractor interface {
+	// Extract gets a token from the given HTTP request
+	Extract(r *http.Request) (string, error)
+}
+
+// TokenVerifier knows how to verify a token
+type TokenVerifier interface {
+	// Verify parses a raw ID Token, verifies it's been signed by the provider, preforms
+	// any additional checks depending on the Config, and returns the payload as TokenClaims.
+	Verify(ctx context.Context, token string) (TokenClaims, error)
+}
+
+var _ TokenVerifier = &TokenVerifierPlugins{}
+
+// TokenVerifierPlugins implements TokenVerifier interface
+// by calling registered plugins for a token verification
+type TokenVerifierPlugins struct {
+	plugins []TokenVerifier
+}
+
+// Verify calls all registered plugins to check the given token.
+// This method stops when a token has been validated and doesn't try remaining plugins.
+// If all plugins were checked an error is returned.
+func (p *TokenVerifierPlugins) Verify(ctx context.Context, token string) (TokenClaims, error) {
+	if len(p.plugins) == 0 {
+		return TokenClaims{}, errors.New("cannot validate the token - no plugins registered")
+	}
+	for _, plugin := range p.plugins {
+		if claims, err := plugin.Verify(ctx, token); err == nil {
+			return claims, err
+		}
+	}
+	return TokenClaims{}, errors.New("unable to verify the given token")
+}
+
+var _ TokenExtractor = &TokenExtractorPlugins{}
+
+// TokenExtractorPlugins implements TokenExtractor
+// by calling registered plugins for a token extraction
+type TokenExtractorPlugins struct {
+	plugins []TokenExtractor
+}
+
+// Extract calls all registered plugins to get a token from the given request.
+// This method stops when a token has been found and doesn't try remaining plugins.
+// If all plugins were checked an error is returned.
+func (p *TokenExtractorPlugins) Extract(r *http.Request) (string, error) {
+	if len(p.plugins) == 0 {
+		return "", errors.New("cannot validate the token - no plugins registered")
+	}
+	for _, plugin := range p.plugins {
+		if token, err := plugin.Extract(r); err == nil {
+			return token, err
+		}
+	}
+	return "", errors.New("unable to verify the given token")
+}

--- a/api/pkg/handler/test/fake_auth.go
+++ b/api/pkg/handler/test/fake_auth.go
@@ -69,8 +69,8 @@ type IssuerVerifier struct {
 }
 
 // Extractor knows how to extract the ID token from the request
-func (o *IssuerVerifier) Extract(_ *http.Request) string {
-	return IDToken
+func (o *IssuerVerifier) Extract(_ *http.Request) (string, error) {
+	return IDToken, nil
 }
 
 // AuthCodeURL returns a URL to OpenID provider's consent page
@@ -107,19 +107,19 @@ func (o *IssuerVerifier) Exchange(ctx context.Context, code string) (auth.OIDCTo
 }
 
 // Verify parses a raw ID Token, verifies it's been signed by the provider, preforms
-// any additional checks depending on the Config, and returns the payload as OIDCClaims.
-func (o *IssuerVerifier) Verify(ctx context.Context, token string) (auth.OIDCClaims, error) {
+// any additional checks depending on the Config, and returns the payload as TokenClaims.
+func (o *IssuerVerifier) Verify(ctx context.Context, token string) (auth.TokenClaims, error) {
 	if o == nil {
-		return auth.OIDCClaims{}, nil
+		return auth.TokenClaims{}, nil
 
 	}
 	if ctx == nil {
-		return auth.OIDCClaims{}, nil
+		return auth.TokenClaims{}, nil
 	}
 	if token != IDToken {
-		return auth.OIDCClaims{}, errors.New("incorrect code")
+		return auth.TokenClaims{}, errors.New("incorrect code")
 	}
-	return auth.OIDCClaims{
+	return auth.TokenClaims{
 		Email:   o.user.Email,
 		Subject: o.user.Email,
 		Name:    o.user.Name,

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -105,7 +105,7 @@ func createInitialNodeDeploymentWithRetries(nodeDeployment *apiv1.NodeDeployment
 			glog.V(6).Infof("retrying creating initial Node Deployments for cluster %s (%s) due to %v", cluster.Name, cluster.Spec.HumanReadableName, err)
 			return false, nil
 		}
-		glog.V(6).Infof("giving up creating initial Node Deployments for cluster %s (%s) due to an unknown err %v", cluster.Name, cluster.Spec.HumanReadableName, err)
+		glog.V(6).Infof("giving up creating initial Node Deployments for cluster %s (%s) due to an unknown err %#v", cluster.Name, cluster.Spec.HumanReadableName, err)
 		return false, err
 	})
 }

--- a/api/pkg/handler/v1/cluster/kubeconfig.go
+++ b/api/pkg/handler/v1/cluster/kubeconfig.go
@@ -55,7 +55,7 @@ func GetAdminKubeconfigEndpoint(projectProvider provider.ProjectProvider) endpoi
 func CreateOIDCKubeconfigEndpoint(projectProvider provider.ProjectProvider, oidcIssuerVerifier auth.OIDCIssuerVerifier, oidcCfg common.OIDCConfiguration) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		oidcIssuer := oidcIssuerVerifier.(auth.OIDCIssuer)
-		oidcVerifier := oidcIssuerVerifier.(auth.OIDCVerifier)
+		oidcVerifier := oidcIssuerVerifier.(auth.TokenVerifier)
 		req := request.(CreateOIDCKubeconfigReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)


### PR DESCRIPTION
**What this PR does / why we need it**: this pull introduces plugins for token extraction and verification as it is needed for service accounts. The plugins are used by middlewares
in order to get and verify tokens from request in a generic way.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #3033 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
