### PR TITLE
removes "serviceaccount-" prefix when returning sa api object

### DIFF
--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -690,7 +690,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		{
 			Name:                   "scenario 3: unable to create a cluster when the user doesn't belong to the project",
 			Body:                   `{"cluster":{"humanReadableName":"keen-snyder","version":"1.9.7","pause":false,"cloud":{"digitalocean":{},"dc":"do-fra1"}},"sshKeys":["key-c08aa5c7abf34504f18552846485267d-yafn"]}`,
-			ExpectedResponse:       `{"error":{"code":403,"message":"forbidden: The user \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
+			ExpectedResponse:       `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
 			HTTPStatus:             http.StatusForbidden,
 			ProjectToSync:          test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenUser("", "John", "john@acme.com")),

--- a/api/pkg/handler/v1/project/project_test.go
+++ b/api/pkg/handler/v1/project/project_test.go
@@ -114,7 +114,7 @@ func TestRenameProjectEndpoint(t *testing.T) {
 				test.GenDefaultOwnerBinding(),
 			},
 			ExistingAPIUser:  *test.GenDefaultAPIUser(),
-			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: The user \"bob@acme.com\" doesn't belong to the given project = some-ID"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't belong to the given project = some-ID"}}`,
 		},
 		{
 			Name:            "scenario 5: rename a project with empty name",

--- a/api/pkg/handler/v1/serviceaccount/sa.go
+++ b/api/pkg/handler/v1/serviceaccount/sa.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
+	"net/http"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
@@ -158,11 +157,12 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, serviceAccountProv
 			sa.Labels[serviceaccount.ServiceAccountLabelGroup] = newGroup
 		}
 
-		if _, err := serviceAccountProvider.Update(userInfo, sa); err != nil {
+		updatedSA, err := serviceAccountProvider.Update(userInfo, sa)
+		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		result := convertInternalServiceAccountToExternal(sa)
+		result := convertInternalServiceAccountToExternal(updatedSA)
 		result.Group = newGroup
 		return result, nil
 	}

--- a/api/pkg/handler/v1/serviceaccount/sa_test.go
+++ b/api/pkg/handler/v1/serviceaccount/sa_test.go
@@ -135,7 +135,7 @@ func TestCreateServiceAccountProject(t *testing.T) {
 					t.Fatalf("expected Inactive state got %s", sa.Status)
 				}
 
-				expectedSA, err := client.FakeKubermaticClient.KubermaticV1().Users().Get(sa.ID, metav1.GetOptions{})
+				expectedSA, err := client.FakeKubermaticClient.KubermaticV1().Users().Get(fmt.Sprintf("serviceaccount-%s", sa.ID), metav1.GetOptions{})
 				if err != nil {
 					t.Fatalf("expected SA object got error %v", err)
 				}
