### PR TITLE
symlink Grafana datasources

### DIFF
--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -14,6 +14,60 @@ spec:
       labels:
         app: grafana
     spec:
+      {{ if .Values.grafana.provisioning.datasources.paths }}
+      initContainers:
+      - image: quay.io/kubermatic/util:1.0.0-2
+        name: datasource-assembler
+        command: [/bin/bash]
+        args:
+        - -c
+        - |
+          set -euo pipefail
+
+          target=/etc/grafana/provisioning/datasources
+
+          create_symlinks() {
+            local base="$(realpath $1)/" # keep a trailing slash for the rel trim later
+
+            if [ ! -d "$base" ]; then
+              echo "Error: directory $1 does not exist, check your Helm chart configuration and mounts!"
+              exit 1
+            fi
+
+            for abs in $(find "$base" -maxdepth 1 -name '*.yaml'); do
+              relative="${abs#$base}"
+              filename=$(echo "$relative" | sed 's#/#-#g')
+
+              echo "Symlinking $abs to $filename"
+              ln -s "$abs" "$target/$filename"
+            done
+          }
+
+          mkdir -p "$target"
+          rm -rf "$target/*"
+
+          {{- range .Values.grafana.provisioning.datasources.paths }}
+          create_symlinks "{{ . }}"
+          {{- end }}
+
+          echo "Datasource provisioning completed successfully."
+
+        volumeMounts:
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: grafana-datasources
+          readOnly: false
+        - mountPath: /etc/grafana/provisioning/default-datasources
+          name: grafana-default-datasources
+          readOnly: true
+        {{- if .Values.grafana.volumes }}
+        {{- range .Values.grafana.volumes }}
+        - mountPath: {{ .mountPath }}
+          name: {{ .name }}
+          readOnly: true
+        {{- end }}
+        {{- end }}
+      {{ end }}
+
       containers:
       - image: '{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}'
         name: grafana
@@ -31,6 +85,9 @@ spec:
           readOnly: true
         - mountPath: /etc/grafana/provisioning/datasources
           name: grafana-datasources
+          readOnly: false
+        - mountPath: /etc/grafana/provisioning/default-datasources
+          name: grafana-default-datasources
           readOnly: true
         - mountPath: /etc/grafana/provisioning/dashboards
           name: grafana-dashboards
@@ -45,6 +102,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- end }}
+
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -52,10 +110,12 @@ spec:
       volumes:
       - emptyDir: {}
         name: grafana-storage
+      - emptyDir: {}
+        name: grafana-datasources
       - name: grafana-config
         secret:
           secretName: grafana-config
-      - name: grafana-datasources
+      - name: grafana-default-datasources
         configMap:
           name: grafana-datasources
       - name: grafana-dashboards

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -26,8 +26,9 @@ spec:
 
           target=/etc/grafana/provisioning/datasources
 
-          create_symlinks() {
-            local base="$(realpath $1)/" # keep a trailing slash for the rel trim later
+          provide_datasources() {
+            local index="$1"
+            local base="$(realpath $2)"
 
             if [ ! -d "$base" ]; then
               echo "Error: directory $1 does not exist, check your Helm chart configuration and mounts!"
@@ -35,19 +36,18 @@ spec:
             fi
 
             for abs in $(find "$base" -maxdepth 1 -name '*.yaml'); do
-              relative="${abs#$base}"
-              filename=$(echo "$relative" | sed 's#/#-#g')
+              filename="$index-$(basename "$abs")"
 
-              echo "Symlinking $abs to $filename"
-              ln -s "$abs" "$target/$filename"
+              echo "Copying $abs to $filename"
+              cp "$abs" "$target/$filename"
             done
           }
 
           mkdir -p "$target"
           rm -rf "$target/*"
 
-          {{- range .Values.grafana.provisioning.datasources.paths }}
-          create_symlinks "{{ . }}"
+          {{- range $idx, $path := .Values.grafana.provisioning.datasources.paths }}
+          provide_datasources "$(printf "%02d" {{ $idx }})" "{{ $path }}"
           {{- end }}
 
           echo "Datasource provisioning completed successfully."

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app: grafana
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
     spec:
       {{ if .Values.grafana.provisioning.datasources.paths }}
       initContainers:

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -43,8 +43,10 @@ grafana:
       source: provisioning/datasources/*
 
       # If you have more datasources from additional volumes,
-      # specify their mount paths here to have them symlinked to
-      # /etc/grafana/provisioning/datasources.
+      # specify their mount paths here to have them copied to
+      # /etc/grafana/provisioning/datasources. Files will get
+      # a prefix to ensure that identical filenames from
+      # multiple paths do not overwrite each other.
       paths:
       - /etc/grafana/provisioning/default-datasources
 

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -38,7 +38,15 @@ grafana:
       #  type: file
 
     datasources:
+      # read datasources from this path in the Helm chart; this is
+      # evaluated during deployment, not during Grafana runtime!
       source: provisioning/datasources/*
+
+      # If you have more datasources from additional volumes,
+      # specify their mount paths here to have them symlinked to
+      # /etc/grafana/provisioning/datasources.
+      paths:
+      - /etc/grafana/provisioning/default-datasources
 
       # You can specify additional datasources inline as well.
       #extra:


### PR DESCRIPTION
**What this PR does / why we need it**:
In contrast to dashboards, where we can configure Grafana to look into random paths to find JSON files, datasources must be a flat list of YAML files inside one specific directory with no support for sub-directories. This makes it complicated to provision Grafana in an environment like our master where some datasources (master prometheus) are configured statically via Helm and some are created dynamically via the new seed-proxy controller.

This PR makes it so that datasources are not mounted directly to `/etc/grafana/provisioning/datasources` anymore, but instead we now have an initContainer that takes a list of source directory and symlinks each file into the special datasource directory. Since Grafana does not yet allow to reload datasources at runtime (see https://github.com/grafana/grafana/pull/16579), it does not help to have a permanent sidecar that would reload Grafana everytime a mounted volume (most likely ConfigMaps) changes. Instead we will maybe work using annotations that are updated by the seed-proxy controller to trigger restarts.

Since we use a new configuration key (`grafana.provisioning.datasources.paths`) I don't expect any compatibility breaks.

The provision logic itself seems complicated (compared to a simple rsync), but it takes care of

* flattening the directory structure and ignoring any sub directories,
* providing a nice, readable log and
* prepending an index number so that two volumes with a `prometheus.yaml` will not end up overwriting each other (if you do not want a certain datasource, do not include it in your `paths` list)

**Which issue(s) this PR fixes**:
Relates to #3238

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```