### PR TITLE
implements token verification and extraction for service accounts

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -162,7 +162,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	sshKeyProvider := kubernetesprovider.NewSSHKeyProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserSSHKeys().Lister())
 	userProvider := kubernetesprovider.NewUserProvider(kubermaticMasterClient, userLister)
 
-	serviceAccountTokenProvider := kubernetesprovider.NewServiceAccountTokenProvider(defaultKubernetesImpersonationClient.CreateImpersonatedKubernetesClientSet, kubeInformerFactory.Core().V1().Secrets().Lister())
+	serviceAccountTokenProvider, err := kubernetesprovider.NewServiceAccountTokenProvider(defaultKubernetesImpersonationClient.CreateImpersonatedKubernetesClientSet, kubeInformerFactory.Core().V1().Secrets().Lister())
 	if err != nil {
 		return providers{}, fmt.Errorf("failed to create service account token provider due to %v", err)
 	}

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -101,15 +101,16 @@ func (o serverRunOptions) validate() error {
 }
 
 type providers struct {
-	sshKey                      provider.SSHKeyProvider
-	user                        provider.UserProvider
-	serviceAccountProvider      provider.ServiceAccountProvider
-	serviceAccountTokenProvider provider.ServiceAccountTokenProvider
-	project                     provider.ProjectProvider
-	privilegedProject           provider.PrivilegedProjectProvider
-	projectMember               provider.ProjectMemberProvider
-	memberMapper                provider.ProjectMemberMapper
-	cloud                       provider.CloudRegistry
-	clusters                    map[string]provider.ClusterProvider
-	datacenters                 map[string]provider.DatacenterMeta
+	sshKey                                provider.SSHKeyProvider
+	user                                  provider.UserProvider
+	serviceAccountProvider                provider.ServiceAccountProvider
+	serviceAccountTokenProvider           provider.ServiceAccountTokenProvider
+	privilegedServiceAccountTokenProvider provider.PrivilegedServiceAccountTokenProvider
+	project                               provider.ProjectProvider
+	privilegedProject                     provider.PrivilegedProjectProvider
+	projectMember                         provider.ProjectMemberProvider
+	memberMapper                          provider.ProjectMemberMapper
+	cloud                                 provider.CloudRegistry
+	clusters                              map[string]provider.ClusterProvider
+	datacenters                           map[string]provider.DatacenterMeta
 }

