### PR TITLE
Set the loglevel to v2 for the kubermatic controller manager

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -62,7 +62,7 @@ spec:
         command:
         - kubermatic-controller-manager
         args:
-        - -v=4
+        - -v=2
         - -logtostderr
         - -external-url={{ .Values.kubermatic.domain }}
         - -datacenter-name={{ .Values.kubermatic.controller.datacenterName }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the loglevel to v2 for the kubermatic controller manager.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
