### PR TITLE
Add container linux update operator

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,3 +38,4 @@ issues:
   - "`store` can be `github.com/kubermatic/kubermatic/api/vendor/k8s.io/client-go/tools/cache.KeyGetter`"
   - 'func `\(\*ClusterProvider\)\.withImpersonation` is unused'
   - "`osData` can be `github.com/kubermatic/kubermatic/api/pkg/resources.RoleBindingDataProvider`"
+  - "cyclomatic complexity 31 of func `main` is high"

--- a/api/codegen/reconcile/main.go
+++ b/api/codegen/reconcile/main.go
@@ -49,6 +49,11 @@ func main() {
 				// Don't specify ResourceImportPath so this block does not create a new import line in the generated code
 			},
 			{
+				ResourceName: "DaemonSet",
+				ImportAlias:  "appsv1",
+				// Don't specify ResourceImportPath so this block does not create a new import line in the generated code
+			},
+			{
 				ResourceName:       "PodDisruptionBudget",
 				ImportAlias:        "policyv1beta1",
 				ResourceImportPath: "k8s.io/api/policy/v1beta1",

--- a/api/pkg/controller/container-linux/container_linux_controller.go
+++ b/api/pkg/controller/container-linux/container_linux_controller.go
@@ -1,0 +1,167 @@
+package containerlinux
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kubermatic/kubermatic/api/pkg/controller/container-linux/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "kubermatic_container_linux_controller"
+)
+
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	overwriteRegistry string
+}
+
+func Add(mgr manager.Manager, overwriteRegistry string) error {
+
+	reconciler := &Reconciler{
+		Client:            mgr.GetClient(),
+		overwriteRegistry: overwriteRegistry,
+	}
+
+	ctrlOptions := controller.Options{
+		Reconciler: reconciler,
+		// Only use 1 worker to prevent concurrent operator deployments
+		MaxConcurrentReconciles: 1,
+	}
+	c, err := controller.New(ControllerName, mgr, ctrlOptions)
+	if err != nil {
+		return err
+	}
+
+	predicates := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newNode := e.ObjectNew.(*corev1.Node)
+			// Only sync if the node uses ContainerLinux & is missing the label
+			return isContainerLinuxNode(newNode) && !hasContainerLinuxLabel(newNode)
+		},
+	}
+	return c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}, predicates)
+}
+
+func (r *Reconciler) Reconcile(_ reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hasContainerLinuxNodes, err := r.labelAllContainerLinuxNodes(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to ensure that all ContainerLinux nodes have the %s label: %v", resources.NodeSelectorLabelKey, err)
+	}
+
+	// If we have no ContainerLinux node, we just skip the rest
+	if !hasContainerLinuxNodes {
+		return reconcile.Result{}, nil
+	}
+
+	if err := r.reconcileUpdateOperatorResources(ctx); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile the UpdateOperator resources: %v", err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// labelAllContainerLinuxNodes labels all nodes which use ContainerLinux.
+// If at least one ContainerLinux node exists, true will be returned
+func (r *Reconciler) labelAllContainerLinuxNodes(ctx context.Context) (bool, error) {
+	var hasContainerLinuxNode bool
+	nodeList := &corev1.NodeList{}
+	if err := r.List(ctx, &ctrlruntimeclient.ListOptions{}, nodeList); err != nil {
+		return false, fmt.Errorf("failed to list nodes: %v", err)
+	}
+
+	for _, node := range nodeList.Items {
+		usesContainerLinux := isContainerLinuxNode(&node)
+		hasLabel := hasContainerLinuxLabel(&node)
+
+		if usesContainerLinux && !hasLabel {
+			if node.Labels == nil {
+				node.Labels = map[string]string{}
+			}
+			node.Labels[resources.NodeSelectorLabelKey] = resources.NodeSelectorLabelValue
+
+			if err := r.Client.Update(ctx, &node); err != nil {
+				return false, fmt.Errorf("failed to update node: %v", err)
+			}
+		}
+
+		if usesContainerLinux {
+			hasContainerLinuxNode = true
+		}
+	}
+
+	return hasContainerLinuxNode, nil
+}
+
+// reconcileUpdateOperatorResources deploys the ContainerLinuxUpdateOperator
+// https://github.com/coreos/container-linux-update-operator
+func (r *Reconciler) reconcileUpdateOperatorResources(ctx context.Context) error {
+	saCreators := []reconciling.NamedServiceAccountCreatorGetter{
+		resources.ServiceAccountCreator(),
+	}
+	if err := reconciling.ReconcileServiceAccounts(ctx, saCreators, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the ServiceAccounts: %v", err)
+	}
+
+	crCreators := []reconciling.NamedClusterRoleCreatorGetter{
+		resources.ClusterRoleCreator(),
+	}
+	if err := reconciling.ReconcileClusterRoles(ctx, crCreators, metav1.NamespaceNone, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the ClusterRoles: %v", err)
+	}
+
+	crbCreators := []reconciling.NamedClusterRoleBindingCreatorGetter{
+		resources.ClusterRoleBindingCreator(),
+	}
+	if err := reconciling.ReconcileClusterRoleBindings(ctx, crbCreators, metav1.NamespaceNone, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the ClusterRoleBindings: %v", err)
+	}
+
+	depCreators := []reconciling.NamedDeploymentCreatorGetter{
+		resources.DeploymentCreator(r.DefaultRegistry),
+	}
+	if err := reconciling.ReconcileDeployments(ctx, depCreators, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the Deployments: %v", err)
+	}
+
+	dsCreators := []reconciling.NamedDaemonSetCreatorGetter{
+		resources.DaemonSetCreator(r.DefaultRegistry),
+	}
+	if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the DaemonSet: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) DefaultRegistry(defaultRegistry string) string {
+	if r.overwriteRegistry != "" {
+		return r.overwriteRegistry
+	}
+	return defaultRegistry
+}
+
+func isContainerLinuxNode(node *corev1.Node) bool {
+	osImage := strings.ToLower(node.Status.NodeInfo.OSImage)
+	return strings.Contains(osImage, "container linux")
+}
+
+func hasContainerLinuxLabel(node *corev1.Node) bool {
+	return node.Labels[resources.NodeSelectorLabelKey] == resources.NodeSelectorLabelValue
+}

--- a/api/pkg/controller/container-linux/resources/clusterrole.go
+++ b/api/pkg/controller/container-linux/resources/clusterrole.go
@@ -15,6 +15,7 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 		return ClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Rules = []rbacv1.PolicyRule{
 				{
+					APIGroups: []string{""},
 					Resources: []string{"nodes"},
 					Verbs: []string{
 						"get",
@@ -24,6 +25,7 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 					},
 				},
 				{
+					APIGroups: []string{""},
 					Resources: []string{"configmaps"},
 					Verbs: []string{
 						"create",
@@ -34,6 +36,7 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 					},
 				},
 				{
+					APIGroups: []string{""},
 					Resources: []string{"events"},
 					Verbs: []string{
 						"create",
@@ -41,6 +44,7 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 					},
 				},
 				{
+					APIGroups: []string{""},
 					Resources: []string{"pods"},
 					Verbs: []string{
 						"get",

--- a/api/pkg/controller/container-linux/resources/clusterrole.go
+++ b/api/pkg/controller/container-linux/resources/clusterrole.go
@@ -1,0 +1,63 @@
+package resources
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+const (
+	ClusterRoleName = "container_linux_update_operator"
+)
+
+func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return ClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			cr.Rules = []rbacv1.PolicyRule{
+				{
+					Resources: []string{"nodes"},
+					Verbs: []string{
+						"get",
+						"list",
+						"watch",
+						"update",
+					},
+				},
+				{
+					Resources: []string{"configmaps"},
+					Verbs: []string{
+						"create",
+						"get",
+						"update",
+						"list",
+						"watch",
+					},
+				},
+				{
+					Resources: []string{"events"},
+					Verbs: []string{
+						"create",
+						"watch",
+					},
+				},
+				{
+					Resources: []string{"pods"},
+					Verbs: []string{
+						"get",
+						"list",
+						"delete",
+					},
+				},
+				{
+					APIGroups: []string{"extensions"},
+					Resources: []string{"daemonsets"},
+					Verbs: []string{
+						"get",
+					},
+				},
+			}
+
+			return cr, nil
+		}
+	}
+}

--- a/api/pkg/controller/container-linux/resources/clusterrole.go
+++ b/api/pkg/controller/container-linux/resources/clusterrole.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	ClusterRoleName = "container_linux_update_operator"
+	ClusterRoleName = "container-linux-update-operator"
 )
 
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {

--- a/api/pkg/controller/container-linux/resources/clusterrolebinding.go
+++ b/api/pkg/controller/container-linux/resources/clusterrolebinding.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClusterRoleBindingName = "container_linux_update_operator"
+	ClusterRoleBindingName = "container-linux-update-operator"
 )
 
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {

--- a/api/pkg/controller/container-linux/resources/clusterrolebinding.go
+++ b/api/pkg/controller/container-linux/resources/clusterrolebinding.go
@@ -1,0 +1,33 @@
+package resources
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ClusterRoleBindingName = "container_linux_update_operator"
+)
+
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return ClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     ClusterRoleName,
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Namespace: metav1.NamespaceSystem,
+					Name:      ServiceAccountName,
+				},
+			}
+
+			return crb, nil
+		}
+	}
+}

