### PR TITLE
there is no metrics endpoint on the cainjector

### DIFF
--- a/config/cert-manager/templates/cainjector-deployment.yaml
+++ b/config/cert-manager/templates/cainjector-deployment.yaml
@@ -12,8 +12,6 @@ spec:
       labels:
         app: cainjector
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '9402'
         fluentbit.io/parser: glog
     spec:
       serviceAccountName: cainjector


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a copy-paste mistake when updating the cert-manager to 0.7.

**Release note**:
```release-note
NONE
```
