### PR TITLE
removes "sa-token-" from token.ID field

### DIFF
--- a/api/pkg/handler/auth/sa.go
+++ b/api/pkg/handler/auth/sa.go
@@ -38,7 +38,7 @@ func (s *ServiceAccountAuthClient) Verify(ctx context.Context, token string) (To
 		return TokenClaims{}, err
 	}
 
-	tokenList, err := s.saTokenProvider.ListUnsecured(&provider.ServiceAccountTokenListOptions{TokenName: customClaims.TokenID})
+	tokenList, err := s.saTokenProvider.ListUnsecured(&provider.ServiceAccountTokenListOptions{TokenID: customClaims.TokenID})
 	if kerrors.IsNotFound(err) {
 		return TokenClaims{}, fmt.Errorf("sa: the token %s has been revoked for %s", customClaims.TokenID, customClaims.Email)
 	}

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -682,7 +682,9 @@ func AuthorizeRequest(sa *kubermaticapiv1.User, s *v1.Secret) AuthorizeRequestFu
 		if owner.Kind != kubermaticapiv1.ProjectKindName || owner.APIVersion != kubermaticapiv1.SchemeGroupVersion.String() {
 			return fmt.Errorf("the given sa %s should belong (owner) to a project but it doesn't", sa.Name)
 		}
-		token, err := tokenGenerator.Generate(serviceaccount.Claims(sa.Spec.Email, owner.Name, s.Name))
+
+		tokenName := strings.TrimPrefix(s.Name, "sa-token-")
+		token, err := tokenGenerator.Generate(serviceaccount.Claims(sa.Spec.Email, owner.Name, tokenName))
 		if err != nil {
 			return err
 		}

--- a/api/pkg/handler/v1/serviceaccount/token.go
+++ b/api/pkg/handler/v1/serviceaccount/token.go
@@ -43,7 +43,7 @@ func CreateTokenEndpoint(projectProvider provider.ProjectProvider, serviceAccoun
 		}
 
 		// check if token name is already reserved for service account
-		existingTokenList, err := serviceAccountTokenProvider.List(userInfo, project, sa, &provider.ServiceAccountTokenListOptions{TokenName: req.Body.Name})
+		existingTokenList, err := serviceAccountTokenProvider.List(userInfo, project, sa, &provider.ServiceAccountTokenListOptions{TokenID: req.Body.Name})
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -51,7 +51,7 @@ func CreateTokenEndpoint(projectProvider provider.ProjectProvider, serviceAccoun
 			return nil, errors.NewAlreadyExists("token", req.Body.Name)
 		}
 
