### PR TITLE
fix mc in util Docker image

### DIFF
--- a/config/kubermatic/templates/hook-migration-crd-check.yaml
+++ b/config/kubermatic/templates/hook-migration-crd-check.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: kubermatic
       containers:
       - name: check-crd-migration
-        image: "quay.io/kubermatic/util:1.0.0-1"
+        image: "quay.io/kubermatic/util:1.0.0-2"
         command: ["/bin/bash"]
         args:
         - "-c"

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -16,7 +16,7 @@ logging:
     setupContainer:
       image:
         repository: quay.io/kubermatic/util
-        tag: 1.0.0-1
+        tag: 1.0.0-2
         pullPolicy: IfNotPresent
       resources:
         requests:

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -11,7 +11,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.0.0-1
+      tag: 1.0.0-2
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -7,7 +7,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.0.0-1
+      tag: 1.0.0-2
 
   # Specify additional external labels which will be added to all
   # alerts sent by Prometheus.

--- a/containers/util/Dockerfile
+++ b/containers/util/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 
-ENV MC_VERSION=RELEASE.2019-04-03T17-59-57Z \
+ENV MC_VERSION=RELEASE.2019-04-10T22-11-28Z \
     KUBECTL_VERSION=v1.14.1 \
     HELM_VERSION=v2.13.1 \
     VAULT_VERSION=0.11.6
@@ -13,7 +13,7 @@ RUN apk add --no-cache -U \
     rsync \
     unzip
 
-RUN curl -Lo /usr/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/mc.${MC_VERSION} && \
+RUN curl -Lo /usr/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} && \
     chmod +x /usr/bin/mc
 
 RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \

--- a/containers/util/release.sh
+++ b/containers/util/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-NUMBER=1
+NUMBER=2
 VERSION=1.0.0
 
 set -euox pipefail


### PR DESCRIPTION
**What this PR does / why we need it**:
Only the most recent version of mc is available in the top-level directory. This new URL is stable and works for current and older releases.

**Release note**:
```release-note
NONE
```
