### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Fixes #
 **Documentation**:
 <!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
 
-**Release note**:
+**Does this PR introduce a user-facing change?**:
 <!--  Write your release note:
 1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
 2. If  no release note is required, just write "NONE".


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the PR template to:

* Make it clear that only user-facing changes should be mentioned in the release note
* Allow using the kubernetes changelog generator tool without patching, it checks for the string `Does this PR introduce a user-facing change?`: https://github.com/kubernetes/release/blob/01d80c9536c37cf2b823e0d5cbd7c94a33e82242/pkg/notes/notes.go#L380

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