--- a/api/pkg/handler/auth/oidc.go
+++ b/api/pkg/handler/auth/oidc.go
@@ -121,7 +121,6 @@ func (o *OpenIDClient) Verify(ctx context.Context, token string) (TokenClaims, e
 
 	idToken, err := o.verifier.Verify(ctx, token)
 	if err != nil {
-		fmt.Printf("%v", err)
 		return TokenClaims{}, err
 	}
 

--- a/api/pkg/handler/auth/sa.go
+++ b/api/pkg/handler/auth/sa.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/serviceaccount"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ServiceAccountAuthClient implements TokenExtractorVerifier interface
+type ServiceAccountAuthClient struct {
+	headerBearerTokenExtractor TokenExtractor
+	jwtTokenAuthenticator      serviceaccount.TokenAuthenticator
+	saTokenProvider            provider.PrivilegedServiceAccountTokenProvider
+}
+
+var _ TokenExtractorVerifier = &ServiceAccountAuthClient{}
+
+// NewServiceAccountAuthClient returns a client that knows how to read and verify service account's tokens
+func NewServiceAccountAuthClient(headerBearerTokenExtractor TokenExtractor, jwtTokenAuthenticator serviceaccount.TokenAuthenticator, saTokenProvider provider.PrivilegedServiceAccountTokenProvider) *ServiceAccountAuthClient {
+	return &ServiceAccountAuthClient{headerBearerTokenExtractor: headerBearerTokenExtractor, jwtTokenAuthenticator: jwtTokenAuthenticator, saTokenProvider: saTokenProvider}
+}
+
+// Extractor knows how to extract the ID token from the request
+func (s *ServiceAccountAuthClient) Extract(rq *http.Request) (string, error) {
+	return s.headerBearerTokenExtractor.Extract(rq)
+}
+
+// Verify parses a raw ID Token, verifies it's been signed by the provider, preforms
+// any additional checks depending on the Config, and returns the payload as TokenClaims.
+func (s *ServiceAccountAuthClient) Verify(ctx context.Context, token string) (TokenClaims, error) {
+	_, customClaims, err := s.jwtTokenAuthenticator.Authenticate(token)
+	if err != nil {
+		return TokenClaims{}, err
+	}
+
+	tokenList, err := s.saTokenProvider.ListUnsecured(&provider.ServiceAccountTokenListOptions{customClaims.TokenID})
+	if kerrors.IsNotFound(err) {
+		return TokenClaims{}, fmt.Errorf("sa: the token %s has been revoked for %s", customClaims.TokenID, customClaims.Email)
+	}
+	if len(tokenList) > 1 {
+		return TokenClaims{}, fmt.Errorf("sa: found more than one token with the given id %s", customClaims.TokenID)
+	}
+
+	return TokenClaims{
+		Name:    customClaims.TokenID,
+		Email:   customClaims.Email,
+		Subject: customClaims.Email,
+	}, nil
+}

--- a/api/pkg/handler/auth/sa.go
+++ b/api/pkg/handler/auth/sa.go
@@ -38,7 +38,7 @@ func (s *ServiceAccountAuthClient) Verify(ctx context.Context, token string) (To
 		return TokenClaims{}, err
 	}
 
-	tokenList, err := s.saTokenProvider.ListUnsecured(&provider.ServiceAccountTokenListOptions{customClaims.TokenID})
+	tokenList, err := s.saTokenProvider.ListUnsecured(&provider.ServiceAccountTokenListOptions{TokenName: customClaims.TokenID})
 	if kerrors.IsNotFound(err) {
 		return TokenClaims{}, fmt.Errorf("sa: the token %s has been revoked for %s", customClaims.TokenID, customClaims.Email)
 	}

--- a/api/pkg/handler/middleware/middleware.go
+++ b/api/pkg/handler/middleware/middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -180,7 +181,7 @@ func TokenVerifier(tokenVerifier auth.TokenVerifier) endpoint.Middleware {
 			defer cancel()
 			claims, err := tokenVerifier.Verify(verifyCtx, token)
 			if err != nil {
-				return nil, k8cerrors.NewNotAuthorized()
+				return nil, k8cerrors.New(http.StatusUnauthorized, fmt.Sprintf("access denied due to an invalid token, details = %v", err))
 			}
 
 			if claims.Subject == "" {

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -145,7 +145,7 @@ func CreateTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.Dat
 	}
 
 	tokenAuth := serviceaccount.JWTTokenAuthenticator([]byte(TestServiceAccountHashKey))
-	serviceAccountTokenProvider := kubernetes.NewServiceAccountTokenProvider(fakeKubernetesImpersonationClient, kubernetesInformerFactory.Core().V1().Secrets().Lister())
+	serviceAccountTokenProvider, err := kubernetes.NewServiceAccountTokenProvider(fakeKubernetesImpersonationClient, kubernetesInformerFactory.Core().V1().Secrets().Lister())
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -146,6 +146,9 @@ func CreateTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.Dat
 
 	tokenAuth := serviceaccount.JWTTokenAuthenticator([]byte(TestServiceAccountHashKey))
 	serviceAccountTokenProvider := kubernetes.NewServiceAccountTokenProvider(fakeKubernetesImpersonationClient, kubernetesInformerFactory.Core().V1().Secrets().Lister())
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	serviceAccountProvider := kubernetes.NewServiceAccountProvider(fakeKubermaticImpersonationClient, userLister, "localhost")
 	projectMemberProvider := kubernetes.NewProjectMemberProvider(fakeKubermaticImpersonationClient, kubermaticInformerFactory.Kubermatic().V1().UserProjectBindings().Lister(), userLister)
 	projectProvider, err := kubernetes.NewProjectProvider(fakeKubermaticImpersonationClient, kubermaticInformerFactory.Kubermatic().V1().Projects().Lister())

--- a/api/pkg/provider/kubernetes/sa_token.go
+++ b/api/pkg/provider/kubernetes/sa_token.go
@@ -22,7 +22,7 @@ const (
 )
 
 // NewServiceAccountProvider returns a service account provider
-func NewServiceAccountTokenProvider(kubernetesImpersonationClient kubernetesImpersonationClient, secretLister kubev1.SecretLister) *ServiceAccountTokenProvider {
+func NewServiceAccountTokenProvider(kubernetesImpersonationClient kubernetesImpersonationClient, secretLister kubev1.SecretLister) (*ServiceAccountTokenProvider, error) {
 	kubernetesClient, err := kubernetesImpersonationClient(rest.ImpersonationConfig{})
 	if err != nil {
 		return nil, err
@@ -153,8 +153,6 @@ func (p *ServiceAccountTokenProvider) List(userInfo *provider.UserInfo, project 
 	return filteredList, nil
 }
 
-}
-
 // ListUnsecured returns all tokens in kubermatic namespace
 //
 // Note that this function:
@@ -187,3 +185,4 @@ func isToken(secret *v1.Secret) bool {
 		return false
 	}
 	return strings.HasPrefix(secret.Name, "sa-token")
+}

--- a/api/pkg/provider/kubernetes/sa_token_test.go
+++ b/api/pkg/provider/kubernetes/sa_token_test.go
@@ -65,7 +65,7 @@ func TestCreateToken(t *testing.T) {
 			tokenLister := listers.NewSecretLister(indexer)
 
 			// act
-			target := kubernetes.NewServiceAccountTokenProvider(impersonationClient.CreateKubernetesFakeImpersonatedClientSet, tokenLister)
+			target, err := kubernetes.NewServiceAccountTokenProvider(impersonationClient.CreateKubernetesFakeImpersonatedClientSet, tokenLister)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -156,7 +156,7 @@ func TestListTokens(t *testing.T) {
 			tokenLister := listers.NewSecretLister(indexer)
 
 			// act
-			target := kubernetes.NewServiceAccountTokenProvider(impersonationClient.CreateKubernetesFakeImpersonatedClientSet, tokenLister)
+			target, err := kubernetes.NewServiceAccountTokenProvider(impersonationClient.CreateKubernetesFakeImpersonatedClientSet, tokenLister)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -349,3 +349,13 @@ type ServiceAccountTokenListOptions struct {
 	// TokenName list only tokens with the specified name
 	TokenName string
 }
+
+// PrivilegedServiceAccountTokenProvider declares the set of method for interacting with kubermatic's sa's tokens and uses privileged account for it
+type PrivilegedServiceAccountTokenProvider interface {
+	// ListUnsecured returns all tokens in kubermatic namespace
+	//
+	// Note that this function:
+	// is unsafe in a sense that it uses privileged account to get the resource
+	// gets resources from the cache
+	ListUnsecured(*ServiceAccountTokenListOptions) ([]*v1.Secret, error)
+}

--- a/api/pkg/util/errors/aggregate.go
+++ b/api/pkg/util/errors/aggregate.go
@@ -1,0 +1,61 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Aggregate represents an object that contains multiple errors, but does not
+// necessarily have singular semantic meaning.
+type Aggregate interface {
+	error
+	Errors() []error
+}
+
+// NewAggregate converts a slice of errors into an Aggregate interface, which
+// is itself an implementation of the error interface.  If the slice is empty,
+// this returns nil.
+// It will check if any of the element of input error list is nil, to avoid
+// nil pointer panic when call Error().
+func NewAggregate(errlist []error) Aggregate {
+	if len(errlist) == 0 {
+		return nil
+	}
+	// In case of input error list contains nil
+	var errs []error
+	for _, e := range errlist {
+		if e != nil {
+			errs = append(errs, e)
+		}
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return aggregate(errs)
+}
+
+// This helper implements the error and Errors interfaces.  Keeping it private
+// prevents people from making an aggregate of 0 errors, which is not
+// an error, but does satisfy the error interface.
+type aggregate []error
+
+// Error is part of the error interface.
+func (agg aggregate) Error() string {
+	if len(agg) == 0 {
+		// This should never happen, really.
+		return ""
+	}
+	if len(agg) == 1 {
+		return agg[0].Error()
+	}
+	result := fmt.Sprintf("[%s", agg[0].Error())
+	for i := 1; i < len(agg); i++ {
+		result += fmt.Sprintf(", %s", agg[i].Error())
+	}
+	result += "]"
+	return result
+}
+
+// Errors is part of the Aggregate interface.
+func (agg aggregate) Errors() []error {
+	return []error(agg)
+}


### PR DESCRIPTION
**What this PR does / why we need it**: adds ServiceAccountAuthClient struct that implements TokenExtractorVerifier interface. For token extraction we delegate to HeaderBearerTokenExtractor as sa's tokens are just JWT tokens

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #3158 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
