### PR TITLE
simplify address handling by storing the internal dns name in the cluster object

### DIFF
--- a/api/pkg/controller/openshift/data.go
+++ b/api/pkg/controller/openshift/data.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"net/url"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -205,18 +204,6 @@ func (od *openshiftData) GetApiserverExternalNodePort(ctx context.Context) (int3
 func (od *openshiftData) NodePortRange(_ context.Context) string {
 	//TODO: softcode this
 	return "30000-32767"
-}
-
-func (od *openshiftData) InClusterApiserverURL() (*url.URL, error) {
-	// We have to fullfull the templateData interface here which doesn't have a context as arg
-	// Needed for pkg/resources/apiserver.IsRunningInitContainer
-	ctx := context.TODO()
-	port, err := od.GetApiserverExternalNodePort(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get apiserver nodeport: %v", err)
-	}
-	dnsName := kubernetesresources.GetAbsoluteServiceDNSName(kubernetesresources.ApiserverExternalServiceName, od.cluster.Status.NamespaceName)
-	return url.Parse(fmt.Sprintf("https://%s:%d", dnsName, port))
 }
 
 func (od *openshiftData) GetOpenVPNServerPort() (int32, error) {

--- a/api/pkg/controller/openshift/resources/interfaces.go
+++ b/api/pkg/controller/openshift/resources/interfaces.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"net/url"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -27,7 +26,6 @@ type openshiftData interface {
 	GetClusterRef() metav1.OwnerReference
 	GetRootCA() (*triple.KeyPair, error)
 	GetRootCAWithContext(context.Context) (*triple.KeyPair, error)
-	InClusterApiserverURL() (*url.URL, error)
 	DC() *provider.DatacenterMeta
 	HasEtcdOperatorService() (bool, error)
 	EtcdDiskSize() resource.Quantity

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -142,7 +142,7 @@ type ClusterAddress struct {
 	Port int32 `json:"port"`
 	// ExternalName is the DNS name for this cluster
 	ExternalName string `json:"externalName"`
-	// InternalName is seed cluster internal absolute DNS name the API server
+	// InternalName is the seed cluster internal absolute DNS name to the API server
 	InternalName string `json:"internalURL"`
 	// AdminToken is the token for the kubeconfig, the user can download
 	AdminToken string `json:"adminToken"`

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -138,8 +138,12 @@ type NetworkRanges struct {
 type ClusterAddress struct {
 	// URL under which the Apiserver is available
 	URL string `json:"url"`
+	// Port is the port the API server listens on
+	Port int32 `json:"port"`
 	// ExternalName is the DNS name for this cluster
 	ExternalName string `json:"externalName"`
+	// InternalName is seed cluster internal absolute DNS name the API server
+	InternalName string `json:"internalURL"`
 	// AdminToken is the token for the kubeconfig, the user can download
 	AdminToken string `json:"adminToken"`
 	// IP is the external IP under which the apiserver is available

--- a/api/pkg/resources/address/address.go
+++ b/api/pkg/resources/address/address.go
@@ -51,7 +51,7 @@ func SyncClusterAddress(ctx context.Context,
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.IP = ip
 		})
-		glog.V(4).Infof("Set IP for cluster %s to '%s'", cluster.Name, ip)
+		glog.V(2).Infof("Set IP for cluster %s to '%s'", cluster.Name, ip)
 	}
 
 	// We fetch the Apiserver service as its a NodePort and we'll take the first NodePort (so far we only have one)
@@ -59,18 +59,34 @@ func SyncClusterAddress(ctx context.Context,
 	serviceKey := types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.ApiserverExternalServiceName}
 	if err := client.Get(ctx, serviceKey, service); err != nil {
 		if kerrors.IsNotFound(err) {
-			glog.V(6).Infof("Skipping URL setting for cluster %s as no external apiserver service exists yet. Will retry later", cluster.Name)
+			glog.V(4).Infof("Skipping URL setting for cluster %s as no external apiserver service exists yet. Will retry later", cluster.Name)
 			return nil, nil
 		}
 		return nil, err
 	}
 
-	url := fmt.Sprintf("https://%s:%d", externalName, int(service.Spec.Ports[0].NodePort))
+	nodePort := service.Spec.Ports[0].NodePort
+	if cluster.Address.Port != nodePort {
+		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
+			c.Address.Port = nodePort
+		})
+		glog.V(2).Infof("Set port for cluster %s to %d", cluster.Name, nodePort)
+	}
+
+	url := fmt.Sprintf("https://%s:%d", externalName, nodePort)
 	if cluster.Address.URL != url {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.URL = url
 		})
-		glog.V(4).Infof("Set URL for cluster %s to '%s'", cluster.Name, url)
+		glog.V(2).Infof("Set URL for cluster %s to '%s'", cluster.Name, url)
+	}
+
+	internalName := fmt.Sprintf("%s.%s.svc.cluster.local", resources.ApiserverExternalServiceName, cluster.Status.NamespaceName)
+	if cluster.Address.InternalName != internalName {
+		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
+			c.Address.InternalName = internalName
+		})
+		glog.V(2).Infof("Set internal name for cluster %s to '%s'", cluster.Name, internalName)
 	}
 
 	return modifiers, nil

