### PR TITLE
Add emptyDir mount to /tmp for the CoreDNS pod to avoid fatal glog invocations

### DIFF
--- a/addons/dns/coredns-deployment.yaml
+++ b/addons/dns/coredns-deployment.yaml
@@ -94,6 +94,8 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
+        - name: tmp
+          mountPath: /tmp
         ports:
         - containerPort: 53
           name: dns
@@ -134,6 +136,8 @@ spec:
           items:
           - key: Corefile
             path: Corefile
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.7
+export TAG=v0.2.8-dev1
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.8-dev1
+export TAG=v0.2.8
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -68,7 +68,7 @@ kubermatic:
         - node-exporter
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.7"
+          tag: "v0.2.8-dev1"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -68,7 +68,7 @@ kubermatic:
         - node-exporter
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.8-dev1"
+          tag: "v0.2.8"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image


### PR DESCRIPTION
**What this PR does / why we need it**:
This is required as CoreDNS crashes in case any error gets logged from the kube-client.
We see this a lot on cloud.kubermatic.io since we use preemtible machines & the API server will become unavailable multiple times a day.
Adding a emptyDir to `/tmp` is the proposed fix from the CoreDNS maintainers.

See https://github.com/coredns/deployment/pull/138

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