--- a/api/pkg/controller/container-linux/resources/daemonset.go
+++ b/api/pkg/controller/container-linux/resources/daemonset.go
@@ -1,0 +1,123 @@
+package resources
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	DaemonSetName = "container-linux-update-agent"
+)
+
+var (
+	daemonSetMaxUnavailable = intstr.FromInt(1)
+)
+
+func DaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemonSetCreatorGetter {
+	return func() (string, reconciling.DaemonSetCreator) {
+		return DaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+			ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &daemonSetMaxUnavailable,
+				},
+			}
+
+			labels := map[string]string{"app": "container-linux-update-agent"}
+			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+			ds.Spec.Template.ObjectMeta.Labels = labels
+
+			// The agent should only run on ContainerLinux nodes
+			ds.Spec.Template.Spec.NodeSelector = map[string]string{NodeSelectorLabelKey: NodeSelectorLabelValue}
+
+			ds.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            "update-agent",
+					Image:           getRegistry(resources.RegistryQuay) + "/coreos/container-linux-update-operator:v0.7.0",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/bin/update-agent"},
+					Env: []corev1.EnvVar{
+						{
+							Name: "UPDATE_AGENT_NODE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+						{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+					},
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "var-run-dbus",
+							MountPath: "/var/run/dbus",
+						},
+						{
+							Name:      "etc-coreos",
+							MountPath: "/etc/coreos",
+						},
+						{
+							Name:      "usr-share-coreos",
+							MountPath: "/usr/share/coreos",
+						},
+						{
+							Name:      "etc-os-release",
+							MountPath: "/etc/os-release",
+						},
+					},
+				},
+			}
+
+			ds.Spec.Template.Spec.Volumes = []corev1.Volume{
+				{
+					Name: "var-run-dbus",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/run/dbus",
+						},
+					},
+				},
+				{
+					Name: "etc-coreos",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/etc/coreos",
+						},
+					},
+				},
+				{
+					Name: "usr-share-coreos",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/usr/share/coreos",
+						},
+					},
+				},
+				{
+					Name: "etc-os-release",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/etc/os-release",
+						},
+					},
+				},
+			}
+
+			return ds, nil
+		}
+	}
+}

