### PR TITLE
add endpoint to edit tokens

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2281,11 +2281,11 @@
         ],
         "responses": {
           "200": {
-            "description": "ServiceAccountToken",
+            "description": "PublicServiceAccountToken",
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/ServiceAccountToken"
+                "$ref": "#/definitions/PublicServiceAccountToken"
               }
             }
           },
@@ -2340,6 +2340,128 @@
             "description": "ServiceAccountToken",
             "schema": {
               "$ref": "#/definitions/ServiceAccountToken"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/serviceaccounts/{serviceaccount_id}/tokens/{token_id}": {
+      "put": {
+        "description": "Updates and regenerates the token",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "tokens"
+        ],
+        "operationId": "updateServiceAccountToken",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ServiceAccountID",
+            "name": "serviceaccount_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "TokenID",
+            "name": "token_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/PublicServiceAccountToken"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ServiceAccountToken",
+            "schema": {
+              "$ref": "#/definitions/ServiceAccountToken"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      },
+      "patch": {
+        "description": "Patches the token name",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "tokens"
+        ],
+        "operationId": "patchServiceAccountToken",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ServiceAccountID",
+            "name": "serviceaccount_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "TokenID",
+            "name": "token_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/tokenPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PublicServiceAccountToken",
+            "schema": {
+              "$ref": "#/definitions/PublicServiceAccountToken"
             }
           },
           "401": {
@@ -5324,6 +5446,16 @@
       "type": "object",
       "title": "Version represents a single semantic version.",
       "x-go-package": "github.com/kubermatic/kubermatic/api/vendor/github.com/Masterminds/semver"
+    },
+    "tokenPatch": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/handler/v1/serviceaccount"
     }
   },
   "responses": {

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2453,7 +2453,11 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/tokenPatch"
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint8"
+              }
             }
           }
         ],
@@ -5446,16 +5450,6 @@
       "type": "object",
       "title": "Version represents a single semantic version.",
       "x-go-package": "github.com/kubermatic/kubermatic/api/vendor/github.com/Masterminds/semver"
