### PR TITLE
fix Kibana's sidecar container

### DIFF
--- a/config/logging/kibana/Chart.yaml
+++ b/config/logging/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.1.0
+version: 6.6.2
 description: kibana
 keywords:
 - k8s

--- a/config/logging/kibana/config/ensure-index-pattern.sh
+++ b/config/logging/kibana/config/ensure-index-pattern.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ ${DEBUG+x} ]]; then
+if [[ ${DEBUG+false} ]]; then
   set -x
 fi
 

--- a/config/logging/kibana/config/ensure-index-pattern.sh
+++ b/config/logging/kibana/config/ensure-index-pattern.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ -n "$DEBUG" ]]; then
+if [[ ${DEBUG+x} ]]; then
   set -x
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes the Kibana sidecar container not crash anymore due to `DEBUG` not being defined.

**Which issue(s) this PR fixes**:
Fixes #3208 

**Release note**:
```release-note
NONE
```
