### PR TITLE
harmonise chart metadata / define proper versions

### DIFF
--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -6,7 +6,7 @@ apk add --no-cache -U git bash openssh
 cd $(dirname $0)/../../..
 git fetch
 export LATEST_VERSION=$(git describe --tags --abbrev=0)
-sed -i "s/__KUBERMATIC_TAG__/$LATEST_VERSION/g" config/kubermatic/values.yaml
+sed -i "s/__KUBERMATIC_TAG__/$LATEST_VERSION/g" config/kubermatic/values.yaml config/kubermatic/Chart.yaml
 git config --global user.email "dev@loodse.com"
 git config --global user.name "Prow CI Robot"
 git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'

--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: velero
-version: 0.11.0-1
+version: 1.0.0
 appVersion: v0.11.0
 description: A Helm chart for Heptio Velero
 keywords:

--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,3 +1,15 @@
-description: A Helm chart for Heptio Velero
+apiVersion: v1
 name: velero
-version: 0.11.0
+version: 0.11.0-1
+appVersion: v0.11.0
+description: A Helm chart for Heptio Velero
+keywords:
+- kubermatic
+- backup
+- velero
+home: https://heptio.com/community/velero/
+sources:
+- https://github.com/heptio/velero/tree/master/examples
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cert-manager
-version: 0.7.0-1
+version: 1.0.0
 appVersion: v0.7.0
 description: A Helm chart for cert-manager
 keywords:

--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,9 +1,17 @@
+apiVersion: v1
 name: cert-manager
-version: v0.7.0-1
+version: 0.7.0-1
+appVersion: v0.7.0
 description: A Helm chart for cert-manager
-home: https://github.com/jetstack/cert-manager
 keywords:
+- kubermatic
 - cert-manager
 - kube-lego
 - letsencrypt
 - tls
+home: https://github.com/jetstack/cert-manager
+sources:
+- https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/certs/Chart.yaml
+++ b/config/certs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: certs
-version: 0.1.0
+version: 1.0.0
 description: Chart for creating the required certificates for Kubermatic master clusters.
 keywords:
 - kubermatic

--- a/config/certs/Chart.yaml
+++ b/config/certs/Chart.yaml
@@ -1,4 +1,11 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
 name: certs
 version: 0.1.0
+description: Chart for creating the required certificates for Kubermatic master clusters.
+keywords:
+- kubermatic
+- tls
+home: https://www.kubermatic.io/
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/iap/Chart.yaml
+++ b/config/iap/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v1
-appVersion: "1.0"
-description: A Helm to install IAP
 name: iap
-version: 0.1.0
+version: 2.3.0-1
+appVersion: v2.3.0
+description: A Helm to install Keycloak-Proxy as an identity-aware proxy.
+keywords:
+- kubermatic
+- keycloak-proxy
+- iap
+home: https://github.com/keycloak/keycloak-gatekeeper
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/iap/Chart.yaml
+++ b/config/iap/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: iap
-version: 2.3.0-1
+version: 1.0.0
 appVersion: v2.3.0
 description: A Helm to install Keycloak-Proxy as an identity-aware proxy.
 keywords:

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,12 +1,13 @@
+apiVersion: v1
 name: kubermatic
 version: 0.1.0
-description: Kubermatic
+appVersion: '__KUBERMATIC_TAG__'
+description: Kubermatic chart for master and/or seed clusters.
 keywords:
-- k8s
 - kubermatic
-home: http://www.kubermatic.io/
+home: https://www.kubermatic.io/
 sources:
-- https://github.com/kubermatic
+- https://github.com/kubermatic/kubermatic
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 0.1.0
+version: 1.0.0
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -176,7 +176,7 @@ kubermatic:
     replicas: 1
     image:
       repository: quay.io/kubermatic/api
-      tag: __KUBERMATIC_TAG__
+      tag: "__KUBERMATIC_TAG__"
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/config/logging/elasticsearch/Chart.yaml
+++ b/config/logging/elasticsearch/Chart.yaml
@@ -1,14 +1,16 @@
+apiVersion: v1
 name: elasticsearch
-version: 0.1.0
-description: ElasticSearch
+version: 6.6.2-1
+appVersion: 6.6.2
+description: Chart to deploy Elasticsearch master and data nodes.
 keywords:
-- k8s
 - kubermatic
+- logging
 - elasticsearch
 - elastic
-home: http://www.kubermatic.io/
+home: https://www.elastic.co/products/elasticsearch
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/helm/charts/tree/master/stable/elasticsearch
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/logging/elasticsearch/Chart.yaml
+++ b/config/logging/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 6.6.2-1
+version: 1.0.0
 appVersion: 6.6.2
 description: Chart to deploy Elasticsearch master and data nodes.
 keywords:

--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.0.4-1
+version: 1.0.0
 appVersion: 1.0.4
 description: fluentbit
 keywords:

--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,13 +1,15 @@
+apiVersion: v1
 name: fluentbit
