### PR TITLE
fix context handling

### DIFF
--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -21,12 +20,8 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 
-	"github.com/golang/glog"
-	"github.com/oklog/run"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // allControllers stores the list of all controllers that we want to run,
@@ -52,22 +47,6 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 		}
 	}
 	return nil
-}
-
-func runAllControllers(workerCnt int,
-	done <-chan struct{},
-	cancel context.CancelFunc,
-	mgr manager.Runnable) error {
-	var g run.Group
-
-	g.Add(func() error {
-		return fmt.Errorf("mgr finished/died: %v", mgr.Start(done))
-	}, func(err error) {
-		glog.Errorf("Got error=%v, shuttind down....", err)
-		cancel()
-	})
-
-	return g.Run()
 }
 
 func createCloudController(ctrlCtx *controllerContext) error {

--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -203,7 +203,6 @@ func (o controllerRunOptions) validateCABundle() error {
 // needs to be initialized first
 type controllerContext struct {
 	runOptions           controllerRunOptions
-	stopCh               <-chan struct{}
 	mgr                  manager.Manager
 	clientProvider       client.UserClusterConnectionProvider
 	dcs                  map[string]provider.DatacenterMeta


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the context handling.
Now each go routine has its own context which gets canceled inside the interrupt function.

I've tested:
- Stopping via ctrl+c
- Turning off wifi so it cannot renew the lease

In both scenarios it performs a clean shutdown with meaningful log messages.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
