### PR TITLE
check usercluster-controller health status

### DIFF
--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -309,6 +309,7 @@ func (r *Reconciler) syncHeath(ctx context.Context, osData *openshiftData) error
 		openshiftresources.ControllerManagerDeploymentName: {healthy: &currentHealth.Controller, minReady: 1},
 		resources.MachineControllerDeploymentName:          {healthy: &currentHealth.MachineController, minReady: 1},
 		resources.OpenVPNServerDeploymentName:              {healthy: &currentHealth.OpenVPN, minReady: 1},
+		resources.UserClusterControllerDeploymentName:      {healthy: &currentHealth.UserClusterControllerManager, minReady: 1},
 	}
 
 	var err error


### PR DESCRIPTION
**What this PR does / why we need it**: add a health check for usercluster-controller when openshift is deployed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3317 

```release-note
NONE
```
