### PR TITLE
delete endpoint for tokens

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2415,6 +2415,53 @@
           }
         }
       },
+      "delete": {
+        "description": "Deletes the token",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "tokens"
+        ],
+        "operationId": "deleteServiceAccountToken",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ServiceAccountID",
+            "name": "serviceaccount_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "TokenID",
+            "name": "token_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/empty"
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      },
       "patch": {
         "description": "Patches the token name",
         "consumes": [

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -223,7 +223,7 @@ func CreateTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.Dat
 		tokenGenerator,
 	)
 
-	return mainRouter, &ClientsSets{kubermaticClient, fakeClient, tokenAuth, tokenGenerator}, nil
+	return mainRouter, &ClientsSets{kubermaticClient, fakeClient, kubernetesClient, tokenAuth, tokenGenerator}, nil
 }
 
 // CreateTestEndpoint does exactly the same as CreateTestEndpointAndGetClients except it omits ClientsSets when returning
@@ -285,6 +285,8 @@ func (f *fakeUserClusterConnection) GetAdminKubeconfig(c *kubermaticapiv1.Cluste
 type ClientsSets struct {
 	FakeKubermaticClient *kubermaticfakeclentset.Clientset
 	FakeClient           ctrlruntimeclient.Client
+	// this client is used for unprivileged methods where impersonated client is used
+	FakeKubernetesCoreClient kubernetesclientset.Interface
 
 	TokenAuthenticator serviceaccount.TokenAuthenticator
 	TokenGenerator     serviceaccount.TokenGenerator

--- a/api/pkg/handler/v1/serviceaccount/token.go
+++ b/api/pkg/handler/v1/serviceaccount/token.go
@@ -187,12 +187,15 @@ func DeleteTokenEndpoint(projectProvider provider.ProjectProvider, serviceAccoun
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		_, err = serviceAccountProvider.Get(userInfo, req.ServiceAccountID, &provider.ServiceAccountGetOptions{RemovePrefix: false})
+		_, err = serviceAccountProvider.Get(userInfo, req.ServiceAccountID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		return nil, serviceAccountTokenProvider.Delete(userInfo, req.TokenID)
+		if err := serviceAccountTokenProvider.Delete(userInfo, req.TokenID); err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		return nil, nil
 	}
 }
 

--- a/api/pkg/handler/v1/serviceaccount/token_test.go
+++ b/api/pkg/handler/v1/serviceaccount/token_test.go
@@ -12,6 +12,8 @@ import (
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -527,6 +529,71 @@ func TestUpdateToken(t *testing.T) {
 
 			} else {
 				test.CompareWithResult(t, res, tc.expectedErrorMsg)
+			}
+		})
+	}
+}
+
+func TestDeleteToken(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name                   string
+		existingKubermaticObjs []runtime.Object
+		existingKubernetesObjs []runtime.Object
+		projectToSync          string
+		saToSync               string
+		tokenToDelete          string
+		httpStatus             int
+		existingAPIUser        apiv1.User
+	}{
+		{
+			name:       "scenario 1: delete token",
+			httpStatus: http.StatusOK,
+			existingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("plan9-ID", "john@acme.com", "owners"),
+				test.GenBinding("plan9-ID", "serviceaccount-1@sa.kubermatic.io", "editors"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				genActiveServiceAccount("1", "test-1", "editors", "plan9-ID"),
+			},
+			existingKubernetesObjs: []runtime.Object{
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1"),
+				test.GenSecret("plan10-ID", "serviceaccount-2", "test-2", "2"),
+				test.GenSecret("plan9-ID", "serviceaccount-1", "test-3", "3"),
+				test.GenSecret("plan11-ID", "serviceaccount-3", "test-4", "4"),
+			},
+			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
+			projectToSync:   "plan9-ID",
+			saToSync:        "1",
+			tokenToDelete:   "sa-token-3",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/serviceaccounts/%s/tokens/%s", tc.projectToSync, tc.saToSync, tc.tokenToDelete), strings.NewReader(""))
+			res := httptest.NewRecorder()
+
+			ep, clientset, err := test.CreateTestEndpointAndGetClients(tc.existingAPIUser, nil, tc.existingKubernetesObjs, []runtime.Object{}, tc.existingKubermaticObjs, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			if _, err := clientset.FakeKubernetesCoreClient.CoreV1().Secrets("kubermatic").Get(tc.tokenToDelete, metav1.GetOptions{}); err != nil {
+				t.Fatalf("failed to check token %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.httpStatus {
+				t.Fatalf("expected HTTP status code %d, got %d: %s", tc.httpStatus, res.Code, res.Body.String())
+			}
+
+			if _, err := clientset.FakeKubernetesCoreClient.CoreV1().Secrets("kubermatic").Get(tc.tokenToDelete, metav1.GetOptions{}); err == nil {
+				t.Fatalf("failed to delete token %s", tc.tokenToDelete)
 			}
 		})
 	}

--- a/api/pkg/handler/v1/serviceaccount/token_test.go
+++ b/api/pkg/handler/v1/serviceaccount/token_test.go
@@ -545,6 +545,7 @@ func TestDeleteToken(t *testing.T) {
 		tokenToDelete          string
 		httpStatus             int
 		existingAPIUser        apiv1.User
+		expectedResponse       string
 	}{
 		{
 			name:       "scenario 1: delete token",
@@ -565,10 +566,11 @@ func TestDeleteToken(t *testing.T) {
 				test.GenSecret("plan9-ID", "serviceaccount-1", "test-3", "3"),
 				test.GenSecret("plan11-ID", "serviceaccount-3", "test-4", "4"),
 			},
-			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
-			projectToSync:   "plan9-ID",
-			saToSync:        "1",
-			tokenToDelete:   "sa-token-3",
+			existingAPIUser:  *test.GenAPIUser("john", "john@acme.com"),
+			projectToSync:    "plan9-ID",
+			saToSync:         "1",
+			tokenToDelete:    "sa-token-3",
+			expectedResponse: "{}",
 		},
 	}
 
@@ -591,6 +593,8 @@ func TestDeleteToken(t *testing.T) {
 			if res.Code != tc.httpStatus {
 				t.Fatalf("expected HTTP status code %d, got %d: %s", tc.httpStatus, res.Code, res.Body.String())
 			}
+
+			test.CompareWithResult(t, res, tc.expectedResponse)
 
 			if _, err := clientset.FakeKubernetesCoreClient.CoreV1().Secrets("kubermatic").Get(tc.tokenToDelete, metav1.GetOptions{}); err == nil {
 				t.Fatalf("failed to delete token %s", tc.tokenToDelete)

--- a/api/pkg/provider/kubernetes/sa_token.go
+++ b/api/pkg/provider/kubernetes/sa_token.go
@@ -190,7 +190,7 @@ func (p *ServiceAccountTokenProvider) Get(userInfo *provider.UserInfo, name stri
 		return nil, kerrors.NewBadRequest("userInfo cannot be nil")
 	}
 	if len(name) == 0 {
-		return nil, kerrors.NewBadRequest("service account name cannot be empty")
+		return nil, kerrors.NewBadRequest("token name cannot be empty")
 	}
 
 	kubernetesImpersonatedClient, err := createKubernetesImpersonationClientWrapperFromUserInfo(userInfo, p.kubernetesImpersonationClient)
@@ -214,4 +214,20 @@ func (p *ServiceAccountTokenProvider) Update(userInfo *provider.UserInfo, secret
 		return nil, kerrors.NewInternalError(err)
 	}
 	return kubernetesImpersonatedClient.CoreV1().Secrets(kubermaticNamespace).Update(secret)
+}
+
+// Delete method deletes given token
+func (p *ServiceAccountTokenProvider) Delete(userInfo *provider.UserInfo, name string) error {
+	if userInfo == nil {
+		return kerrors.NewBadRequest("userInfo cannot be nil")
+	}
+	if len(name) == 0 {
+		return kerrors.NewBadRequest("token name cannot be empty")
+	}
+
+	kubernetesImpersonatedClient, err := createKubernetesImpersonationClientWrapperFromUserInfo(userInfo, p.kubernetesImpersonationClient)
+	if err != nil {
+		return kerrors.NewInternalError(err)
+	}
+	return kubernetesImpersonatedClient.CoreV1().Secrets(kubermaticNamespace).Delete(name, &metav1.DeleteOptions{})
 }

--- a/api/pkg/provider/kubernetes/sa_token_test.go
+++ b/api/pkg/provider/kubernetes/sa_token_test.go
@@ -1,10 +1,7 @@
 package kubernetes_test
 
 import (
-	"sort"
 	"testing"
-
-	"gopkg.in/square/go-jose.v2/jwt"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
@@ -14,12 +11,9 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubernetesclient "k8s.io/client-go/kubernetes"
-	fakerestclient "k8s.io/client-go/kubernetes/fake"
 	listers "k8s.io/client-go/listers/core/v1"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 )
 
 func TestCreateToken(t *testing.T) {
@@ -385,39 +379,4 @@ func TestDeleteToken(t *testing.T) {
 			}
 		})
 	}