-version: 0.1.0
+version: 1.0.4-1
+appVersion: 1.0.4
 description: fluentbit
 keywords:
-- k8s
 - kubermatic
+- logging
 - fluentbit
-home: http://www.kubermatic.io/
+home: http://fluentbit.org/
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/kubermatic/kubermatic
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - kubermatic
 - logging
 - fluentbit
-home: http://fluentbit.org/
+home: http://fluentbit.io/
 sources:
 - https://github.com/kubermatic/kubermatic
 maintainers:

--- a/config/logging/kibana/Chart.yaml
+++ b/config/logging/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 6.6.2-1
+version: 1.0.0
 appVersion: 6.6.2
 description: kibana
 keywords:

--- a/config/logging/kibana/Chart.yaml
+++ b/config/logging/kibana/Chart.yaml
@@ -1,13 +1,16 @@
+apiVersion: v1
 name: kibana
-version: 6.6.2
+version: 6.6.2-1
+appVersion: 6.6.2
 description: kibana
 keywords:
-- k8s
 - kubermatic
+- logging
 - kibana
-home: http://www.kubermatic.io/
+- elastic
+home: https://www.elastic.co/products/kibana
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/helm/charts/tree/master/stable/kibana
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/minio/Chart.yaml
+++ b/config/minio/Chart.yaml
@@ -1,13 +1,16 @@
+apiVersion: v1
 name: minio
-version: 1.0.0
+version: 2019.4.9-1.22.30-1
+appVersion: RELEASE.2019-04-09T01-22-30Z
 description: minio
 keywords:
-- k8s
 - kubermatic
 - minio
+- s3
 home: https://www.minio.io/kubernetes.html
 sources:
 - https://www.minio.io/kubernetes.html
+- https://github.com/helm/charts/tree/master/stable/minio
 maintainers:
-- name: Henrik Schmidt
-  email: henrik@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/minio/Chart.yaml
+++ b/config/minio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minio
-version: 2019.4.9-1.22.30-1
+version: 1.0.0
 appVersion: RELEASE.2019-04-09T01-22-30Z
 description: minio
 keywords:

--- a/config/monitoring/alertmanager/Chart.yaml
+++ b/config/monitoring/alertmanager/Chart.yaml
@@ -1,15 +1,16 @@
+apiVersion: v1
 name: alertmanager
-version: 0.1.0
+version: 0.16.2-1
+appVersion: v0.16.2
 description: Alertmanager for Kubermatic
 keywords:
-- k8s
 - kubermatic
+- monitoring
 - prometheus
 - alertmanager
-- oidc
-home: http://www.kubermatic.io/
+home: https://prometheus.io/
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/kubermatic/kubermatic
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/monitoring/alertmanager/Chart.yaml
+++ b/config/monitoring/alertmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: alertmanager
-version: 0.16.2-1
+version: 1.0.0
 appVersion: v0.16.2
 description: Alertmanager for Kubermatic
 keywords:

--- a/config/monitoring/blackbox-exporter/Chart.yaml
+++ b/config/monitoring/blackbox-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: blackbox-exporter
-version: 0.14.0-1
+version: 1.0.0
 appVersion: v0.14.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:

--- a/config/monitoring/blackbox-exporter/Chart.yaml
+++ b/config/monitoring/blackbox-exporter/Chart.yaml
@@ -1,3 +1,16 @@
+apiVersion: v1
 name: blackbox-exporter
-version: 1.0.0
+version: 0.14.0-1
+appVersion: v0.14.0
 description: Deploys the Prometheus Blackbox Exporter
+keywords:
+- kubermatic
+- monitoring
+- prometheus
+- blackbox-exporter
+home: https://github.com/prometheus/blackbox_exporter
+sources:
+- https://github.com/helm/charts/tree/master/stable/prometheus-blackbox-exporter
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,14 +1,15 @@
+apiVersion: v1
 name: grafana
-version: 0.1.0
+version: 6.1.3-1
+appVersion: 6.1.3
 description: Grafana for Kubermatic
 keywords:
-- k8s
 - kubermatic
+- monitoring
 - grafana
-- prometheus
-home: http://www.kubermatic.io/
+home: https://grafana.com/
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/helm/charts/tree/master/stable/grafana
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 6.1.3-1
+version: 1.0.0
 appVersion: 6.1.3
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-state-metrics
-version: 1.5.0-1
+version: 1.0.0
 appVersion: v1.5.0
 description: Kube-State-Metrics for Kubermatic
 keywords:

--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,14 +1,16 @@
+apiVersion: v1
 name: kube-state-metrics
-version: 0.1.0
+version: 1.5.0-1
+appVersion: v1.5.0
 description: Kube-State-Metrics for Kubermatic
 keywords:
-- k8s
 - kubermatic
+- monitoring
 - prometheus
 - kube-state-metrics
