### PR TITLE
Multi-Monitoring Stack

### DIFF
--- a/config/monitoring/alertmanager/Chart.yaml
+++ b/config/monitoring/alertmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: alertmanager
-version: 1.0.0
+version: 1.0.1
 appVersion: v0.16.2
 description: Alertmanager for Kubermatic
 keywords:

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -24,9 +24,9 @@ spec:
         - --web.listen-address=:9093
         - --web.external-url=https://{{ .Values.alertmanager.host | trim }}
         - --web.route-prefix=/
-        - --cluster.peer=alertmanager-kubermatic-0.alertmanager-kubermatic.monitoring.svc.cluster.local:6783
-        - --cluster.peer=alertmanager-kubermatic-1.alertmanager-kubermatic.monitoring.svc.cluster.local:6783
-        - --cluster.peer=alertmanager-kubermatic-2.alertmanager-kubermatic.monitoring.svc.cluster.local:6783
+        - --cluster.peer=alertmanager-kubermatic-0.alertmanager-kubermatic.{{ .Release.Namespace }}.svc.cluster.local:6783
+        - --cluster.peer=alertmanager-kubermatic-1.alertmanager-kubermatic.{{ .Release.Namespace }}.svc.cluster.local:6783
+        - --cluster.peer=alertmanager-kubermatic-2.alertmanager-kubermatic.{{ .Release.Namespace }}.svc.cluster.local:6783
         env:
         - name: POD_IP
           valueFrom:

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.0.0
+version: 1.0.1
 appVersion: 6.1.3
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/dashboards/cleanup.sh
+++ b/config/monitoring/grafana/dashboards/cleanup.sh
@@ -11,6 +11,8 @@ for dashboard in */*.json; do
     jq '(.templating.list[] | select(.type=="query") | .options) = []' | \
     jq '(.templating.list[] | select(.type=="query") | .refresh) = 2' | \
     jq '(.templating.list[] | select(.type=="query") | .current) = {}' | \
+    jq '(.templating.list[] | select(.type=="datasource") | .current) = {}' | \
+    jq '(.templating.list[] | select(.type=="datasource") | .hide) = "<< datasourceHide | toJson >>"' | \
     jq '(.annotations.list) = []' | \
     jq '(.links) = []' | \
     jq '(.refresh) = "<< refresh | default `30s` | toJson >>"' | \

--- a/config/monitoring/grafana/dashboards/kubermatic/machine-controller.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/machine-controller.json
@@ -376,11 +376,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": "Data Source",
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubermatic/nginx.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/nginx.json
@@ -1074,11 +1074,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": "Data Source",
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/etcd-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/etcd-overview.json
@@ -1737,11 +1737,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": "Data Source",
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/etcd.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/etcd.json
@@ -1945,11 +1945,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": "Data Source",
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/kubelets-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/kubelets-overview.json
@@ -1704,12 +1704,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/kubelets.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/kubelets.json
@@ -2227,12 +2227,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-resources.json
@@ -889,11 +889,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
@@ -905,12 +905,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/nodes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/nodes.json
@@ -1156,12 +1156,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/pods.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/pods.json
@@ -404,11 +404,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
@@ -1574,11 +1574,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
@@ -787,11 +787,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
@@ -1043,11 +1043,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
@@ -719,11 +719,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/kubernetes/volumes.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/volumes.json
@@ -815,11 +815,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/dashboards/prometheus/seed.json
+++ b/config/monitoring/grafana/dashboards/prometheus/seed.json
@@ -2498,11 +2498,8 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        "hide": 2,
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
         "label": null,
         "name": "datasource",
         "options": [],

--- a/config/monitoring/grafana/provisioning/datasources/prometheus.yaml
+++ b/config/monitoring/grafana/provisioning/datasources/prometheus.yaml
@@ -4,6 +4,6 @@ datasources:
   type: prometheus
   access: proxy
   org_id: 1
-  url: http://prometheus-kubermatic.monitoring.svc.cluster.local:9090
+  url: 'http://prometheus-kubermatic.{{ .Release.Namespace }}.svc.cluster.local:9090'
   version: 1
   editable: false

--- a/config/monitoring/grafana/templates/configmaps.yaml
+++ b/config/monitoring/grafana/templates/configmaps.yaml
@@ -1,39 +1,44 @@
 apiVersion: v1
-kind: List
-items:
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: grafana-datasources
-  data:
-{{ (.Files.Glob (.Values.grafana.provisioning.datasources.source | default "provisioning/datasources/*")).AsConfig | indent 4 }}
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+data:
+{{- range $filename, $_ := (.Files.Glob (.Values.grafana.provisioning.datasources.source | default "provisioning/datasources/*")) }}
+  {{ $filename }}: |
+{{ tpl ($.Files.Get $filename) $ | indent 4 }}
+{{- end }}
 {{- if .Values.grafana.provisioning.datasources.extra }}
-    _extra.yaml: |
-      apiVersion: 1
-      datasources:
-{{ toYaml .Values.grafana.provisioning.datasources.extra | indent 6 }}
+  _extra.yaml: |
+    apiVersion: 1
+    datasources:
+{{ toYaml .Values.grafana.provisioning.datasources.extra | indent 4 }}
 {{- end }}
 
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: grafana-dashboards
-  data:
-{{ (.Files.Glob (.Values.grafana.provisioning.dashboards.source | default "provisioning/dashboards/*")).AsConfig | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+data:
+{{- range $filename, $_ := (.Files.Glob (.Values.grafana.provisioning.dashboards.source | default "provisioning/dashboards/*")) }}
+  {{ $filename }}: |
+{{ tpl ($.Files.Get $filename) $ | indent 4 }}
+{{- end }}
 {{- if .Values.grafana.provisioning.dashboards.extra }}
-    _extra.yaml: |
-      apiVersion: 1
-      providers:
-{{ toYaml .Values.grafana.provisioning.dashboards.extra | indent 6 }}
+  _extra.yaml: |
+    apiVersion: 1
+    providers:
+{{ toYaml .Values.grafana.provisioning.dashboards.extra | indent 4 }}
 {{- end }}
 
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: grafana-dashboard-definitions
-  data:
-    # See the README.md for more details on how dashboards are treated as templates.
-    {{- range $file, $content := (.Files.Glob "dashboards/**") }}
-    {{ $file | replace "dashboards/" "" | replace "/" "-" }}: |
-{{ (regexReplaceAllLiteral "\\n\\s+" ((tpl (($.Files.Get $file) | replace "{{" "_{_{" | replace "}}" "_}_}" | replace "[[ " "{{ .Values.grafana.dashboards." | replace "]]" "}}" | replace "\"<< " "{{ .Values.grafana.dashboards." | replace ">>\"" "}}") $) | replace "_{_{" "{{" | replace "_}_}" "}}") " ") | indent 6 }}
-    {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-definitions
+data:
+  # See the README.md for more details on how dashboards are treated as templates.
+  {{- range $file, $content := (.Files.Glob "dashboards/**") }}
+  {{ $file | replace "dashboards/" "" | replace "/" "-" }}: |
+{{ ((tpl (($.Files.Get $file) | replace "{{" "_{_{" | replace "}}" "_}_}" | replace "[[ " "{{ .Values.grafana.dashboards." | replace "]]" "}}" | replace "\"<< " "{{ .Values.grafana.dashboards." | replace ">>\"" "}}") $) | replace "_{_{" "{{" | replace "_}_}" "}}") | fromJson | toJson | indent 4 }}
+  {{- end }}

--- a/config/monitoring/grafana/templates/configmaps.yaml
+++ b/config/monitoring/grafana/templates/configmaps.yaml
@@ -3,9 +3,11 @@ kind: ConfigMap
 metadata:
   name: grafana-datasources
 data:
-{{- range $filename, $_ := (.Files.Glob (.Values.grafana.provisioning.datasources.source | default "provisioning/datasources/*")) }}
-  {{ $filename }}: |
+{{- if .Values.grafana.provisioning.datasources.source }}
+{{- range $filename, $_ := (.Files.Glob .Values.grafana.provisioning.datasources.source) }}
+  {{ base $filename }}: |
 {{ tpl ($.Files.Get $filename) $ | indent 4 }}
+{{- end }}
 {{- end }}
 {{- if .Values.grafana.provisioning.datasources.extra }}
   _extra.yaml: |
@@ -20,9 +22,11 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboards
 data:
-{{- range $filename, $_ := (.Files.Glob (.Values.grafana.provisioning.dashboards.source | default "provisioning/dashboards/*")) }}
-  {{ $filename }}: |
+{{- if .Values.grafana.provisioning.dashboards.source }}
+{{- range $filename, $_ := (.Files.Glob .Values.grafana.provisioning.dashboards.source) }}
+  {{ base $filename }}: |
 {{ tpl ($.Files.Get $filename) $ | indent 4 }}
+{{- end }}
 {{- end }}
 {{- if .Values.grafana.provisioning.dashboards.extra }}
   _extra.yaml: |

--- a/config/monitoring/grafana/templates/service.yaml
+++ b/config/monitoring/grafana/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: monitoring
 spec:
   ports:
   - name: http

--- a/config/monitoring/grafana/templates/serviceAccount.yaml
+++ b/config/monitoring/grafana/templates/serviceAccount.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana
-  namespace: monitoring

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -89,3 +89,4 @@ grafana:
     #
     # Do not use double quotes inside this value.
     volumeDashboardNamespaceFilter: ""
+    datasourceHide: 2

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 1.1.1
+version: 1.1.2
 appVersion: v2.8.1
 description: Prometheus for Kubermatic
 keywords:

--- a/config/monitoring/prometheus/config/alertmanagers/kubermatic.yaml
+++ b/config/monitoring/prometheus/config/alertmanagers/kubermatic.yaml
@@ -3,7 +3,7 @@ kubernetes_sd_configs:
   role: endpoints
   namespaces:
     names:
-    - monitoring
+    - '{{ .Release.Namespace }}'
 scheme: http
 path_prefix: /
 timeout: 10s

--- a/config/monitoring/prometheus/config/prometheus.yaml
+++ b/config/monitoring/prometheus/config/prometheus.yaml
@@ -19,29 +19,29 @@ rule_files:
 {{- end }}
 {{- end }}
 
-{{ if or .Values.prometheus.alertmanagers.files .Values.prometheus.alertmanagers.configs }}
+{{- if or .Values.prometheus.alertmanagers.files .Values.prometheus.alertmanagers.configs }}
 alerting:
   alertmanagers:
   {{- range .Values.prometheus.alertmanagers.files }}
   {{- range $filename, $content := $.Files.Glob . }}
-  - {{ ($.Files.Get $filename) | fromYaml | toJson }}
+  - {{ (tpl ($.Files.Get $filename) $) | fromYaml | toJson }}
   {{- end }}
   {{- end }}
 
   {{- range .Values.prometheus.alertmanagers.configs }}
   - {{ . | toJson }}
   {{- end }}
-{{ end }}
+{{- end }}
 
-{{ if or .Values.prometheus.scraping.files .Values.prometheus.scraping.configs }}
+{{- if or .Values.prometheus.scraping.files .Values.prometheus.scraping.configs }}
 scrape_configs:
 {{- range .Values.prometheus.scraping.files }}
 {{- range $filename, $content := $.Files.Glob . }}
-- {{ ($.Files.Get $filename) | fromYaml | toJson }}
+- {{ (tpl ($.Files.Get $filename) $) | fromYaml | toJson }}
 {{- end }}
 {{- end }}
 
 {{- range .Values.prometheus.scraping.configs }}
 - {{ . | toJson }}
 {{- end }}
-{{ end }}
+{{- end }}

--- a/config/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
@@ -8,7 +8,7 @@ kubernetes_sd_configs:
   role: endpoints
   namespaces:
     names:
-    - monitoring
+    - '{{ .Release.Namespace }}'
 relabel_configs:
 - source_labels: [__meta_kubernetes_service_label_app]
   separator: ;

--- a/config/monitoring/prometheus/config/scraping/node-exporter.yaml
+++ b/config/monitoring/prometheus/config/scraping/node-exporter.yaml
@@ -9,7 +9,7 @@ kubernetes_sd_configs:
 relabel_configs:
 # only keep node-exporters
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
-  regex: monitoring;node-exporter
+  regex: '{{ .Release.Namespace }};node-exporter'
   action: keep
 - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape]
   action: keep

--- a/config/monitoring/prometheus/config/scraping/pods.yaml
+++ b/config/monitoring/prometheus/config/scraping/pods.yaml
@@ -8,7 +8,7 @@ relabel_configs:
   action: drop
 # drop node-exporters, as they need HTTPS scraping with credentials
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
-  regex: monitoring;node-exporter
+  regex: '{{ .Release.Namespace }};node-exporter'
   action: drop
 - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape]
   action: keep

--- a/config/monitoring/prometheus/templates/clusterrole.yaml
+++ b/config/monitoring/prometheus/templates/clusterrole.yaml
@@ -1,8 +1,7 @@
-{{ if .Values.prometheus.createGlobalRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-kubermatic
+  name: 'prometheus-kubermatic-{{ .Release.Name }}'
 rules:
 - apiGroups:
   - ""
@@ -26,4 +25,3 @@ rules:
   - /metrics
   verbs:
   - get
-{{ end }}

--- a/config/monitoring/prometheus/templates/clusterrole.yaml
+++ b/config/monitoring/prometheus/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.createGlobalRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -25,3 +26,4 @@ rules:
   - /metrics
   verbs:
   - get
+{{ end }}

--- a/config/monitoring/prometheus/templates/clusterrolebinding.yaml
+++ b/config/monitoring/prometheus/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-kubermatic
+  name: {{ .Release.Name }}:prometheus-kubermatic
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/monitoring/prometheus/templates/clusterrolebinding.yaml
+++ b/config/monitoring/prometheus/templates/clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}:prometheus-kubermatic
+  name: 'prometheus-kubermatic-{{ .Release.Name }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-kubermatic
+  name: 'prometheus-kubermatic-{{ .Release.Name }}'
 subjects:
 - kind: ServiceAccount
   name: prometheus-kubermatic

--- a/config/monitoring/prometheus/templates/role.yaml
+++ b/config/monitoring/prometheus/templates/role.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.prometheus.createGlobalRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -34,6 +35,7 @@ rules:
   - get
   - list
   - watch
+{{ end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/monitoring/prometheus/templates/role.yaml
+++ b/config/monitoring/prometheus/templates/role.yaml
@@ -1,8 +1,7 @@
-{{ if .Values.prometheus.createGlobalRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: prometheus-kubermatic
+  name: 'prometheus-kubermatic-{{ .Release.Name }}'
   namespace: default
 rules:
 - apiGroups:
@@ -21,7 +20,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: prometheus-kubermatic
+  name: 'prometheus-kubermatic-{{ .Release.Name }}'
   namespace: kube-system
 rules:
 - apiGroups:
@@ -35,7 +34,6 @@ rules:
   - get
   - list
   - watch
-{{ end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -3,6 +3,10 @@ prometheus:
   host: ''
   storageSize: 100Gi
 
+  # if you install this chart multiple times inside a single
+  # cluster, set this to false on all but one installation
+  createGlobalRoles: true
+
   backup:
     enabled: true
     image:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -3,10 +3,6 @@ prometheus:
   host: ''
   storageSize: 100Gi
 
-  # if you install this chart multiple times inside a single
-  # cluster, set this to false on all but one installation
-  createGlobalRoles: true
-
   backup:
     enabled: true
     image:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows to install the Prometheus/Grafana/Alertmanager multiple times into the same cluster, as long as it's into different namespaces. This is useful for the future master-monitoring stack discussed in #3238.

At the same time this also changes:

* Dashboard datasources can now be shown as a dropdown, so that when we have a master with multiple seeds, the user can select the datasource (= seed) to look at. This allows us to re-use the same dashboards we already have without adjusting them to run on aggregated data inside the master.
* The provisioning files for Grafana can now be templated.
* The Prometheus chart has a new flag to disable creating the cluster-wide resources. This is not perfect, but seems good enough for our usecase.

**Release note**:
```release-note
NONE
```
