### PR TITLE
Remove -kubermatic suffix from Prometheus Chart

### DIFF
--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -45,7 +45,7 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&s.listenAddress, "address", ":8080", "The address to listen on")
 	flag.StringVar(&s.kubeconfig, "kubeconfig", "", "Path to the kubeconfig.")
 	flag.StringVar(&s.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the internal handler should be exposed")
-	flag.StringVar(&s.prometheusURL, "prometheus-url", "http://prometheus-kubermatic.monitoring.svc.local:web", "The URL on which this API can talk to Prometheus")
+	flag.StringVar(&s.prometheusURL, "prometheus-url", "http://prometheus.monitoring.svc.local:web", "The URL on which this API can talk to Prometheus")
 	flag.StringVar(&s.masterResources, "master-resources", "", "The path to the master resources (Required).")
 	flag.StringVar(&s.dcFile, "datacenters", "datacenters.yaml", "The datacenters.yaml file path")
 	flag.StringVar(&s.workerName, "worker-name", "", "Create clusters only processed by worker-name cluster controller")

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -46,7 +46,7 @@ iap:
     #   client_secret: xxx
     #   encryption_key: xxx
     #   config: {} ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
-    #   upstream_service: prometheus-kubermatic.monitoring.svc.cluster.local
+    #   upstream_service: prometheus.monitoring.svc.cluster.local
     #   upstream_port: 9090
     #   ingress:
     #     host: "prometheus.kubermatic.tld"

--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - "--logtostderr"
         - "--v=4"
         - "--storage=prometheus"
-        - "--prometheus-address=http://prometheus-kubermatic.monitoring.svc.cluster.local:9090"
+        - "--prometheus-address=http://prometheus.monitoring.svc.cluster.local:9090"
         - "--prometheus-cadvisor-job-name=cadvisor-vpa"
         - "--metric-for-pod-labels=kube_pod_labels"
         - "--pod-namespace-label=namespace"

--- a/config/monitoring/grafana/provisioning/datasources/prometheus.yaml
+++ b/config/monitoring/grafana/provisioning/datasources/prometheus.yaml
@@ -1,9 +1,11 @@
+{{ range .Values.grafana.provisioning.datasources.prometheusServices }}
 apiVersion: 1
 datasources:
-- name: prometheus
+- name: {{ . }}
   type: prometheus
   access: proxy
   org_id: 1
-  url: 'http://prometheus-kubermatic.{{ .Release.Namespace }}.svc.cluster.local:9090'
+  url: 'http://{{ . }}.{{ $.Release.Namespace }}.svc.cluster.local:9090'
   version: 1
   editable: false
+{{ end }}

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -46,6 +46,10 @@ grafana:
       #  type: file
 
     datasources:
+      # Kubernetes Service names to configure as data sources
+      prometheusServices:
+      - prometheus
+
       # read datasources from this path in the Helm chart; this is
       # evaluated during deployment, not during Grafana runtime!
       source: provisioning/datasources/*

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 1.1.3
+version: 2.0.0
 appVersion: v2.9.2
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: prometheus
 version: 1.1.3
 appVersion: v2.9.2
-description: Prometheus for Kubermatic
+description: Prometheus Monitoring for Kubernetes
 keywords:
 - kubermatic
 - monitoring

--- a/config/monitoring/prometheus/rules/src/general/prometheus.yaml
+++ b/config/monitoring/prometheus/rules/src/general/prometheus.yaml
@@ -23,8 +23,8 @@ groups:
       severity: critical
     runbook:
       steps:
-      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-kubermatic-0` and `-1`.
-      - Check the `prometheus-kubermatic-rules` configmap via `kubectl -n monitoring get configmap prometheus-kubermatic-rules -o yaml`.
+      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-0` and `-1`.
+      - Check the `prometheus-rules` configmap via `kubectl -n monitoring get configmap prometheus-rules -o yaml`.
 
   - alert: PromAlertmanagerBadConfig
     annotations:
@@ -49,7 +49,7 @@ groups:
       severity: critical
     runbook:
       steps:
-      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-kubermatic-0` and `-1`.
+      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-0` and `-1`.
       - 'Make sure the Alertmanager StatefulSet is running: `kubectl -n monitoring get pods`.'
 
   - alert: PromRemoteStorageFailures
@@ -67,7 +67,7 @@ groups:
     runbook:
       steps:
       - Ensure that the Prometheus volume has not reached capacity.
-      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-kubermatic-0` and `-1`.
+      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-0` and `-1`.
 
   - alert: PromRuleFailures
     annotations:
@@ -79,5 +79,5 @@ groups:
       severity: critical
     runbook:
       steps:
-      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-kubermatic-0` and `-1`.
+      - Check Prometheus pod's logs via `kubectl -n monitoring logs prometheus-0` and `-1`.
       - Check CPU/memory pressure on the node.

--- a/config/monitoring/prometheus/templates/_helpers.tpl
+++ b/config/monitoring/prometheus/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "name" -}}
+{{- default .Release.Name .Values.prometheus.nameOverride -}}
+{{- end }}

--- a/config/monitoring/prometheus/templates/clusterrole.yaml
+++ b/config/monitoring/prometheus/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 'prometheus-kubermatic-{{ .Release.Name }}'
+  name: '{{ template "name" . }}'
 rules:
 - apiGroups:
   - ""

--- a/config/monitoring/prometheus/templates/clusterrolebinding.yaml
+++ b/config/monitoring/prometheus/templates/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: 'prometheus-kubermatic-{{ .Release.Name }}'
+  name: '{{ template "name" . }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: 'prometheus-kubermatic-{{ .Release.Name }}'
+  name: '{{ template "name" . }}'
 subjects:
 - kind: ServiceAccount
-  name: prometheus-kubermatic
-  namespace: {{ .Release.Namespace }}
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/config/monitoring/prometheus/templates/configmaps.yaml
+++ b/config/monitoring/prometheus/templates/configmaps.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-kubermatic-config
+  name: '{{ template "name" . }}-config'
+  namespace: '{{ .Release.Namespace }}'
 data:
 {{ (tpl (.Files.Glob "config/*").AsConfig .) | indent 2 }}
 
@@ -9,9 +10,8 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-kubermatic-rules
-  labels:
-    role: prometheus-rulefiles
+  name: '{{ template "name" . }}-rules'
+  namespace: '{{ .Release.Namespace }}'
 data:
 {{- range $name, $content := .Files.Glob "rules/*.yaml" }}
   {{ replace "rules/" "" $name }}: |

--- a/config/monitoring/prometheus/templates/configmaps.yaml
+++ b/config/monitoring/prometheus/templates/configmaps.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: '{{ template "name" . }}-config'
-  namespace: '{{ .Release.Namespace }}'
 data:
 {{ (tpl (.Files.Glob "config/*").AsConfig .) | indent 2 }}
 
@@ -11,7 +10,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: '{{ template "name" . }}-rules'
-  namespace: '{{ .Release.Namespace }}'
 data:
 {{- range $name, $content := .Files.Glob "rules/*.yaml" }}
   {{ replace "rules/" "" $name }}: |

--- a/config/monitoring/prometheus/templates/migration.yaml
+++ b/config/monitoring/prometheus/templates/migration.yaml
@@ -72,7 +72,7 @@ spec:
           claimName: prometheus-kubermatic-db-prometheus-kubermatic-{{ . }}
       - name: db-new-{{ . }}
         persistentVolumeClaim:
-          claimName: db-prometheus-{{ . }}
+          claimName: db-{{ template "name" $ }}-{{ . }}
       {{- end }}
 
 {{- range (until 2) }}
@@ -80,7 +80,7 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: db-prometheus-{{ . }}
+  name: db-{{ template "name" $ }}-{{ . }}
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/config/monitoring/prometheus/templates/migration.yaml
+++ b/config/monitoring/prometheus/templates/migration.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.prometheus.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: '{{ template "name" . }}-migration'
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: migrate-volumes
+        image: '{{ .Values.prometheus.migration.image.repository }}:{{ .Values.prometheus.migration.image.tag }}'
+        command: [/bin/bash]
+        args:
+        - -c
+        - |
+          set -euo pipefail
+
+          migrate() {
+            local ordinal="$1"
+
+            echo "Migrating volume for Prometheus replica $ordinal..."
+
+            lockfile=/prometheus/new-$ordinal/.migrated
+
+            if [ -f $lockfile ]; then
+              echo "Target volume has already been migrated, skipping rsync."
+              return 0
+            fi
+
+            rsync \
+              --archive \
+              --delete \
+              --hard-links \
+              --whole-file \
+              /prometheus/old-$ordinal/ /prometheus/new-$ordinal/
+
+            echo $(date) > $lockfile
+
+            echo "Volume was successfully migrated."
+          }
+
+          {{- range (until 2) }}
+          migrate {{ . }}
+          {{- end }}
+
+          echo "Migration completed!"
+          echo "Please disable the prometheus.migration.enabled flag in your values.yaml now."
+          echo "To force a re-run, delete the $lockfile from the volume."
+
+        volumeMounts:
+        {{- range (until 2) }}
+        - name: db-old-{{ . }}
+          mountPath: /prometheus/old-{{ . }}
+          readOnly: false
+          subPath: prometheus-db
+        - name: db-new-{{ . }}
+          mountPath: /prometheus/new-{{ . }}
+          readOnly: false
+          subPath: prometheus-db
+        {{- end }}
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        resources:
+{{ toYaml .Values.prometheus.containers.migration.resources | indent 10 }}
+
+      volumes:
+      {{- range (until 2) }}
+      - name: db-old-{{ . }}
+        persistentVolumeClaim:
+          claimName: prometheus-kubermatic-db-prometheus-kubermatic-{{ . }}
+      - name: db-new-{{ . }}
+        persistentVolumeClaim:
+          claimName: db-prometheus-{{ . }}
+      {{- end }}
+
+{{- range (until 2) }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: db-prometheus-{{ . }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  storageClassName: kubermatic-fast
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $.Values.prometheus.storageSize }}
+{{- end }}
+{{ end }}

--- a/config/monitoring/prometheus/templates/role.yaml
+++ b/config/monitoring/prometheus/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: 'prometheus-kubermatic-{{ .Release.Name }}'
+  name: '{{ template "name" . }}'
   namespace: default
 rules:
 - apiGroups:
@@ -20,7 +20,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: 'prometheus-kubermatic-{{ .Release.Name }}'
+  name: '{{ template "name" . }}'
   namespace: kube-system
 rules:
 - apiGroups:
@@ -39,8 +39,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: prometheus-kubermatic
-  namespace: {{ .Release.Namespace }}
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'
 rules:
 - apiGroups:
   - ""

--- a/config/monitoring/prometheus/templates/role.yaml
+++ b/config/monitoring/prometheus/templates/role.yaml
@@ -40,7 +40,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: '{{ template "name" . }}'
-  namespace: '{{ .Release.Namespace }}'
 rules:
 - apiGroups:
   - ""

--- a/config/monitoring/prometheus/templates/rolebinding.yaml
+++ b/config/monitoring/prometheus/templates/rolebinding.yaml
@@ -1,59 +1,43 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: prometheus-kubermatic-config
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-kubermatic-config
-subjects:
-- kind: ServiceAccount
-  name: prometheus-kubermatic
-  namespace: {{ .Release.Namespace }}
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: prometheus-kubermatic
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-kubermatic
-subjects:
-- kind: ServiceAccount
-  name: prometheus-kubermatic
-  namespace: {{ .Release.Namespace }}
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: prometheus-kubermatic
+  name: '{{ template "name" . }}'
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: prometheus-kubermatic
+  name: '{{ template "name" . }}'
 subjects:
 - kind: ServiceAccount
-  name: prometheus-kubermatic
-  namespace: {{ .Release.Namespace }}
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: prometheus-kubermatic
+  name: '{{ template "name" . }}'
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: prometheus-kubermatic
+  name: '{{ template "name" . }}'
 subjects:
 - kind: ServiceAccount
-  name: prometheus-kubermatic
-  namespace: {{ .Release.Namespace }}
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ template "name" . }}'
+subjects:
+- kind: ServiceAccount
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/config/monitoring/prometheus/templates/rolebinding.yaml
+++ b/config/monitoring/prometheus/templates/rolebinding.yaml
@@ -32,7 +32,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: '{{ template "name" . }}'
-  namespace: '{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -40,4 +39,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: '{{ template "name" . }}'
-  namespace: '{{ .Release.Namespace }}'

--- a/config/monitoring/prometheus/templates/service.yaml
+++ b/config/monitoring/prometheus/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: '{{ template "name" . }}'
-  namespace: '{{ .Release.Namespace }}'
   labels:
     app: '{{ template "name" . }}'
 spec:

--- a/config/monitoring/prometheus/templates/service.yaml
+++ b/config/monitoring/prometheus/templates/service.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'
   labels:
-    app: prometheus-kubermatic
-  name: prometheus-kubermatic
+    app: '{{ template "name" . }}'
 spec:
   ports:
   - name: web
     port: 9090
     targetPort: web
   selector:
-    app: prometheus-kubermatic
+    app: '{{ template "name" . }}'

--- a/config/monitoring/prometheus/templates/serviceaccount.yaml
+++ b/config/monitoring/prometheus/templates/serviceaccount.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: '{{ template "name" . }}'
-  namespace: '{{ .Release.Namespace }}'

--- a/config/monitoring/prometheus/templates/serviceaccount.yaml
+++ b/config/monitoring/prometheus/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: prometheus-kubermatic
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.prometheus.migration.enabled }}
 apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
@@ -19,7 +20,7 @@ spec:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '9090'
         {{- if .Values.prometheus.backup.enabled }}
-        backup.velero.io/backup-volumes: prometheus-backup
+        backup.velero.io/backup-volumes: backup
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: '{{ .Values.prometheus.backup.timeout | default "60m" }}'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
@@ -170,13 +171,15 @@ spec:
         requests:
           storage: {{ .Values.prometheus.storageSize }}
       storageClassName: kubermatic-fast
+{{ end }}
+
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: prometheus-kubermatic
+  name: '{{ template "name" . }}'
 spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: prometheus-kubermatic
+      app: '{{ template "name" . }}'

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
-  name: prometheus-kubermatic
+  name: '{{ template "name" . }}'
 spec:
   replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: prometheus-kubermatic
-  serviceName: prometheus-kubermatic
+      app: '{{ template "name" . }}'
+  serviceName: '{{ template "name" . }}'
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: prometheus-kubermatic
+        app: '{{ template "name" . }}'
       annotations:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '9090'
@@ -63,20 +63,20 @@ spec:
         resources:
 {{ toYaml .Values.prometheus.containers.prometheus.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/prometheus/config/
-          name: prometheus-kubermatic-config
+        - name: config
+          mountPath: /etc/prometheus/config/
           readOnly: false
-        - mountPath: /etc/prometheus/rules/
-          name: prometheus-kubermatic-rules
+        - name: rules
+          mountPath: /etc/prometheus/rules/
           readOnly: false
-        - mountPath: /var/prometheus/data
-          name: prometheus-kubermatic-db
+        - name: db
+          mountPath: /var/prometheus/data
           readOnly: false
           subPath: prometheus-db
         {{- if .Values.prometheus.volumes }}
         {{- range .Values.prometheus.volumes }}
-        - mountPath: {{ .mountPath }}
-          name: {{ .name }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
           readOnly: true
         {{- end }}
         {{- end }}
@@ -90,16 +90,16 @@ spec:
         resources:
 {{ toYaml .Values.prometheus.containers.reloader.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/prometheus/config/
-          name: prometheus-kubermatic-config
+        - name: config
+          mountPath: /etc/prometheus/config/
           readOnly: false
-        - mountPath: /etc/prometheus/rules/
-          name: prometheus-kubermatic-rules
+        - name: rules
+          mountPath: /etc/prometheus/rules/
           readOnly: false
         {{- if .Values.prometheus.volumes }}
         {{- range .Values.prometheus.volumes }}
-        - mountPath: {{ .mountPath }}
-          name: {{ .name }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
           readOnly: true
         {{- end }}
         {{- end }}
@@ -112,12 +112,12 @@ spec:
         - -c
         - while true; do sleep 1h; done
         volumeMounts:
-        - mountPath: /prometheus
-          name: prometheus-kubermatic-db
+        - name: db
+          mountPath: /prometheus
           readOnly: false
           subPath: prometheus-db
-        - mountPath: /backup
-          name: prometheus-backup
+        - name: backup
+          mountPath: /backup
           readOnly: false
         securityContext:
           runAsNonRoot: false
@@ -125,18 +125,19 @@ spec:
         resources:
 {{ toYaml .Values.prometheus.containers.backup.resources | indent 10 }}
       {{- end }}
-      serviceAccountName: prometheus-kubermatic
+
+      serviceAccountName: '{{ template "name" . }}'
       securityContext:
         fsGroup: 2000
         runAsNonRoot: true
         runAsUser: 1000
       volumes:
-      - name: prometheus-kubermatic-config
+      - name: config
         configMap:
-          name: prometheus-kubermatic-config
-      - name: prometheus-kubermatic-rules
+          name: '{{ template "name" . }}-config'
+      - name: rules
         configMap:
-          name: prometheus-kubermatic-rules
+          name: '{{ template "name" . }}-rules'
       {{- if .Values.prometheus.volumes }}
       {{- range .Values.prometheus.volumes }}
       - name: {{ .name }}
@@ -150,7 +151,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.prometheus.backup.enabled }}
-      - name: prometheus-backup
+      - name: backup
         emptyDir: {}
       {{- end }}
       nodeSelector:
@@ -161,7 +162,7 @@ spec:
 {{ toYaml .Values.prometheus.tolerations | indent 8 }}
   volumeClaimTemplates:
   - metadata:
-      name: prometheus-kubermatic-db
+      name: db
     spec:
       accessModes:
       - ReadWriteOnce

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -158,7 +158,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.prometheus.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.prometheus.affinity | indent 8 }}
+{{ (tpl (toYaml .Values.prometheus.affinity) .) | fromYaml | toYaml | indent 8 }}
       tolerations:
 {{ toYaml .Values.prometheus.tolerations | indent 8 }}
   volumeClaimTemplates:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -88,6 +88,20 @@ prometheus:
   #  mountPath: /initech/recordings
   #  secretName: initech-recording-rules-secret
 
+  # When upgrading the chart from 1.x => 2.0, the naming for volumes
+  # has changed and without a migration your existing Prometheus database
+  # would not be used anymore. Set the enabled flag to true to let an
+  # init container copy the data over. A lockfile is created so that when
+  # the pod for whatever reason restarts the migration is not executed
+  # again.
+  # Once the migration has finished and you set the flag to false again,
+  # you can safely remove the old `prometheus-kubermatic-db-...` PVCs.
+  migration:
+    enabled: true
+    image:
+      repository: quay.io/kubermatic/util
+      tag: 1.0.0-2
+
   containers:
     prometheus:
       resources:
@@ -105,6 +119,14 @@ prometheus:
         limits:
           cpu: 500m
           memory: 10Gi
+    migration:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
     reloader:
       resources:
         requests:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -97,7 +97,7 @@ prometheus:
   # Once the migration has finished and you set the flag to false again,
   # you can safely remove the old `prometheus-kubermatic-db-...` PVCs.
   migration:
-    enabled: true
+    enabled: false
     image:
       repository: quay.io/kubermatic/util
       tag: 1.0.0-2

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -3,6 +3,12 @@ prometheus:
   host: ''
   storageSize: 100Gi
 
+  # If you install Prometheus using a different Helm release name,
+  # you can override the name used for the resources, e.g. to have
+  # multiple Prometheus installed into distinct namespaces but still
+  # have the same Service names, ConfigMap names etc.
+  #nameOverride: prometheus
+
   backup:
     enabled: true
     image:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -143,7 +143,7 @@ prometheus:
       - podAffinityTerm:
           labelSelector:
             matchLabels:
-              app: prometheus-kubermatic
+              app: '{{ template "name" . }}'
           topologyKey: kubernetes.io/hostname
         weight: 100
   tolerations: []


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to install some of our charts multiple times into a cluster, especially Prometheus. In #3252 we started to make this easier by putting the release name into each identifier of the Prometheus chart (e.g. `prometheus-kubermatic-{{ .Release.Name }}`.

This was a good start, but leads to "stuttering" and ugly names, like a role being named `prometheus-kubermatic-prometheus` (guess which part is the release name). Having a `kubermatic` inside the names is only a hack someone made a long time ago to allow running a "Loodse Prometheus" next to the one used for Kubermatic. Considering that we "publish" the monitoring stack in github.com/kubermatic/monitoring and use it for non-Kubermatic customers, we should also think about not putting `kubermatic` anywhere into the charts.

This PR attemps to rectify all these issues by doing a "light" version of what many popular Helm charts already do: Use the release name unless the `nameOverride` variable is set. This allows us to for example install Prometheus as `prometheus-master` (release name) Into `monitoring-master` namespace and still have the resources be named `prometheus-config`, `prometheus-rules` etc.

For our dev master/seed cluster, we would have this configuration:

1. (seed prometheus): release name: `prometheus-seed`, namespace `monitoring`, name override `prometheus`
    * We would change the release name from `prometheus` to `prometheus-seed` because it makes the distinction to the master clearer *and* we can easily run this new release along the old (see below).
2. (master prometheus): release name: `prometheus-master`, namespace `monitoring-master`, name override `prometheus`

The biggest, gigantic, downside to this is that we lose data because the PVCs are not named `prometheus-kubermatic-db-[statefulset-name]-[index]` anymore, but `db-[statefulset-name]-[index]` (the name of the StatefulSet is already unique enough, no need to duplicate it into the PVC name). This means that customers "lose" their data (in the sense that it becomes inaccessible). A migration path could be that customers run Prometheus twice and keep the old for the duration of their retention period.

The Grafana and Alertmanager charts would need the same treatment, but at worst we lose configured silences.

**Which issue(s) this PR fixes**:
Relates to #3238

**Does this PR introduce a user-facing change?**:
```release-note
BREAK: refactored Prometheus Helm Chart for Master-Cluster monitoring, see documentation for migration notes 
```
