### PR TITLE
Add events for initial node deployment

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -1979,6 +1979,7 @@
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
     "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/listers/core/v1",
     "k8s.io/client-go/listers/rbac/v1",
     "k8s.io/client-go/rest",

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -185,7 +185,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	kubermaticMasterInformerFactory.Start(wait.NeverStop)
 	kubermaticMasterInformerFactory.WaitForCacheSync(wait.NeverStop)
 
-	eventRecorderProvider := kubernetesprovider.NewEventRecorder(config)
+	eventRecorderProvider := kubernetesprovider.NewEventRecorder()
 
 	return providers{
 			sshKey:                                sshKeyProvider,

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -136,7 +136,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 				kubermaticSeedInformerFactory.Kubermatic().V1().Clusters().Lister(),
 				options.workerName,
 				rbac.ExtractGroupPrefix,
-				cfg,
+				client.NewSeedClient(seedCtrlruntimeClient, cfg),
 			)
 
 			kubeInformerFactory.Start(wait.NeverStop)

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	prometheusapi "github.com/prometheus/client_golang/api"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
@@ -45,7 +46,6 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/serviceaccount"
 	"github.com/kubermatic/kubermatic/api/pkg/util/informer"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -136,6 +136,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 				kubermaticSeedInformerFactory.Kubermatic().V1().Clusters().Lister(),
 				options.workerName,
 				rbac.ExtractGroupPrefix,
+				cfg,
 			)
 
 			kubeInformerFactory.Start(wait.NeverStop)
@@ -184,6 +185,8 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	kubermaticMasterInformerFactory.Start(wait.NeverStop)
 	kubermaticMasterInformerFactory.WaitForCacheSync(wait.NeverStop)
 
+	eventRecorderProvider := kubernetesprovider.NewEventRecorder(config)
+
 	return providers{
 			sshKey:                                sshKeyProvider,
 			user:                                  userProvider,
@@ -195,6 +198,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 			projectMember:                         projectMemberProvider,
 			memberMapper:                          projectMemberProvider,
 			cloud:                                 cloudProviders,
+			eventRecorderProvider:                 eventRecorderProvider,
 			clusters:                              clusterProviders,
 			datacenters:                           datacenters},
 		nil
@@ -278,6 +282,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 		prov.memberMapper,
 		serviceAccountTokenAuth,
 		serviceAccountTokenGenerator,
+		prov.eventRecorderProvider,
 	)
 
 	registerMetrics()

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -136,7 +136,8 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 				kubermaticSeedInformerFactory.Kubermatic().V1().Clusters().Lister(),
 				options.workerName,
 				rbac.ExtractGroupPrefix,
-				client.NewSeedClient(seedCtrlruntimeClient, cfg),
+				seedCtrlruntimeClient,
+				kubeClient,
 			)
 
 			kubeInformerFactory.Start(wait.NeverStop)

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -111,6 +111,7 @@ type providers struct {
 	projectMember                         provider.ProjectMemberProvider
 	memberMapper                          provider.ProjectMemberMapper
 	cloud                                 provider.CloudRegistry
+	eventRecorderProvider                 provider.EventRecorderProvider
 	clusters                              map[string]provider.ClusterProvider
 	datacenters                           map[string]provider.DatacenterMeta
 }

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -617,6 +617,66 @@
         }
       }
     },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/events": {