-    },
-    "tokenPatch": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "x-go-name": "Name"
-        }
-      },
-      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/handler/v1/serviceaccount"
     }
   },
   "responses": {

--- a/api/pkg/handler/v1/serviceaccount/sa.go
+++ b/api/pkg/handler/v1/serviceaccount/sa.go
@@ -206,8 +206,8 @@ type addReq struct {
 	Body apiv1.ServiceAccount
 }
 
-// idReq represents a request that contains service account ID in the path
-type idReq struct {
+// serviceAccountIDReq represents a request that contains service account ID in the path
+type serviceAccountIDReq struct {
 	// in: path
 	ServiceAccountID string `json:"serviceaccount_id"`
 }
@@ -216,14 +216,14 @@ type idReq struct {
 // swagger:parameters updateServiceAccount
 type updateReq struct {
 	addReq
-	idReq
+	serviceAccountIDReq
 }
 
 // deleteReq defines HTTP request for deleteServiceAccount
 // swagger:parameters deleteServiceAccount
 type deleteReq struct {
 	common.ProjectReq
-	idReq
+	serviceAccountIDReq
 }
 
 // Validate validates DeleteEndpoint request
@@ -322,8 +322,8 @@ func DecodeDeleteReq(c context.Context, r *http.Request) (interface{}, error) {
 	return req, nil
 }
 
-func decodeServiceAccountIDReq(c context.Context, r *http.Request) (idReq, error) {
-	var req idReq
+func decodeServiceAccountIDReq(c context.Context, r *http.Request) (serviceAccountIDReq, error) {
+	var req serviceAccountIDReq
 
 	saID, ok := mux.Vars(r)["serviceaccount_id"]
 	if !ok {

--- a/api/pkg/handler/v1/serviceaccount/token.go
+++ b/api/pkg/handler/v1/serviceaccount/token.go
@@ -192,7 +192,11 @@ func updateToken(projectProvider provider.ProjectProvider, serviceAccountProvide
 	}
 	existingName, ok := existingSecret.Labels["name"]
 	if !ok {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("can not find token name in secret %s", existingSecret.Name))
+		return nil, fmt.Errorf("can not find token name in secret %s", existingSecret.Name)
+	}
+
+	if newName == existingName && !regenerateToken {
+		return existingSecret, nil
 	}
 
 	if newName != existingName {
@@ -210,7 +214,7 @@ func updateToken(projectProvider provider.ProjectProvider, serviceAccountProvide
 	if regenerateToken {
 		token, err := tokenGenerator.Generate(serviceaccount.Claims(sa.Spec.Email, project.Name, existingSecret.Name))
 		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, "can not generate token data")
+			return nil, fmt.Errorf("can not generate token data")
 		}
 
 		existingSecret.Data["token"] = []byte(token)

--- a/api/pkg/handler/v1/serviceaccount/token_test.go
+++ b/api/pkg/handler/v1/serviceaccount/token_test.go
@@ -268,6 +268,270 @@ func TestServiceAccountCanGetProject(t *testing.T) {
 	}
 }
 
+func TestPatchToken(t *testing.T) {
+	t.Parallel()
+	expiry, err := test.GenDefaultExpiry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	testcases := []struct {
+		name                   string
+		body                   string
+		existingKubermaticObjs []runtime.Object
+		existingKubernetesObjs []runtime.Object
+		expectedToken          apiv1.PublicServiceAccountToken
+		expectedErrorMsg       string
+		projectToSync          string
+		saToSync               string
+		tokenToSync            string
+		httpStatus             int
+		existingAPIUser        apiv1.User
+	}{
+		{
+			name:       "scenario 1: change token name successfully",
+			httpStatus: http.StatusOK,
+			body:       `{"name":"test-new-name"}`,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "editors"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				genActiveServiceAccount("1", "test-1", "editors", "plan9-ID"),
+			},
+			existingKubernetesObjs: []runtime.Object{
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1"),
+			},
+			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
+			projectToSync:   "plan9-ID",
+			saToSync:        "1",
+			tokenToSync:     "sa-token-1",
+			expectedToken:   genPublicServiceAccountToken("sa-token-1", "test-new-name", expiry),
+		},
+		{
+			name:       "scenario 2: changed name is empty",
+			httpStatus: http.StatusBadRequest,
+			body:       `{"name":""}`,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "editors"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				genActiveServiceAccount("1", "test-1", "editors", "plan9-ID"),
+			},
+			existingKubernetesObjs: []runtime.Object{
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1"),
+			},
+			existingAPIUser:  *test.GenAPIUser("john", "john@acme.com"),
+			projectToSync:    "plan9-ID",
+			saToSync:         "1",
+			tokenToSync:      "sa-token-1",
+			expectedErrorMsg: `{"error":{"code":400,"message":"new name can not be empty"}}`,
+		},
+		{
+			name:       "scenario 3: new name exists for other token",
+			httpStatus: http.StatusConflict,
+			body:       `{"name":"test-2"}`,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "editors"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				genActiveServiceAccount("1", "test-1", "editors", "plan9-ID"),
+			},
+			existingKubernetesObjs: []runtime.Object{
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1"),
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-2", "2"),
+			},
+			existingAPIUser:  *test.GenAPIUser("john", "john@acme.com"),
+			projectToSync:    "plan9-ID",
+			saToSync:         "1",
+			tokenToSync:      "sa-token-1",
+			expectedErrorMsg: `{"error":{"code":409,"message":"token \"test-2\" already exists"}}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToSync), strings.NewReader(tc.body))
+			res := httptest.NewRecorder()
+
+			ep, _, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, tc.existingKubernetesObjs, []runtime.Object{}, tc.existingKubermaticObjs, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.httpStatus {
+				t.Fatalf("expected HTTP status code %d, got %d: %s", tc.httpStatus, res.Code, res.Body.String())
+			}
+
+			if len(tc.expectedErrorMsg) == 0 {
+				var token apiv1.PublicServiceAccountToken
+				err = json.Unmarshal(res.Body.Bytes(), &token)
+				if err != nil {
+					t.Fatal(err.Error())
+				}
+
+				if token.Name != tc.expectedToken.Name {
+					t.Fatalf("expected new name %s got %s", tc.expectedToken.Name, token.Name)
+				}
+				if token.ID != tc.expectedToken.ID {
+					t.Fatalf("expected ID %s got %s", tc.expectedToken.ID, token.ID)
+				}
+				if token.Expiry != tc.expectedToken.Expiry {
+					t.Fatalf("expected expiry %v got %v", tc.expectedToken.Expiry, token.Expiry)
+				}
+			} else {
+				test.CompareWithResult(t, res, tc.expectedErrorMsg)
+			}
+		})
+	}
+}
+
+func TestUpdateToken(t *testing.T) {
+	t.Parallel()
+	expiry, err := test.GenDefaultExpiry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	testcases := []struct {
+		name                   string
+		body                   string
+		existingKubermaticObjs []runtime.Object
+		existingKubernetesObjs []runtime.Object
+		expectedToken          apiv1.PublicServiceAccountToken
+		expectedErrorMsg       string
+		projectToSync          string
+		saToSync               string
+		tokenToSync            string
+		httpStatus             int
+		existingAPIUser        apiv1.User
+	}{
+		{
+			name:       "scenario 1: change token name successfully and regenerate token",
+			httpStatus: http.StatusOK,
+			body:       `{"name":"test-new-name", "id":"sa-token-1"}`,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "editors"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				genActiveServiceAccount("1", "test-1", "editors", "plan9-ID"),
+			},
+			existingKubernetesObjs: []runtime.Object{
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1"),
+			},
+			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
+			projectToSync:   "plan9-ID",
+			saToSync:        "1",
+			tokenToSync:     "sa-token-1",
+			expectedToken:   genPublicServiceAccountToken("sa-token-1", "test-new-name", expiry),
+		},
+		{
+			name:       "scenario 2: changed name is empty",
+			httpStatus: http.StatusBadRequest,
+			body:       `{"name":"","id":"sa-token-1"}`,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "editors"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				genActiveServiceAccount("1", "test-1", "editors", "plan9-ID"),
+			},
+			existingKubernetesObjs: []runtime.Object{
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1"),
+			},
+			existingAPIUser:  *test.GenAPIUser("john", "john@acme.com"),
+			projectToSync:    "plan9-ID",
+			saToSync:         "1",
+			tokenToSync:      "sa-token-1",
+			expectedErrorMsg: `{"error":{"code":400,"message":"new name can not be empty"}}`,
+		},
+		{
+			name:       "scenario 3: new name exists for other token",
+			httpStatus: http.StatusConflict,
+			body:       `{"name":"test-2","id":"sa-token-1"}`,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "editors"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				genActiveServiceAccount("1", "test-1", "editors", "plan9-ID"),
+			},
+			existingKubernetesObjs: []runtime.Object{
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1"),
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-2", "2"),
+			},
+			existingAPIUser:  *test.GenAPIUser("john", "john@acme.com"),
+			projectToSync:    "plan9-ID",
+			saToSync:         "1",
+			tokenToSync:      "sa-token-1",
+			expectedErrorMsg: `{"error":{"code":409,"message":"token \"test-2\" already exists"}}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToSync), strings.NewReader(tc.body))
+			res := httptest.NewRecorder()
+
+			ep, _, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, tc.existingKubernetesObjs, []runtime.Object{}, tc.existingKubermaticObjs, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.httpStatus {
+				t.Fatalf("expected HTTP status code %d, got %d: %s", tc.httpStatus, res.Code, res.Body.String())
+			}
+
+			if len(tc.expectedErrorMsg) == 0 {
+				var token apiv1.ServiceAccountToken
+				err = json.Unmarshal(res.Body.Bytes(), &token)
+				if err != nil {
+					t.Fatal(err.Error())
+				}
+
+				if token.Name != tc.expectedToken.Name {
+					t.Fatalf("expected new name %s got %s", tc.expectedToken.Name, token.Name)
+				}
+				if token.ID != tc.expectedToken.ID {
+					t.Fatalf("expected ID %s got %s", tc.expectedToken.ID, token.ID)
+				}
+				if token.Expiry == tc.expectedToken.Expiry {
+					t.Fatalf("token should be regenerated and expiration times should not be equal but got %v", token.Expiry)
+				}
+				if token.Token == test.TestFakeToken {
+					t.Fatalf("token should be regenerated")
+				}
+
+			} else {
+				test.CompareWithResult(t, res, tc.expectedErrorMsg)
+			}
+		})
+	}
+}
+
 func genPublicServiceAccountToken(id, name string, expiry apiv1.Time) apiv1.PublicServiceAccountToken {
 	token := apiv1.PublicServiceAccountToken{}
 	token.ID = id

--- a/api/pkg/provider/kubernetes/sa_token.go
+++ b/api/pkg/provider/kubernetes/sa_token.go
@@ -183,3 +183,35 @@ func isToken(secret *v1.Secret) bool {
 	}
 	return strings.HasPrefix(secret.Name, "sa-token")
 }
