### PR TITLE
Fix upgrade test to work with a base that is not master

### DIFF
--- a/api/hack/run-kubermatic-upgrade-test.sh
+++ b/api/hack/run-kubermatic-upgrade-test.sh
@@ -10,4 +10,9 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api/hack/ci
 
 export UPGRADE_TEST_BASE_HASH=${UPGRADE_TEST_BASE_HASH:-$(git rev-parse master)}
 
+# We need to fetch UPGRADE_TEST_BASE_HASH in case its not in either the PRs base or the Prs HEAD
+git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /ssh/id_rsa'
+git remote add origin git@github.com:kubermatic/kubermatic.git
+git fetch origin ${UPGRADE_TEST_BASE_HASH}
+
 ./ci-run-minimal-conformance-tests.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the upgrade test to work when testing to upgrade from sth that is not master. Requires https://github.com/kubermatic/infra/pull/287

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 