### PR TITLE
double memory request for the kubermatic controller manager deployment

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -81,10 +81,10 @@ kubermatic:
     resources:
       requests:
         cpu: 200m
-        memory: 256Mi
+        memory: 512Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1Gi
   api:
     replicas: 2
     image:


### PR DESCRIPTION
**What this PR does / why we need it**:
Double memory request for the kubermatic controller manager deployment

**Release note**:
```release-note
Double memory request for the Kubermatic controller manager
```
