### PR TITLE
Run DNAT controller as root to fix the permission issues

### DIFF
--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -138,6 +138,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -156,6 +156,7 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/api/pkg/resources/vpnsidecar/dnatController.go
+++ b/api/pkg/resources/vpnsidecar/dnatController.go
@@ -48,6 +48,7 @@ func DnatControllerContainer(data dnatControllerData, name, apiserverAddress str
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{"NET_ADMIN"},
 			},
+			RunAsUser: resources.Int64(0),
 			ProcMount: &procMountType,
 		},
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,


### PR DESCRIPTION
**What this PR does / why we need it**:
Run DNAT controller as root to fix the permission issues:
```
E0423 11:29:51.970855       1 kubeletdnat_controller.go:108] Failed reconciling: failed to read iptable rules: failed to execute "iptables-save -t nat": exit status 1. Output: 
iptables-save v1.6.2: Cannot initialize: Permission denied (you must be root)
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
