### PR TITLE
Respect override registry in addons

### DIFF
--- a/addons/canal/canal.yaml
+++ b/addons/canal/canal.yaml
@@ -104,7 +104,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v2.6.12
+          image: '{{ Registry "quay.io" }}/calico/node:v2.6.12'
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -169,7 +169,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.11.8
+          image: '{{ Registry "quay.io" }}/calico/cni:v1.11.8'
           command: ["/install-cni.sh"]
           env:
             - name: CNI_CONF_NAME
@@ -192,7 +192,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.9.1
+          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.9.1'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           # Taken from https://github.com/Dieken/flannel/blob/master/Documentation/kube-flannel.yml#L127
           resources:

--- a/addons/dashboard/kubernetes-dashboard.yaml
+++ b/addons/dashboard/kubernetes-dashboard.yaml
@@ -109,7 +109,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+        image: '{{ Registry "gcr.io" }}/google_containers/kubernetes-dashboard-amd64:v1.10.1'
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -163,7 +163,7 @@ spec:
       serviceAccount: hcloud-csi
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.0.1
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-attacher:v1.0.1'
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
             - --v=5
@@ -176,7 +176,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.0.1
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-provisioner:v1.0.1'
           args:
             - --provisioner=csi.hetzner.cloud
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -190,7 +190,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-cluster-driver-registrar
-          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-cluster-driver-registrar:v1.0.1'
           args:
             - --pod-info-mount-version="v1"
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -199,7 +199,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: hcloud-csi-driver
-          image: hetznercloud/hcloud-csi-driver:1.0.0
+          image: '{{ Registry "docker.io" }}/hetznercloud/hcloud-csi-driver:1.0.0'
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT
@@ -241,7 +241,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-node-driver-registrar:v1.0.1'
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -260,7 +260,7 @@ spec:
           securityContext:
             privileged: true
         - name: hcloud-csi-driver
-          image: hetznercloud/hcloud-csi-driver:1.0.0
+          image: '{{ Registry "docker.io" }}hetznercloud/hcloud-csi-driver:1.0.0'
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT

--- a/addons/dns/coredns-deployment.yaml
+++ b/addons/dns/coredns-deployment.yaml
@@ -81,7 +81,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.3.1
+        image: '{{ Registry "docker.io" }}/coredns/coredns:1.3.1'
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/addons/heapster/heapster-controller.yaml
+++ b/addons/heapster/heapster-controller.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       serviceAccount: heapster
       containers:
-      - image: gcr.io/google_containers/heapster-amd64:v1.5.2
+      - image: '{{ Registry "gcr.io" }}/google_containers/heapster-amd64:v1.5.2'
         name: heapster
         livenessProbe:
           httpGet:

--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: kube-proxy
-        image: k8s.gcr.io/kube-proxy:v{{ .Cluster.Spec.Version }}
+        image: '{{ Registry "gcr.io" }}/google_containers/hyperkube-amd64:v{{ .Cluster.Spec.Version }}'
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/kube-proxy

--- a/addons/metrics-server/metrics-server-deployment.yaml
+++ b/addons/metrics-server/metrics-server-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
+        image: '{{ Registry "gcr.io" }}/google_containers/metrics-server-amd64:v0.2.1'
         command:
         - /metrics-server
         - '--source=kubernetes.summary_api:https://kubernetes.default.svc?kubeletHttps=true&kubeletPort=10250&insecure=true'

--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: node-exporter
       containers:
       - name: node-exporter
-        image: 'quay.io/prometheus/node-exporter:v0.17.0'
+        image: '{{ Registry "quay.io" }}/prometheus/node-exporter:v0.17.0'
         args:
         - '--path.procfs=/host/proc'
         - '--path.sysfs=/host/sys'
@@ -47,7 +47,7 @@ spec:
           mountPropagation: HostToContainer
 
       - name: kube-rbac-proxy
-        image: 'quay.io/coreos/kube-rbac-proxy:v0.4.1'
+        image: '{{ Registry "quay.io" }}/coreos/kube-rbac-proxy:v0.4.1'
         args:
         - '--logtostderr'
         - '--secure-listen-address=$(IP):9100'

--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.5'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -57,7 +57,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.5'
         command:
         - bash
         - -ec

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.8
+export TAG=v0.2.9-dev1
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.9-dev1
+export TAG=v0.2.9
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/kubermatic/kubermatic/api/pkg/cluster/client"
@@ -112,6 +113,10 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 		return c, fmt.Errorf("failed to parse value of flag etcd-disk-size (%q): %v", rawEtcdDiskSize, err)
 	}
 	c.etcdDiskSize = etcdDiskSize
+
+	if c.overwriteRegistry != "" {
+		c.overwriteRegistry = path.Clean(strings.TrimSpace(c.overwriteRegistry))
+	}
 
 	return c, nil
 }

--- a/api/pkg/controller/addon/addon_controller_test.go
+++ b/api/pkg/controller/addon/addon_controller_test.go
@@ -65,11 +65,11 @@ kind: Deployment
 metadata:
   name: test-deployment
 spec:
