### PR TITLE
actually quote caBundle value

### DIFF
--- a/config/kubermatic/templates/dex-ca-secret.yaml
+++ b/config/kubermatic/templates/dex-ca-secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: dex-ca
 type: Opaque
 data:
-  caBundle.pem: {{ .Values.kubermatic.auth.caBundle | quote }}
+  caBundle.pem: {{ .Values.kubermatic.auth.caBundle | default "" | quote }}

--- a/config/kubermatic/templates/dex-ca-secret.yaml
+++ b/config/kubermatic/templates/dex-ca-secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: dex-ca
 type: Opaque
 data:
-  caBundle.pem: "{{ .Values.kubermatic.auth.caBundle }}"
+  caBundle.pem: {{ .Values.kubermatic.auth.caBundle | quote }}


### PR DESCRIPTION
**What this PR does / why we need it**:
this change allow to be encoded with base64 breaks, which formats much better in text editors.

```
kubermatic:
  auth:
    caBundle: |
      LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lSQUlJUXo3RF
      NRT05aUkdQZ3UyT0Npd0F3RFFZSktvWklodmNOQVFFTEJRQXcNClR6RUxNQWtHQTFVRUJoTUNW
      ...
```

```release-note
NONE
```