@@ -184,7 +184,7 @@ func TestList(t *testing.T) {
 			expectedSA: []apiv1.ServiceAccount{
 				{
 					ObjectMeta: apiv1.ObjectMeta{
-						ID:   "serviceaccount-1",
+						ID:   "1",
 						Name: "test-1",
 					},
 					Group:  "editors-plan9-ID",
@@ -192,7 +192,7 @@ func TestList(t *testing.T) {
 				},
 				{
 					ObjectMeta: apiv1.ObjectMeta{
-						ID:   "serviceaccount-3",
+						ID:   "3",
 						Name: "test-3",
 					},
 					Group:  "viewers-plan9-ID",
@@ -220,7 +220,7 @@ func TestList(t *testing.T) {
 			expectedSA: []apiv1.ServiceAccount{
 				{
 					ObjectMeta: apiv1.ObjectMeta{
-						ID:   "serviceaccount-1",
+						ID:   "1",
 						Name: "test-1",
 					},
 					Group:  "editors-plan9-ID",
@@ -228,7 +228,7 @@ func TestList(t *testing.T) {
 				},
 				{
 					ObjectMeta: apiv1.ObjectMeta{
-						ID:   "serviceaccount-3",
+						ID:   "3",
 						Name: "test-3",
 					},
 					Group:  "viewers-plan9-ID",
@@ -281,14 +281,13 @@ func TestEdit(t *testing.T) {
 		expectedSAName         string
 		projectToSync          string
 		saToUpdate             string
-		bindingName            string
 		httpStatus             int
 		existingAPIUser        apiv1.User
 		existingKubermaticObjs []runtime.Object
 	}{
 		{
 			name:       "scenario 1: update service account, change name and group",
-			body:       `{"id":"serviceaccount-1", "name":"newName", "group":"editors"}`,
+			body:       `{"id":"19840801", "name":"newName", "group":"editors"}`,
 			httpStatus: http.StatusOK,
 			existingKubermaticObjs: []runtime.Object{
 				/*add projects*/
@@ -298,22 +297,21 @@ func TestEdit(t *testing.T) {
 				/*add bindings*/
 				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
 				test.GenBinding("my-third-project-ID", "john@acme.com", "editors"),
-				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "viewers"),
+				test.GenBinding("plan9-ID", "serviceaccount-19840801@sa.kubermatic.io", "viewers"),
 				/*add users*/
 				test.GenUser("", "john", "john@acme.com"),
 				/*add service account*/
-				genActiveServiceAccount("1", "test", "viewers", "plan9-ID"),
+				genActiveServiceAccount("19840801", "test", "viewers", "plan9-ID"),
 			},
 			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
 			projectToSync:   "plan9-ID",
 			expectedSAName:  "newName",
 			expectedGroup:   "editors-plan9-ID",
-			saToUpdate:      "serviceaccount-1",
-			bindingName:     "plan9-ID-serviceaccount-1@sa.kubermatic.io-viewers",
+			saToUpdate:      "19840801",
 		},
 		{
 			name:       "scenario 2: change service account name for already existing in project",
-			body:       `{"id":"serviceaccount-1", "name":"test-2", "group":"viewers"}`,
+			body:       `{"id":"19840801", "name":"test-2", "group":"viewers"}`,
 			httpStatus: http.StatusConflict,
 			existingKubermaticObjs: []runtime.Object{
 				/*add projects*/
@@ -325,12 +323,12 @@ func TestEdit(t *testing.T) {
 				/*add users*/
 				test.GenUser("", "john", "john@acme.com"),
 				/*add service account*/
-				genActiveServiceAccount("1", "test-1", "viewers", "plan9-ID"),
+				genActiveServiceAccount("19840801", "test-1", "viewers", "plan9-ID"),
 				genActiveServiceAccount("2", "test-2", "viewers", "plan9-ID"),
 			},
 			existingAPIUser:       *test.GenAPIUser("john", "john@acme.com"),
 			projectToSync:         "plan9-ID",
-			saToUpdate:            "serviceaccount-1",
+			saToUpdate:            "19840801",
 			expectedErrorResponse: `{"error":{"code":409,"message":"service account \"test-2\" already exists"}}`,
 		},
 	}
@@ -363,7 +361,7 @@ func TestEdit(t *testing.T) {
 					t.Fatalf("expected name %s got %s", tc.expectedSAName, sa.Name)
 				}
 
-				expectedSA, err := client.FakeKubermaticClient.KubermaticV1().Users().Get(sa.ID, metav1.GetOptions{})
+				expectedSA, err := client.FakeKubermaticClient.KubermaticV1().Users().Get(fmt.Sprintf("serviceaccount-%s", sa.ID), metav1.GetOptions{})
 				if err != nil {
 					t.Fatalf("expected SA object got error %v", err)
 				}
@@ -413,9 +411,9 @@ func TestDelete(t *testing.T) {
 				test.GenDefaultOwnerBinding(),
 				test.GenBinding("my-first-project-ID", "serviceaccount-1@sa.kubermatic.io", "viewers"),
 				/*add service account*/
-				genActiveServiceAccount("1", "test", "viewers", "my-first-project-ID"),
+				genActiveServiceAccount("19840801", "test", "viewers", "my-first-project-ID"),
 			},
-			saToDelete: "serviceaccount-1",
+			saToDelete: "19840801",
 		},
 	}
 	for _, tc := range testcases {

--- a/api/pkg/handler/v1/serviceaccount/token_test.go
+++ b/api/pkg/handler/v1/serviceaccount/token_test.go
@@ -51,7 +51,7 @@ func TestCreateTokenProject(t *testing.T) {
 			existingKubernetesObjs: []runtime.Object{},
 			existingAPIUser:        *test.GenAPIUser("john", "john@acme.com"),
 			projectToSync:          "plan9-ID",
-			saToSync:               "serviceaccount-1",
+			saToSync:               "1",
 			expectedName:           "test",
 		},
 		{
@@ -76,7 +76,7 @@ func TestCreateTokenProject(t *testing.T) {
 			},
 			existingAPIUser:       *test.GenAPIUser("john", "john@acme.com"),
 			projectToSync:         "plan9-ID",
-			saToSync:              "serviceaccount-1",
+			saToSync:              "1",
 			expectedErrorResponse: `{"error":{"code":409,"message":"token \"test\" already exists"}}`,
 		},
 	}
@@ -120,7 +120,7 @@ func TestCreateTokenProject(t *testing.T) {
 				if saTokenClaim.ProjectID != tc.projectToSync {
 					t.Fatalf("expected project name %s got %s", tc.projectToSync, saTokenClaim.ProjectID)
 				}
-				if saTokenClaim.Email != fmt.Sprintf("%s@sa.kubermatic.io", tc.saToSync) {
+				if saTokenClaim.Email != fmt.Sprintf("serviceaccount-%s@sa.kubermatic.io", tc.saToSync) {
 					t.Fatalf("expected email %s@sa.kubermatic.io got %s", tc.saToSync, saTokenClaim.Email)
 				}
 			}

--- a/api/pkg/handler/v1/user/user_test.go
+++ b/api/pkg/handler/v1/user/user_test.go
@@ -131,7 +131,7 @@ func TestGetUsersForProject(t *testing.T) {
 				genDefaultUser(), /*bob*/
 			},
 			ExistingAPIUser:        *genAPIUser("alice2", "alice2@acme.com"),
-			ExpectedResponseString: `{"error":{"code":403,"message":"forbidden: The user \"alice2@acme.com\" doesn't belong to the given project = foo2InternalName"}}`,
+			ExpectedResponseString: `{"error":{"code":403,"message":"forbidden: \"alice2@acme.com\" doesn't belong to the given project = foo2InternalName"}}`,
 		},
 	}
 

--- a/api/pkg/provider/kubernetes/member.go
+++ b/api/pkg/provider/kubernetes/member.go
@@ -179,7 +179,7 @@ func (p *ProjectMemberProvider) MapUserToGroup(userEmail string, projectID strin
 		}
 	}
 
-	return "", kerrors.NewForbidden(schema.GroupResource{}, projectID, fmt.Errorf("The user %q doesn't belong to the given project = %s", userEmail, projectID))
+	return "", kerrors.NewForbidden(schema.GroupResource{}, projectID, fmt.Errorf("%q doesn't belong to the given project = %s", userEmail, projectID))
 }
 
 // MappingsFor returns the list of projects (bindings) for the given user

--- a/api/pkg/provider/kubernetes/sa_token.go
+++ b/api/pkg/provider/kubernetes/sa_token.go
@@ -93,9 +93,15 @@ func (p *ServiceAccountTokenProvider) List(userInfo *provider.UserInfo, project 
 	if project == nil {
 		return nil, kerrors.NewBadRequest("project cannot be nil")
 	}
+	if sa == nil {
+		return nil, kerrors.NewBadRequest("sa cannot be nil")
+	}
 	if options == nil {
 		options = &provider.ServiceAccountTokenListOptions{}
 	}
+	saCopy := *sa
+	saCopy.Name = addSAPrefix(saCopy.Name)
+
 	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", kubermaticv1.ProjectIDLabelKey, project.Name))
 	if err != nil {
 		return nil, err
@@ -110,7 +116,7 @@ func (p *ServiceAccountTokenProvider) List(userInfo *provider.UserInfo, project 
 		if strings.HasPrefix(secret.Name, "sa-token") {
 			for _, owner := range secret.GetOwnerReferences() {
 				if owner.APIVersion == kubermaticv1.SchemeGroupVersion.String() && owner.Kind == kubermaticv1.UserKindName &&
-					owner.Name == sa.Name && owner.UID == sa.UID {
+					owner.Name == saCopy.Name && owner.UID == saCopy.UID {
 					resultList = append(resultList, secret)
 				}
 			}

--- a/api/pkg/provider/kubernetes/sa_token_test.go
+++ b/api/pkg/provider/kubernetes/sa_token_test.go
@@ -88,9 +88,14 @@ func TestListTokens(t *testing.T) {
 		tokenName      string
 	}{
 		{
-			name:          "scenario 1, get all tokens for the service account 'serviceaccount-1' in project: 'my-first-project-ID'",
-			userInfo:      &provider.UserInfo{Email: "john@acme.com", Group: "owners-abcd"},
-			saToSync:      createSA("test-1", "my-first-project-ID", "viewers", "1"),
+			name:     "scenario 1, get all tokens for the service account 'serviceaccount-1' in project: 'my-first-project-ID'",
+			userInfo: &provider.UserInfo{Email: "john@acme.com", Group: "owners-abcd"},
+			saToSync: func() *kubermaticv1.User {
+				sa := createSA("test-1", "my-first-project-ID", "viewers", "1")
+				// "serviceaccount-" prefix is removed by the provider
+				sa.Name = "1"
+				return sa
+			}(),
 			projectToSync: test.GenDefaultProject(),
 			secrets: []*v1.Secret{
 				test.GenSecret("my-first-project-ID", "serviceaccount-1", "test-token-1", "1"),
@@ -106,9 +111,14 @@ func TestListTokens(t *testing.T) {
 			},
 		},
 		{
-			name:          "scenario 2, get token with specific name",
-			userInfo:      &provider.UserInfo{Email: "john@acme.com", Group: "owners-abcd"},
-			saToSync:      createSA("test-1", "my-first-project-ID", "viewers", "1"),
+			name:     "scenario 2, get token with specific name",
+			userInfo: &provider.UserInfo{Email: "john@acme.com", Group: "owners-abcd"},
+			saToSync: func() *kubermaticv1.User {
+				sa := createSA("test-1", "my-first-project-ID", "viewers", "1")
+				// "serviceaccount-" prefix is removed by the provider
+				sa.Name = "1"
+				return sa
+			}(),
 			projectToSync: test.GenDefaultProject(),
 			secrets: []*v1.Secret{
 				test.GenSecret("my-first-project-ID", "serviceaccount-1", "test-token-1", "1"),


### PR DESCRIPTION
**What this PR does / why we need it**: so that callers can use `api/v1/projects/{id}/serviceaccounts/7d4b5695vb`
instead of `api/v1/projects/{id}/serviceaccounts/serviceaccount-7d4b5695vb`

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #3215.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
