### PR TITLE
update envoy to v1.10

### DIFF
--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -59,7 +59,6 @@ spec:
         - "cluster0"
         - "--service-node"
         - "kube"
-        - "--v2-config-only"
         lifecycle:
           preStop:
             exec:

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -3,7 +3,7 @@ nodePortPoxy:
   envoy:
     image:
       repository: "envoyproxy/envoy-alpine"
-      tag: "v1.9.0"
+      tag: "v1.10.0"
   image:
     repository: "quay.io/kubermatic/nodeport-proxy"
     tag: "v2.0.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update envoy to v1.10.
I did a quick test on dev and clusters are still available from the outside.

**Does this PR introduce a user-facing change?**:
```release-note
Update envoy to v1.10
```
