### PR TITLE
add options for getting service accounts

### DIFF
--- a/api/pkg/handler/v1/serviceaccount/sa.go
+++ b/api/pkg/handler/v1/serviceaccount/sa.go
@@ -121,7 +121,7 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, serviceAccountProv
 		}
 		saFromRequest := req.Body
 
-		sa, err := serviceAccountProvider.Get(userInfo, req.ServiceAccountID)
+		sa, err := serviceAccountProvider.Get(userInfo, req.ServiceAccountID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -187,7 +187,7 @@ func DeleteEndpoint(serviceAccountProvider provider.ServiceAccountProvider, proj
 		}
 
 		// check if service account exist before deleting it
-		if _, err := serviceAccountProvider.Get(userInfo, req.ServiceAccountID); err != nil {
+		if _, err := serviceAccountProvider.Get(userInfo, req.ServiceAccountID, nil); err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 

--- a/api/pkg/handler/v1/serviceaccount/token.go
+++ b/api/pkg/handler/v1/serviceaccount/token.go
@@ -35,7 +35,7 @@ func CreateTokenEndpoint(projectProvider provider.ProjectProvider, serviceAccoun
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		sa, err := serviceAccountProvider.Get(userInfo, req.ServiceAccountID)
+		sa, err := serviceAccountProvider.Get(userInfo, req.ServiceAccountID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/provider/kubernetes/sa_test.go
+++ b/api/pkg/provider/kubernetes/sa_test.go
@@ -178,7 +178,7 @@ func TestGet(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			sa, err := target.Get(tc.userInfo, tc.saName)
+			sa, err := target.Get(tc.userInfo, tc.saName, nil)
 			// validate
 			if err != nil {
 				t.Fatal(err)
@@ -230,7 +230,7 @@ func TestUpdate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			sa, err := target.Get(tc.userInfo, tc.saName)
+			sa, err := target.Get(tc.userInfo, tc.saName, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -287,7 +287,7 @@ func TestDelete(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = target.Get(tc.userInfo, tc.saName)
+			_, err = target.Get(tc.userInfo, tc.saName, nil)
 			if err == nil {
 				t.Fatal("expected error")
 			}

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -327,9 +327,18 @@ func DatacenterCloudProviderName(spec *DatacenterSpec) (string, error) {
 type ServiceAccountProvider interface {
 	Create(userInfo *UserInfo, project *kubermaticv1.Project, name, group string) (*kubermaticv1.User, error)
 	List(userInfo *UserInfo, project *kubermaticv1.Project, options *ServiceAccountListOptions) ([]*kubermaticv1.User, error)
-	Get(userInfo *UserInfo, name string) (*kubermaticv1.User, error)
+	Get(userInfo *UserInfo, name string, options *ServiceAccountGetOptions) (*kubermaticv1.User, error)
 	Update(userInfo *UserInfo, serviceAccount *kubermaticv1.User) (*kubermaticv1.User, error)
 	Delete(userInfo *UserInfo, name string) error
+}
+
+// ServiceAccountGetOptions allows to set filters that will be applied to filter the get result.
+type ServiceAccountGetOptions struct {
+	// RemovePrefix when set to false will NOT remove "serviceaccount-" prefix from the ID
+	//
+	// Note:
+	// By default the prefix IS removed, for example given "serviceaccount-7d4b5695vb" it returns "7d4b5695vb"
+	RemovePrefix bool
 }
 
 // ServiceAccountListOptions allows to set filters that will be applied to filter the result.


### PR DESCRIPTION
**What this PR does / why we need it**: callers can specify whether to remove "serviceaccount-" prefix or not.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #3142

**Special notes for your reviewer**: could be used in https://github.com/kubermatic/kubermatic/pull/3226

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