-}
-
-// FakeKubernetesImpersonationClient gives kubernetes client set that uses user impersonation
-type FakeKubernetesImpersonationClient struct {
-	kubernetesClent *fakerestclient.Clientset
-}
-
-func (f *FakeKubernetesImpersonationClient) CreateKubernetesFakeImpersonatedClientSet(impCfg restclient.ImpersonationConfig) (kubernetesclient.Interface, error) {
-	return f.kubernetesClent, nil
-}
-
-func createFakeKubernetesClients(kubermaticObjects []runtime.Object) (*FakeKubernetesImpersonationClient, *fakerestclient.Clientset, cache.Indexer, error) {
-	kubermaticClient := fakerestclient.NewSimpleClientset(kubermaticObjects...)
-
-	indexer, err := createIndexer(kubermaticObjects)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	return &FakeKubernetesImpersonationClient{kubermaticClient}, kubermaticClient, indexer, nil
-}
-
-type fakeJWTTokenGenerator struct {
-}
-
-// Generate generates new fake token
-func (j *fakeJWTTokenGenerator) Generate(claims *jwt.Claims, privateClaims *serviceaccount.CustomTokenClaim) (string, error) {
-	return test.TestFakeToken, nil
-}
-
-func sortByName(tokens []*v1.Secret) {
-	sort.SliceStable(tokens, func(i, j int) bool {
-		mi, mj := tokens[i], tokens[j]
-		return mi.Name < mj.Name
-	})
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -353,6 +353,7 @@ type ServiceAccountTokenProvider interface {
 	List(userInfo *UserInfo, project *kubermaticv1.Project, sa *kubermaticv1.User, options *ServiceAccountTokenListOptions) ([]*v1.Secret, error)
 	Get(userInfo *UserInfo, name string) (*v1.Secret, error)
 	Update(userInfo *UserInfo, secret *v1.Secret) (*v1.Secret, error)
+	Delete(userInfo *UserInfo, name string) error
 }
 
 // ServiceAccountTokenListOptions allows to set filters that will be applied to filter the result.


### PR DESCRIPTION
**What this PR does / why we need it**: add an endpoint to delete token from the service account

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3258 

```release-note
a new endpoint to delete tokens from the service accounts: DELETE /api/v1/projects/{project_id}/serviceaccounts/{serviceaccount_id}/tokens/{token_id}
```
