### PR TITLE
temporarily disable dynamic cert mode

### DIFF
--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -35,6 +35,7 @@ spec:
         - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
         - --default-ssl-certificate=default/kubermatic-tls-certificates
         - --annotations-prefix=ingress.kubernetes.io
+        - --enable-dynamic-certificates=false
         securityContext:
           capabilities:
             drop:


### PR DESCRIPTION
**What this PR does / why we need it**:
When updating to 0.24.0, we got bit by https://github.com/kubernetes/ingress-nginx/issues/3910. This PR makes the ingress work again until 0.24.1 properly fixes the issue.

**Release note**:
```release-note
NONE
```
