### PR TITLE
update to nginx 0.24.1

### DIFF
--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress-controller
-version: 0.1.0
+version: 0.24.1
 description: nginx-ingress-controller
 keywords:
 - k8s

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -35,7 +35,6 @@ spec:
         - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
         - --default-ssl-certificate=default/kubermatic-tls-certificates
         - --annotations-prefix=ingress.kubernetes.io
-        - --enable-dynamic-certificates=false
         securityContext:
           capabilities:
             drop:

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -4,7 +4,7 @@ nginx:
   replicas: 3
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: 0.24.0
+    tag: 0.24.1
   config: {}
 #    load-balance: "least_conn"
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Time to revert the temporary hack.

**Release note**:
```release-note
update nginx-ingress-controller to 0.24.1
```
