### PR TITLE
set missing backup cronjob properties

### DIFF
--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -380,6 +380,9 @@ func (r *Reconciler) cronjob(cluster *kubermaticv1.Cluster) (string, reconciling
 					"--key", "/etc/etcd/client/backup-etcd-client.key",
 					"snapshot", "save", "/backup/snapshot.db",
 				},
+				ImagePullPolicy:          corev1.PullIfNotPresent,
+				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      SharedVolumeName,


### PR DESCRIPTION
**What this PR does / why we need it**:
Set missing backup cronjob properties.
The missing properties get defaulted by the API server which caused it to be endlessly reconciled.

Logs from the controller manager on cloud.kubermatic.io:
```
I0417 07:49:01.789622       1 compare.go:30] Object *v1beta1.CronJob kube-system/etcd-backup-bpk2jflp56 differs from the one, generated: [Spec.JobTemplate.Spec.Template.Spec.InitContainers.slice[0].TerminationMessagePath:  != /dev/termination-log Spec.JobTemplate.Spec.Template.Spec.InitContainers.slice[0].TerminationMessagePolicy:  != File Spec.JobTemplate.Spec.Template.Spec.InitContainers.slice[0].ImagePullPolicy:  != IfNotPresent]
```

**Release note**:
```release-note
NONE
```
