### PR TITLE
Openshiftcontroller: Handle all Deployments, PDBs and CronJobs

### DIFF
--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -88,8 +88,10 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 	}
 
 	// check that all PodDisruptionBudgets are created
-	if err := r.ensurePodDisruptionBudgets(cluster, data); err != nil {
-		return err
+	if cluster.Annotations["kubermatic.io/openshift"] == "" {
+		if err := r.ensurePodDisruptionBudgets(cluster, data); err != nil {
+			return err
+		}
 	}
 
 	// check that all StatefulSets are created

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -81,8 +81,10 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 	}
 
 	// check that all CronJobs are created
-	if err := r.ensureCronJobs(cluster, data); err != nil {
-		return err
+	if cluster.Annotations["kubermatic.io/openshift"] == "" {
+		if err := r.ensureCronJobs(cluster, data); err != nil {
+			return err
+		}
 	}
 
 	// check that all PodDisruptionBudgets are created

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -434,6 +434,8 @@ func (r *Reconciler) getAllDeploymentCreators(ctx context.Context, osData *opens
 	return []reconciling.NamedDeploymentCreatorGetter{openshiftresources.APIDeploymentCreator(ctx, osData),
 		openshiftresources.ControllerManagerDeploymentCreator(ctx, osData),
 		openshiftresources.MachineController(osData),
+		openvpn.DeploymentCreator(osData),
+		dns.DeploymentCreator(osData),
 		machinecontroller.WebhookDeploymentCreator(osData),
 		usercluster.DeploymentCreator(osData, true)}
 }

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -219,6 +220,10 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 
 	if err := r.cronJobs(ctx, osData); err != nil {
 		return nil, fmt.Errorf("failed to reconcile CronJobs: %v", err)
+	}
+
+	if err := r.podDisruptionBudgets(ctx, osData); err != nil {
+		return nil, fmt.Errorf("failed to reconcile PodDisruptionBudgets: %v", err)
 	}
 
 	if err := r.syncHeath(ctx, osData); err != nil {
@@ -468,6 +473,27 @@ func (r *Reconciler) cronJobs(ctx context.Context, osData *openshiftData) error 
 		if err := reconciling.EnsureNamedObjectV2(ctx,
 			nn(osData.Cluster().Status.NamespaceName, cronJobName), reconciling.CronJobObjectWrapper(cronJobCreator), r.Client, &batchv1beta1.CronJob{}); err != nil {
 			return fmt.Errorf("failed to ensure CronJob %q: %v", cronJobName, err)
+		}
+	}
+	return nil
+}
+
+func GetPodDisruptionBudgetCreators(osData *openshiftData) []reconciling.NamedPodDisruptionBudgetCreatorGetter {
+	return []reconciling.NamedPodDisruptionBudgetCreatorGetter{
+		etcd.PodDisruptionBudgetCreator(osData),
+		apiserver.PodDisruptionBudgetCreator(),
+	}
+}
+
+func (r *Reconciler) podDisruptionBudgets(ctx context.Context, osData *openshiftData) error {
+	for _, podDisruptionBudgetCreator := range GetPodDisruptionBudgetCreators(osData) {
+		pdbName, pdbCreator := podDisruptionBudgetCreator()
+		if err := reconciling.EnsureNamedObjectV2(ctx,
+			nn(osData.Cluster().Status.NamespaceName, pdbName),
+			reconciling.PodDisruptionBudgetObjectWrapper(pdbCreator),
+			r.Client,
+			&policyv1beta1.PodDisruptionBudget{}); err != nil {
+			return fmt.Errorf("failed to ensure PodDisruptionBudget %q: %v", pdbName, err)
 		}
 	}
 	return nil

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -48,8 +48,14 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 	}
 }
 
+type deploymentCreatorData interface {
+	Cluster() *kubermaticv1.Cluster
+	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
+	ImageRegistry(string) string
+}
+
 // DeploymentCreator returns the function to create and update the DNS resolver deployment
-func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.DNSResolverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.DNSResolverDeploymentName

--- a/api/pkg/resources/etcd/pdb.go
+++ b/api/pkg/resources/etcd/pdb.go
@@ -4,13 +4,18 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+type pdbData interface {
+	Cluster() *kubermaticv1.Cluster
+}
+
 // PodDisruptionBudgetCreator returns a func to create/update the etcd PodDisruptionBudget
-func PodDisruptionBudgetCreator(data *resources.TemplateData) reconciling.NamedPodDisruptionBudgetCreatorGetter {
+func PodDisruptionBudgetCreator(data pdbData) reconciling.NamedPodDisruptionBudgetCreatorGetter {
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return resources.EtcdPodDisruptionBudgetName, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
 			minAvailable := intstr.FromInt((resources.EtcdClusterSize / 2) + 1)

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
@@ -42,8 +43,15 @@ const (
 	name = "openvpn-server"
 )
 
+type openVPNDeploymentCreatorData interface {
+	Cluster() *kubermaticv1.Cluster
+	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
+	NodeAccessNetwork() string
+	ImageRegistry(string) string
+}
+
 // DeploymentCreator returns the function to create and update the openvpn server deployment
-func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(data openVPNDeploymentCreatorData) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.OpenVPNServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.OpenVPNServerDeploymentName


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the Openshiftcontroller handle all deployments, PDBs and Cronjobs. I've omitted VPAs for now, because #3173 changes the handling and I don't want to have merge conflicts for either PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Works towards fixing #3117 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 