### PR TITLE
prevents inviting a service account to a project

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -160,7 +160,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	cloudProviders := cloud.Providers(datacenters)
 	userLister := kubermaticMasterInformerFactory.Kubermatic().V1().Users().Lister()
 	sshKeyProvider := kubernetesprovider.NewSSHKeyProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserSSHKeys().Lister())
-	userProvider := kubernetesprovider.NewUserProvider(kubermaticMasterClient, userLister)
+	userProvider := kubernetesprovider.NewUserProvider(kubermaticMasterClient, userLister, kubernetesprovider.IsServiceAccount)
 
 	serviceAccountTokenProvider, err := kubernetesprovider.NewServiceAccountTokenProvider(defaultKubernetesImpersonationClient.CreateImpersonatedKubernetesClientSet, kubeInformerFactory.Core().V1().Secrets().Lister())
 	if err != nil {
@@ -168,7 +168,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	}
 	serviceAccountProvider := kubernetesprovider.NewServiceAccountProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, userLister, options.domain)
 
-	projectMemberProvider := kubernetesprovider.NewProjectMemberProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserProjectBindings().Lister(), userLister)
+	projectMemberProvider := kubernetesprovider.NewProjectMemberProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserProjectBindings().Lister(), userLister, kubernetesprovider.IsServiceAccount)
 	projectProvider, err := kubernetesprovider.NewProjectProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().Projects().Lister())
 	if err != nil {
 		return providers{}, fmt.Errorf("failed to create project provider due to %v", err)

--- a/api/pkg/handler/v1/project/project_test.go
+++ b/api/pkg/handler/v1/project/project_test.go
@@ -317,8 +317,8 @@ func TestListProjectMethod(t *testing.T) {
 
 			userLister := kubermaticInformerFactory.Kubermatic().V1().Users().Lister()
 			projectBindingLister := kubermaticInformerFactory.Kubermatic().V1().UserProjectBindings().Lister()
-			projectMemberProvider := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, projectBindingLister, userLister)
-			userProvider := kubernetes.NewUserProvider(kubermaticClient, kubermaticInformerFactory.Kubermatic().V1().Users().Lister())
+			projectMemberProvider := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, projectBindingLister, userLister, kubernetes.IsServiceAccount)
+			userProvider := kubernetes.NewUserProvider(kubermaticClient, kubermaticInformerFactory.Kubermatic().V1().Users().Lister(), kubernetes.IsServiceAccount)
 
 			kubermaticInformerFactory.Start(wait.NeverStop)
 			kubermaticInformerFactory.WaitForCacheSync(wait.NeverStop)

--- a/api/pkg/handler/v1/serviceaccount/sa.go
+++ b/api/pkg/handler/v1/serviceaccount/sa.go
@@ -143,7 +143,6 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, serviceAccountProv
 				return nil, errors.NewAlreadyExists("service account", saFromRequest.Name)
 			}
 			sa.Spec.Name = saFromRequest.Name
-
 		}
 
 		currentGroup, err := memberMapper.MapUserToGroup(sa.Spec.Email, project.Name)

--- a/api/pkg/provider/kubernetes/member_test.go
+++ b/api/pkg/provider/kubernetes/member_test.go
@@ -34,7 +34,7 @@ func TestCreateBinding(t *testing.T) {
 	bindingLister := kubermaticv1lister.NewUserProjectBindingLister(indexer)
 	userLister := kubermaticv1lister.NewUserLister(indexer)
 	// act
-	target := kubernetes.NewProjectMemberProvider(impersonationClient.CreateFakeImpersonatedClientSet, bindingLister, userLister)
+	target := kubernetes.NewProjectMemberProvider(impersonationClient.CreateFakeImpersonatedClientSet, bindingLister, userLister, kubernetes.IsServiceAccount)
 	result, err := target.Create(&provider.UserInfo{Email: authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", existingProject.Name)}, existingProject, memberEmail, groupName)
 
 	// validate
@@ -99,7 +99,6 @@ func TestListBinding(t *testing.T) {
 			expectedBindings: []*kubermaticv1.UserProjectBinding{
 				createBinding("abcdBinding", "my-first-project-ID", "bob@acme.com", "owners"),
 				createBinding("cdBinding", "my-first-project-ID", "bob@acme.com", "owners"),
-				createBinding("fakeServiceAccount", "my-first-project-ID", "serviceaccount-test@localhost", "editors"),
 			},
 		},
 	}
@@ -131,7 +130,7 @@ func TestListBinding(t *testing.T) {
 			bindingLister := kubermaticv1lister.NewUserProjectBindingLister(bindingIndexer)
 			userLister := kubermaticv1lister.NewUserLister(saIndexer)
 			// act
-			target := kubernetes.NewProjectMemberProvider(impersonationClient.CreateFakeImpersonatedClientSet, bindingLister, userLister)
+			target := kubernetes.NewProjectMemberProvider(impersonationClient.CreateFakeImpersonatedClientSet, bindingLister, userLister, kubernetes.IsServiceAccount)
 			result, err := target.List(&provider.UserInfo{Email: tc.authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", tc.projectToSync.Name)}, tc.projectToSync, nil)
 
 			// validate


### PR DESCRIPTION
**What this PR does / why we need it**: although a service account is a special type of user it should not become a member of a project. This functionality is reserved only for humans :)

service accounts are mainly for programmatic access to the API and will be managed on a dedicated page. Note that this pulls also adds a restriction on an email address a user can have, it cannot start with "serviceaccount-" prefix.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3271 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
