### PR TITLE
get rid of the name Kubermatic for resources visible to the end user

### DIFF
--- a/addons/kube-proxy/configmap.yaml
+++ b/addons/kube-proxy/configmap.yaml
@@ -20,7 +20,7 @@ data:
     conntrack:
       max: null
       maxPerCore: 0
-      # Following the recommendation from https://github.com/kubermatic/kubermatic/issues/3026#issuecomment-473936154
+      # Following the recommendation from thz #3026
       min: 524288
       tcpCloseWaitTimeout: 15m
       tcpEstablishedTimeout: 2h

--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -14,9 +14,8 @@ spec:
     metadata:
       labels:
         role: openvpn-client
-        kubermatic-revision: "1"
     spec:
-      serviceAccountName: vpn-client-kubermatic
+      serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
         image: kubermatic/openvpn:v0.4

--- a/addons/openvpn/vpn-client-cluster-role-binding.yaml
+++ b/addons/openvpn/vpn-client-cluster-role-binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: vpn-client-kubermatic
+  name: vpn-client
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpn-client-kubermatic
+  name: vpn-client
 subjects:
 - kind: ServiceAccount
-  name: vpn-client-kubermatic
+  name: vpn-client
   namespace: kube-system

--- a/addons/openvpn/vpn-client-cluster-role.yaml
+++ b/addons/openvpn/vpn-client-cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: vpn-client-kubermatic
+  name: vpn-client
   namespace: kube-system
 rules:
 - apiGroups: [""]

