### PR TITLE
Add alert for the machine-controller admission webhook

### DIFF
--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -26,6 +26,14 @@ groups:
     labels:
       kubermatic: federate
 
+  - alert: KubernetesAdmissionWebhookHighRejectionRate
+    annotations:
+      message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+    expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+    for: 5m
+    labels:
+      severity: warning
+
 - name: kubermatic.etcd
   rules:
   - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -239,6 +239,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -235,6 +235,14 @@ data:
         labels:
           kubermatic: federate
 
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
     - name: kubermatic.etcd
       rules:
       - record: job:etcd_server_has_leader:sum


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an alert in case we have a high reject rate coming from the machine controller admission webhook. It indicates that we have invalid Machine/MachineSet/MachineDeployment objects.

This is a requirement for https://github.com/kubermatic/machine-controller/issues/469

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