-home: http://www.kubermatic.io/
+home: https://github.com/kubernetes/kube-state-metrics
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/kubermatic/kubermatic
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/monitoring/node-exporter/Chart.yaml
+++ b/config/monitoring/node-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-exporter
-version: 0.17.0-1
+version: 1.0.0
 appVersion: v0.17.0
 description: Prometheus Node Exporter for Kubermatic
 keywords:

--- a/config/monitoring/node-exporter/Chart.yaml
+++ b/config/monitoring/node-exporter/Chart.yaml
@@ -1,14 +1,16 @@
+apiVersion: v1
 name: node-exporter
-version: 0.1.0
+version: 0.17.0-1
+appVersion: v0.17.0
 description: Prometheus Node Exporter for Kubermatic
 keywords:
-- k8s
 - kubermatic
+- monitoring
 - prometheus
 - node-exporter
-home: http://www.kubermatic.io/
+home: https://github.com/prometheus/node_exporter
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.8.1-1
+version: 1.1.0
 appVersion: v2.8.1
 description: Prometheus for Kubermatic
 keywords:

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,13 +1,15 @@
+apiVersion: v1
 name: prometheus
-version: 1.1.0
+version: 2.8.1-1
+appVersion: v2.8.1
 description: Prometheus for Kubermatic
 keywords:
-- k8s
 - kubermatic
+- monitoring
 - prometheus
-home: http://www.kubermatic.io/
+home: https://prometheus.io/
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/helm/charts/tree/master/stable/prometheus
 maintainers:
-- name: Christoph Mewes
-  email: christoph@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 0.24.1-1
+version: 1.0.0
 appVersion: 0.24.1
 description: nginx-ingress-controller
 keywords:

--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,12 +1,15 @@
+apiVersion: v1
 name: nginx-ingress-controller
-version: 0.24.1
+version: 0.24.1-1
+appVersion: 0.24.1
 description: nginx-ingress-controller
 keywords:
-- k8s
 - kubermatic
+- nginx-ingress-controller
+- nginx
 home: https://github.com/kubernetes/ingress/
 sources:
 - https://github.com/kubernetes/ingress/tree/master/controllers/nginx
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nodeport-proxy
-version: 2.0.0-1
+version: 1.0.0
 appVersion: v2.0.0
 description: Kubermatic nodeport-proxy
 keywords:

--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,13 +1,14 @@
+apiVersion: v1
 name: nodeport-proxy
-version: 1.0.0
+version: 2.0.0-1
+appVersion: v2.0.0
 description: Kubermatic nodeport-proxy
 keywords:
-- k8s
 - kubermatic
 - nodeport-proxy
-home: http://www.kubermatic.io/
+home: https://www.kubermatic.io/
 sources:
 - https://github.com/kubermatic/nodeport-proxy
 maintainers:
-- name: Henrik Schmidt
-  email: henrik@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: oauth
-version: 2.15.0-1
+version: 1.0.0
 appVersion: v2.15.0
 description: Dex
 keywords:

--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -1,13 +1,15 @@
+apiVersion: v1
 name: oauth
-version: 0.1.0
+version: 2.15.0-1
+appVersion: v2.15.0
 description: Dex
 keywords:
-- k8s
 - kubermatic
-- Oauth
-home: http://www.kubermatic.io/
+- oauth
+- dex
+home: https://github.com/dexidp/dex
 sources:
-- https://github.com/kubermatic/kubermatic/config
+- https://github.com/kubermatic/kubermatic
 maintainers:
-- name: Sebastian Scheele
-  email: sebastian@loodse.com
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/s3-exporter/Chart.yaml
+++ b/config/s3-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: s3-exporter
-version: 0.3-1
+version: 1.0.0
 appVersion: v0.3
 keywords:
 - kubermatic

--- a/config/s3-exporter/Chart.yaml
+++ b/config/s3-exporter/Chart.yaml
@@ -1,8 +1,15 @@
+apiVersion: v1
 name: s3-exporter
-version: 0.1.0
+version: 0.3-1
+appVersion: v0.3
 keywords:
-- k8s
 - kubermatic
 - prometheus
 - s3
 - minio
+home: https://www.kubermatic.io/
+sources:
+- https://github.com/kubermatic/kubermatic
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com


### PR DESCRIPTION
**What this PR does / why we need it**:
This is primarily a spring cleanup:

* `apiVersion` is a mandatory field in Chart.yaml files.
* All charts have a (somewhat) more meaningful version number.
* Maintainer, homepage and sources updated.

---

I propose that we give our charts a meaningful version that we actually update with each revision (on a best-effort basis; kinda not sure how often we would have parallel PRs for the same charts). As Helm versions must be SemVer2 compatible, this means

* no leading "v" prefix
* "a.b.c-d" means "is a pre-release", not "is a patch-release", i.e. `1.0.0 > 1.0.0-1`.

I think this will make a `helm ls` much more meaningful, especially for clusters not permanently kept up-to-date like ours.

**Release note**:
```release-note
improve Helm charts metadata to make Helm-based workflows easier and aid in cluster updates
```