### PR TITLE
Make Openstack "trust-device-path" configurable via datacenters.yaml

### DIFF
--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -44,6 +44,9 @@ type OpenstackSpec struct {
 	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
 	// To make this change backwards compatible, this will default to true.
 	ManageSecurityGroups *bool `yaml:"manage_security_groups"`
+	// Gets mapped to the "trust-device-path" setting in the cloud config.
+	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage
+	TrustDevicePath *bool `yaml:"trust_device_path"`
 }
 
 // AzureSpec describes an Azure cloud datacenter

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -90,6 +90,7 @@ func CloudConfig(cluster *kubermaticv1.Cluster, dc *provider.DatacenterMeta) (cl
 		}
 	} else if cloud.Openstack != nil {
 		manageSecurityGroups := dc.Spec.Openstack.ManageSecurityGroups
+		trustDevicePath := dc.Spec.Openstack.TrustDevicePath
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
 				AuthURL:    dc.Spec.Openstack.AuthURL,
@@ -101,7 +102,7 @@ func CloudConfig(cluster *kubermaticv1.Cluster, dc *provider.DatacenterMeta) (cl
 			},
 			BlockStorage: openstack.BlockStorageOpts{
 				BSVersion:       "auto",
-				TrustDevicePath: false,
+				TrustDevicePath: trustDevicePath != nil && *trustDevicePath,
 				IgnoreVolumeAZ:  dc.Spec.Openstack.IgnoreVolumeAZ,
 			},
 			LoadBalancer: openstack.LoadBalancerOpts{

--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -160,6 +160,10 @@ func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 		config.FloatingIPPool = providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.FloatingIPPool}
 	}
 
+	if dc.Spec.Openstack.TrustDevicePath != nil {
+		config.TrustDevicePath = providerconfig.ConfigVarBool{Value: *dc.Spec.Openstack.TrustDevicePath}
+	}
+
 	config.Tags = map[string]string{}
 	for key, value := range nodeSpec.Cloud.Openstack.Tags {
 		config.Tags[key] = value


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes the `trust-device-path` setting on Openstack datacenters configurable.

Related change to machine controller: https://github.com/kubermatic/machine-controller/pull/506
Machine-controller bump: https://github.com/kubermatic/kubermatic/pull/3298


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/kubermatic/issues/3110

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The trust-device-path cloud config property of Openstack clusters can be configured via datacenters.yaml.
```
