### PR TITLE
update Seed-Prometheus to 2.9.2

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus
-version: 1.1.2
-appVersion: v2.8.1
+version: 1.1.3
+appVersion: v2.9.2
 description: Prometheus for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,5 +1,5 @@
 prometheus:
-  version: v2.8.1
+  version: v2.9.2
   host: ''
   storageSize: 100Gi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This simply bumps the Prometheus version to the latest stable,

The release notes entry encompasses the change from #3331.

**Does this PR introduce a user-facing change?**:
```release-note
updated Prometheus to `v2.9.2`
```
