### PR TITLE
update documentation for kube cert expiration alerts

### DIFF
--- a/config/monitoring/prometheus/rules/general-kube-apiserver.yaml
+++ b/config/monitoring/prometheus/rules/general-kube-apiserver.yaml
@@ -69,17 +69,23 @@ groups:
       severity: warning
   - alert: KubeClientCertificateExpiration
     annotations:
-      message: Kubernetes API certificate is expiring in less than 7 days.
+      message: A client certificate used to authenticate to the apiserver is expiring
+        in less than 7 days.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclientcertificateexpiration
     expr: |
+      apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
+      and
       histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
     labels:
       severity: warning
   - alert: KubeClientCertificateExpiration
     annotations:
-      message: Kubernetes API certificate is expiring in less than 24 hours.
+      message: A client certificate used to authenticate to the apiserver is expiring
+        in less than 24 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclientcertificateexpiration
     expr: |
+      apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
+      and
       histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
+++ b/config/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
@@ -80,18 +80,33 @@ groups:
 
   - alert: KubeClientCertificateExpiration
     annotations:
-      message: Kubernetes API certificate is expiring in less than 7 days.
+      message: A client certificate used to authenticate to the apiserver is expiring in less than 7 days.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclientcertificateexpiration
     expr: |
+      apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
+      and
       histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
     labels:
       severity: warning
+    runbook:
+      steps:
+      - Check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/) on how to renew certificates.
+      - If your certificate has already expired, the steps in the documentation might not work. Check [Github](https://github.com/kubernetes/kubeadm/issues/581#issuecomment-421477139)
+        for hints about fixing your cluster.
 
   - alert: KubeClientCertificateExpiration
     annotations:
-      message: Kubernetes API certificate is expiring in less than 24 hours.
+      message: A client certificate used to authenticate to the apiserver is expiring in less than 24 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclientcertificateexpiration
     expr: |
+      apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
+      and
       histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
     labels:
       severity: critical
+    runbook:
+      steps:
+      - Urgently renew your certificates. Expired certificates can make fixing the cluster difficult to begin with.
+      - Check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/) on how to renew certificates.
+      - If your certificate has already expired, the steps in the documentation might not work. Check [Github](https://github.com/kubernetes/kubeadm/issues/581#issuecomment-421477139)
+        for hints about fixing your cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
The `KubeClientCertificateExpiration` has been bogus. This PR attempts to improve the description and provide remediation steps for the runbook.

**Which issue(s) this PR fixes**:
Fixes #3291

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
