### PR TITLE
fixes kubernetes providers to return copies of resources

### DIFF
--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -122,7 +122,7 @@ func (p *ClusterProvider) List(project *kubermaticapiv1.Project, options *provid
 	projectClusters := []*kubermaticapiv1.Cluster{}
 	for _, cluster := range clusters {
 		if clusterProject := cluster.GetLabels()[kubermaticapiv1.ProjectIDLabelKey]; clusterProject == project.Name {
-			projectClusters = append(projectClusters, cluster)
+			projectClusters = append(projectClusters, cluster.DeepCopy())
 		}
 	}
 

--- a/api/pkg/provider/kubernetes/member.go
+++ b/api/pkg/provider/kubernetes/member.go
@@ -98,7 +98,7 @@ func (p *ProjectMemberProvider) List(userInfo *provider.UserInfo, project *kuber
 					}
 				}
 			}
-			projectMembers = append(projectMembers, member)
+			projectMembers = append(projectMembers, member.DeepCopy())
 		}
 	}
 

--- a/api/pkg/provider/kubernetes/project.go
+++ b/api/pkg/provider/kubernetes/project.go
@@ -185,14 +185,14 @@ func (p *ProjectProvider) List(options *provider.ProjectListOptions) ([]*kuberma
 			owners := project.GetOwnerReferences()
 			for _, owner := range owners {
 				if owner.UID == options.OwnerUID {
-					ret = append(ret, project)
+					ret = append(ret, project.DeepCopy())
 					continue
 				}
 			}
 			continue
 		}
 
-		ret = append(ret, project)
+		ret = append(ret, project.DeepCopy())
 	}
 	return ret, nil
 }

--- a/api/pkg/provider/kubernetes/sa_token.go
+++ b/api/pkg/provider/kubernetes/sa_token.go
@@ -111,7 +111,7 @@ func (p *ServiceAccountTokenProvider) List(userInfo *provider.UserInfo, project 
 			for _, owner := range secret.GetOwnerReferences() {
 				if owner.APIVersion == kubermaticv1.SchemeGroupVersion.String() && owner.Kind == kubermaticv1.UserKindName &&
 					owner.Name == sa.Name && owner.UID == sa.UID {
-					resultList = append(resultList, secret)
+					resultList = append(resultList, secret.DeepCopy())
 				}
 			}
 		}
@@ -163,7 +163,7 @@ func (p *ServiceAccountTokenProvider) ListUnsecured(options *provider.ServiceAcc
 	allTokens := []*v1.Secret{}
 	for _, secret := range allSecrets {
 		if isToken(secret) {
-			allTokens = append(allSecrets, secret)
+			allTokens = append(allSecrets, secret.DeepCopy())
 		}
 	}
 	if options == nil {

--- a/api/pkg/provider/kubernetes/ssh.go
+++ b/api/pkg/provider/kubernetes/ssh.go
@@ -99,7 +99,7 @@ func (p *SSHKeyProvider) List(project *kubermaticapiv1.Project, options *provide
 		owners := key.GetOwnerReferences()
 		for _, owner := range owners {
 			if owner.APIVersion == kubermaticapiv1.SchemeGroupVersion.String() && owner.Kind == kubermaticapiv1.ProjectKindName && owner.Name == project.Name {
-				projectKeys = append(projectKeys, key)
+				projectKeys = append(projectKeys, key.DeepCopy())
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: items returned form the cache cannot be directly modified because there is only one copy in the cache.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #3215 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