+      "get": {
+        "produces": [
+          "application/yaml"
+        ],
+        "tags": [
+          "project"
+        ],
+        "summary": "Gets the events related to the specified cluster.",
+        "operationId": "getClusterEvents",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Type",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Event",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Event"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/health": {
       "get": {
         "description": "Returns the cluster's component health status",

--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -170,34 +170,3 @@ func (p *provider) GetDynamicClient(c *kubermaticv1.Cluster, options ...ConfigOp
 	}
 	return dynamicClient, nil
 }
-
-// SeedClusterConnectionProvider offers functions to interact with a seed cluster
-type SeedClusterConnectionProvider interface {
-	GetSeedClusterAdminClient() ctrlruntimeclient.Client
-	GetSeedClusterAdminConfig() *restclient.Config
-}
-
-// NewSeedClient returns a new instance of the client connection provider that
-// gives user access to the seed cluster client and config
-func NewSeedClient(seedClient ctrlruntimeclient.Client, seedConfig *restclient.Config) SeedClusterConnectionProvider {
-	return &seedProvider{seedClient: seedClient, seedConfig: seedConfig}
-}
-
-type seedProvider struct {
-	seedClient ctrlruntimeclient.Client
-	seedConfig *restclient.Config
-}
-
-// GetSeedClusterAdminClient returns a client to interact with the seed cluster resources.
-//
-// Note that this client has admin privileges in the seed cluster.
-func (s *seedProvider) GetSeedClusterAdminClient() ctrlruntimeclient.Client {
-	return s.seedClient
-}
-
-// GetSeedClusterAdminConfig returns a config that gives access to the seed cluster.
-//
-// Note that this config has admin privileges in the seed cluster.
-func (s *seedProvider) GetSeedClusterAdminConfig() *restclient.Config {
-	return s.seedConfig
-}

--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -170,3 +170,34 @@ func (p *provider) GetDynamicClient(c *kubermaticv1.Cluster, options ...ConfigOp
 	}
 	return dynamicClient, nil
 }
+
+// SeedClusterConnectionProvider offers functions to interact with a seed cluster
+type SeedClusterConnectionProvider interface {
+	GetSeedClusterAdminClient() ctrlruntimeclient.Client
+	GetSeedClusterAdminConfig() *restclient.Config
+}
+
+// NewSeedClient returns a new instance of the client connection provider that
+// gives user access to the seed cluster client and config
+func NewSeedClient(seedClient ctrlruntimeclient.Client, seedConfig *restclient.Config) SeedClusterConnectionProvider {
+	return &seedProvider{seedClient: seedClient, seedConfig: seedConfig}
+}
+
+type seedProvider struct {
+	seedClient ctrlruntimeclient.Client
+	seedConfig *restclient.Config
+}
+
+// GetSeedClusterAdminClient returns a client to interact with the seed cluster resources.
+//
+// Note that this client has admin privileges in the seed cluster.
+func (s *seedProvider) GetSeedClusterAdminClient() ctrlruntimeclient.Client {
+	return s.seedClient
+}
+
+// GetSeedClusterAdminConfig returns a config that gives access to the seed cluster.
+//
+// Note that this config has admin privileges in the seed cluster.
+func (s *seedProvider) GetSeedClusterAdminConfig() *restclient.Config {
+	return s.seedConfig
+}

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -808,7 +808,8 @@ func (r Routing) createCluster(initNodeDeploymentFailures *prometheus.CounterVec
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
+			middleware.SetPrivilegedClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.CreateEndpoint(r.sshKeyProvider, r.cloudProviders, r.projectProvider, r.datacenters, initNodeDeploymentFailures, r.eventRecorderProvider)),
 		cluster.DecodeCreateReq,
@@ -834,7 +835,7 @@ func (r Routing) listClusters() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.ListEndpoint(r.projectProvider)),
 		cluster.DecodeListReq,
@@ -885,7 +886,7 @@ func (r Routing) getCluster() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.GetEndpoint(r.projectProvider)),
 		common.DecodeGetClusterReq,
@@ -911,7 +912,7 @@ func (r Routing) patchCluster() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.PatchEndpoint(r.cloudProviders, r.projectProvider, r.datacenters)),
 		cluster.DecodePatchReq,
@@ -938,7 +939,8 @@ func (r Routing) getClusterEvents() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
+			middleware.SetPrivilegedClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.GetClusterEventsEndpoint()),
 		cluster.DecodeGetClusterEvents,
@@ -965,7 +967,7 @@ func (r Routing) getClusterKubeconfig() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.GetAdminKubeconfigEndpoint(r.projectProvider)),
 		cluster.DecodeGetAdminKubeconfig,
@@ -992,7 +994,7 @@ func (r Routing) deleteCluster() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.DeleteEndpoint(r.sshKeyProvider, r.projectProvider)),
 		cluster.DecodeDeleteReq,
@@ -1018,7 +1020,7 @@ func (r Routing) getClusterHealth() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.HealthEndpoint(r.projectProvider)),
 		common.DecodeGetClusterReq,
@@ -1047,7 +1049,7 @@ func (r Routing) assignSSHKeyToCluster() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.AssignSSHKeyEndpoint(r.sshKeyProvider, r.projectProvider)),
 		cluster.DecodeAssignSSHKeyReq,
@@ -1077,7 +1079,7 @@ func (r Routing) listSSHKeysAssignedToCluster() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.ListSSHKeysEndpoint(r.sshKeyProvider, r.projectProvider)),
 		cluster.DecodeListSSHKeysReq,
@@ -1106,7 +1108,7 @@ func (r Routing) detachSSHKeyFromCluster() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.DetachSSHKeyEndpoint(r.sshKeyProvider, r.projectProvider)),
 		cluster.DecodeDetachSSHKeysReq,
@@ -1132,7 +1134,7 @@ func (r Routing) revokeClusterAdminToken() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.RevokeAdminTokenEndpoint(r.projectProvider)),
 		cluster.DecodeAdminTokenReq,
@@ -1158,7 +1160,7 @@ func (r Routing) getClusterUpgrades() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.GetUpgradesEndpoint(r.updateManager, r.projectProvider)),
 		common.DecodeGetClusterReq,
@@ -1208,7 +1210,7 @@ func (r Routing) upgradeClusterNodeDeployments() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.UpgradeNodeDeploymentsEndpoint(r.projectProvider)),
 		cluster.DecodeUpgradeNodeDeploymentsReq,