-		tokenID := fmt.Sprintf("sa-token-%s", rand.String(10))
+		tokenID := rand.String(10)
 
 		token, err := tokenGenerator.Generate(serviceaccount.Claims(sa.Spec.Email, project.Name, tokenID))
 		if err != nil {
@@ -228,7 +228,7 @@ func updateToken(projectProvider provider.ProjectProvider, serviceAccountProvide
 
 	if newName != existingName {
 		// check if token name is already reserved for service account
-		existingTokenList, err := serviceAccountTokenProvider.List(userInfo, project, sa, &provider.ServiceAccountTokenListOptions{TokenName: newName})
+		existingTokenList, err := serviceAccountTokenProvider.List(userInfo, project, sa, &provider.ServiceAccountTokenListOptions{TokenID: newName})
 		if err != nil {
 			return nil, err
 		}

--- a/api/pkg/handler/v1/serviceaccount/token_test.go
+++ b/api/pkg/handler/v1/serviceaccount/token_test.go
@@ -168,8 +168,8 @@ func TestListTokens(t *testing.T) {
 			projectToSync:   "plan9-ID",
 			saToSync:        "1",
 			expectedTokens: []apiv1.PublicServiceAccountToken{
-				genPublicServiceAccountToken("sa-token-1", "test-1", expiry),
-				genPublicServiceAccountToken("sa-token-3", "test-3", expiry),
+				genPublicServiceAccountToken("1", "test-1", expiry),
+				genPublicServiceAccountToken("3", "test-3", expiry),
 			},
 		},
 	}
@@ -230,7 +230,7 @@ func TestServiceAccountCanGetProject(t *testing.T) {
 			/*given sa and secret it knows how to generate a valid token*/
 			authReqestFunc: test.AuthorizeRequest(
 				test.GenServiceAccount("1", "test-1", "editors", "plan9-ID"),
-				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1")),
+				test.GenSecret("plan9-ID", "serviceaccount-1", "sa-token-1", "1")),
 			existingKubernetesObjs: []runtime.Object{
 				test.GenSecret("plan9-ID", "serviceaccount-1", "test-1", "1"),
 				test.GenSecret("plan10-ID", "serviceaccount-2", "test-2", "2"),
@@ -309,8 +309,8 @@ func TestPatchToken(t *testing.T) {
 			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
 			projectToSync:   "plan9-ID",
 			saToSync:        "1",
-			tokenToSync:     "sa-token-1",
-			expectedToken:   genPublicServiceAccountToken("sa-token-1", "test-new-name", expiry),
+			tokenToSync:     "1",
+			expectedToken:   genPublicServiceAccountToken("1", "test-new-name", expiry),
 		},
 		{
 			name:       "scenario 2: changed name is empty",
@@ -422,7 +422,7 @@ func TestUpdateToken(t *testing.T) {
 		{
 			name:       "scenario 1: change token name successfully and regenerate token",
 			httpStatus: http.StatusOK,
-			body:       `{"name":"test-new-name", "id":"sa-token-1"}`,
+			body:       `{"name":"test-new-name", "id":"1"}`,
 			existingKubermaticObjs: []runtime.Object{
 				/*add projects*/
 				test.GenProject("plan9", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
@@ -439,8 +439,8 @@ func TestUpdateToken(t *testing.T) {
 			existingAPIUser: *test.GenAPIUser("john", "john@acme.com"),
 			projectToSync:   "plan9-ID",
 			saToSync:        "1",
-			tokenToSync:     "sa-token-1",
-			expectedToken:   genPublicServiceAccountToken("sa-token-1", "test-new-name", expiry),
+			tokenToSync:     "1",
+			expectedToken:   genPublicServiceAccountToken("1", "test-new-name", expiry),
 		},
 		{
 			name:       "scenario 2: changed name is empty",

--- a/api/pkg/provider/kubernetes/sa_token_test.go
+++ b/api/pkg/provider/kubernetes/sa_token_test.go
@@ -1,6 +1,7 @@
 package kubernetes_test
 
 import (
+	"strings"
 	"testing"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -106,9 +107,9 @@ func TestListTokens(t *testing.T) {
 				genSecret("project-ID", "6", "test-token-1", "5"),
 			},
 			expectedTokens: []*v1.Secret{
-				genSecret("my-first-project-ID", "1", "test-token-1", "1"),
-				genSecret("my-first-project-ID", "1", "test-token-2", "2"),
-				genSecret("my-first-project-ID", "1", "test-token-3", "3"),
+				rmTokenPrefix(genSecret("my-first-project-ID", "1", "test-token-1", "1")),
+				rmTokenPrefix(genSecret("my-first-project-ID", "1", "test-token-2", "2")),
+				rmTokenPrefix(genSecret("my-first-project-ID", "1", "test-token-3", "3")),
 			},
 		},
 		{
@@ -129,7 +130,7 @@ func TestListTokens(t *testing.T) {
 				genSecret("project-ID", "6", "test-token-1", "5"),
 			},
 			expectedTokens: []*v1.Secret{
-				genSecret("my-first-project-ID", "1", "test-token-3", "3"),
+				rmTokenPrefix(genSecret("my-first-project-ID", "1", "test-token-3", "3")),
 			},
 			tokenName: "test-token-3",
 		},
@@ -155,7 +156,7 @@ func TestListTokens(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			resultList, err := target.List(tc.userInfo, tc.projectToSync, tc.saToSync, &provider.ServiceAccountTokenListOptions{TokenName: tc.tokenName})
+			resultList, err := target.List(tc.userInfo, tc.projectToSync, tc.saToSync, &provider.ServiceAccountTokenListOptions{TokenID: tc.tokenName})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -202,7 +203,7 @@ func TestGetToken(t *testing.T) {
 				genSecret("project-ID", "6", "test-token-1", "5"),
 			},
 			tokenToGet:    "sa-token-3",
-			expectedToken: genSecret("my-first-project-ID", "1", "test-token-3", "3"),
+			expectedToken: rmTokenPrefix(genSecret("my-first-project-ID", "1", "test-token-3", "3")),
 		},
 	}
 	for _, tc := range testcases {
@@ -269,7 +270,7 @@ func TestUpdateToken(t *testing.T) {
 			},
 			tokenToUpdate: "sa-token-3",
 			tokenNewName:  "new-updated-name",
-			expectedToken: genSecret("my-first-project-ID", "1", "new-updated-name", "3"),
+			expectedToken: rmTokenPrefix(genSecret("my-first-project-ID", "1", "new-updated-name", "3")),
 		},
 	}
 	for _, tc := range testcases {
@@ -379,4 +380,9 @@ func TestDeleteToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+func rmTokenPrefix(token *v1.Secret) *v1.Secret {
+	token.Name = strings.TrimPrefix(token.Name, "sa-token-")
+	return token
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -374,8 +374,8 @@ type ServiceAccountTokenProvider interface {
 
 // ServiceAccountTokenListOptions allows to set filters that will be applied to filter the result.
 type ServiceAccountTokenListOptions struct {
-	// TokenName list only tokens with the specified name
-	TokenName string
+	// TokenID list only tokens with the specified name
+	TokenID string
 }
 
 // PrivilegedServiceAccountTokenProvider declares the set of method for interacting with kubermatic's sa's tokens and uses privileged account for it


### PR DESCRIPTION
**What this PR does / why we need it**: simply removes "sa-token-" from token.ID field

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #3215 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