+
+// Get method returns token by name
+func (p *ServiceAccountTokenProvider) Get(userInfo *provider.UserInfo, name string) (*v1.Secret, error) {
+	if userInfo == nil {
+		return nil, kerrors.NewBadRequest("userInfo cannot be nil")
+	}
+	if len(name) == 0 {
+		return nil, kerrors.NewBadRequest("service account name cannot be empty")
+	}
+
+	kubernetesImpersonatedClient, err := createKubernetesImpersonationClientWrapperFromUserInfo(userInfo, p.kubernetesImpersonationClient)
+	if err != nil {
+		return nil, kerrors.NewInternalError(err)
+	}
+	return kubernetesImpersonatedClient.CoreV1().Secrets(kubermaticNamespace).Get(name, metav1.GetOptions{})
+}
+
+// Update method updates given token
+func (p *ServiceAccountTokenProvider) Update(userInfo *provider.UserInfo, secret *v1.Secret) (*v1.Secret, error) {
+	if userInfo == nil {
+		return nil, kerrors.NewBadRequest("userInfo cannot be nil")
+	}
+	if secret == nil {
+		return nil, kerrors.NewBadRequest("secret cannot be empty")
+	}
+
+	kubernetesImpersonatedClient, err := createKubernetesImpersonationClientWrapperFromUserInfo(userInfo, p.kubernetesImpersonationClient)
+	if err != nil {
+		return nil, kerrors.NewInternalError(err)
+	}
+	return kubernetesImpersonatedClient.CoreV1().Secrets(kubermaticNamespace).Update(secret)
+}

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -351,6 +351,8 @@ type ServiceAccountListOptions struct {
 type ServiceAccountTokenProvider interface {
 	Create(userInfo *UserInfo, sa *kubermaticv1.User, projectID, tokenName, tokenID, tokenData string) (*v1.Secret, error)
 	List(userInfo *UserInfo, project *kubermaticv1.Project, sa *kubermaticv1.User, options *ServiceAccountTokenListOptions) ([]*v1.Secret, error)
+	Get(userInfo *UserInfo, name string) (*v1.Secret, error)
+	Update(userInfo *UserInfo, secret *v1.Secret) (*v1.Secret, error)
 }
 
 // ServiceAccountTokenListOptions allows to set filters that will be applied to filter the result.


### PR DESCRIPTION
**What this PR does / why we need it**: new endpoints to edit token for the service account. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3204

```release-note
new endpoints to edit token for the service account:
PUT /api/v1/projects/{project_id}/serviceaccounts/{serviceaccount_id}/tokens/{token_id} - updates and regenerates token data
PATCH /api/v1/projects/{project_id}/serviceaccounts/{serviceaccount_id}/tokens/{token_id} - changes token name
```
