### PR TITLE
Fix sync_charts script

### DIFF
--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -16,8 +16,15 @@ if ! git describe --exact-match --tags HEAD &>/dev/null; then
   exit 0
 fi
 
+git remote add origin git@github.com:kubermatic/kubermatic.git
+git fetch origin
 export INSTALLER_BRANCH="$(git branch --contains HEAD --all \
   |tr -d ' '|grep -E 'remotes/origin/release/v2.[0-9]+$'|cut -d '/' -f3-)"
+
+if [[ -z ${INSTALLER_BRANCH} ]]; then
+  echo "Error, the INSTALLER_BRANCH varible was empty"
+  exit 1
+fi
 
 export CHARTS='kubermatic cert-manager certs nginx-ingress-controller nodeport-proxy oauth minio iap'
 export MONITORING_CHARTS='alertmanager blackbox-exporter grafana kube-state-metrics node-exporter prometheus'
@@ -38,7 +45,7 @@ rm -rf ${TARGET_DIR}
 mkdir ${TARGET_DIR}
 git clone git@github.com:kubermatic/kubermatic-installer.git ${TARGET_DIR}
 cd ${TARGET_DIR}
-git checkout ${INSTALLER_BRANCH}
+git checkout ${INSTALLER_BRANCH} || git checkout -b ${INSTALLER_BRANCH}
 cd ..
 
 # re-assemble example values.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the sync_charts script to actually find its target branch. So far it never was able to do so, because we have a shallow copy of the repo. Because `git checkout` without an extra arg leaves you on the branch you are already at, which is the default one, which is `release/v2.9` for the installer repo, it looked like it worked.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
