### PR TITLE
Add defaulting for Deployment containers

### DIFF
--- a/api/codegen/reconcile/main.go
+++ b/api/codegen/reconcile/main.go
@@ -47,6 +47,7 @@ func main() {
 				ResourceName: "Deployment",
 				ImportAlias:  "appsv1",
 				// Don't specify ResourceImportPath so this block does not create a new import line in the generated code
+				DefaultingFunc: "DefaultDeployment",
 			},
 			{
 				ResourceName: "DaemonSet",
@@ -147,7 +148,7 @@ import (
 )
 
 {{ range .Resources }}
-{{ namedReconcileFunc .ResourceName .ImportAlias }}
+{{ namedReconcileFunc .ResourceName .ImportAlias .DefaultingFunc }}
 {{- end }}
 
 `))
@@ -157,16 +158,21 @@ type reconcileFunctionData struct {
 	ResourceName       string
 	ResourceImportPath string
 	ImportAlias        string
+	// Optional: A defaulting func for the given object type
+	// Must be defined inside the resources package
+	DefaultingFunc string
 }
 
-func namedReconcileFunc(resourceName, importAlias string) (string, error) {
+func namedReconcileFunc(resourceName, importAlias, defaultingFunc string) (string, error) {
 	b := &bytes.Buffer{}
 	err := namedReconcileFunctionTemplate.Execute(b, struct {
-		ResourceName string
-		ImportAlias  string
+		ResourceName   string
+		ImportAlias    string
+		DefaultingFunc string
 	}{
-		ResourceName: resourceName,
-		ImportAlias:  importAlias,
+		ResourceName:   resourceName,
+		ImportAlias:    importAlias,
+		DefaultingFunc: defaultingFunc,
 	})
 	if err != nil {
 		return "", err
@@ -202,35 +208,9 @@ func {{ .ResourceName }}ObjectWrapper(create {{ .ResourceName }}Creator) ObjectC
 func Reconcile{{ .ResourceName }}s(ctx context.Context, namedGetters []Named{{ .ResourceName }}CreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-{{ if eq .ResourceName "Deployments" }}
-
-		defaultContainer := func(c *corev1.Container) {
-			if c.ImagePullPolicy == "" {
-				c.ImagePullPolicy = corev1.PullIfNotPresent
-			}
-			if c.TerminationMessagePath == "" {
-				c.TerminationMessagePath = corev1.TerminationMessagePathDefault
-			}
-			if c.TerminationMessagePolicy == "" {
-				c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
-			}
-		}
-
-		create = func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			d, err := create(d)
-			if err != nil {
-				return nil, err
-			}
-			for idx, _ := range d.Spec.Template.Spec.InitContainers {
-				defaultContainer(&d.Spec.Template.Spec.Containers[idx])
-			}
-			for idx, _ := range d.Spec.Template.Spec.Containers {
-				defaultContainer(&d.Spec.Template.Spec.Containers[idx])
-			}
-			return d, nil
-		}
-
-{{ end }}
+{{- if .DefaultingFunc }}
+		create = {{ .DefaultingFunc }}(create)
+{{- end }}
 		createObject := {{ .ResourceName }}ObjectWrapper(create)
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)

--- a/api/pkg/controller/openshift/resources/apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/apiserver_deployment.go
@@ -99,16 +99,13 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.N
 			dep.Spec.Template.Spec.Volumes = volumes
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
-					Name:            "etcd-running",
-					Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag,
-					ImagePullPolicy: corev1.PullIfNotPresent,
+					Name:  "etcd-running",
+					Image: data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag,
 					Command: []string{
 						"/bin/sh",
 						"-ec",
 						fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' endpoint health; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      resources.ApiserverEtcdClientCertificateSecretName,
@@ -138,15 +135,12 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.N
 				*openvpnSidecar,
 				*dnatControllerSidecar,
 				{
-					Name:                     ApiserverDeploymentName,
-					Image:                    data.ImageRegistry(resources.RegistryDocker) + "/openshift/origin-control-plane:v3.11",
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Command:                  []string{"/usr/bin/openshift", "start", "master", "api"},
-					Args:                     []string{"--config=/etc/origin/master/master-config.yaml"},
-					Env:                      getAPIServerEnvVars(data.Cluster()),
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                *resourceRequirements,
+					Name:      ApiserverDeploymentName,
+					Image:     data.ImageRegistry(resources.RegistryDocker) + "/openshift/origin-control-plane:v3.11",
+					Command:   []string{"/usr/bin/openshift", "start", "master", "api"},
+					Args:      []string{"--config=/etc/origin/master/master-config.yaml"},
+					Env:       getAPIServerEnvVars(data.Cluster()),
+					Resources: *resourceRequirements,
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: externalNodePort,

--- a/api/pkg/controller/openshift/resources/machinecontroller.go
+++ b/api/pkg/controller/openshift/resources/machinecontroller.go
@@ -26,17 +26,14 @@ func MachineController(osData openshiftData) reconciling.NamedDeploymentCreatorG
 			d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, corev1.Volume{Name: "userdata-plugins",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
 			d.Spec.Template.Spec.InitContainers = append(d.Spec.Template.Spec.InitContainers, corev1.Container{
-				Name:            "copy-userdata-plugin",
-				Image:           osData.ImageRegistry(resources.RegistryQuay) + "/kubermatic/api:" + resources.KUBERMATICCOMMIT,
-				ImagePullPolicy: corev1.PullIfNotPresent,
+				Name:  "copy-userdata-plugin",
+				Image: osData.ImageRegistry(resources.RegistryQuay) + "/kubermatic/api:" + resources.KUBERMATICCOMMIT,
 				Command: []string{
 					"/bin/sh",
 					"-c",
 					"set -e && cp /usr/local/bin/userdata-openshift /target/machine-controller-userdata-centos",
 				},
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-				VolumeMounts:             []corev1.VolumeMount{{Name: "userdata-plugins", MountPath: "/target"}},
+				VolumeMounts: []corev1.VolumeMount{{Name: "userdata-plugins", MountPath: "/target"}},
 			})
 			for idx := range d.Spec.Template.Spec.Containers {
 				if d.Spec.Template.Spec.Containers[idx].Name != "machine-controller" {

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -94,17 +94,14 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 			dep.Spec.Template.Spec.Volumes = volumes
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
-					Name:            "etcd-running",
-					Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag,
-					ImagePullPolicy: corev1.PullIfNotPresent,
+					Name:  "etcd-running",
+					Image: data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag,
 					Command: []string{
 						"/bin/sh",
 						"-ec",
 						// Write a key to etcd. If we have quorum it will succeed.
 						fmt.Sprintf("until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key --dial-timeout=2s --endpoints='%s' put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2; done;", strings.Join(etcdEndpoints, ",")),
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      resources.ApiserverEtcdClientCertificateSecretName,
@@ -143,15 +140,12 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				*openvpnSidecar,
 				*dnatControllerSidecar,
 				{
-					Name:                     name,
-					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Command:                  []string{"/hyperkube", "apiserver"},
-					Env:                      getEnvVars(data.Cluster()),
-					Args:                     flags,
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                *resourceRequirements,
+					Name:      name,
+					Image:     data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Command:   []string{"/hyperkube", "apiserver"},
+					Env:       getEnvVars(data.Cluster()),
+					Args:      flags,
+					Resources: *resourceRequirements,
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: data.Cluster().Address.Port,

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -138,15 +138,12 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
-					Name:                     name,
-					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Command:                  []string{"/hyperkube", "controller-manager"},
-					Args:                     flags,
-					Env:                      getEnvVars(data.Cluster()),
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                resourceRequirements,
+					Name:      name,
+					Image:     data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Command:   []string{"/hyperkube", "controller-manager"},
+					Args:      flags,
+					Env:       getEnvVars(data.Cluster()),
+					Resources: resourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: getHealthGetAction(data),

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -93,13 +93,10 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
-					Name:                     resources.DNSResolverDeploymentName,
-					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.1.3",
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Args:                     []string{"-conf", "/etc/coredns/Corefile"},
-					Resources:                defaultResourceRequirements,
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Name:      resources.DNSResolverDeploymentName,
+					Image:     data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.1.3",
+					Args:      []string{"-conf", "/etc/coredns/Corefile"},
+					Resources: defaultResourceRequirements,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      resources.DNSResolverConfigMapName,

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -65,17 +65,14 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            name,
-					Image:           data.ImageRegistry(resources.RegistryQuay) + "/coreos/kube-state-metrics:" + version,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/kube-state-metrics"},
+					Name:    name,
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/coreos/kube-state-metrics:" + version,
+					Command: []string{"/kube-state-metrics"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 						"--port", "8080",
 						"--telemetry-port", "8081",
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      resources.KubeStateMetricsKubeconfigSecretName,

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -96,10 +96,9 @@ func DeploymentCreator(data machinecontrollerData) reconciling.NamedDeploymentCr
 			}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            Name,
-					Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/usr/local/bin/machine-controller"},
+					Name:    Name,
+					Image:   data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
+					Command: []string{"/usr/local/bin/machine-controller"},
 					Args: []string{
 						"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 						"-logtostderr",
@@ -107,10 +106,8 @@ func DeploymentCreator(data machinecontrollerData) reconciling.NamedDeploymentCr
 						"-cluster-dns", clusterDNSIP,
 						"-internal-listen-address", "0.0.0.0:8085",
 					},
-					Env:                      getEnvVars(data),
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                controllerResourceRequirements,
+					Env:       getEnvVars(data),
+					Resources: controllerResourceRequirements,
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -69,20 +69,17 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            Name,
-					Image:           data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/usr/local/bin/webhook"},
+					Name:    Name,
+					Image:   data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
+					Command: []string{"/usr/local/bin/webhook"},
 					Args: []string{
 						"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 						"-logtostderr",
 						"-v", "4",
 						"-listen-address", "0.0.0.0:9876",
 					},
-					Env:                      getEnvVars(data),
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                webhookResourceRequirements,
+					Env:       getEnvVars(data),
+					Resources: webhookResourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -88,10 +88,9 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            name,
-					Image:           data.ImageRegistry(resources.RegistryGCR) + "/google_containers/metrics-server-amd64:" + tag,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/metrics-server"},
+					Name:    name,
+					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/metrics-server-amd64:" + tag,
+					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 						"--authentication-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
@@ -103,9 +102,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 						"--v", "1",
 						"--logtostderr",
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                defaultResourceRequirements,
+					Resources: defaultResourceRequirements,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      resources.MetricsServerKubeconfigSecretName,

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -119,10 +119,9 @@ func DeploymentCreator(data openVPNDeploymentCreatorData) reconciling.NamedDeplo
 
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
-					Name:            "iptables-init",
-					Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/bin/bash"},
+					Name:    "iptables-init",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
+					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but
 # masquerade to openvpn-server's IP instead:
@@ -146,9 +145,7 @@ iptables -A INPUT -i tun0 -j DROP
 						},
 						ProcMount: &procMountType,
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                defaultResourceRequirements,
+					Resources: defaultResourceRequirements,
 				},
 			}
 
@@ -178,13 +175,10 @@ iptables -A INPUT -i tun0 -j DROP
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:                     name,
-					Image:                    data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Command:                  []string{"/usr/sbin/openvpn"},
-					Args:                     vpnArgs,
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Name:    name,
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
+					Command: []string{"/usr/sbin/openvpn"},
+					Args:    vpnArgs,
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: 1194,
@@ -231,17 +225,14 @@ iptables -A INPUT -i tun0 -j DROP
 					},
 				},
 				{
-					Name:            "ip-forward",
-					Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/bin/bash"},
+					Name:    "ip-forward",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
+					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c",
 						// Always set IP forwarding as a CNI plugin might reset this to 0 (Like Calico 3).
 						"while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done",
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: resources.Bool(true),
 						ProcMount:  &procMountType,

--- a/api/pkg/resources/reconciling/wrapper.go
+++ b/api/pkg/resources/reconciling/wrapper.go
@@ -1,6 +1,8 @@
 package reconciling
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -17,5 +19,35 @@ func OwnerRefWrapper(ref metav1.OwnerReference) ObjectModifier {
 			obj.(metav1.Object).SetOwnerReferences([]metav1.OwnerReference{ref})
 			return obj, nil
 		}
+	}
+}
+
+// DefaultContainer defaults all Container attributes to the same values as they would get from the Kubernetes API
+func DefaultContainer(c *corev1.Container) {
+	if c.ImagePullPolicy == "" {
+		c.ImagePullPolicy = corev1.PullIfNotPresent
+	}
+	if c.TerminationMessagePath == "" {
+		c.TerminationMessagePath = corev1.TerminationMessagePathDefault
+	}
+	if c.TerminationMessagePolicy == "" {
+		c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+	}
+}
+
+// DefaultDeployment defaults all Deployment attributes to the same values as they would et from the Kubernetes API
+func DefaultDeployment(creator DeploymentCreator) DeploymentCreator {
+	return func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+		d, err := creator(d)
+		if err != nil {
+			return nil, err
+		}
+		for idx := range d.Spec.Template.Spec.InitContainers {
+			DefaultContainer(&d.Spec.Template.Spec.InitContainers[idx])
+		}
+		for idx := range d.Spec.Template.Spec.Containers {
+			DefaultContainer(&d.Spec.Template.Spec.Containers[idx])
+		}
+		return d, nil
 	}
 }

--- a/api/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/api/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -211,6 +211,33 @@ func DeploymentObjectWrapper(create DeploymentCreator) ObjectCreator {
 func ReconcileDeployments(ctx context.Context, namedGetters []NamedDeploymentCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+
+		defaultContainer := func(c *corev1.Container) {
+			if c.ImagePullPolicy == "" {
+				c.ImagePullPolicy = corev1.PullIfNotPresent
+			}
+			if c.TerminationMessagePath == "" {
+				c.TerminationMessagePath = corev1.TerminationMessagePathDefault
+			}
+			if c.TerminationMessagePolicy == "" {
+				c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+			}
+		}
+
+		create = func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+			d, err := create(d)
+			if err != nil {
+				return nil, err
+			}
+			for idx, _ := range d.Spec.Template.Spec.InitContainers {
+				defaultContainer(&d.Spec.Template.Spec.Containers[idx])
+			}
+			for idx, _ := range d.Spec.Template.Spec.Containers {
+				defaultContainer(&d.Spec.Template.Spec.Containers[idx])
+			}
+			return d, nil
+		}
+
 		createObject := DeploymentObjectWrapper(create)
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -106,13 +106,10 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
-					Name:                     name,
-					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Command:                  []string{"/hyperkube", "scheduler"},
-					Args:                     flags,
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Name:    name,
+					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Command: []string{"/hyperkube", "scheduler"},
+					Args:    flags,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      resources.SchedulerKubeconfigSecretName,

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -240,7 +235,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -271,8 +265,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -327,11 +319,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -141,7 +138,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -169,8 +165,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -240,7 +235,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -271,8 +265,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -327,11 +319,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -141,7 +138,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -169,8 +165,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -238,7 +233,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -269,8 +263,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -325,11 +317,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -141,7 +138,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -169,8 +165,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -238,7 +233,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -269,8 +263,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -325,11 +317,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -141,7 +138,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -169,8 +165,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -238,7 +233,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -269,8 +263,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -325,11 +317,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -146,7 +143,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -174,8 +170,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -111,7 +108,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,8 +135,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -238,7 +233,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -269,8 +263,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -325,11 +317,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -151,7 +148,6 @@ spec:
         - name: AWS_AVAILABILITY_ZONE
           value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -179,8 +175,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -119,7 +116,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -147,8 +143,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -231,7 +226,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -262,8 +256,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -318,11 +310,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -231,7 +226,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -262,8 +256,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -318,11 +310,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -137,7 +134,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -165,8 +161,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -111,7 +108,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,8 +135,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -142,7 +139,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -170,8 +166,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -119,7 +116,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -147,8 +143,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -227,7 +222,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -258,8 +252,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -314,11 +306,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -128,7 +125,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -156,8 +152,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -227,7 +222,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -258,8 +252,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -314,11 +306,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -128,7 +125,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -156,8 +152,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -225,7 +220,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -256,8 +250,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -312,11 +304,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -128,7 +125,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -156,8 +152,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -225,7 +220,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -256,8 +250,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -312,11 +304,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -128,7 +125,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -156,8 +152,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -225,7 +220,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -256,8 +250,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -312,11 +304,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -133,7 +130,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -161,8 +157,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -111,7 +108,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,8 +135,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -225,7 +220,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -256,8 +250,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -312,11 +304,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -138,7 +135,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -166,8 +162,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -34,7 +34,6 @@ spec:
         command:
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -62,8 +61,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -58,8 +57,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -119,7 +116,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -147,8 +143,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -227,7 +222,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -258,8 +252,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -314,11 +306,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -128,7 +125,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -156,8 +152,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -37,7 +37,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -65,8 +64,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -42,7 +42,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,8 +60,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -227,7 +222,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -258,8 +252,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -314,11 +306,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -128,7 +125,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -156,8 +152,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -37,7 +37,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -65,8 +64,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -42,7 +42,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,8 +60,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -225,7 +220,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -256,8 +250,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -312,11 +304,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -128,7 +125,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -156,8 +152,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -37,7 +37,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -65,8 +64,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -42,7 +42,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,8 +60,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -225,7 +220,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -256,8 +250,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -312,11 +304,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -128,7 +125,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -156,8 +152,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -37,7 +37,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -65,8 +64,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -42,7 +42,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,8 +60,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -225,7 +220,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -256,8 +250,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -312,11 +304,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -133,7 +130,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -161,8 +157,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -37,7 +37,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -65,8 +64,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -42,7 +42,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,8 +60,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -111,7 +108,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,8 +135,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -225,7 +220,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -256,8 +250,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -312,11 +304,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -138,7 +135,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -166,8 +162,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -37,7 +37,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -65,8 +64,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -42,7 +42,6 @@ spec:
         - name: DO_TOKEN
           value: do-token
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,8 +60,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -119,7 +116,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -147,8 +143,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -231,7 +226,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -262,8 +256,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -318,11 +310,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -45,7 +45,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -73,8 +72,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -50,7 +50,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -69,8 +68,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -231,7 +226,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -262,8 +256,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -318,11 +310,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -45,7 +45,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -73,8 +72,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -50,7 +50,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -69,8 +68,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -45,7 +45,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -73,8 +72,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -50,7 +50,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -69,8 +68,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -45,7 +45,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -73,8 +72,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -50,7 +50,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -69,8 +68,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -137,7 +134,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -165,8 +161,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -45,7 +45,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -73,8 +72,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -50,7 +50,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -69,8 +68,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -111,7 +108,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,8 +135,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -142,7 +139,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -170,8 +166,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -45,7 +45,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -73,8 +72,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -50,7 +50,6 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -69,8 +68,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -119,7 +116,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -147,8 +143,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -231,7 +226,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -262,8 +256,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -318,11 +310,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -231,7 +226,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -262,8 +256,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -318,11 +310,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -132,7 +129,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -160,8 +156,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -109,7 +106,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -137,8 +133,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -137,7 +134,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -165,8 +161,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -111,7 +108,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -139,8 +135,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -93,7 +93,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -105,8 +104,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -139,8 +136,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig
@@ -229,7 +224,6 @@ spec:
         - /hyperkube
         - apiserver
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -260,8 +254,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/tls
           name: apiserver-tls
@@ -316,11 +308,8 @@ spec:
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd-running
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -86,7 +86,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -98,8 +97,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -142,7 +139,6 @@ spec:
         - /hyperkube
         - controller-manager
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -170,8 +166,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -80,7 +80,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -92,8 +91,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -102,7 +99,6 @@ spec:
         - -conf
         - /etc/coredns/Corefile
         image: gcr.io/google_containers/coredns:1.1.3
-        imagePullPolicy: IfNotPresent
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3
@@ -121,8 +117,6 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/coredns
           name: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -28,7 +28,6 @@ spec:
         command:
         - /kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
-        imagePullPolicy: IfNotPresent
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -53,8 +52,6 @@ spec:
           requests:
             cpu: 10m
             memory: 12Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -39,7 +39,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -44,7 +44,6 @@ spec:
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
         image: docker.io/kubermatic/machine-controller:v1.1.5
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -63,8 +62,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -58,7 +58,6 @@ spec:
         command:
         - /metrics-server
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
-        imagePullPolicy: IfNotPresent
         name: metrics-server
         resources:
           limits:
@@ -67,8 +66,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
@@ -113,7 +110,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -125,8 +121,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -157,8 +151,6 @@ spec:
             - NET_ADMIN
           procMount: Default
           runAsUser: 0
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeletdnatcontroller-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -83,7 +83,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -109,8 +108,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/server
           name: openvpn-server-certificates
@@ -127,7 +124,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: ip-forward
         resources:
           limits:
@@ -139,8 +135,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -164,7 +158,6 @@ spec:
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: iptables-init
         resources:
           limits:
@@ -178,8 +171,6 @@ spec:
             add:
             - NET_ADMIN
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       volumes:
       - name: ca
         secret:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -84,7 +84,6 @@ spec:
         command:
         - /usr/sbin/openvpn
         image: quay.io/kubermatic/openvpn:v0.5
-        imagePullPolicy: IfNotPresent
         name: openvpn-client
         resources:
           limits:
@@ -96,8 +95,6 @@ spec:
         securityContext:
           privileged: true
           procMount: Default
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -119,7 +116,6 @@ spec:
         - /hyperkube
         - scheduler
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -147,8 +143,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: scheduler-kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -62,7 +62,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5
@@ -80,8 +79,6 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -101,10 +101,9 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            name,
-					Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/api:" + resources.KUBERMATICCOMMIT,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/usr/local/bin/user-cluster-controller-manager"},
+					Name:    name,
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/api:" + resources.KUBERMATICCOMMIT,
+					Command: []string{"/usr/local/bin/user-cluster-controller-manager"},
 					Args: append([]string{
 						"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
 						"-metrics-listen-address", "0.0.0.0:8085",
@@ -131,9 +130,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 							},
 						},
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                defaultResourceRequirements,
+					Resources: defaultResourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{

--- a/api/pkg/resources/vpnsidecar/dnatController.go
+++ b/api/pkg/resources/vpnsidecar/dnatController.go
@@ -51,9 +51,7 @@ func DnatControllerContainer(data dnatControllerData, name, apiserverAddress str
 			RunAsUser: resources.Int64(0),
 			ProcMount: &procMountType,
 		},
-		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		Resources:                dnatControllerResourceRequirements,
+		Resources: dnatControllerResourceRequirements,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: "/etc/kubernetes/kubeconfig",

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -34,10 +34,9 @@ type openvpnData interface {
 func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, error) {
 	procMountType := corev1.DefaultProcMount
 	return &corev1.Container{
-		Name:            name,
-		Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"/usr/sbin/openvpn"},
+		Name:    name,
+		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
+		Command: []string{"/usr/sbin/openvpn"},
 		Args: []string{
 			"--client",
 			"--proto", "tcp",
@@ -63,9 +62,7 @@ func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, 
 			Privileged: resources.Bool(true),
 			ProcMount:  &procMountType,
 		},
-		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		Resources:                vpnClientResourceRequirements,
+		Resources: vpnClientResourceRequirements,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: "/etc/openvpn/pki/client",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds defaulting for Deployment containers to prevent reconciliation loops because someone forgot to set ImagePullPolicy/TerminationMessagePath/TerminationMessagePolicy

If you are okay with this approach I would probably like to even expand it further. Right now its too simple to get this wrong and too easy to miss in reviews.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 
