### PR TITLE
Set app anti affinity

### DIFF
--- a/api/pkg/controller/openshift/resources/apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/apiserver_deployment.go
@@ -184,7 +184,7 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.N
 				},
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(ApiserverDeploymentName, data.Cluster().Name, nil))
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(ApiserverDeploymentName, data.Cluster().Name)
 
 			return dep, nil
 		}

--- a/api/pkg/controller/openshift/resources/controller_manager_deployment.go
+++ b/api/pkg/controller/openshift/resources/controller_manager_deployment.go
@@ -184,7 +184,7 @@ func ControllerManagerDeploymentCreator(ctx context.Context, data openshiftData)
 				},
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(ControllerManagerDeploymentName, data.Cluster().Name, nil))
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(ControllerManagerDeploymentName, data.Cluster().Name)
 
 			return dep, nil
 		}

--- a/api/pkg/resources/antiaffinity.go
+++ b/api/pkg/resources/antiaffinity.go
@@ -5,17 +5,37 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// HostnameAntiAffinity returns a simple Affinity rule to prevent* scheduling of same kind pods on the same node
+// HostnameAntiAffinity returns a simple Affinity rule to prevent* scheduling of same kind pods on the same node.
+// It contains 2 AntiAffinity terms:
+// High priority: We don't schedule multiple pods of this app & cluster on a single node
+// Low priority: We don't schedule multiple pods of this app on a single node - regardless of the cluster.
+// This prevents that we schedule all API server pods on a single node
 // *if scheduling is not possible with this rule, it will be ignored.
-func HostnameAntiAffinity(labels map[string]string) *corev1.Affinity {
+func HostnameAntiAffinity(app, clusterName string) *corev1.Affinity {
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
 			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				// Avoid that we schedule multiple same-kind pods of a cluster on a single node
 				{
 					Weight: 100,
 					PodAffinityTerm: corev1.PodAffinityTerm{
 						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: labels,
+							MatchLabels: map[string]string{
+								AppLabelKey:     app,
+								ClusterLabelKey: clusterName,
+							},
+						},
+						TopologyKey: TopologyKeyHostname,
+					},
+				},
+				// Avoid that we schedule multiple same-kind pods on a single node
+				{
+					Weight: 10,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								AppLabelKey: app,
+							},
 						},
 						TopologyKey: TopologyKeyHostname,
 					},

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -189,7 +189,7 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				},
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
 			return dep, nil
 		}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -170,7 +170,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				},
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
 			return dep, nil
 		}

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -126,7 +126,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(resources.DNSResolverDeploymentName, data.Cluster().Name, nil))
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.DNSResolverDeploymentName, data.Cluster().Name)
 
 			return dep, nil
 		}

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -175,7 +175,7 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 				},
 			}
 
-			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(baseLabels)
+			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.EtcdStatefulSetName, data.Cluster().Name)
 
 			set.Spec.Template.Spec.Volumes = volumes
 

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -118,7 +118,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				*dnatControllerSidecar,
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
 			return dep, nil
 		}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -226,6 +226,8 @@ const (
 
 	// AppLabelKey defines the label key app which should be used within resources
 	AppLabelKey = "app"
+	// ClusterLabelKey defines the label key for the cluster name
+	ClusterLabelKey = "cluster"
 
 	// EtcdClusterSize defines the size of the etcd to use
 	EtcdClusterSize = 3

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -148,7 +148,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				},
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.AppClusterLabel(name, data.Cluster().Name, nil))
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
 			return dep, nil
 		}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -46,6 +46,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -39,6 +39,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -33,6 +33,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -37,6 +37,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - args:
         - --client

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-etcd.yaml
@@ -30,6 +30,12 @@ spec:
                   cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
       containers:
       - command:
         - /bin/sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Set antiaffinity to prevent that we schedule all pods of a component on a single node.

Fixes #3268

**Does this PR introduce a user-facing change?**:
```release-note
Set AntiAffinity for pods to prevent situations where the API servers of all clusters got scheduled on a single node
```