--- a/addons/openvpn/vpn-client-serviceaccount.yaml
+++ b/addons/openvpn/vpn-client-serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vpn-client-kubermatic
+  name: vpn-client
   namespace: kube-system

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.4-dev1
+export TAG=v0.2.4
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.3
+export TAG=v0.2.4-dev1
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/api/pkg/provider/cloud/azure/provider.go
+++ b/api/pkg/provider/cloud/azure/provider.go
@@ -19,6 +19,8 @@ import (
 )
 
 const (
+	resourceNamePrefix = "kubernetes-"
+
 	clusterTagKey = "cluster"
 
 	// FinalizerSecurityGroup will instruct the deletion of the security group
@@ -485,7 +487,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 	location := dc.Spec.Azure.Location
 
 	if cluster.Spec.Cloud.Azure.ResourceGroup == "" {
-		cluster.Spec.Cloud.Azure.ResourceGroup = "cluster-" + cluster.Name
+		cluster.Spec.Cloud.Azure.ResourceGroup = resourceNamePrefix + cluster.Name
 
 		glog.Infof("cluster %q: ensuring resource group %q", cluster.Name, cluster.Spec.Cloud.Azure.ResourceGroup)
 		if err = ensureResourceGroup(cluster.Spec.Cloud, location, cluster.Name); err != nil {
@@ -502,7 +504,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 	}
 
 	if cluster.Spec.Cloud.Azure.VNetName == "" {
-		cluster.Spec.Cloud.Azure.VNetName = "cluster-" + cluster.Name
+		cluster.Spec.Cloud.Azure.VNetName = resourceNamePrefix + cluster.Name
 
 		glog.Infof("cluster %q: ensuring vnet %q", cluster.Name, cluster.Spec.Cloud.Azure.VNetName)
 		if err = ensureVNet(cluster.Spec.Cloud, location, cluster.Name); err != nil {
@@ -519,7 +521,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 	}
 
 	if cluster.Spec.Cloud.Azure.SubnetName == "" {
-		cluster.Spec.Cloud.Azure.SubnetName = "cluster-" + cluster.Name
+		cluster.Spec.Cloud.Azure.SubnetName = resourceNamePrefix + cluster.Name
 
 		glog.Infof("cluster %q: ensuring subnet %q", cluster.Name, cluster.Spec.Cloud.Azure.SubnetName)
 		if err = ensureSubnet(cluster.Spec.Cloud); err != nil {
@@ -536,7 +538,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 	}
 
 	if cluster.Spec.Cloud.Azure.RouteTableName == "" {
-		cluster.Spec.Cloud.Azure.RouteTableName = "cluster-" + cluster.Name
+		cluster.Spec.Cloud.Azure.RouteTableName = resourceNamePrefix + cluster.Name
 
 		glog.Infof("cluster %q: ensuring route table %q", cluster.Name, cluster.Spec.Cloud.Azure.RouteTableName)
 		if err = ensureRouteTable(cluster.Spec.Cloud, location); err != nil {
@@ -553,7 +555,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 	}
 
 	if cluster.Spec.Cloud.Azure.SecurityGroup == "" {
-		cluster.Spec.Cloud.Azure.SecurityGroup = "cluster-" + cluster.Name
+		cluster.Spec.Cloud.Azure.SecurityGroup = resourceNamePrefix + cluster.Name
 
 		glog.Infof("cluster %q: ensuring security group %q", cluster.Name, cluster.Spec.Cloud.Azure.SecurityGroup)
 		if err = ensureSecurityGroup(cluster.Spec.Cloud, location, cluster.Name); err != nil {
@@ -570,7 +572,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 	}
 
 	if cluster.Spec.Cloud.Azure.AvailabilitySet == "" {
-		asName := "cluster-" + cluster.Name
+		asName := resourceNamePrefix + cluster.Name
 		glog.Infof("cluster %q: ensuring AvailabilitySet %q", cluster.Name, asName)
 
 		if err := ensureAvailabilitySet(asName, location, cluster.Spec.Cloud); err != nil {

--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -27,7 +27,7 @@ const (
 	subnetFirstAddress = "192.168.1.2"
 	subnetLastAddress  = "192.168.1.254"
 
-	kubermaticNamePrefix = "kubermatic-"
+	resourceNamePrefix = "kubernetes-"
 )
 
 var (
@@ -155,7 +155,7 @@ func deleteSecurityGroup(netClient *gophercloud.ServiceClient, sgName string) er
 
 func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, clusterName string) (*ossecuritygroups.SecGroup, error) {
 	gres := ossecuritygroups.Create(netClient, ossecuritygroups.CreateOpts{
-		Name:        kubermaticNamePrefix + clusterName,
+		Name:        resourceNamePrefix + clusterName,
 		Description: "Contains security rules for the kubermatic worker nodes",
 	})
 	if gres.Err != nil {
@@ -218,7 +218,7 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 func createKubermaticNetwork(netClient *gophercloud.ServiceClient, clusterName string) (*osnetworks.Network, error) {
 	iTrue := true
 	res := osnetworks.Create(netClient, osnetworks.CreateOpts{
-		Name:         kubermaticNamePrefix + clusterName,
+		Name:         resourceNamePrefix + clusterName,
 		AdminStateUp: &iTrue,
 	})
 	if res.Err != nil {
@@ -259,7 +259,7 @@ func deleteRouter(netClient *gophercloud.ServiceClient, routerID string) error {
 func createKubermaticSubnet(netClient *gophercloud.ServiceClient, clusterName, networkID string, dnsServers []string) (*ossubnets.Subnet, error) {
 	iTrue := true
 	res := ossubnets.Create(netClient, ossubnets.CreateOpts{
-		Name:       kubermaticNamePrefix + clusterName,
+		Name:       resourceNamePrefix + clusterName,
 		NetworkID:  networkID,
 		IPVersion:  gophercloud.IPv4,
 		CIDR:       subnetCIDR,
@@ -291,7 +291,7 @@ func createKubermaticRouter(netClient *gophercloud.ServiceClient, clusterName, e
 	}
 
 	res := osrouters.Create(netClient, osrouters.CreateOpts{
-		Name:         kubermaticNamePrefix + clusterName,
+		Name:         resourceNamePrefix + clusterName,
 		AdminStateUp: &iTrue,
 		GatewayInfo:  &gwi,
 	})

--- a/api/pkg/resources/machine/machine.go
+++ b/api/pkg/resources/machine/machine.go
@@ -2,14 +2,12 @@ package machine
 
 import (
 	"errors"
-	"fmt"
-
-	"github.com/kubermatic/kubermatic/api/pkg/validation"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/cloudconfig"
+	"github.com/kubermatic/kubermatic/api/pkg/validation"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +21,7 @@ func Machine(c *kubermaticv1.Cluster, node *apiv1.Node, dc provider.DatacenterMe
 	m := clusterv1alpha1.Machine{}
 
 	m.Namespace = metav1.NamespaceSystem
-	m.GenerateName = fmt.Sprintf("machine-kubermatic-%s-", c.Name)
+	m.GenerateName = "worker-"
 
 	m.Spec.Versions.Kubelet = node.Spec.Versions.Kubelet
 

--- a/api/pkg/resources/machine/machinedeployment.go
+++ b/api/pkg/resources/machine/machinedeployment.go
@@ -30,7 +30,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc provider.D
 	} else {
 		// GenerateName can be set only if Name is empty to avoid confusing error:
 		// https://github.com/kubernetes/kubernetes/issues/32220
-		md.GenerateName = fmt.Sprintf("kubermatic-%s-", c.Name)
+		md.GenerateName = "worker-"
 	}
 
 	md.Namespace = metav1.NamespaceSystem
@@ -45,6 +45,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc provider.D
 	md.Spec.Template.Spec.Versions.Kubelet = nd.Spec.Template.Versions.Kubelet
 
 	if len(c.Spec.MachineNetworks) > 0 {
+		// TODO(mrIncompetent): Rename this finalizer to not contain the word "kubermatic" (For whitelabeling purpose)
 		md.Spec.Template.Annotations = map[string]string{
 			"machine-controller.kubermatic.io/initializers": "ipam",
 		}

--- a/api/pkg/resources/test/fixtures/machine-aws.yaml
+++ b/api/pkg/resources/test/fixtures/machine-aws.yaml
@@ -1,6 +1,6 @@
 metadata:
   creationTimestamp: null
-  generateName: machine-kubermatic-awscluster-1a2b3c4d5e-
+  generateName: worker-
   namespace: kube-system
 spec:
   metadata:

--- a/api/pkg/resources/test/fixtures/machine-azure.yaml
+++ b/api/pkg/resources/test/fixtures/machine-azure.yaml
@@ -1,6 +1,6 @@
 metadata:
   creationTimestamp: null
-  generateName: machine-kubermatic-azurecluster-1a2b3c4d5e-
+  generateName: worker-
   namespace: kube-system
 spec:
   metadata:

--- a/api/pkg/resources/test/fixtures/machine-digitalocean.yaml
+++ b/api/pkg/resources/test/fixtures/machine-digitalocean.yaml
@@ -1,6 +1,6 @@
 metadata:
   creationTimestamp: null
-  generateName: machine-kubermatic-docluster-1a2b3c4d5e-
+  generateName: worker-
   namespace: kube-system
 spec:
   metadata:

--- a/api/pkg/resources/test/fixtures/machine-hetzner.yaml
+++ b/api/pkg/resources/test/fixtures/machine-hetzner.yaml
@@ -1,6 +1,6 @@
 metadata:
   creationTimestamp: null
-  generateName: machine-kubermatic-hetznercluster-1a2b3c4d5e-
+  generateName: worker-
   namespace: kube-system
 spec:
   metadata:

--- a/api/pkg/resources/test/fixtures/machine-openstack.yaml
+++ b/api/pkg/resources/test/fixtures/machine-openstack.yaml
@@ -1,6 +1,6 @@
 metadata:
   creationTimestamp: null
-  generateName: machine-kubermatic-openstackcluster-1a2b3c4d5e-
+  generateName: worker-
   namespace: kube-system
 spec:
   metadata:

--- a/api/pkg/resources/test/fixtures/machine-vsphere.yaml
+++ b/api/pkg/resources/test/fixtures/machine-vsphere.yaml
@@ -1,6 +1,6 @@
 metadata:
   creationTimestamp: null
-  generateName: machine-kubermatic-vsphere-1a2b3c4d5e-
+  generateName: worker-
   namespace: kube-system
 spec:
   metadata:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -66,7 +66,7 @@ kubermatic:
         - node-exporter
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.4-dev1"
+          tag: "v0.2.4"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image
@@ -76,7 +76,7 @@ kubermatic:
         - rbac
         image:
           repository: "quay.io/kubermatic/openshift-addons"
-          tag: "v0.6-dev1"
+          tag: "v0.6"
           pullPolicy: "IfNotPresent"
     resources:
       requests:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -66,7 +66,7 @@ kubermatic:
         - node-exporter
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.3"
+          tag: "v0.2.4-dev1"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image
@@ -76,7 +76,7 @@ kubermatic:
         - rbac
         image:
           repository: "quay.io/kubermatic/openshift-addons"
-          tag: "v0.5"
+          tag: "v0.6-dev1"
           pullPolicy: "IfNotPresent"
     resources:
       requests:

--- a/openshift_addons/openvpn/openvpn-client-dep.yaml
+++ b/openshift_addons/openvpn/openvpn-client-dep.yaml
@@ -14,9 +14,8 @@ spec:
     metadata:
       labels:
         role: openvpn-client
-        kubermatic-revision: "1"
     spec:
-      serviceAccountName: vpn-client-kubermatic
+      serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
         image: kubermatic/openvpn:v0.4

--- a/openshift_addons/openvpn/vpn-client-cluster-role-binding.yaml
+++ b/openshift_addons/openvpn/vpn-client-cluster-role-binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: vpn-client-kubermatic
+  name: vpn-client
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpn-client-kubermatic
+  name: vpn-client
 subjects:
 - kind: ServiceAccount
-  name: vpn-client-kubermatic
+  name: vpn-client
   namespace: kube-system

--- a/openshift_addons/openvpn/vpn-client-cluster-role.yaml
+++ b/openshift_addons/openvpn/vpn-client-cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: vpn-client-kubermatic
+  name: vpn-client
   namespace: kube-system
 rules:
 - apiGroups: [""]

--- a/openshift_addons/openvpn/vpn-client-serviceaccount.yaml
+++ b/openshift_addons/openvpn/vpn-client-serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vpn-client-kubermatic
+  name: vpn-client
   namespace: kube-system

--- a/openshift_addons/release.sh
+++ b/openshift_addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.6-dev1
+export TAG=v0.6
 
 docker build -t quay.io/kubermatic/openshift-addons:${TAG} .
 docker push quay.io/kubermatic/openshift-addons:${TAG}

--- a/openshift_addons/release.sh
+++ b/openshift_addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.5
+export TAG=v0.6-dev1
 
 docker build -t quay.io/kubermatic/openshift-addons:${TAG} .
 docker push quay.io/kubermatic/openshift-addons:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the name "kubermatic" from all resources visible by end users.

Fixes #2533

**Release note**:
```release-note
Avoid the name "kubermatic" for resources visible by end users
```