--- a/api/pkg/resources/address/address.go
+++ b/api/pkg/resources/address/address.go
@@ -81,7 +81,7 @@ func SyncClusterAddress(ctx context.Context,
 		glog.V(2).Infof("Set URL for cluster %s to '%s'", cluster.Name, url)
 	}
 
-	internalName := fmt.Sprintf("%s.%s.svc.cluster.local", resources.ApiserverExternalServiceName, cluster.Status.NamespaceName)
+	internalName := fmt.Sprintf("%s.%s.svc.cluster.local.", resources.ApiserverExternalServiceName, cluster.Status.NamespaceName)
 	if cluster.Address.InternalName != internalName {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.InternalName = internalName

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -2,8 +2,8 @@ package apiserver
 
 import (
 	"fmt"
-	"net/url"
 
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,24 +11,19 @@ import (
 
 // IsRunningInitContainer returns a init container which will wait until the apiserver is reachable via its ClusterIP
 type isRunningInitContainerData interface {
-	InClusterApiserverURL() (*url.URL, error)
 	ImageRegistry(string) string
+	Cluster() *kubermaticv1.Cluster
 }
 
 func IsRunningInitContainer(data isRunningInitContainerData) (*corev1.Container, error) {
 	// get clusterIP of apiserver
-	url, err := data.InClusterApiserverURL()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get the ClusterIP of the apiserver: %v", err)
-	}
-
 	return &corev1.Container{
 		Name:            "apiserver-running",
 		Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/http-prober:v0.1",
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/usr/local/bin/http-prober"},
 		Args: []string{
-			"-endpoint", fmt.Sprintf("%s/healthz", url.String()),
+			"-endpoint", fmt.Sprintf("https://%s:%d/healthz", data.Cluster().Address.InternalName, data.Cluster().Address.Port),
 			"-insecure",
 			"-retries", "100",
 			"-retry-wait", "2",

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
-	"net/url"
 	"strings"
 
 	"github.com/golang/glog"
@@ -191,31 +190,6 @@ func (d *TemplateData) ProviderName() string {
 		glog.V(0).Infof("could not identify cloud provider: %v", err)
 	}
 	return p
-}
-
-// GetApiserverExternalNodePort returns the nodeport of the external apiserver service
-func (d *TemplateData) GetApiserverExternalNodePort() (int32, error) {
-	service := &corev1.Service{}
-	key := types.NamespacedName{Namespace: d.cluster.Status.NamespaceName, Name: ApiserverExternalServiceName}
-	if err := d.client.Get(d.ctx, key, service); err != nil {
-		return 0, fmt.Errorf("could not get service %s: %v", key, err)
-	}
-
-	return service.Spec.Ports[0].NodePort, nil
-}
-
-// InClusterApiserverAddress takes the ClusterIP and node-port of the external/secure apiserver service
-// and returns them joined by a `:`.
-// Service lookup happens within `Cluster.Status.NamespaceName`.
-func (d *TemplateData) InClusterApiserverAddress() (string, error) {
-	return GetClusterApiserverAddress(d.ctx, d.cluster, d.client)
-}
-
-// InClusterApiserverURL takes the ClusterIP and node-port of the external/secure apiserver service
-// and returns them joined by a `:` and the used protocol.
-// Service lookup happens within `Cluster.Status.NamespaceName`.
-func (d *TemplateData) InClusterApiserverURL() (*url.URL, error) {
-	return GetClusterApiserverURL(d.ctx, d.cluster, d.client)
 }
 
 // ImageRegistry returns the image registry to use or the passed in default if no override is specified

--- a/api/pkg/resources/kubeconfig_test.go
+++ b/api/pkg/resources/kubeconfig_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"net"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,7 +85,6 @@ func (fake *fakeDataProvider) GetClusterRef() metav1.OwnerReference       { retu
 func (fake *fakeDataProvider) GetFrontProxyCA() (*triple.KeyPair, error)  { return nil, nil }
 func (fake *fakeDataProvider) GetRootCA() (*triple.KeyPair, error)        { return fake.caPair, nil }
 func (fake *fakeDataProvider) GetOpenVPNCA() (*ECDSAKeyPair, error)       { return &ECDSAKeyPair{}, nil }
-func (fake *fakeDataProvider) InClusterApiserverURL() (*url.URL, error)   { return &url.URL{}, nil }
 func (fake *fakeDataProvider) InClusterApiserverAddress() (string, error) { return "", nil }
 func (fake *fakeDataProvider) GetDexCA() ([]*x509.Certificate, error)     { return nil, nil }
 

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -2,7 +2,6 @@ package machinecontroller
 
 import (
 	"fmt"
-	"net/url"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -40,7 +39,6 @@ type machinecontrollerData interface {
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
 	ImageRegistry(string) string
 	Cluster() *kubermaticv1.Cluster
-	InClusterApiserverURL() (*url.URL, error)
 	ClusterIPByServiceName(string) (string, error)
 	DC() *provider.DatacenterMeta
 }

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"net/url"
 	"os"
 	"time"
 
@@ -340,32 +339,6 @@ type CRDCreateor = func(version semver.Semver, existing *apiextensionsv1beta1.Cu
 
 // APIServiceCreator defines an interface to create/update APIService's
 type APIServiceCreator = func(existing *apiregistrationv1beta1.APIService) (*apiregistrationv1beta1.APIService, error)
-
-// GetClusterApiserverAddress returns the apiserver address for the given Cluster
-func GetClusterApiserverAddress(ctx context.Context, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) (string, error) {
-	service := &corev1.Service{}
-	key := types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: ApiserverExternalServiceName}
-	if err := client.Get(ctx, key, service); err != nil {
-		return "", fmt.Errorf("could not get service %s: %v", key, err)
-	}
-
-	if len(service.Spec.Ports) != 1 {
-		return "", errors.New("apiserver service does not have exactly one port")
-	}
-
-	dnsName := GetAbsoluteServiceDNSName(ApiserverExternalServiceName, cluster.Status.NamespaceName)
-	return fmt.Sprintf("%s:%d", dnsName, service.Spec.Ports[0].NodePort), nil
-}
-
-// GetClusterApiserverURL returns the apiserver url for the given Cluster
-func GetClusterApiserverURL(ctx context.Context, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) (*url.URL, error) {
-	addr, err := GetClusterApiserverAddress(ctx, cluster, client)
-	if err != nil {
-		return nil, err
-	}
-
-	return url.Parse(fmt.Sprintf("https://%s", addr))
-}
 
 // GetClusterExternalIP returns a net.IP for the given Cluster
 func GetClusterExternalIP(cluster *kubermaticv1.Cluster) (*net.IP, error) {

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -230,6 +230,8 @@ func TestLoadFiles(t *testing.T) {
 						ExternalName: "jh8j81chn.europe-west3-c.dev.kubermatic.io",
 						IP:           "35.198.93.90",
 						AdminToken:   "6hzr76.u8txpkk4vhgmtgdp",
+						InternalName: "apiserver-external.cluster-de-test-01.svc.cluster.local.",
+						Port:         30000,
 					},
 					Status: kubermaticv1.ClusterStatus{
 						NamespaceName: "cluster-de-test-01",

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -2,7 +2,6 @@ package usercluster
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -42,7 +41,6 @@ const (
 type userclusterControllerData interface {
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
 	ImageRegistry(string) string
-	InClusterApiserverURL() (*url.URL, error)
 	Cluster() *kubermaticv1.Cluster
 	GetOpenVPNServerPort() (int32, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplify address handling by storing the internal dns name in the cluster object

**Release note**:
```release-note
NONE
```
