### PR TITLE
Seed-Proxy Controller for Master Clusters

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -169,7 +169,7 @@ func createServiceAccountsController(ctrlCtx *controllerContext) (runnerFn, erro
 }
 
 func createSeedProxyController(ctrlCtx *controllerContext) (runnerFn, error) {
-	if err := seedproxy.Add(ctrlCtx.mgr, 1); err != nil {
+	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.kubeconfig, ctrlCtx.datacenters); err != nil {
 		return nil, err
 	}
 	return noop, nil

--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -30,10 +30,10 @@ func noop(workerCount int, stopCh <-chan struct{}) error { <-stopCh; return nil 
 // each entry holds the name of the controller and the corresponding
 // start function that will essentially run the controller
 var allControllers = map[string]controllerCreator{
-	// "RBAC":               createRBACContoller,
-	// "UserProjectBinding": createUserProjectBindingController,
-	// "ServiceAccounts":    createServiceAccountsController,
-	"SeedProxy": createSeedProxyController,
+	"RBAC":               createRBACContoller,
+	"UserProjectBinding": createUserProjectBindingController,
+	"ServiceAccounts":    createServiceAccountsController,
+	"SeedProxy":          createSeedProxyController,
 }
 
 func createAllControllers(ctrlCtx *controllerContext) (map[string]runnerFn, error) {

--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oklog/run"
 
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
+	seedproxy "github.com/kubermatic/kubermatic/api/pkg/controller/seed-proxy"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/service-account"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/user-project-binding"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
@@ -29,9 +30,10 @@ func noop(workerCount int, stopCh <-chan struct{}) error { <-stopCh; return nil 
 // each entry holds the name of the controller and the corresponding
 // start function that will essentially run the controller
 var allControllers = map[string]controllerCreator{
-	"RBAC":               createRBACContoller,
-	"UserProjectBinding": createUserProjectBindingController,
-	"ServiceAccounts":    createServiceAccountsController,
+	// "RBAC":               createRBACContoller,
+	// "UserProjectBinding": createUserProjectBindingController,
+	// "ServiceAccounts":    createServiceAccountsController,
+	"SeedProxy": createSeedProxyController,
 }
 
 func createAllControllers(ctrlCtx *controllerContext) (map[string]runnerFn, error) {
@@ -161,6 +163,13 @@ func createUserProjectBindingController(ctrlCtx *controllerContext) (runnerFn, e
 
 func createServiceAccountsController(ctrlCtx *controllerContext) (runnerFn, error) {
 	if err := serviceaccount.Add(ctrlCtx.mgr); err != nil {
+		return nil, err
+	}
+	return noop, nil
+}
+
+func createSeedProxyController(ctrlCtx *controllerContext) (runnerFn, error) {
+	if err := seedproxy.Add(ctrlCtx.mgr, 1); err != nil {
 		return nil, err
 	}
 	return noop, nil

--- a/api/hack/run-master-controller-manager.sh
+++ b/api/hack/run-master-controller-manager.sh
@@ -10,6 +10,7 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 ./_build/master-controller-manager \
+  -datacenters=../../secrets/seed-clusters/dev.kubermatic.io/datacenters.yaml \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
   -internal-address=127.0.0.1:8086 \
   -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \

--- a/api/pkg/controller/seed-proxy/OWNERS
+++ b/api/pkg/controller/seed-proxy/OWNERS
@@ -1,15 +1,12 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - team-ui
-  - teem-seed
+  - team-seed
 
 reviewers:
-  - team-ui
-  - teem-seed
+  - team-seed
 
 labels:
-  - team/ui
   - team/seed
 
 options:

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -75,11 +75,12 @@ func Add(
 		pred predicate.Funcs
 	}
 
+	ownedByPred := makePredicateFuncs(managedByController)
 	typesToWatch := []watcher{
-		{obj: &appsv1.Deployment{}, pred: deploymentPredicate()},
-		{obj: &corev1.Service{}, pred: servicePredicate()},
-		{obj: &corev1.Secret{}, pred: secretsPredicate()},
-		{obj: &corev1.ConfigMap{}, pred: configMapPredicate()},
+		{obj: &appsv1.Deployment{}, pred: ownedByPred},
+		{obj: &corev1.Service{}, pred: ownedByPred},
+		{obj: &corev1.Secret{}, pred: ownedByPred},
+		{obj: &corev1.ConfigMap{}, pred: ownedByPred},
 	}
 
 	for _, t := range typesToWatch {
@@ -94,22 +95,6 @@ func Add(
 func managedByController(meta metav1.Object) bool {
 	labels := meta.GetLabels()
 	return labels[ManagedByLabel] == ControllerName
-}
-
-func secretsPredicate() predicate.Funcs {
-	return makePredicateFuncs(managedByController)
-}
-
-func deploymentPredicate() predicate.Funcs {
-	return makePredicateFuncs(managedByController)
-}
-
-func servicePredicate() predicate.Funcs {
-	return makePredicateFuncs(managedByController)
-}
-
-func configMapPredicate() predicate.Funcs {
-	return makePredicateFuncs(managedByController)
 }
 
 func makePredicateFuncs(pred func(metav1.Object) bool) predicate.Funcs {

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -94,15 +94,13 @@ func Add(
 	return nil
 }
 
-func secretsPredicate() predicate.Funcs {
-	return makePredicateFuncs(func(meta metav1.Object) bool {
-		return meta.GetNamespace() == KubermaticNamespace && (meta.GetName() == KubeconfigSecret || meta.GetName() == DatacentersSecret)
-	})
-}
-
 func managedByController(meta metav1.Object) bool {
 	labels := meta.GetLabels()
 	return labels[ManagedByLabel] == ManagedByLabelValue
+}
+
+func secretsPredicate() predicate.Funcs {
+	return makePredicateFuncs(managedByController)
 }
 
 func deploymentPredicate() predicate.Funcs {

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -1,0 +1,118 @@
+package seedproxy
+
+import (
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	healthCheckPeriod   = 5 * time.Second
+	ControllerName      = "seed-proxy-controller"
+	KubermaticNamespace = "kubermatic"
+	KubeconfigSecret    = "kubeconfig"
+	DatacentersSecret   = "datacenters"
+	OwnerLabel          = "kubermatic.io/controller"
+	OwnerLabelValue     = ControllerName
+)
+
+// userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
+type userClusterConnectionProvider interface {
+	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (kubernetes.Interface, error)
+}
+
+// Add creates a new Monitoring controller that is responsible for
+// operating the monitoring components for all managed user clusters
+func Add(
+	mgr manager.Manager,
+	numWorkers int,
+	// userClusterConnProvider userClusterConnectionProvider,
+) error {
+	reconciler := &Reconciler{
+		Client: mgr.GetClient(),
+		// userClusterConnProvider: userClusterConnProvider,
+		recorder: mgr.GetRecorder(ControllerName),
+	}
+
+	ctrlOptions := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers}
+	c, err := controller.New(ControllerName, mgr, ctrlOptions)
+	if err != nil {
+		return err
+	}
+
+	eventHandler := &handler.EnqueueRequestForObject{}
+
+	type watcher struct {
+		obj  runtime.Object
+		pred predicate.Funcs
+	}
+
+	typesToWatch := []watcher{
+		{obj: &appsv1.Deployment{}, pred: deploymentPredicate()},
+		{obj: &corev1.Service{}, pred: servicePredicate()},
+		{obj: &corev1.Secret{}, pred: secretsPredicate()},
+	}
+
+	for _, t := range typesToWatch {
+		if err := c.Watch(&source.Kind{Type: t.obj}, eventHandler, t.pred); err != nil {
+			return fmt.Errorf("failed to create watcher for %T: %v", t, err)
+		}
+	}
+
+	return nil
+}
+
+func secretsPredicate() predicate.Funcs {
+	return makePredicateFuncs(func(meta metav1.Object) bool {
+		return meta.GetNamespace() == KubermaticNamespace && (meta.GetName() == KubeconfigSecret || meta.GetName() == DatacentersSecret)
+	})
+}
+
+func deploymentPredicate() predicate.Funcs {
+	return makePredicateFuncs(func(meta metav1.Object) bool {
+		labels := meta.GetLabels()
+		return meta.GetNamespace() == KubermaticNamespace && labels[OwnerLabel] == OwnerLabelValue
+	})
+}
+
+func servicePredicate() predicate.Funcs {
+	return makePredicateFuncs(func(meta metav1.Object) bool {
+		labels := meta.GetLabels()
+		return meta.GetNamespace() == KubermaticNamespace && labels[OwnerLabel] == OwnerLabelValue
+	})
+}
+
+func makePredicateFuncs(pred func(metav1.Object) bool) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return pred(e.Meta)
+		},
+
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return pred(e.MetaOld) || pred(e.MetaNew)
+		},
+
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return pred(e.Meta)
+		},
+
+		GenericFunc: func(e event.GenericEvent) bool {
+			return pred(e.Meta)
+		},
+	}
+}

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -25,33 +25,16 @@ const (
 	// ControllerName is the name of this very controller.
 	ControllerName = "seed-proxy-controller"
 
-	// KubermaticNamespace is the namespace inside the
-	// master where Kubermatic has been installed to and
-	// where the master-level components will be created in.
-	KubermaticNamespace = "kubermatic"
+	// MasterTargetNamespace is the namespace inside the
+	// master where the components will be created in.
+	MasterTargetNamespace = "kubermatic"
 
-	// DeploymentName is the name used for deployments.
-	DeploymentName = "seed-proxy"
+	// MasterDeploymentName is the name used for deployments'
+	// NameLabel value.
+	MasterDeploymentName = "seed-proxy"
 
-	// ServiceAccountName is the name used for service accounts
-	// inside the seed cluster.
-	ServiceAccountName = "seed-proxy"
-
-	// ServiceAccountNamespace is the namespace inside the seed
-	// cluster where the service account will be created.
-	ServiceAccountNamespace = metav1.NamespaceSystem
-
-	// SeedPrometheusNamespace is the namespace inside the seed
-	// cluster where Prometheus is installed.
-	SeedPrometheusNamespace = "monitoring"
-
-	// SeedPrometheusRoleName is the name inside the seed
-	// used for the new role used for proxying to Prometheus.
-	SeedPrometheusRoleName = "seed-proxy-prometheus"
-
-	// SeedPrometheusRoleName is the name inside the seed
-	// used for the new role binding used for proxying to Prometheus.
-	SeedPrometheusRoleBindingName = "seed-proxy-prometheus"
+	// MasterServiceName is the name used for services' NameLabel value.
+	MasterServiceName = "seed-proxy"
 
 	// MasterGrafanaNamespace is the namespace inside the master
 	// cluster where Grafana is installed and where the ConfigMap
@@ -61,6 +44,34 @@ const (
 	// MasterGrafanaConfigMapName is the name used for the newly
 	// created Grafana ConfigMap.
 	MasterGrafanaConfigMapName = "grafana-seed-proxies"
+
+	// SeedServiceAccountName is the name used for service accounts
+	// inside the seed cluster.
+	SeedServiceAccountName = "seed-proxy"
+
+	// SeedServiceAccountNamespace is the namespace inside the seed
+	// cluster where the service account will be created.
+	SeedServiceAccountNamespace = metav1.NamespaceSystem
+
+	// SeedPrometheusNamespace is the namespace inside the seed
+	// cluster where Prometheus is installed.
+	SeedPrometheusNamespace = "monitoring"
+
+	// SeedPrometheusServiceName is the service that is provided by
+	// Prometheus inside the seed cluster.
+	SeedPrometheusServiceName = "prometheus-kubermatic"
+
+	// SeedPrometheusServicePort is the port name that is provided by
+	// Prometheus inside the seed cluster.
+	SeedPrometheusServicePort = "web"
+
+	// SeedPrometheusRoleName is the name inside the seed
+	// used for the new role used for proxying to Prometheus.
+	SeedPrometheusRoleName = "seed-proxy-prometheus"
+
+	// SeedPrometheusRoleBindingName is the name inside the seed
+	// used for the new role binding used for proxying to Prometheus.
+	SeedPrometheusRoleBindingName = "seed-proxy-prometheus"
 
 	// KubectlProxyPort is the port used by kubectl to provide the
 	// proxy connection on. This is not the port on which any of the

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -8,7 +8,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -37,25 +35,21 @@ const (
 	SeedPrometheusNamespace       = "monitoring"
 	SeedPrometheusRoleName        = "seed-proxy-prometheus"
 	SeedPrometheusRoleBindingName = "seed-proxy-prometheus"
+	MasterGrafanaNamespace        = "monitoring-master"
+	MasterGrafanaConfigMapName    = "grafana-seed-proxies"
+	KubectlProxyPort              = 8001
 )
-
-// seedClusterConnectionProvider offers functions to retrieve clients for the given seed clusters
-type seedClusterConnectionProvider interface {
-	GetClient(*kubermaticv1.Cluster) (kubernetes.Interface, error)
-}
 
 // Add creates a new Monitoring controller that is responsible for
 // operating the monitoring components for all managed user clusters
 func Add(
 	mgr manager.Manager,
 	numWorkers int,
-	// userClusterConnProvider seedClusterConnectionProvider,
 	kubeconfig *clientcmdapi.Config,
 	datacenters map[string]provider.DatacenterMeta,
 ) error {
 	reconciler := &Reconciler{
-		Client: mgr.GetClient(),
-		// userClusterConnProvider: userClusterConnProvider,
+		Client:      mgr.GetClient(),
 		recorder:    mgr.GetRecorder(ControllerName),
 		kubeconfig:  kubeconfig,
 		datacenters: datacenters,

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -22,24 +22,69 @@ import (
 )
 
 const (
-	ControllerName                = "seed-proxy-controller"
-	KubermaticNamespace           = "kubermatic"
-	DeploymentName                = "seed-proxy"
-	ServiceAccountName            = "seed-proxy"
-	ServiceAccountNamespace       = metav1.NamespaceSystem
-	SeedPrometheusNamespace       = "monitoring"
-	SeedPrometheusRoleName        = "seed-proxy-prometheus"
+	// ControllerName is the name of this very controller.
+	ControllerName = "seed-proxy-controller"
+
+	// KubermaticNamespace is the namespace inside the
+	// master where Kubermatic has been installed to and
+	// where the master-level components will be created in.
+	KubermaticNamespace = "kubermatic"
+
+	// DeploymentName is the name used for deployments.
+	DeploymentName = "seed-proxy"
+
+	// ServiceAccountName is the name used for service accounts
+	// inside the seed cluster.
+	ServiceAccountName = "seed-proxy"
+
+	// ServiceAccountNamespace is the namespace inside the seed
+	// cluster where the service account will be created.
+	ServiceAccountNamespace = metav1.NamespaceSystem
+
+	// SeedPrometheusNamespace is the namespace inside the seed
+	// cluster where Prometheus is installed.
+	SeedPrometheusNamespace = "monitoring"
+
+	// SeedPrometheusRoleName is the name inside the seed
+	// used for the new role used for proxying to Prometheus.
+	SeedPrometheusRoleName = "seed-proxy-prometheus"
+
+	// SeedPrometheusRoleName is the name inside the seed
+	// used for the new role binding used for proxying to Prometheus.
 	SeedPrometheusRoleBindingName = "seed-proxy-prometheus"
-	MasterGrafanaNamespace        = "monitoring-master"
-	MasterGrafanaConfigMapName    = "grafana-seed-proxies"
-	KubectlProxyPort              = 8001
-	NameLabel                     = "app.kubernetes.io/name"
-	InstanceLabel                 = "app.kubernetes.io/instance"
-	ManagedByLabel                = "app.kubernetes.io/managed-by"
+
+	// MasterGrafanaNamespace is the namespace inside the master
+	// cluster where Grafana is installed and where the ConfigMap
+	// should be created in.
+	MasterGrafanaNamespace = "monitoring-master"
+
+	// MasterGrafanaConfigMapName is the name used for the newly
+	// created Grafana ConfigMap.
+	MasterGrafanaConfigMapName = "grafana-seed-proxies"
+
+	// KubectlProxyPort is the port used by kubectl to provide the
+	// proxy connection on. This is not the port on which any of the
+	// target applications inside the seed (Prometheus, Grafana)
+	// listen on.
+	KubectlProxyPort = 8001
+
+	// NameLabel is the recommended name for an identifying label.
+	NameLabel = "app.kubernetes.io/name"
+
+	// InstanceLabel is the recommended label for distinguishing
+	// multiple elements of the same name. The label is used to store
+	// the seed cluster name.
+	InstanceLabel = "app.kubernetes.io/instance"
+
+	// ManagedByLabel is the label used to identify the resources
+	// created by this controller.
+	ManagedByLabel = "app.kubernetes.io/managed-by"
 )
 
-// Add creates a new Monitoring controller that is responsible for
-// operating the monitoring components for all managed user clusters
+// Add creates a new Seed-Proxy controller that is responsible for
+// establishing ServiceAccounts in all seeds and setting up proxy
+// pods to allow access to monitoring applications inside the seed
+// clusters, like Prometheus and Grafana.
 func Add(
 	mgr manager.Manager,
 	numWorkers int,

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -24,8 +24,6 @@ import (
 const (
 	ControllerName                = "seed-proxy-controller"
 	KubermaticNamespace           = "kubermatic"
-	KubeconfigSecret              = "kubeconfig"
-	DatacentersSecret             = "datacenters"
 	DeploymentName                = "seed-proxy"
 	ServiceAccountName            = "seed-proxy"
 	ServiceAccountNamespace       = metav1.NamespaceSystem
@@ -38,7 +36,6 @@ const (
 	NameLabel                     = "app.kubernetes.io/name"
 	InstanceLabel                 = "app.kubernetes.io/instance"
 	ManagedByLabel                = "app.kubernetes.io/managed-by"
-	ManagedByLabelValue           = ControllerName
 )
 
 // Add creates a new Monitoring controller that is responsible for
@@ -96,7 +93,7 @@ func Add(
 
 func managedByController(meta metav1.Object) bool {
 	labels := meta.GetLabels()
-	return labels[ManagedByLabel] == ManagedByLabelValue
+	return labels[ManagedByLabel] == ControllerName
 }
 
 func secretsPredicate() predicate.Funcs {

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -60,14 +60,17 @@ func Add(
 	}
 
 	eventHandler := &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
-		return []reconcile.Request{
-			{
+		requests := make([]reconcile.Request, 0)
+
+		for name := range kubeconfig.Contexts {
+			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Namespace: "",
-					Name:      "seed-proxy-reconcile",
+					Name: name,
 				},
-			},
+			})
 		}
+
+		return requests
 	})}
 
 	type watcher struct {

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -287,7 +287,7 @@ func (r *Reconciler) fetchServiceAccountSecret(ctx context.Context, client ctrlr
 		Name:      ServiceAccountName,
 	}
 
-	if err := r.Get(ctx, name, sa); err != nil {
+	if err := client.Get(ctx, name, sa); err != nil {
 		return nil, fmt.Errorf("could not find ServiceAccount '%s'", name)
 	}
 

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -249,8 +249,8 @@ func (r *Reconciler) ensureSeedServiceAccounts(ctx context.Context, client ctrlr
 		seedServiceAccountCreator(),
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx, creators, ServiceAccountNamespace, client); err != nil {
-		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", ServiceAccountNamespace, err)
+	if err := reconciling.ReconcileServiceAccounts(ctx, creators, SeedServiceAccountNamespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", SeedServiceAccountNamespace, err)
 	}
 
 	return nil
@@ -283,8 +283,8 @@ func (r *Reconciler) ensureSeedRoleBindings(ctx context.Context, client ctrlrunt
 func (r *Reconciler) fetchServiceAccountSecret(ctx context.Context, client ctrlruntimeclient.Client) (*corev1.Secret, error) {
 	sa := &corev1.ServiceAccount{}
 	name := types.NamespacedName{
-		Namespace: ServiceAccountNamespace,
-		Name:      ServiceAccountName,
+		Namespace: SeedServiceAccountNamespace,
+		Name:      SeedServiceAccountName,
 	}
 
 	if err := client.Get(ctx, name, sa); err != nil {
@@ -297,7 +297,7 @@ func (r *Reconciler) fetchServiceAccountSecret(ctx context.Context, client ctrlr
 
 	secret := &corev1.Secret{}
 	name = types.NamespacedName{
-		Namespace: ServiceAccountNamespace,
+		Namespace: SeedServiceAccountNamespace,
 		Name:      sa.Secrets[0].Name,
 	}
 
@@ -332,8 +332,8 @@ func (r *Reconciler) ensureMasterSecrets(ctx context.Context, contextName string
 		masterSecretCreator(contextName, credentials),
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, creators, KubermaticNamespace, r.Client); err != nil {
-		return fmt.Errorf("failed to reconcile Secrets in the namespace %s: %v", KubermaticNamespace, err)
+	if err := reconciling.ReconcileSecrets(ctx, creators, MasterTargetNamespace, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Secrets in the namespace %s: %v", MasterTargetNamespace, err)
 	}
 
 	return nil
@@ -344,8 +344,8 @@ func (r *Reconciler) ensureMasterDeployments(ctx context.Context, contextName st
 		masterDeploymentCreator(contextName),
 	}
 
-	if err := reconciling.ReconcileDeployments(ctx, creators, KubermaticNamespace, r.Client); err != nil {
-		return fmt.Errorf("failed to reconcile Deployments in the namespace %s: %v", KubermaticNamespace, err)
+	if err := reconciling.ReconcileDeployments(ctx, creators, MasterTargetNamespace, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Deployments in the namespace %s: %v", MasterTargetNamespace, err)
 	}
 
 	return nil
@@ -356,8 +356,8 @@ func (r *Reconciler) ensureMasterServices(ctx context.Context, contextName strin
 		masterServiceCreator(contextName),
 	}
 
-	if err := reconciling.ReconcileServices(ctx, creators, KubermaticNamespace, r.Client); err != nil {
-		return fmt.Errorf("failed to reconcile Services in the namespace %s: %v", KubermaticNamespace, err)
+	if err := reconciling.ReconcileServices(ctx, creators, MasterTargetNamespace, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Services in the namespace %s: %v", MasterTargetNamespace, err)
 	}
 
 	return nil

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -19,7 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// Reconciler stores all components required for monitoring
+// Reconciler (re)stores all components required for proxying requests to
+// seed clusters. It also takes care of creating a nice ConfigMap for
+// Grafana's provisioning mechanism.
 type Reconciler struct {
 	ctrlruntimeclient.Client
 
@@ -29,6 +31,10 @@ type Reconciler struct {
 	recorder record.EventRecorder
 }
 
+// Reconcile acts upon requests and will restore the state of resources
+// for the given seed cluster context (the request's name). Will return
+// an error if any API operation failed, otherwise will return an empty
+// dummy Result struct.
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -49,7 +49,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	glog.V(4).Info("Reconciling Grafana provisioning...")
-	if err := r.reconcileGrafana(ctx); err != nil {
+	if err := r.ensureMasterGrafanaProvisioning(ctx); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile Grafana: %v", err)
 	}
 
@@ -283,14 +283,6 @@ func (r *Reconciler) ensureMasterServices(ctx context.Context, contextName strin
 
 	if err := reconciling.ReconcileServices(ctx, creators, MasterTargetNamespace, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile Services in the namespace %s: %v", MasterTargetNamespace, err)
-	}
-
-	return nil
-}
-
-func (r *Reconciler) reconcileGrafana(ctx context.Context) error {
-	if err := r.ensureMasterGrafanaProvisioning(ctx); err != nil {
-		return err
 	}
 
 	return nil

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -2,10 +2,15 @@ package seedproxy
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	glog "github.com/kubermatic/glog-logrus"
+	"github.com/golang/glog"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,7 +20,10 @@ import (
 // Reconciler stores all components required for monitoring
 type Reconciler struct {
 	ctrlruntimeclient.Client
-	userClusterConnProvider userClusterConnectionProvider
+
+	// userClusterConnProvider userClusterConnectionProvider
+	kubeconfig  *clientcmdapi.Config
+	datacenters map[string]provider.DatacenterMeta
 
 	recorder record.EventRecorder
 }
@@ -26,62 +34,196 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	glog.V(4).Info("Reconciling seed proxies...")
 
-	kubeconfig := &corev1.Secret{}
-	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "kubermatic", Name: "kubeconfig"}, kubeconfig); err != nil {
-		if errors.IsNotFound(err) {
-			glog.V(6).Info("No kubermatic/kubeconfig secret found.")
-			return reconcile.Result{}, nil
+	for name := range r.kubeconfig.Contexts {
+		if err := r.reconcileContext(ctx, name); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to reconcile seed %s: %v", name, err)
 		}
-		return reconcile.Result{}, err
 	}
 
-	config := &clientcmdapi.Config{}
-
 	return reconcile.Result{}, nil
+}
 
-	// cluster := &kubermaticv1.Cluster{}
-	// if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
-	// 	if kubeapierrors.IsNotFound(err) {
-	// 		return reconcile.Result{}, nil
-	// 	}
-	// 	return reconcile.Result{}, err
+func (r *Reconciler) reconcileContext(ctx context.Context, contextName string) error {
+	var context *clientcmdapi.Context
+
+	for name, c := range r.kubeconfig.Contexts {
+		if name == contextName {
+			context = c
+			break
+		}
+	}
+
+	if context == nil {
+		return errors.New("could not find context in kubeconfig")
+	}
+
+	client, err := r.seedClusterClient(contextName)
+	if err != nil {
+		return fmt.Errorf("failed to create client for seed: %v", err)
+	}
+
+	if err := r.ensureSeed(ctx, client); err != nil {
+		return fmt.Errorf("failed to ensure seed %s: %v", contextName, err)
+	}
+
+	glog.V(6).Info("Fetching service account details from seed cluster...")
+	serviceAccountSecret, err := r.fetchServiceAccountSecret(ctx, client)
+	if err != nil {
+		return fmt.Errorf("failed to ensure seed %s: %v", contextName, err)
+	}
+
+	if err := r.ensureMaster(ctx, contextName, serviceAccountSecret); err != nil {
+		return fmt.Errorf("failed to ensure master: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) seedClusterClient(contextName string) (ctrlruntimeclient.Client, error) {
+	clientConfig := clientcmd.NewNonInteractiveClientConfig(
+		*r.kubeconfig,
+		contextName,
+		&clientcmd.ConfigOverrides{CurrentContext: contextName},
+		nil,
+	)
+
+	cfg, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
+}
+
+func (r *Reconciler) ensureSeed(ctx context.Context, client ctrlruntimeclient.Client) error {
+	glog.V(6).Info("Reconciling service accounts in seed cluster...")
+	if err := r.ensureSeedServiceAccounts(ctx, client); err != nil {
+		return fmt.Errorf("failed to ensure service account: %v", err)
+	}
+
+	glog.V(6).Info("Reconciling roles in seed cluster...")
+	if err := r.ensureSeedRoles(ctx, client); err != nil {
+		return fmt.Errorf("failed to ensure role: %v", err)
+	}
+
+	glog.V(6).Info("Reconciling role bindings in seed cluster...")
+	if err := r.ensureSeedRoleBindings(ctx, client); err != nil {
+		return fmt.Errorf("failed to ensure role binding: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) ensureSeedServiceAccounts(ctx context.Context, client ctrlruntimeclient.Client) error {
+	creators := []reconciling.NamedServiceAccountCreatorGetter{
+		seedServiceAccountCreator(),
+	}
+
+	if err := reconciling.ReconcileServiceAccounts(ctx, creators, ServiceAccountNamespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", ServiceAccountNamespace, err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) ensureSeedRoles(ctx context.Context, client ctrlruntimeclient.Client) error {
+	creators := []reconciling.NamedRoleCreatorGetter{
+		seedPrometheusRoleCreator(),
+	}
+
+	if err := reconciling.ReconcileRoles(ctx, creators, SeedPrometheusNamespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %v", SeedPrometheusNamespace, err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) ensureSeedRoleBindings(ctx context.Context, client ctrlruntimeclient.Client) error {
+	creators := []reconciling.NamedRoleBindingCreatorGetter{
+		seedPrometheusRoleBindingCreator(),
+	}
+
+	if err := reconciling.ReconcileRoleBindings(ctx, creators, SeedPrometheusNamespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile RoleBindings in the namespace %s: %v", SeedPrometheusNamespace, err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) fetchServiceAccountSecret(ctx context.Context, client ctrlruntimeclient.Client) (*corev1.Secret, error) {
+	sa := &corev1.ServiceAccount{}
+	name := types.NamespacedName{
+		Namespace: ServiceAccountNamespace,
+		Name:      ServiceAccountName,
+	}
+
+	if err := r.Get(ctx, name, sa); err != nil {
+		return nil, fmt.Errorf("could not find ServiceAccount '%s'", name)
+	}
+
+	if len(sa.Secrets) == 0 {
+		return nil, fmt.Errorf("no Secret associated with ServiceAccount '%s'", name)
+	}
+
+	secret := &corev1.Secret{}
+	name = types.NamespacedName{
+		Namespace: ServiceAccountNamespace,
+		Name:      sa.Secrets[0].Name,
+	}
+
+	if err := r.Get(ctx, name, secret); err != nil {
+		return nil, fmt.Errorf("could not find Secret '%s'", name)
+	}
+
+	return secret, nil
+}
+
+func (r *Reconciler) ensureMaster(ctx context.Context, contextName string, credentials *corev1.Secret) error {
+	glog.V(6).Info("Reconciling service account secret in master cluster...")
+	if err := r.ensureMasterSecrets(ctx, contextName, credentials); err != nil {
+		return fmt.Errorf("failed to ensure service account: %v", err)
+	}
+
+	glog.V(6).Info("Reconciling deployment in master cluster...")
+	if err := r.ensureMasterDeployments(ctx, contextName); err != nil {
+		return fmt.Errorf("failed to ensure deployments: %v", err)
+	}
+
+	// glog.V(6).Info("Reconciling roles in seed cluster...")
+	// if err := r.ensureSeedRoles(ctx, client); err != nil {
+	// 	return fmt.Errorf("failed to ensure role: %v", err)
 	// }
 
-	// if cluster.Spec.Pause {
-	// 	glog.V(4).Infof("skipping cluster %s due to it was set to paused", cluster.Name)
-	// 	return reconcile.Result{}, nil
+	// glog.V(6).Info("Reconciling role bindings in seed cluster...")
+	// if err := r.ensureSeedRoleBindings(ctx, client); err != nil {
+	// 	return fmt.Errorf("failed to ensure role binding: %v", err)
 	// }
 
-	// if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
-	// 	return reconcile.Result{}, nil
-	// }
+	return nil
+}
 
-	// if cluster.DeletionTimestamp != nil {
-	// 	// Cluster got deleted - all monitoring components will be automatically garbage collected (Due to the ownerRef)
-	// 	return reconcile.Result{}, nil
-	// }
+func (r *Reconciler) ensureMasterSecrets(ctx context.Context, contextName string, credentials *corev1.Secret) error {
+	creators := []reconciling.NamedSecretCreatorGetter{
+		masterSecretCreator(contextName, credentials),
+	}
 
-	// if cluster.Status.NamespaceName == "" {
-	// 	glog.V(4).Infof("skipping cluster %s because it has no namespace yet", cluster.Name)
-	// 	return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
-	// }
+	if err := reconciling.ReconcileSecrets(ctx, creators, KubermaticNamespace, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Secrets in the namespace %s: %v", KubermaticNamespace, err)
+	}
 
-	// // Wait until the UCCM is ready - otherwise we deploy with missing RBAC resources
-	// if !cluster.Status.Health.UserClusterControllerManager {
-	// 	glog.V(6).Infof("skipping cluster %s because the UserClusterControllerManager is not ready yet", cluster.Name)
-	// 	return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
-	// }
+	return nil
+}
 
-	// // Add a wrapping here so we can emit an event on error
-	// result, err := r.reconcile(ctx, cluster)
-	// if err != nil {
-	// 	glog.Errorf("Failed to reconcile cluster %s: %v", cluster.Name, err)
-	// 	r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
-	// }
-	// if result == nil {
-	// 	result = &reconcile.Result{}
-	// }
-	// return *result, err
+func (r *Reconciler) ensureMasterDeployments(ctx context.Context, contextName string) error {
+	creators := []reconciling.NamedDeploymentCreatorGetter{
+		masterDeploymentCreator(contextName),
+	}
+
+	if err := reconciling.ReconcileDeployments(ctx, creators, KubermaticNamespace, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Deployments in the namespace %s: %v", KubermaticNamespace, err)
+	}
+
+	return nil
 }
 
 // func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -1,0 +1,144 @@
+package seedproxy
+
+import (
+	"context"
+
+	glog "github.com/kubermatic/glog-logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Reconciler stores all components required for monitoring
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	userClusterConnProvider userClusterConnectionProvider
+
+	recorder record.EventRecorder
+}
+
+func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	glog.V(4).Info("Reconciling seed proxies...")
+
+	kubeconfig := &corev1.Secret{}
+	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "kubermatic", Name: "kubeconfig"}, kubeconfig); err != nil {
+		if errors.IsNotFound(err) {
+			glog.V(6).Info("No kubermatic/kubeconfig secret found.")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	config := &clientcmdapi.Config{}
+
+	return reconcile.Result{}, nil
+
+	// cluster := &kubermaticv1.Cluster{}
+	// if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
+	// 	if kubeapierrors.IsNotFound(err) {
+	// 		return reconcile.Result{}, nil
+	// 	}
+	// 	return reconcile.Result{}, err
+	// }
+
+	// if cluster.Spec.Pause {
+	// 	glog.V(4).Infof("skipping cluster %s due to it was set to paused", cluster.Name)
+	// 	return reconcile.Result{}, nil
+	// }
+
+	// if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+	// 	return reconcile.Result{}, nil
+	// }
+
+	// if cluster.DeletionTimestamp != nil {
+	// 	// Cluster got deleted - all monitoring components will be automatically garbage collected (Due to the ownerRef)
+	// 	return reconcile.Result{}, nil
+	// }
+
+	// if cluster.Status.NamespaceName == "" {
+	// 	glog.V(4).Infof("skipping cluster %s because it has no namespace yet", cluster.Name)
+	// 	return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
+	// }
+
+	// // Wait until the UCCM is ready - otherwise we deploy with missing RBAC resources
+	// if !cluster.Status.Health.UserClusterControllerManager {
+	// 	glog.V(6).Infof("skipping cluster %s because the UserClusterControllerManager is not ready yet", cluster.Name)
+	// 	return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
+	// }
+
+	// // Add a wrapping here so we can emit an event on error
+	// result, err := r.reconcile(ctx, cluster)
+	// if err != nil {
+	// 	glog.Errorf("Failed to reconcile cluster %s: %v", cluster.Name, err)
+	// 	r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
+	// }
+	// if result == nil {
+	// 	result = &reconcile.Result{}
+	// }
+	// return *result, err
+}
+
+// func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+// 	glog.V(4).Infof("Reconciling cluster %s", cluster.Name)
+
+// 	ctx, cancel := context.WithCancel(context.Background())
+// 	defer cancel()
+
+// 	data, err := r.getClusterTemplateData(context.Background(), r.Client, cluster)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all service accounts are created
+// 	if err := r.ensureServiceAccounts(ctx, cluster, data); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all roles are created
+// 	if err := r.ensureRoles(ctx, cluster); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all role bindings are created
+// 	if err := r.ensureRoleBindings(ctx, cluster); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all secrets are created
+// 	if err := r.ensureSecrets(ctx, cluster, data); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all ConfigMaps are available
+// 	if err := r.ensureConfigMaps(ctx, cluster, data); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all Deployments are available
+// 	if err := r.ensureDeployments(ctx, cluster, data); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all StatefulSets are created
+// 	if err := r.ensureStatefulSets(ctx, cluster, data); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all VerticalPodAutoscaler's are created
+// 	if err := r.ensureVerticalPodAutoscalers(ctx, cluster); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// check that all Services's are created
+// 	if err := r.ensureServices(ctx, cluster, data); err != nil {
+// 		return nil, err
+// 	}
+
+// 	return &reconcile.Result{}, nil
+// }

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -1,0 +1,143 @@
+package seedproxy
+
+import (
+	"fmt"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func secretName(contextName string) string {
+	return fmt.Sprintf("seed-proxy-%s", contextName)
+}
+
+func deploymentName(contextName string) string {
+	return fmt.Sprintf("seed-proxy-%s", contextName)
+}
+
+func seedServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return ServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			sa.Labels = map[string]string{
+				"app.kubernetes.io/name":       ServiceAccountName,
+				"app.kubernetes.io/managed-by": ControllerName,
+			}
+
+			return sa, nil
+		}
+	}
+}
+
+func seedPrometheusRoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
+		return SeedPrometheusRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
+			r.Name = SeedPrometheusRoleName
+			r.Namespace = SeedPrometheusNamespace
+			r.Labels = map[string]string{
+				"app.kubernetes.io/name":       SeedPrometheusRoleName,
+				"app.kubernetes.io/managed-by": ControllerName,
+			}
+
+			r.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"services/proxy"},
+					Verbs:     []string{"get", "list", "watch", "create"},
+				},
+			}
+
+			return r, nil
+		}
+	}
+}
+
+func seedPrometheusRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
+		return SeedPrometheusRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+			rb.Name = SeedPrometheusRoleBindingName
+			rb.Namespace = SeedPrometheusNamespace
+			rb.Labels = map[string]string{
+				"app.kubernetes.io/name":       SeedPrometheusRoleName,
+				"app.kubernetes.io/managed-by": ControllerName,
+			}
+
+			rb.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "Role",
+				Name:     SeedPrometheusRoleName,
+			}
+
+			rb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      SeedPrometheusRoleName,
+					Namespace: ServiceAccountNamespace,
+				},
+			}
+
+			return rb, nil
+		}
+	}
+}
+
+func masterSecretCreator(contextName string, credentials *corev1.Secret) reconciling.NamedSecretCreatorGetter {
+	name := secretName(contextName)
+
+	return func() (string, reconciling.SecretCreator) {
+		return name, func(s *corev1.Secret) (*corev1.Secret, error) {
+			s.Name = name
+			s.Namespace = KubermaticNamespace
+			s.Labels = map[string]string{
+				"app.kubernetes.io/name":       "seed-proxy",
+				"app.kubernetes.io/instance":   contextName,
+				"app.kubernetes.io/managed-by": ControllerName,
+			}
+
+			if s.Data == nil {
+				s.Data = make(map[string][]byte)
+			}
+
+			for k, v := range credentials.Data {
+				s.Data[k] = v
+			}
+
+			return s, nil
+		}
+	}
+}
+
+func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCreatorGetter {
+	name := deploymentName(contextName)
+	// secretName := secretName(contextName)
+
+	return func() (string, reconciling.DeploymentCreator) {
+		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+			labels := map[string]string{
+				"app.kubernetes.io/name":       "seed-proxy",
+				"app.kubernetes.io/instance":   contextName,
+				"app.kubernetes.io/managed-by": ControllerName,
+			}
+
+			d.Name = name
+			d.Namespace = KubermaticNamespace
+			d.Labels = labels
+
+			d.Spec.Replicas = i32ptr(1)
+			d.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: labels,
+			}
+
+			d.Spec.Template.Labels = labels
+
+			return d, nil
+		}
+	}
+}
+
+func i32ptr(i int32) *int32 {
+	return &i
+}

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -164,6 +164,10 @@ func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCrea
 							Name:  "PROXY_PORT",
 							Value: fmt.Sprintf("%d", KubectlProxyPort),
 						},
+						{
+							Name:  "TARGET_NAMESPACE",
+							Value: SeedPrometheusNamespace,
+						},
 					},
 					Ports: []corev1.ContainerPort{
 						{
@@ -310,15 +314,12 @@ set -euo pipefail
 
 echo "Starting kubectl proxy for $KUBERNETES_CONTEXT on port $PROXY_PORT..."
 
-while true; do
-  kubectl proxy \
-	 --address=0.0.0.0 \
-	 --port=$PROXY_PORT \
-	 --accept-hosts='' \
-	 --accept-paths='^/api/v1/namespaces/monitoring/services/.*/proxy/.*$' \
-	 --reject-methods='^(POST|PUT|PATCH|DELETE)$'
-  sleep 1
-done
+kubectl proxy \
+  --address=0.0.0.0 \
+  --port=$PROXY_PORT \
+  --accept-hosts='' \
+  --accept-paths="^/api/v1/namespaces/$TARGET_NAMESPACE/services/.*/proxy/.*$" \
+  --reject-methods='^(POST|PUT|PATCH|DELETE)$'
 `
 
 const grafanaDatasource = `

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -137,6 +137,9 @@ func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCrea
 			probe := corev1.Probe{
 				InitialDelaySeconds: 3,
 				TimeoutSeconds:      2,
+				PeriodSeconds:       10,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{
 						Port: intstr.Parse("http"),

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -150,7 +150,7 @@ func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCrea
 
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            "prometheus",
+					Name:            "proxy",
 					Image:           "quay.io/kubermatic/util:1.0.0-2",
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/bin/bash"},

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -33,7 +33,7 @@ func serviceName(contextName string) string {
 func defaultLabels(name string, instance string) map[string]string {
 	labels := map[string]string{
 		NameLabel:      name,
-		ManagedByLabel: ManagedByLabelValue,
+		ManagedByLabel: ControllerName,
 	}
 
 	if instance != "" {
@@ -137,7 +137,7 @@ func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCrea
 			d.Name = name
 			d.Namespace = KubermaticNamespace
 			d.Labels = labels()
-			d.Labels[ManagedByLabel] = ManagedByLabelValue
+			d.Labels[ManagedByLabel] = ControllerName
 
 			d.Spec.Replicas = i32ptr(1)
 			d.Spec.Selector = &metav1.LabelSelector{
@@ -227,7 +227,7 @@ func masterServiceCreator(contextName string) reconciling.NamedServiceCreatorGet
 			s.Namespace = KubermaticNamespace
 
 			s.Labels = labels()
-			s.Labels[ManagedByLabel] = ManagedByLabelValue
+			s.Labels[ManagedByLabel] = ControllerName
 
 			s.Spec.Ports = []corev1.ServicePort{
 				{
@@ -262,7 +262,7 @@ func masterGrafanaConfigmapCreator(datacenters map[string]provider.DatacenterMet
 			c.Data = make(map[string]string)
 
 			c.Labels = labels()
-			c.Labels[ManagedByLabel] = ManagedByLabelValue
+			c.Labels[ManagedByLabel] = ControllerName
 
 			for dcName, dc := range datacenters {
 				if dc.IsSeed {

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -134,6 +134,16 @@ func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCrea
 				}
 			}
 
+			probe := corev1.Probe{
+				InitialDelaySeconds: 3,
+				TimeoutSeconds:      2,
+				Handler: corev1.Handler{
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.Parse("http"),
+					},
+				},
+			}
+
 			d.Name = name
 			d.Namespace = KubermaticNamespace
 			d.Labels = labels()
@@ -195,6 +205,7 @@ func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCrea
 					},
 					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 					TerminationMessagePath:   "/dev/termination-log",
+					ReadinessProbe:           &probe,
 				},
 			}
 

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -89,8 +89,8 @@ func seedPrometheusRoleBindingCreator() reconciling.NamedRoleBindingCreatorGette
 			rb.Subjects = []rbacv1.Subject{
 				{
 					Kind:      rbacv1.ServiceAccountKind,
-					Name:      SeedPrometheusRoleName,
 					Namespace: ServiceAccountNamespace,
+					Name:      SeedServiceAccountName,
 				},
 			}
 

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -2,13 +2,16 @@ package seedproxy
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func secretName(contextName string) string {
@@ -16,6 +19,10 @@ func secretName(contextName string) string {
 }
 
 func deploymentName(contextName string) string {
+	return fmt.Sprintf("seed-proxy-%s", contextName)
+}
+
+func serviceName(contextName string) string {
 	return fmt.Sprintf("seed-proxy-%s", contextName)
 }
 
@@ -112,28 +119,116 @@ func masterSecretCreator(contextName string, credentials *corev1.Secret) reconci
 
 func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCreatorGetter {
 	name := deploymentName(contextName)
-	// secretName := secretName(contextName)
+	secretName := secretName(contextName)
 
 	return func() (string, reconciling.DeploymentCreator) {
 		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			labels := map[string]string{
-				"app.kubernetes.io/name":       "seed-proxy",
-				"app.kubernetes.io/instance":   contextName,
-				"app.kubernetes.io/managed-by": ControllerName,
+			labels := func() map[string]string {
+				return map[string]string{
+					"app.kubernetes.io/name":     "seed-proxy",
+					"app.kubernetes.io/instance": contextName,
+				}
 			}
 
 			d.Name = name
 			d.Namespace = KubermaticNamespace
-			d.Labels = labels
+			d.Labels = labels()
+			d.Labels["app.kubernetes.io/managed-by"] = ControllerName
 
 			d.Spec.Replicas = i32ptr(1)
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: labels(),
 			}
 
-			d.Spec.Template.Labels = labels
+			d.Spec.Template.Labels = labels()
+			d.Spec.Template.Labels["prometheus.io/scrape"] = "true"
+			d.Spec.Template.Labels["prometheus.io/port"] = "8001"
+
+			d.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:    "prometheus",
+					Image:   "quay.io/kubermatic/util:1.0.0-2",
+					Command: []string{"/bin/bash"},
+					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "KUBERNETES_CONTEXT",
+							Value: contextName,
+						},
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8001,
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							MountPath: "var/run/secrets/kubernetes.io/serviceaccount/",
+							Name:      "serviceaccount",
+							ReadOnly:  true,
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("24Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+					},
+				},
+			}
+
+			d.Spec.Template.Spec.Volumes = []corev1.Volume{
+				{
+					Name: "serviceaccount",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: secretName,
+						},
+					},
+				},
+			}
 
 			return d, nil
+		}
+	}
+}
+
+func masterServiceCreator(contextName string) reconciling.NamedServiceCreatorGetter {
+	name := serviceName(contextName)
+
+	return func() (string, reconciling.ServiceCreator) {
+		return name, func(s *corev1.Service) (*corev1.Service, error) {
+			labels := func() map[string]string {
+				return map[string]string{
+					"app.kubernetes.io/name":     "seed-proxy",
+					"app.kubernetes.io/instance": contextName,
+				}
+			}
+
+			s.Name = name
+			s.Namespace = KubermaticNamespace
+
+			s.Labels = labels()
+			s.Labels["app.kubernetes.io/managed-by"] = ControllerName
+
+			s.Spec.Ports = []corev1.ServicePort{
+				{
+					Name: "http",
+					Port: 8001,
+					TargetPort: intstr.IntOrString{
+						StrVal: "http",
+					},
+				},
+			}
+
+			s.Spec.Selector = labels()
+
+			return s, nil
 		}
 	}
 }
@@ -141,3 +236,19 @@ func masterDeploymentCreator(contextName string) reconciling.NamedDeploymentCrea
 func i32ptr(i int32) *int32 {
 	return &i
 }
+
+const proxyScript = `
+set -euo pipefail
+
+echo "Starting kubectl proxy for $KUBERNETES_CONTEXT on port 8001..."
+
+while true; do
+  kubectl proxy \
+	 --address=0.0.0.0 \
+	 --port=8001 \
+	 --accept-hosts='' \
+	 --accept-paths='^/api/v1/namespaces/monitoring/services/.*/proxy/.*$' \
+	 --reject-methods='^(POST|PUT|PATCH|DELETE)$'
+  sleep 1
+done
+`


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to properly monitor the master cluster and scrape Prometheus inside the seed clusters. To make this easy and automated, this PR adds a new controller to the master-controller-manager that takes care of providing the configuration needed for Prometheus and Grafana to do their thing. Based on the datanceters.yaml and kubeconfig this controller

* provisions a ServiceAccount in each seed cluster,
* creates new roles that only have proxy permissions,
* binds SA to the roles for Grafana and Prometheus,
* copies the token and CA information from the seed into the master and creates a new Secret that holds the ServiceAccount credentials,
* adds a Deployment per seed that runs a single replica of a pod that just runs `kubectl proxy`. This Deployment makes use of the newly created secret from the steps above,
* creates a Service for the kubectl-proxy's opened port (8001),
* and lastly creates a ConfigMap with specialized Grafana config files.

It would have been possible to "simply" configure Prometheus to directly scrape `https://<seed-ip>:6443/api/proxy/monitoring/bla/bla/bla`, but configuring Prometheus dynamically sucks. By having dedicated "proxy pods",  we can instead use Prometheus' service discovery and hide the technical details inside the pods.

To keep the state handling simple, this controller explicitly does not watch resources inside the seeds, i.e. if someone deletes the ServiceAccount in a seed, it won't be reconciled until the reconcile loop is ran again on the master.

**Open Questions**
* A lot of stuff is hardcoded, like the namespace where Grafana is running. Can/should this be turned into CLI flags for the master-controller-manager?
* Given that the controller also creates a Grafana ConfigMap, maybe "seed proxy" is not a good name for the controller?

**Which issue(s) this PR fixes**:
Relates to #3238

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
