### PR TITLE
Enable scale subresource for MachineSet and MachineDeployment

### DIFF
--- a/api/pkg/controller/usercluster/resources/machine-controller/crds.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/crds.go
@@ -43,7 +43,12 @@ func MachineSetCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGett
 			crd.Spec.Names.Plural = "machinesets"
 			crd.Spec.Names.Singular = "machineset"
 			crd.Spec.Names.ShortNames = []string{"ms"}
-			crd.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{}}
+			crd.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+				Scale: &apiextensionsv1beta1.CustomResourceSubresourceScale{
+					SpecReplicasPath:   ".spec.replicas",
+					StatusReplicasPath: ".status.replicas",
+				}}
 
 			return crd, nil
 		}
@@ -62,7 +67,12 @@ func MachineDeploymentCRDCreator() reconciling.NamedCustomResourceDefinitionCrea
 			crd.Spec.Names.Plural = "machinedeployments"
 			crd.Spec.Names.Singular = "machinedeployment"
 			crd.Spec.Names.ShortNames = []string{"md"}
-			crd.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{}}
+			crd.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+				Scale: &apiextensionsv1beta1.CustomResourceSubresourceScale{
+					SpecReplicasPath:   ".spec.replicas",
+					StatusReplicasPath: ".status.replicas",
+				}}
 
 			return crd, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3232

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
It is now possible to scale MachineDeployments and MachineSets via `kubectl scale`
```
