### PR TITLE
stops creating ND for new cluster for BYO provider

### DIFF
--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -80,6 +80,16 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, cloudProviders map[s
 
 		// Create the initial node deployment in the background.
 		if req.Body.NodeDeployment != nil {
+			// for BringYourOwn provider we don't create ND
+			isBYO, err := common.IsBringYourOwnProvider(spec.Cloud)
+			if err != nil {
+				return nil, errors.NewBadRequest("invalid spec: %v", err)
+			}
+			if isBYO {
+				glog.V(5).Infof("KubeAdm provider detected an initial node deployment won't be created for cluster %s", newCluster.Name)
+				return nil, nil
+			}
+
 			go func() {
 				defer utilruntime.HandleCrash()
 				eventRecorderProvider.ClusterRecorderFor(k8sClient).Eventf(newCluster, corev1.EventTypeNormal, string(nodeDeploymentCreationStart), "started creation of initial node deployment %s for cluster %s", req.Body.NodeDeployment.Name, newCluster.Name)

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -83,11 +83,11 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, cloudProviders map[s
 			// for BringYourOwn provider we don't create ND
 			isBYO, err := common.IsBringYourOwnProvider(spec.Cloud)
 			if err != nil {
-				return nil, errors.NewBadRequest("invalid spec: %v", err)
+				return nil, errors.NewBadRequest("failed to create an initial node deployment due to an invalid spec: %v", err)
 			}
 			if isBYO {
 				glog.V(5).Infof("KubeAdm provider detected an initial node deployment won't be created for cluster %s", newCluster.Name)
-				return nil, nil
+				return convertInternalClusterToExternal(newCluster), nil
 			}
 
 			go func() {

--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -38,4 +40,13 @@ type ServerMetrics struct {
 	HTTPRequestsTotal          *prometheus.CounterVec
 	HTTPRequestsDuration       *prometheus.HistogramVec
 	InitNodeDeploymentFailures *prometheus.CounterVec
+}
+
+// IsBringYourOwnProvider determines whether the spec holds BringYourOwn provider
+func IsBringYourOwnProvider(spec v1.CloudSpec) (bool, error) {
+	providerName, err := provider.ClusterCloudProviderName(spec)
+	if err != nil {
+		return false, err
+	}
+	return providerName == provider.BringYourOwnCloudProvider, nil
 }

--- a/api/pkg/handler/v1/node/node.go
+++ b/api/pkg/handler/v1/node/node.go
@@ -84,6 +84,14 @@ func CreateNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvide
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
+		isBYO, err := common.IsBringYourOwnProvider(cluster.Spec.Cloud)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		if isBYO {
+			return nil, k8cerrors.NewBadRequest("You cannot create a node deployment for KubeAdm provider")
+		}
+
 		keys, err := sshKeyProvider.List(project, &provider.SSHKeyListOptions{ClusterName: req.ClusterID})
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)


### PR DESCRIPTION
**What this PR does / why we need it**: there is no need to create a node deployment if the provider is KubeAdm as in this case the nodes are added manually by an admin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3159 


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
the API will no longer attempt to create an initial node deployment for new kubeadm clusters
```
