### PR TITLE
pass through ami from datacenters.yaml

### DIFF
--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -79,9 +79,9 @@ type VSphereSpec struct {
 
 // AWSSpec describes a aws datacenter
 type AWSSpec struct {
-	Region        string `yaml:"region"`
-	AMI           string `yaml:"ami"`
-	ZoneCharacter string `yaml:"zone_character"`
+	Region        string    `yaml:"region"`
+	Images        ImageList `yaml:"images"`
+	ZoneCharacter string    `yaml:"zone_character"`
 }
 
 // BringYourOwnSpec describes a datacenter our of bring your own nodes

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	ksemver "github.com/kubermatic/kubermatic/api/pkg/semver"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -174,7 +175,11 @@ func TestLoadFiles(t *testing.T) {
 				RootPath:      "vs-cluster",
 			},
 			AWS: &provider.AWSSpec{
-				AMI:           "ami-aujakj",
+				Images: provider.ImageList{
+					providerconfig.OperatingSystemUbuntu: "ubuntu-ami",
+					providerconfig.OperatingSystemCentOS: "centos-ami",
+					providerconfig.OperatingSystemCoreos: "coreos-ami",
+				},
 				Region:        "us-central1",
 				ZoneCharacter: "a",
 			},
@@ -799,8 +804,12 @@ func TestExecute(t *testing.T) {
 					Country:  "DE",
 					Spec: provider.DatacenterSpec{
 						AWS: &provider.AWSSpec{
-							Region:        "fra1",
-							AMI:           "aws-ami",
+							Region: "fra1",
+							Images: provider.ImageList{
+								providerconfig.OperatingSystemUbuntu: "ubuntu-ami",
+								providerconfig.OperatingSystemCentOS: "centos-ami",
+								providerconfig.OperatingSystemCoreos: "coreos-ami",
+							},
 							ZoneCharacter: "aws-zone-character",
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #3168

**Release note**:
```release-note
Make the default AMI's for AWS instances configurable via the datacenters.yaml
```
