### PR TITLE
increase default prometheus backup timeout to 60m

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 1.1.0
+version: 1.1.1
 appVersion: v2.8.1
 description: Prometheus for Kubermatic
 keywords:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -21,7 +21,7 @@ spec:
         {{- if .Values.prometheus.backup.enabled }}
         backup.velero.io/backup-volumes: prometheus-backup
         pre.hook.backup.velero.io/container: backup
-        pre.hook.backup.velero.io/timeout: 30m
+        pre.hook.backup.velero.io/timeout: '{{ .Values.prometheus.backup.timeout | default "60m" }}'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
         {{- end }}
     spec:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -8,6 +8,7 @@ prometheus:
     image:
       repository: quay.io/kubermatic/util
       tag: 1.0.0-2
+    timeout: 60m
 
   # Specify additional external labels which will be added to all
   # alerts sent by Prometheus.


### PR DESCRIPTION
**What this PR does / why we need it**:
Our backups keep failing because Velero stops after 30 minutes. Let's try 60 minutes.

**Release note**:
```release-note
configurable Prometheus backup timeout to accomodate larger seed clusters
```