--- a/api/pkg/controller/container-linux/resources/daemonset.go
+++ b/api/pkg/controller/container-linux/resources/daemonset.go
@@ -35,6 +35,8 @@ func DaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemonSetCr
 			// The agent should only run on ContainerLinux nodes
 			ds.Spec.Template.Spec.NodeSelector = map[string]string{NodeSelectorLabelKey: NodeSelectorLabelValue}
 
+			ds.Spec.Template.Spec.ServiceAccountName = ServiceAccountName
+
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "update-agent",

--- a/api/pkg/controller/container-linux/resources/deployment.go
+++ b/api/pkg/controller/container-linux/resources/deployment.go
@@ -40,6 +40,7 @@ func DeploymentCreator(getRegistry GetImageRegistry) reconciling.NamedDeployment
 			labels := map[string]string{"app": "container-linux-update-operator"}
 			dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 			dep.Spec.Template.ObjectMeta.Labels = labels
+			dep.Spec.Template.Spec.ServiceAccountName = ServiceAccountName
 
 			// The operator should only run on ContainerLinux nodes
 			dep.Spec.Template.Spec.NodeSelector = map[string]string{NodeSelectorLabelKey: NodeSelectorLabelValue}

--- a/api/pkg/controller/container-linux/resources/deployment.go
+++ b/api/pkg/controller/container-linux/resources/deployment.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	DeploymentName = "container-linux-update-operator"
+
+	// Used as NodeSelector on the Agent & Operator. Ensures that we only run those components on ContainerLinux nodes
+	NodeSelectorLabelKey   = "kubernetes.io/uses-container-linux"
+	NodeSelectorLabelValue = "true"
+)
+
+var (
+	deploymentReplicas int32 = 1
+	deploymentMaxSurge       = intstr.FromInt(1)
+)
+
+type GetImageRegistry func(reg string) string
+
+func DeploymentCreator(getRegistry GetImageRegistry) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
+		return DeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Spec.Replicas = &deploymentReplicas
+
+			dep.Spec.Strategy = appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge: &deploymentMaxSurge,
+				},
+			}
+
+			labels := map[string]string{"app": "container-linux-update-operator"}
+			dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+			dep.Spec.Template.ObjectMeta.Labels = labels
+
+			// The operator should only run on ContainerLinux nodes
+			dep.Spec.Template.Spec.NodeSelector = map[string]string{NodeSelectorLabelKey: NodeSelectorLabelValue}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            "update-operator",
+					Image:           getRegistry(resources.RegistryQuay) + "/coreos/container-linux-update-operator:v0.7.0",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/bin/update-operator"},
+					Env: []corev1.EnvVar{
+						{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+					},
+					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+				},
+			}
+
+			return dep, nil
+		}
+	}
+}

