### PR TITLE
[release/v2.10] Remove service-account-signing-key option

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -253,12 +253,6 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 		}
 	}
 
-	serviceAccountTokenGenerator, err := serviceaccount.JWTTokenGenerator([]byte(options.serviceAccountSigningKey))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service account token generator due to %v", err)
-	}
-	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator([]byte(options.serviceAccountSigningKey))
-
 	r := handler.NewRouting(
 		prov.datacenters,
 		prov.clusters,
@@ -276,8 +270,8 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 		prometheusClient,
 		prov.projectMember,
 		prov.memberMapper,
-		serviceAccountTokenAuth,
-		serviceAccountTokenGenerator,
+		nil,
+		nil,
 	)
 
 	registerMetrics()

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/features"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
-	"github.com/kubermatic/kubermatic/api/pkg/serviceaccount"
 )
 
 type serverRunOptions struct {
@@ -62,7 +61,6 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.BoolVar(&s.oidcIssuerOfflineAccessAsScope, "oidc-issuer-offline-access-as-scope", true, "Set it to false if OIDC provider requires to set \"access_type=offline\" query param when accessing the refresh token")
 	flag.StringVar(&rawFeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&s.domain, "domain", "localhost", "A domain name on which the server is deployed")
-	flag.StringVar(&s.serviceAccountSigningKey, "service-account-signing-key", "", "Signing key authenticates the service account's token value using HMAC. It is recommended to use a key with 32 bytes or longer.")
 	flag.Parse()
 
 	featureGates, err := features.NewFeatures(rawFeatureGates)
@@ -91,10 +89,6 @@ func (o serverRunOptions) validate() error {
 		if len(o.oidcIssuerClientID) == 0 {
 			return fmt.Errorf("%s feature is enabled but \"oidc-issuer-client-id\" flag was not specified", OIDCKubeCfgEndpoint)
 		}
-	}
-
-	if err := serviceaccount.ValidateKey([]byte(o.serviceAccountSigningKey)); err != nil {
-		return fmt.Errorf("the service-account-signing-key is incorrect due to error: %v", err)
 	}
 
 	return nil

--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -31,6 +31,5 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -oidc-issuer-client-secret="$(vault kv get -field=oidc-issuer-client-secret dev/seed-clusters/dev.kubermatic.io)" \
   -oidc-issuer-redirect-uri="$(vault kv get -field=oidc-issuer-redirect-uri dev/seed-clusters/dev.kubermatic.io)" \
   -oidc-issuer-cookie-hash-key="$(vault kv get -field=oidc-issuer-cookie-hash-key dev/seed-clusters/dev.kubermatic.io)" \
-  -service-account-signing-key="$(vault kv get -field=service-account-signing-key dev/seed-clusters/dev.kubermatic.io)" \
   -logtostderr \
   -v=8 $@

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -37,7 +37,6 @@ spec:
         - -domain={{ .Values.kubermatic.domain }}
         - -kubeconfig=/opt/.kube/kubeconfig
         - -master-resources=/opt/master-files
-        - -service-account-signing-key={{ .Values.kubermatic.auth.serviceAccountKey }}
         # the following flags enable oidc kubeconfig feature/endpoint
         - -feature-gates={{ .Values.kubermatic.api.featureGates }}
         {{- if regexMatch ".*OIDCKubeCfgEndpoint=true.*" (default "" .Values.kubermatic.api.featureGates) }}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -11,8 +11,6 @@ kubermatic:
     clientID: ""
     # skip tls verification on the token issuer
     skipTokenIssuerTLSVerify: "false"
-    # the service account signing key. Must be 32 bytes or longer
-    serviceAccountKey: ""
   # base64 encoded datacenters.yaml
   datacenters: ""
   # external domain for the kubermatic installation. For example 'dev.kubermatic.io'


### PR DESCRIPTION
**What this PR does / why we need it**: Removes the service-account-signing-key option as the underlying feature is not present in 2.10

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
