### PR TITLE
make Kubermatic controller-manager resources configurable

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -131,12 +131,7 @@ spec:
               readOnly: true
             {{- end }}
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "200m"
-            limits:
-              memory: "256Mi"
-              cpu: "500m"
+{{ toYaml .Values.kubermatic.controller.resources | indent 12 }}
       imagePullSecrets:
         - name: dockercfg
       tolerations:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -64,6 +64,13 @@ kubermatic:
       - rbac
       - kubelet-configmap
       - default-storage-class
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
   api:
     replicas: 2
     image:


### PR DESCRIPTION
**What this PR does / why we need it**:
This increases the resource requirements for the controller-manager and makes them configurable via values.yaml. The increase comes from #3149.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3156

**Release note**:
```release-note
adjust Kubermatic controller-manager resource constraints for mid- to large-size clusters
```