@@ -1608,7 +1610,7 @@ func (r Routing) listDigitaloceanSizesNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.DigitaloceanSizeNoCredentialsEndpoint(r.projectProvider)),
 		provider.DecodeDoSizesNoCredentialsReq,
@@ -1632,7 +1634,7 @@ func (r Routing) listAzureSizesNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.AzureSizeNoCredentialsEndpoint(r.projectProvider, r.datacenters)),
 		provider.DecodeAzureSizesNoCredentialsReq,
@@ -1656,7 +1658,7 @@ func (r Routing) listOpenstackSizesNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.OpenstackSizeNoCredentialsEndpoint(r.projectProvider, r.cloudProviders)),
 		provider.DecodeOpenstackNoCredentialsReq,
@@ -1680,7 +1682,7 @@ func (r Routing) listOpenstackTenantsNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.OpenstackTenantNoCredentialsEndpoint(r.projectProvider, r.cloudProviders)),
 		provider.DecodeOpenstackNoCredentialsReq,
@@ -1704,7 +1706,7 @@ func (r Routing) listOpenstackNetworksNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.OpenstackNetworkNoCredentialsEndpoint(r.projectProvider, r.cloudProviders)),
 		provider.DecodeOpenstackNoCredentialsReq,
@@ -1728,7 +1730,7 @@ func (r Routing) listOpenstackSecurityGroupsNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.OpenstackSecurityGroupNoCredentialsEndpoint(r.projectProvider, r.cloudProviders)),
 		provider.DecodeOpenstackNoCredentialsReq,
@@ -1752,7 +1754,7 @@ func (r Routing) listOpenstackSubnetsNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.OpenstackSubnetsNoCredentialsEndpoint(r.projectProvider, r.cloudProviders)),
 		provider.DecodeOpenstackSubnetNoCredentialsReq,
@@ -1776,7 +1778,7 @@ func (r Routing) listVSphereNetworksNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.VsphereNetworksNoCredentialsEndpoint(r.projectProvider, r.cloudProviders)),
 		provider.DecodeVSphereNetworksNoCredentialsReq,
@@ -1805,7 +1807,7 @@ func (r Routing) createNodeDeployment() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.CreateNodeDeployment(r.sshKeyProvider, r.projectProvider, r.datacenters)),
 		node.DecodeCreateNodeDeployment,
@@ -1831,7 +1833,7 @@ func (r Routing) listNodeDeployments() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.ListNodeDeployments(r.projectProvider)),
 		node.DecodeListNodeDeployments,
@@ -1857,7 +1859,7 @@ func (r Routing) getNodeDeployment() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.GetNodeDeployment(r.projectProvider)),
 		node.DecodeGetNodeDeployment,
@@ -1883,7 +1885,7 @@ func (r Routing) listNodeDeploymentNodes() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.ListNodeDeploymentNodes(r.projectProvider)),
 		node.DecodeListNodeDeploymentNodes,
@@ -1910,7 +1912,7 @@ func (r Routing) listNodeDeploymentNodesEvents() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.ListNodeDeploymentNodesEvents()),
 		node.DecodeListNodeDeploymentNodesEvents,
@@ -1940,7 +1942,7 @@ func (r Routing) patchNodeDeployment() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.PatchNodeDeployment(r.sshKeyProvider, r.projectProvider, r.datacenters)),
 		node.DecodePatchNodeDeployment,
@@ -1966,7 +1968,7 @@ func (r Routing) deleteNodeDeployment() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.DeleteNodeDeployment(r.projectProvider)),
 		node.DecodeDeleteNodeDeployment,

--- a/api/pkg/handler/routes_v1_alpha.go
+++ b/api/pkg/handler/routes_v1_alpha.go
@@ -37,7 +37,7 @@ func (r Routing) getClusterMetrics() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.GetMetricsEndpoint(r.projectProvider, r.prometheusClient)),
 		common.DecodeGetClusterReq,

--- a/api/pkg/handler/routes_v1_legacy.go
+++ b/api/pkg/handler/routes_v1_legacy.go
@@ -56,7 +56,7 @@ func (r Routing) getNodeForClusterLegacy() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.GetNodeForClusterLegacyEndpoint(r.projectProvider)),
 		node.DecodeGetNodeForClusterLegacy,
@@ -89,7 +89,7 @@ func (r Routing) createNodeForClusterLegacy() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.CreateNodeForClusterLegacyEndpoint()),
 		node.DecodeCreateNodeForClusterLegacy,
@@ -118,7 +118,7 @@ func (r Routing) listNodesForClusterLegacy() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.ListNodesForClusterLegacyEndpoint(r.projectProvider)),
 		node.DecodeListNodesForClusterLegacy,
@@ -147,7 +147,7 @@ func (r Routing) deleteNodeForClusterLegacy() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.DeleteNodeForClusterLegacyEndpoint(r.projectProvider)),
 		node.DecodeDeleteNodeForClusterLegacy,

