### PR TITLE
fix envoy CLI args

### DIFF
--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -53,9 +53,12 @@ spec:
         command:
         - /usr/local/bin/envoy
         args:
-        - "-c=/etc/envoy/envoy.yaml"
-        - "--service-cluster=cluster0"
-        - "--service-node=kube"
+        - "-c"
+        - "/etc/envoy/envoy.yaml"
+        - "--service-cluster"
+        - "cluster0"
+        - "--service-node"
+        - "kube"
         - "--v2-config-only"
         lifecycle:
           preStop:


### PR DESCRIPTION
**What this PR does / why we need it**:
envoy cannot parse foo=bar CLI flags

**Release note**:
```release-note
NONE
```
