### PR TITLE
bring back nginx.ignoreMasterTaint flag

### DIFF
--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -81,7 +81,17 @@ spec:
         resources:
 {{ toYaml .Values.nginx.resources | indent 10 }}
       tolerations:
+        {{- if .Values.nginx.ignoreMasterTaint }}
+        - key: dedicated
+          operator: Equal
+          value: master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        {{- end }}
+        {{- if or .Values.nginx.tolerations (not .Values.nginx.ignoreMasterTaint) }}
 {{ toYaml .Values.nginx.tolerations | indent 8 }}
+        {{- end }}
       nodeSelector:
 {{ toYaml .Values.nginx.nodeSelector | indent 8 }}
 {{ if not .Values.nginx.asDaemonSet }}

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -30,9 +30,9 @@ nginx:
     operator: Equal
     value: "true"
     effect: NoSchedule
-  # - key: dedicated
-  #   operator: Equal
-  #   value: master
-  #   effect: NoSchedule
-  # - key: node-role.kubernetes.io/master
-  #   effect: NoSchedule
+
+  # set this to true to automatically add these tolerations
+  # to make nginx run on master nodes:
+  #   - { key: dedicated, operator: Equal, value: master, effect: NoSchedule }
+  #   - { key: node-role.kubernetes.io/master, effect: NoSchedule }
+  ignoreMasterTaint: false


### PR DESCRIPTION
**What this PR does / why we need it**:
The original intent behind removing the flag was to have one single way of configuring tolerations, but apparently moving the tolerations into the values.yamls of the seed clusters is not a good thing(tm).

**Which issue(s) this PR fixes**:
Fixes #3165

**Release note**:
```release-note
NONE
```
