### PR TITLE
E2E: Log not ready controlplane components

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -992,31 +993,10 @@ func (r *testRunner) logNotReadyControlplaneComponents(clusterName string) error
 	if err != nil {
 		return err
 	}
-	notReadyComponents := []string{}
-	if !cluster.Status.Health.ClusterHealthStatus.Apiserver {
-		notReadyComponents = append(notReadyComponents, "apiserver")
+	clusterHealthStatus, err := json.Marshal(cluster.Status.Health.ClusterHealthStatus)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cluster health status: %v", err)
 	}
-	if !cluster.Status.Health.ClusterHealthStatus.Scheduler {
-		notReadyComponents = append(notReadyComponents, "scheduler")
-	}
-	if !cluster.Status.Health.ClusterHealthStatus.Controller {
-		notReadyComponents = append(notReadyComponents, "controller")
-	}
-	if !cluster.Status.Health.ClusterHealthStatus.MachineController {
-		notReadyComponents = append(notReadyComponents, "machine-controller")
-	}
-	if !cluster.Status.Health.ClusterHealthStatus.Etcd {
-		notReadyComponents = append(notReadyComponents, "etcd")
-	}
-	if !cluster.Status.Health.ClusterHealthStatus.OpenVPN {
-		notReadyComponents = append(notReadyComponents, "openvpn")
-	}
-	if !cluster.Status.Health.ClusterHealthStatus.CloudProviderInfrastructure {
-		notReadyComponents = append(notReadyComponents, "cloudProviderInfrastructure")
-	}
-	if !cluster.Status.Health.ClusterHealthStatus.UserClusterControllerManager {
-		notReadyComponents = append(notReadyComponents, "userClusterControllerManager")
-	}
-	r.log.Infof("Failed because the following control plane components were not ready: %v", notReadyComponents)
+	r.log.Infof("ClusterHealthStatus: %q", string(clusterHealthStatus))
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now we log only not ready controlplane pods when we timeout waiting for the controlplane, however before we even check pods, we check the cluster health. This PR logs the cluster health on timeout in an attempt to bring an explanation to the controlplane timeouts were all pods are ready (cloudprovider infra?)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 