--- a/api/pkg/handler/routes_v1_optional.go
+++ b/api/pkg/handler/routes_v1_optional.go
@@ -36,7 +36,7 @@ func (r Routing) RegisterV1Optional(mux *mux.Router, oidcKubeConfEndpoint bool, 
 func (r Routing) createOIDCKubeconfig(oidcCfg common.OIDCConfiguration) http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(
-			middleware.Datacenter(r.clusterProviders, r.datacenters),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoUnauthorized(r.userProjectMapper, r.userProvider),
 		)(cluster.CreateOIDCKubeconfigEndpoint(r.projectProvider, r.oidcIssuerVerifier, oidcCfg)),
 		cluster.DecodeCreateOIDCKubeconfig,

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -45,6 +45,7 @@ type Routing struct {
 	userProjectMapper           provider.ProjectMemberMapper
 	saTokenAuthenticator        serviceaccount.TokenAuthenticator
 	saTokenGenerator            serviceaccount.TokenGenerator
+	eventRecorderProvider       provider.EventRecorderProvider
 }
 
 // NewRouting creates a new Routing.
@@ -67,6 +68,7 @@ func NewRouting(
 	userProjectMapper provider.ProjectMemberMapper,
 	saTokenAuthenticator serviceaccount.TokenAuthenticator,
 	saTokenGenerator serviceaccount.TokenGenerator,
+	eventRecorderProvider provider.EventRecorderProvider,
 ) Routing {
 	return Routing{
 		datacenters:                 datacenters,
@@ -88,6 +90,7 @@ func NewRouting(
 		userProjectMapper:           userProjectMapper,
 		saTokenAuthenticator:        saTokenAuthenticator,
 		saTokenGenerator:            saTokenGenerator,
+		eventRecorderProvider:       eventRecorderProvider,
 	}
 }
 

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -37,7 +37,8 @@ func NewTestRouting(
 	versions []*version.MasterVersion,
 	updates []*version.MasterUpdate,
 	saTokenAuthenticator serviceaccount.TokenAuthenticator,
-	saTokenGenerator serviceaccount.TokenGenerator) http.Handler {
+	saTokenGenerator serviceaccount.TokenGenerator,
+	eventRecorderProvider provider.EventRecorderProvider) http.Handler {
 
 	updateManager := version.New(versions, updates)
 	r := handler.NewRouting(
@@ -59,6 +60,7 @@ func NewTestRouting(
 		projectMemberProvider, /*satisfies also a different interface*/
 		saTokenAuthenticator,
 		saTokenGenerator,
+		eventRecorderProvider,
 	)
 
 	mainRouter := mux.NewRouter()

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/client-go/informers"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	fakerestclient "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -188,14 +188,14 @@ func CreateTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.Dat
 	}
 
 	fUserClusterConnection := &fakeUserClusterConnection{fakeClient}
-	fSeedClusterConnection := &fakeSeedClusterConnection{fakeClient}
 	clusterProvider := kubernetes.NewClusterProvider(
 		fakeKubermaticImpersonationClient,
 		fUserClusterConnection,
 		kubermaticInformerFactory.Kubermatic().V1().Clusters().Lister(),
 		"",
 		rbac.ExtractGroupPrefix,
-		fSeedClusterConnection,
+		fakeClient,
+		kubernetesClient,
 	)
 	clusterProviders := map[string]provider.ClusterProvider{"us-central1": clusterProvider}
 
@@ -287,18 +287,6 @@ func (f *fakeUserClusterConnection) GetDynamicClient(_ *kubermaticapiv1.Cluster,
 
 func (f *fakeUserClusterConnection) GetAdminKubeconfig(c *kubermaticapiv1.Cluster) ([]byte, error) {
 	return []byte(generateTestKubeconfig(ClusterID, IDToken)), nil
-}
-
-type fakeSeedClusterConnection struct {
-	fakeDynamicClient ctrlruntimeclient.Client
-}
-
-func (f *fakeSeedClusterConnection) GetSeedClusterAdminClient() ctrlruntimeclient.Client {
-	return f.fakeDynamicClient
-}
-
-func (f *fakeSeedClusterConnection) GetSeedClusterAdminConfig() *restclient.Config {
-	return &restclient.Config{}
 }
 
 // ClientsSets a simple wrapper that holds fake client sets

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -201,7 +201,7 @@ func CreateTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.Dat
 	kubermaticInformerFactory.Start(wait.NeverStop)
 	kubermaticInformerFactory.WaitForCacheSync(wait.NeverStop)
 
-	eventRecorderProvider := kubernetes.NewEventRecorder(&restclient.Config{})
+	eventRecorderProvider := kubernetes.NewEventRecorder()
 
 	// Disable the metrics endpoint in tests
 	var prometheusClient prometheusapi.Client

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -40,9 +40,9 @@ import (
 type NodeDeploymentEvent string
 
 const (
-	NodeDeploymentCreationStart   NodeDeploymentEvent = "NodeDeploymentCreationStart"
-	NodeDeploymentCreationSuccess NodeDeploymentEvent = "NodeDeploymentCreationSuccess"
-	NodeDeploymentCreationFail    NodeDeploymentEvent = "NodeDeploymentCreationFail"
+	nodeDeploymentCreationStart   NodeDeploymentEvent = "NodeDeploymentCreationStart"
+	nodeDeploymentCreationSuccess NodeDeploymentEvent = "NodeDeploymentCreationSuccess"
+	nodeDeploymentCreationFail    NodeDeploymentEvent = "NodeDeploymentCreationFail"
 )
 
 func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, cloudProviders map[string]provider.CloudProvider, projectProvider provider.ProjectProvider,
@@ -82,14 +82,14 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, cloudProviders map[s
 		if req.Body.NodeDeployment != nil {
 			go func() {
 				defer utilruntime.HandleCrash()
-				eventRecorderProvider.SeedClusterRecorder(k8sClient).Eventf(newCluster, corev1.EventTypeNormal, string(NodeDeploymentCreationStart), "started creation of initial node deployment %s for cluster %s", req.Body.NodeDeployment.Name, newCluster.Name)
+				eventRecorderProvider.ClusterRecorderFor(k8sClient).Eventf(newCluster, corev1.EventTypeNormal, string(nodeDeploymentCreationStart), "started creation of initial node deployment %s for cluster %s", req.Body.NodeDeployment.Name, newCluster.Name)
 				err := createInitialNodeDeploymentWithRetries(req.Body.NodeDeployment, newCluster, project, sshKeyProvider, dcs, clusterProvider, userInfo)
 				if err != nil {
-					eventRecorderProvider.SeedClusterRecorder(k8sClient).Eventf(newCluster, corev1.EventTypeWarning, string(NodeDeploymentCreationFail), "failed to create initial node deployment %s for cluster %s: %v", req.Body.NodeDeployment.Name, newCluster.Name, err)
+					eventRecorderProvider.ClusterRecorderFor(k8sClient).Eventf(newCluster, corev1.EventTypeWarning, string(nodeDeploymentCreationFail), "failed to create initial node deployment %s for cluster %s: %v", req.Body.NodeDeployment.Name, newCluster.Name, err)
 					glog.Errorf("failed to create initial node deployment for cluster %s: %v", newCluster.Name, err)
 					initNodeDeploymentFailures.With(prometheus.Labels{"cluster": newCluster.Name, "seed_dc": req.DC}).Add(1)
 				} else {
-					eventRecorderProvider.SeedClusterRecorder(k8sClient).Eventf(newCluster, corev1.EventTypeNormal, string(NodeDeploymentCreationSuccess), "created initial node deployment %s for cluster %s", req.Body.NodeDeployment.Name, newCluster.Name)
+					eventRecorderProvider.ClusterRecorderFor(k8sClient).Eventf(newCluster, corev1.EventTypeNormal, string(nodeDeploymentCreationSuccess), "created initial node deployment %s for cluster %s", req.Body.NodeDeployment.Name, newCluster.Name)
 					glog.V(5).Infof("created initial node deployment for cluster %s", newCluster.Name)
 				}
 			}()

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// NodeDeploymentEvent represents type of events related to Node Deployment
 type NodeDeploymentEvent string
 
 const (

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -323,13 +323,9 @@ func GetClusterEventsEndpoint() endpoint.Endpoint {
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 		privilegedClusterProvider := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
 		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		client := privilegedClusterProvider.GetSeedClusterAdminClient()
 
 		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
-		if err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
-		}
-
-		client, err := privilegedClusterProvider.GetSeedClusterAdminClient()
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -318,6 +318,7 @@ func GetClusterEventsEndpoint() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(EventsReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+		privilegedClusterProvider := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
 		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
 
 		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
@@ -325,7 +326,7 @@ func GetClusterEventsEndpoint() endpoint.Endpoint {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		client, err := clusterProvider.GetSeedClusterAdminClient()
+		client, err := privilegedClusterProvider.GetSeedClusterAdminClient()
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
 	"github.com/kubermatic/kubermatic/api/pkg/validation"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1264,6 +1265,96 @@ func TestRevokeClusterAdminTokenEndpoint(t *testing.T) {
 
 	if !wasUpdateActionValidated {
 		t.Error("updated admin token in cluster resource was not persisted")
+	}
+}
+
+func TestGetClusterEventsEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		Name                   string
+		HTTPStatus             int
+		ExpectedResult         string
+		ProjectIDToSync        string
+		ClusterIDToSync        string
+		ExistingProject        *kubermaticv1.Project
+		ExistingKubermaticUser *kubermaticv1.User
+		ExistingAPIUser        *apiv1.User
+		ExistingKubermaticObjs []runtime.Object
+		ExistingEvents         []*corev1.Event
+		NodeDeploymentID       string
+		QueryParams            string
+	}{
+		// scenario 1
+		{
+			Name:                   "scenario 1: list all events",
+			HTTPStatus:             http.StatusOK,
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingEvents: []*corev1.Event{
+				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine"),
+				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine"),
+			},
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+		},
+		// scenario 2
+		{
+			Name:                   "scenario 2: list all warning events",
+			QueryParams:            "?type=warning",
+			HTTPStatus:             http.StatusOK,
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingEvents: []*corev1.Event{
+				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine"),
+				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine"),
+			},
+			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+		},
+		// scenario 3
+		{
+			Name:                   "scenario 3: list all normal events",
+			QueryParams:            "?type=normal",
+			HTTPStatus:             http.StatusOK,
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingEvents: []*corev1.Event{
+				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine"),
+				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine"),
+			},
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/events%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.QueryParams), strings.NewReader(""))
+			res := httptest.NewRecorder()
+			kubermaticObj := make([]runtime.Object, 0)
+			machineObj := make([]runtime.Object, 0)
+			kubernetesObj := make([]runtime.Object, 0)
+			for _, existingEvents := range tc.ExistingEvents {
+				kubernetesObj = append(kubernetesObj, existingEvents)
+			}
+			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
+
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.HTTPStatus {
+				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
+			}
+
+			test.CompareWithResult(t, res, tc.ExpectedResult)
+		})
 	}
 }
 

--- a/api/pkg/handler/v1/common/event.go
+++ b/api/pkg/handler/v1/common/event.go
@@ -3,21 +3,21 @@ package common
 import (
 	"context"
 
-	v13 "k8s.io/api/core/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 )
 
 // FilterEventsByType filters Kubernetes Events based on their type. Empty type string will return all of them.
-func FilterEventsByType(events []v1.Event, eventType string) []v1.Event {
+func FilterEventsByType(events []kubermaticapiv1.Event, eventType string) []kubermaticapiv1.Event {
 	if len(eventType) == 0 || len(events) == 0 {
 		return events
 	}
 
-	resultEvents := make([]v1.Event, 0)
+	resultEvents := make([]kubermaticapiv1.Event, 0)
 	for _, event := range events {
 		if event.Type == eventType {
 			resultEvents = append(resultEvents, event)
@@ -27,8 +27,8 @@ func FilterEventsByType(events []v1.Event, eventType string) []v1.Event {
 }
 
 // GetEvents returns events related to an object in a given namespace.
-func GetEvents(ctx context.Context, client ctrlruntimeclient.Client, obj v12.Object, objNamespace string) ([]v1.Event, error) {
-	events := &v13.EventList{}
+func GetEvents(ctx context.Context, client ctrlruntimeclient.Client, obj metav1.Object, objNamespace string) ([]kubermaticapiv1.Event, error) {
+	events := &corev1.EventList{}
 	listOpts := &ctrlruntimeclient.ListOptions{
 		Namespace:     objNamespace,
 		FieldSelector: fields.OneTermEqualSelector("involvedObject.uid", string(obj.GetUID())),
@@ -37,7 +37,7 @@ func GetEvents(ctx context.Context, client ctrlruntimeclient.Client, obj v12.Obj
 		return nil, err
 	}
 
-	kubermaticEvents := make([]v1.Event, 0)
+	kubermaticEvents := make([]kubermaticapiv1.Event, 0)
 	for _, event := range events.Items {
 		kubermaticEvent := ConvertInternalEventToExternal(event)
 		kubermaticEvents = append(kubermaticEvents, kubermaticEvent)

--- a/api/pkg/handler/v1/common/event.go
+++ b/api/pkg/handler/v1/common/event.go
@@ -26,6 +26,7 @@ func FilterEventsByType(events []v1.Event, eventType string) []v1.Event {
 	return resultEvents
 }
 
+// GetEvents returns events related to an object in a given namespace.
 func GetEvents(ctx context.Context, client ctrlruntimeclient.Client, obj v12.Object, objNamespace string) ([]v1.Event, error) {
 	events := &v13.EventList{}
 	listOpts := &ctrlruntimeclient.ListOptions{

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -223,6 +223,10 @@ func (p *ClusterProvider) GetSeedClusterAdminClient() (ctrlruntimeclient.Client,
 	return dynamicClient, nil
 }
 
+func (p *ClusterProvider) GetSeedClusterAdminConfig() *restclient.Config {
+	return p.seedClusterConfig
+}
+
 func (p *ClusterProvider) withImpersonation(userInfo *provider.UserInfo) k8cuserclusterclient.ConfigOption {
 	return func(cfg *restclient.Config) *restclient.Config {
 		cfg.Impersonate = restclient.ImpersonationConfig{

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -215,6 +215,9 @@ func (p *ClusterProvider) GetClientForCustomerCluster(userInfo *provider.UserInf
 	return p.userClusterConnProvider.GetDynamicClient(c, p.withImpersonation(userInfo))
 }
 
+// GetSeedClusterAdminClient returns a client to interact with the seed cluster resources.
+//
+// Note that this client has admin privileges in the seed cluster.
 func (p *ClusterProvider) GetSeedClusterAdminClient() (ctrlruntimeclient.Client, error) {
 	dynamicClient, err := ctrlruntimeclient.New(p.seedClusterConfig, ctrlruntimeclient.Options{})
 	if err != nil {
@@ -223,6 +226,9 @@ func (p *ClusterProvider) GetSeedClusterAdminClient() (ctrlruntimeclient.Client,
 	return dynamicClient, nil
 }
 
+// GetSeedClusterAdminConfig returns a config that gives access to the seed cluster.
+//
+// Note that this config has admin privileges in the seed cluster.
 func (p *ClusterProvider) GetSeedClusterAdminConfig() *restclient.Config {
 	return p.seedClusterConfig
 }

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"strings"
 
-	"k8s.io/client-go/kubernetes"
-
 	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -15,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"

--- a/api/pkg/provider/kubernetes/event.go
+++ b/api/pkg/provider/kubernetes/event.go
@@ -1,0 +1,40 @@
+package kubernetes
+
+import (
+	v12 "k8s.io/api/core/v1"
+
+	"github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/scheme"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+)
+
+const componentName = "kubermatic-api"
+
+func NewEventRecorder(seedClusterConfig *rest.Config) *EventRecorder {
+	recorder := &EventRecorder{
+		seedClusterConfig: seedClusterConfig,
+	}
+
+	recorder.init()
+	return recorder
+}
+
+type EventRecorder struct {
+	seedClusterConfig *rest.Config
+
+	seedClusterRecorder record.EventRecorder
+}
+
+func (e *EventRecorder) SeedClusterRecorder() record.EventRecorder {
+	return e.seedClusterRecorder
+}
+
+func (e *EventRecorder) init() {
+	kubeClient := kubernetes.NewForConfigOrDie(e.seedClusterConfig)
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&v1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	e.seedClusterRecorder = eventBroadcaster.NewRecorder(scheme.Scheme, v12.EventSource{Component: componentName})
+}

--- a/api/pkg/provider/kubernetes/event.go
+++ b/api/pkg/provider/kubernetes/event.go
@@ -1,11 +1,12 @@
 package kubernetes
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
+	"sync"
 
 	"github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/scheme"
 
+	apicorev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 )
@@ -14,21 +15,27 @@ const componentName = "kubermatic-api"
 
 // NewEventRecorder returns a new event recorder provider object. See EventRecorder for more information.
 func NewEventRecorder() *EventRecorder {
-	return &EventRecorder{seedClusterRecorderMap: make(map[string]record.EventRecorder)}
+	return &EventRecorder{
+		seedClusterRecorderMap: make(map[string]record.EventRecorder),
+	}
 }
 
 // EventRecorder gives option to record events for objects. They can be then read from them using K8S API.
 type EventRecorder struct {
 	seedClusterRecorderMap map[string]record.EventRecorder
+	lock                   sync.Mutex
 }
 
-// SeedClusterRecorder returns an event recorder that will be able to record events for objects in the cluster
+// ClusterRecorderFor returns an event recorder that will be able to record events for objects in the cluster
 // accessible using provided client.
-func (e *EventRecorder) SeedClusterRecorder(client kubernetes.Interface) record.EventRecorder {
+func (e *EventRecorder) ClusterRecorderFor(client kubernetes.Interface) record.EventRecorder {
 	return e.getRecorderForClient(client)
 }
 
 func (e *EventRecorder) getRecorderForClient(client kubernetes.Interface) record.EventRecorder {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
 	coreV1Client := client.CoreV1()
 	host := coreV1Client.RESTClient().Get().URL().Host
 	recorder, exists := e.seedClusterRecorderMap[host]

--- a/api/pkg/provider/kubernetes/event.go
+++ b/api/pkg/provider/kubernetes/event.go
@@ -13,14 +13,18 @@ import (
 
 const componentName = "kubermatic-api"
 
+// NewEventRecorder returns a new event recorder provider object. See EventRecorder for more information.
 func NewEventRecorder() *EventRecorder {
 	return &EventRecorder{seedClusterRecorderMap: make(map[string]record.EventRecorder)}
 }
 
+// EventRecorder gives option to record events for objects. They can be then read from them using K8S API.
 type EventRecorder struct {
 	seedClusterRecorderMap map[string]record.EventRecorder
 }
 
+// SeedClusterRecorder returns a event recorder that will be able to record event for objects in the cluster
+// referred by provided cluster config.
 func (e *EventRecorder) SeedClusterRecorder(config *rest.Config) record.EventRecorder {
 	return e.getRecorderForConfig(config)
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -118,7 +118,9 @@ type ClusterProvider interface {
 	//
 	// Note that the client doesn't use admin account instead it authn/authz as userInfo(email, group)
 	GetClientForCustomerCluster(*UserInfo, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
+}
 
+type PrivilegedClusterProvider interface {
 	// GetSeedClusterAdminClient returns a client to interact with all resources in the seed cluster
 	//
 	// Note that the client you will get has admin privileges in the seed cluster

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -127,7 +127,7 @@ type PrivilegedClusterProvider interface {
 	// GetSeedClusterAdminClient returns a client to interact with all resources in the seed cluster
 	//
 	// Note that the client you will get has admin privileges in the seed cluster
-	GetSeedClusterAdminClient() (ctrlruntimeclient.Client, error)
+	GetSeedClusterAdminClient() ctrlruntimeclient.Client
 
 	// GetSeedClusterAdminConfig returns a config that can be used to create client
 	// that gives user access to all resources in the seed cluster

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -4,16 +4,15 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/record"
-
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 
-	"k8s.io/apimachinery/pkg/types"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	apicorev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/record"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -391,7 +390,7 @@ type PrivilegedServiceAccountTokenProvider interface {
 
 // EventRecorderProvider allows to record events for objects that can be read using K8S API.
 type EventRecorderProvider interface {
-	// SeedClusterRecorder returns a event recorder that will be able to record event for objects in the cluster
+	// ClusterRecorderFor returns a event recorder that will be able to record event for objects in the cluster
 	// referred by provided cluster config.
-	SeedClusterRecorder(client kubernetes.Interface) record.EventRecorder
+	ClusterRecorderFor(client kubernetes.Interface) record.EventRecorder
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -125,6 +126,12 @@ type PrivilegedClusterProvider interface {
 	//
 	// Note that the client you will get has admin privileges in the seed cluster
 	GetSeedClusterAdminClient() (ctrlruntimeclient.Client, error)
+
+	// GetSeedClusterAdminConfig returns a config that can be used to create client
+	// that gives user access to all resources in the seed cluster
+	//
+	// Note that the config you will get has admin privileges in the seed cluster
+	GetSeedClusterAdminConfig() *rest.Config
 }
 
 // SSHKeyListOptions allows to set filters that will be applied to filter the result.
@@ -382,5 +389,5 @@ type PrivilegedServiceAccountTokenProvider interface {
 }
 
 type EventRecorderProvider interface {
-	SeedClusterRecorder() record.EventRecorder
+	SeedClusterRecorder(config *rest.Config) record.EventRecorder
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"k8s.io/client-go/tools/record"
+
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -116,6 +118,11 @@ type ClusterProvider interface {
 	//
 	// Note that the client doesn't use admin account instead it authn/authz as userInfo(email, group)
 	GetClientForCustomerCluster(*UserInfo, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
+
+	// GetSeedClusterAdminClient returns a client to interact with all resources in the seed cluster
+	//
+	// Note that the client you will get has admin privileges in the seed cluster
+	GetSeedClusterAdminClient() (ctrlruntimeclient.Client, error)
 }
 
 // SSHKeyListOptions allows to set filters that will be applied to filter the result.
@@ -370,4 +377,8 @@ type PrivilegedServiceAccountTokenProvider interface {
 	// is unsafe in a sense that it uses privileged account to get the resource
 	// gets resources from the cache
 	ListUnsecured(*ServiceAccountTokenListOptions) ([]*v1.Secret, error)
+}
+
+type EventRecorderProvider interface {
+	SeedClusterRecorder() record.EventRecorder
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -121,6 +121,8 @@ type ClusterProvider interface {
 	GetClientForCustomerCluster(*UserInfo, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
 }
 
+// PrivilegedClusterProvider declares the set of methods for interacting with the seed clusters
+// as an admin.
 type PrivilegedClusterProvider interface {
 	// GetSeedClusterAdminClient returns a client to interact with all resources in the seed cluster
 	//
@@ -388,6 +390,9 @@ type PrivilegedServiceAccountTokenProvider interface {
 	ListUnsecured(*ServiceAccountTokenListOptions) ([]*v1.Secret, error)
 }
 
+// EventRecorderProvider allows to record events for objects that can be read using K8S API.
 type EventRecorderProvider interface {
+	// SeedClusterRecorder returns a event recorder that will be able to record event for objects in the cluster
+	//// referred by provided cluster config.
 	SeedClusterRecorder(config *rest.Config) record.EventRecorder
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds basic events to the cluster object informing the user about the status of initial node deployment creation.

![Zrzut ekranu z 2019-04-17 11-29-41](https://user-images.githubusercontent.com/2285385/56277340-71e35c80-6104-11e9-8312-40381ed3c4ad.png)

TODO:
- [x] Documentation
- [x] Add tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3027 

**Release note**:
```release-note
NONE
```
