### PR TITLE
enable controller runtime logger

### DIFF
--- a/api/cmd/kubeletdnat-controller/main.go
+++ b/api/cmd/kubeletdnat-controller/main.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
@@ -23,6 +24,8 @@ func main() {
 	chainNameFlag := flag.String("chain-name", "node-access-dnat", "Name of the chain in nat table.")
 	vpnInterfaceFlag := flag.String("vpn-interface", "tun0", "Name of the vpn interface.")
 	flag.Parse()
+
+	log.SetLogger(log.ZapLogger(false))
 
 	nodeAccessNetwork, _, err := net.ParseCIDR(*networkFlag)
 	if err != nil {

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 type controllerRunOptions struct {
@@ -54,6 +55,8 @@ func main() {
 	flag.IntVar(&ctrlCtx.runOptions.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
 	flag.StringVar(&ctrlCtx.runOptions.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the /metrics endpoint will be served")
 	flag.Parse()
+
+	log.SetLogger(log.ZapLogger(false))
 
 	config, err := clientcmd.BuildConfigFromFlags(ctrlCtx.runOptions.masterURL, ctrlCtx.runOptions.kubeconfig)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable controller runtime logger in all commands which use controller runtime packages

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
