### PR TITLE
Remove openshift references from values.yaml

### DIFF
--- a/api/hack/verify-addon-version.sh
+++ b/api/hack/verify-addon-version.sh
@@ -14,21 +14,13 @@ cd $(dirname $0)/../..
 
 KUBERNETES_IMAGE=quay.io/kubermatic/addons
 KUBERNETES_TAG="$(cat config/kubermatic/values.yaml |grep $KUBERNETES_IMAGE -A2|grep tag|awk '{ print $2 }'|tr -d '"')"
-OPENSHIFT_IMAGE=quay.io/kubermatic/openshift-addons
-OPENSHIFT_TAG="$(cat config/kubermatic/values.yaml |grep $OPENSHIFT_IMAGE -A2|grep tag|awk '{ print $2 }'|tr -d '"')"
 
 KUBERNETES_CONTAINER_NAME=$(docker create $KUBERNETES_IMAGE:$KUBERNETES_TAG)
-OPENSHIFT_CONTAINER_NAME=$(docker create $OPENSHIFT_IMAGE:$OPENSHIFT_TAG)
 
 docker cp $KUBERNETES_CONTAINER_NAME:/addons ./addons-from-container-kubernetes
-docker cp $OPENSHIFT_CONTAINER_NAME:/addons ./addons-from-container-openshift
 
 for ignored_file in $(cat addons/.dockerignore); do
   cp addons/$ignored_file ./addons-from-container-kubernetes/
 done
-for ignored_file in $(cat addons/.dockerignore); do
-  cp openshift_addons/$ignored_file ./addons-from-container-openshift/
-done
 
 diff --brief -r ./addons ./addons-from-container-kubernetes
-diff --brief -r ./openshift_addons ./addons-from-container-openshift

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -70,16 +70,6 @@ kubermatic:
           repository: "quay.io/kubermatic/addons"
           tag: "v0.2.5"
           pullPolicy: "IfNotPresent"
-      openshift:
-        # list of Addons to install into every user-cluster. All need to exist in the addons image
-        defaultAddons:
-        - networking
-        - openvpn
-        - rbac
-        image:
-          repository: "quay.io/kubermatic/openshift-addons"
-          tag: "v0.7"
-          pullPolicy: "IfNotPresent"
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
**What this PR does / why we need it**: Removes openshift references from the values.yaml as it wont be an official feature in the next release. We should revert this PR after 2.10 got branched  off

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