-	template:
-	  spec:
-	    containers:
-	    - name: nginx
-	      image: {{default "foo.io/" .OverwriteRegistry}}test:1.2.3
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: {{Registry "foo.io" }}/test:1.2.3
 `
 
 	testManifestKubeDNS = `apiVersion: v1
@@ -86,7 +86,7 @@ spec:
   selector:
     k8s-app: kube-dns
   clusterIP: {{.DNSClusterIP}}
-	clusterCIDR: "{{first .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks}}"
+  clusterCIDR: "{{first .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks}}"
 `
 )
 
@@ -229,7 +229,7 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 
 	controller := &Reconciler{
 		kubernetesAddonDir: addonDir,
-		registryURI:        parseRegistryURI("bar.io"),
+		overwriteRegistry:  "bar.io",
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(addon, cluster)

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -65,6 +65,7 @@ spec:
         - -openshift-addons-list={{ join "," .Values.kubermatic.controller.addons.openshift.defaultAddons }}
         - -kubernetes-addons-path=/opt/addons/kubernetes
         - -openshift-addons-path=/opt/addons/openshift
+        - -overwrite-registry={{ .Values.kubermatic.controller.overwriteRegistry }}
         - -backup-container=/opt/backup/store-container.yaml
         - -cleanup-container=/opt/backup/cleanup-container.yaml
         - -nodeport-range={{ .Values.kubermatic.controller.nodeportRange }}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -80,6 +80,8 @@ kubermatic:
           repository: "quay.io/kubermatic/openshift-addons"
           tag: "v0.9"
           pullPolicy: "IfNotPresent"
+    # Specify a custom docker registry which will be used for all images (user cluster control plane + addons)
+    overwriteRegistry: ""
     resources:
       requests:
         cpu: 200m

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -68,7 +68,7 @@ kubermatic:
         - node-exporter
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.9-dev1"
+          tag: "v0.2.9"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image
@@ -78,7 +78,7 @@ kubermatic:
         - rbac
         image:
           repository: "quay.io/kubermatic/openshift-addons"
-          tag: "v0.9-dev1"
+          tag: "v0.9"
           pullPolicy: "IfNotPresent"
     resources:
       requests:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -68,7 +68,7 @@ kubermatic:
         - node-exporter
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.8"
+          tag: "v0.2.9-dev1"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image
@@ -78,7 +78,7 @@ kubermatic:
         - rbac
         image:
           repository: "quay.io/kubermatic/openshift-addons"
-          tag: "v0.8"
+          tag: "v0.9-dev1"
           pullPolicy: "IfNotPresent"
     resources:
       requests:

--- a/openshift_addons/networking/openshift-node-configmap-deployer.yaml
+++ b/openshift_addons/networking/openshift-node-configmap-deployer.yaml
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       containers:
       - name: startup-script
-        image: quay.io/kubermatic/startup-script:v0.1.0
+        image: '{{ Registry "quay.io" }}/kubermatic/startup-script:v0.1.0'
         securityContext:
           privileged: true
         env:

--- a/openshift_addons/networking/os-networking.yaml
+++ b/openshift_addons/networking/os-networking.yaml
@@ -94,7 +94,7 @@ spec:
           fi
           /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server --system-id=random
           while true; do sleep 5; done
-        image: docker.io/openshift/origin-node:v3.11
+        image: '{{ Registry "docker.io" }}/openshift/origin-node:v3.11'
         imagePullPolicy: IfNotPresent
         name: openvswitch
         resources:

--- a/openshift_addons/networking/sdn.yaml
+++ b/openshift_addons/networking/sdn.yaml
@@ -104,7 +104,7 @@ spec:
         env:
         - name: OPENSHIFT_DNS_DOMAIN
           value: cluster.local
-        image: docker.io/openshift/origin-node:v3.11
+        image: '{{ Registry "docker.io" }}/openshift/origin-node:v3.11'
         imagePullPolicy: IfNotPresent
         name: sdn
         ports:

--- a/openshift_addons/openvpn/openvpn-client-dep.yaml
+++ b/openshift_addons/openvpn/openvpn-client-dep.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.5'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -57,7 +57,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.5'
         command:
         - bash
         - -ec

--- a/openshift_addons/release.sh
+++ b/openshift_addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.8
+export TAG=v0.9-dev1
 
 docker build -t quay.io/kubermatic/openshift-addons:${TAG} .
 docker push quay.io/kubermatic/openshift-addons:${TAG}

--- a/openshift_addons/release.sh
+++ b/openshift_addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.9-dev1
+export TAG=v0.9
 
 docker build -t quay.io/kubermatic/openshift-addons:${TAG} .
 docker push quay.io/kubermatic/openshift-addons:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a template function to the Addon controller to simplify the override registry usage.
Also all addons got updated to use this function so our addons can be used in offline environments.

Fixes #3240 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