--- a/api/pkg/controller/container-linux/resources/serviceaccount.go
+++ b/api/pkg/controller/container-linux/resources/serviceaccount.go
@@ -1,0 +1,19 @@
+package resources
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	ServiceAccountName = "container_linux_update_operator"
+)
+
+func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return ServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			return sa, nil
+		}
+	}
+}

--- a/api/pkg/controller/container-linux/resources/serviceaccount.go
+++ b/api/pkg/controller/container-linux/resources/serviceaccount.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	ServiceAccountName = "container_linux_update_operator"
+	ServiceAccountName = "container-linux-update-operator"
 )
 
 func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {

--- a/api/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/api/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -223,6 +223,40 @@ func ReconcileDeployments(ctx context.Context, namedGetters []NamedDeploymentCre
 	return nil
 }
 
+// DaemonSetCreator defines an interface to create/update DaemonSets
+type DaemonSetCreator = func(existing *appsv1.DaemonSet) (*appsv1.DaemonSet, error)
+
+// NamedDaemonSetCreatorGetter returns the name of the resource and the corresponding creator function
+type NamedDaemonSetCreatorGetter = func() (name string, create DaemonSetCreator)
+
+// DaemonSetObjectWrapper adds a wrapper so the DaemonSetCreator matches ObjectCreator
+// This is needed as golang does not support function interface matching
+func DaemonSetObjectWrapper(create DaemonSetCreator) ObjectCreator {
+	return func(existing runtime.Object) (runtime.Object, error) {
+		if existing != nil {
+			return create(existing.(*appsv1.DaemonSet))
+		}
+		return create(&appsv1.DaemonSet{})
+	}
+}
+
+// ReconcileDaemonSets will create and update the DaemonSets coming from the passed DaemonSetCreator slice
+func ReconcileDaemonSets(ctx context.Context, namedGetters []NamedDaemonSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
+	for _, get := range namedGetters {
+		name, create := get()
+		createObject := DaemonSetObjectWrapper(create)
+		for _, objectModifier := range objectModifiers {
+			createObject = objectModifier(createObject)
+		}
+
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appsv1.DaemonSet{}); err != nil {
+			return fmt.Errorf("failed to ensure DaemonSet: %v", err)
+		}
+	}
+
+	return nil
+}
+
 // PodDisruptionBudgetCreator defines an interface to create/update PodDisruptionBudgets
 type PodDisruptionBudgetCreator = func(existing *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error)
 

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -43,6 +43,8 @@ spec:
         - ""
         - -openvpn-server-port
         - "30003"
+        - -overwrite-registry
+        - ""
         - -openshift=false
         - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
         - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -113,6 +113,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 						"-ca-cert", "/etc/kubernetes/pki/ca/ca.crt",
 						"-cluster-url", data.Cluster().Address.URL,
 						"-openvpn-server-port", fmt.Sprint(openvpnServerPort),
+						"-overwrite-registry", data.ImageRegistry(""),
 						fmt.Sprintf("-openshift=%t", openshift),
 						fmt.Sprintf("-openvpn-ca-cert-file=%s/%s", openvpnCAMountDir, resources.OpenVPNCACertKey),
 						fmt.Sprintf("-openvpn-ca-key-file=%s/%s", openvpnCAMountDir, resources.OpenVPNCAKeyKey),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ContainerLinux controller which is responsible for:
- Labeling all Nodes which run ContainerLinux
- Deploy the ContainerLinuxUpdateOperator

When there is no ContainerLinux node in the cluster, the operator won't be deployed.
All operator componentes get deployed with a NodeSelector, so they only run on ContainerLinux nodes.

If the user removes all ContainerLinux nodes, the operator will not be removed - I don't think its worth the effort (Rare edge case + It does not hurt to have those resources).

Fixes #2996
Fixes #2080

**Release note**:
```release-note
Add the ContainerLinuxUpdateOperator to all clusters using ContainerLinux nodes
```
