### PR TITLE
Backupcontroller: Fix cleanup

### DIFF
--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -344,11 +344,16 @@ func (r *Reconciler) cleanupJob(cluster *kubermaticv1.Cluster) *batchv1.Job {
 		Name:  clusterEnvVarKey,
 		Value: cluster.Name,
 	})
-	job := &batchv1.Job{
+
+	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("remove-cluster-backups-%s", cluster.Name),
+			Name:      fmt.Sprintf("remove-cluster-backups-%s", cluster.Name),
+			Namespace: metav1.NamespaceSystem,
 			Labels: map[string]string{
 				resources.AppLabelKey: backupCleanupJobLabel,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(cluster, kubermaticv1.SchemeGroupVersion.WithKind(kubermaticv1.ClusterKindName)),
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -374,7 +379,6 @@ func (r *Reconciler) cleanupJob(cluster *kubermaticv1.Cluster) *batchv1.Job {
 			},
 		},
 	}
-	return job
 }
 
 func (r *Reconciler) cronjob(cluster *kubermaticv1.Cluster) (string, reconciling.CronJobCreator) {

--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -352,9 +352,6 @@ func (r *Reconciler) cleanupJob(cluster *kubermaticv1.Cluster) *batchv1.Job {
 			Labels: map[string]string{
 				resources.AppLabelKey: backupCleanupJobLabel,
 			},
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(cluster, kubermaticv1.SchemeGroupVersion.WithKind(kubermaticv1.ClusterKindName)),
-			},
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit:          int32Ptr(10),

--- a/api/pkg/controller/backup/backup_controller_test.go
+++ b/api/pkg/controller/backup/backup_controller_test.go
@@ -125,17 +125,6 @@ func TestCleanupJobSpec(t *testing.T) {
 	}
 
 	cleanupJob := reconciler.cleanupJob(&kubermaticv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}})
-	if len(cleanupJob.OwnerReferences) != 1 {
-		t.Fatalf("cleanup job has no owner ref")
-	}
-
-	if cleanupJob.OwnerReferences[0].Kind != "Cluster" {
-		t.Errorf("cleanup jobs ownerRef.Kind is not 'Cluster' but %q", cleanupJob.OwnerReferences[0].Kind)
-	}
-
-	if cleanupJob.OwnerReferences[0].Name != "test-cluster" {
-		t.Errorf("cleanup jobs owner ref does not point to the right cluster, expected 'test-cluster', got %q", cleanupJob.OwnerReferences[0].Name)
-	}
 
 	if cleanupJob.Namespace != metav1.NamespaceSystem {
 		t.Errorf("expected cleanup jobs Namespace to be %q but was %q", metav1.NamespaceSystem, cleanupJob.Namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the cleanup of backups which currently keeps cluster cleanup from working with the following error:

```
Warning  ReconcilingError  11s (x13 over 43s)   kubermatic_backup_controller  an empty namespace may not be set during creation
```


It also adds the missing owner Ref to the cleanup job to make sure it gets cleaned up

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
