### PR TITLE
Add error handling to migrations

### DIFF
--- a/api/pkg/crd/migrations/migrations.go
+++ b/api/pkg/crd/migrations/migrations.go
@@ -37,14 +37,6 @@ type cleanupContext struct {
 // In case of an error, the correspondent error will be returned, else nil.
 type ClusterTask func(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error
 
-// KeyTask represents a cleanup action, taking the current key for which the cleanup should be executed and the current context.
-// In case of an error, the correspondent error will be returned, else nil.
-type KeyTask func(key *kubermaticv1.UserSSHKey, ctx *cleanupContext) error
-
-// UserTask represents a cleanup action, taking the current user for which the cleanup should be executed and the current context.
-// In case of an error, the correspondent error will be returned, else nil.
-type UserTask func(user *kubermaticv1.User, ctx *cleanupContext) error
-
 // RunAll runs all migrations
 func RunAll(config *rest.Config, workerName string) error {
 	// required when performing calls against manually crafted URL's
@@ -58,8 +50,6 @@ func RunAll(config *rest.Config, workerName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create Kuermatic client: %v", err)
 	}
-
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
 
 	ctx := &cleanupContext{
 		kubeClient:       kubeClient,
@@ -87,12 +77,12 @@ func cleanupClusters(workerName string, ctx *cleanupContext) error {
 	// We remove these empty labels first, since the label selector below expects
 	// them to be absent for empty worker label.
 	if err := purgeEmptyWorkerLabels(ctx.kubermaticClient); err != nil {
-		glog.Fatalf("failed to remove empty worker labels: %v", err)
+		return fmt.Errorf("failed to remove empty worker labels: %v", err)
 	}
 
 	selector, err := workerlabel.LabelSelector(workerName)
 	if err != nil {
-		glog.Fatal(err)
+		return err
 	}
 	options := metav1.ListOptions{}
 	selector(&options)
@@ -101,7 +91,8 @@ func cleanupClusters(workerName string, ctx *cleanupContext) error {
 		return err
 	}
 
-	errCh := make(chan error)
+	var errs []error
+	errLock := &sync.Mutex{}
 	w := sync.WaitGroup{}
 	w.Add(len(clusters.Items))
 	for i := range clusters.Items {
@@ -109,17 +100,14 @@ func cleanupClusters(workerName string, ctx *cleanupContext) error {
 			defer w.Done()
 
 			if err := cleanupCluster(c, ctx); err != nil {
-				errCh <- err
+				errLock.Lock()
+				defer errLock.Unlock()
+				errs = append(errs, err)
 			}
 		}(&clusters.Items[i])
 	}
 	w.Wait()
 
-	close(errCh)
-	errs := []error{}
-	for err := range errCh {
-		errs = append(errs, err)
-	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%v", errs)
 	}
@@ -130,19 +118,29 @@ func cleanupClusters(workerName string, ctx *cleanupContext) error {
 func cleanupKeys(ctx *cleanupContext) error {
 	keys, err := ctx.kubermaticClient.KubermaticV1().UserSSHKeys().List(metav1.ListOptions{})
 	if err != nil {
-		glog.Fatal(err)
+		return err
 	}
 
 	w := sync.WaitGroup{}
 	w.Add(len(keys.Items))
+	var errs []error
+	errLock := &sync.Mutex{}
 
 	for i := range keys.Items {
 		go func(key *kubermaticv1.UserSSHKey) {
 			defer w.Done()
-			cleanupKey(key, ctx)
+			if err := cleanupKey(key, ctx); err != nil {
+				errLock.Lock()
+				defer errLock.Unlock()
+				errs = append(errs, err)
+			}
 		}(&keys.Items[i])
 	}
 	w.Wait()
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%v", errs)
+	}
 
 	return nil
 }
@@ -150,19 +148,29 @@ func cleanupKeys(ctx *cleanupContext) error {
 func cleanupUsers(ctx *cleanupContext) error {
 	userList, err := ctx.kubermaticClient.KubermaticV1().Users().List(metav1.ListOptions{})
 	if err != nil {
-		glog.Fatal(err)
+		return err
 	}
 
 	w := sync.WaitGroup{}
 	w.Add(len(userList.Items))
+	var errs []error
+	errLock := &sync.Mutex{}
 
 	for i := range userList.Items {
 		go func(user *kubermaticv1.User) {
 			defer w.Done()
-			cleanupUser(user, ctx)
+			if err := cleanupUser(user, ctx); err != nil {
+				errLock.Lock()
+				defer errLock.Unlock()
+				errs = append(errs, err)
+			}
 		}(&userList.Items[i])
 	}
 	w.Wait()
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%v", errs)
+	}
 
 	return nil
 }
@@ -199,8 +207,6 @@ func removeWorkerLabelFromCluster(cluster *kubermaticv1.Cluster, kubermaticClien
 func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
 	glog.Infof("Cleaning up cluster %s", cluster.Name)
 
-	errCh := make(chan error)
-
 	tasks := []ClusterTask{
 		cleanupPrometheus,
 		cleanupAPIServer,
@@ -222,6 +228,8 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
 
 	w := sync.WaitGroup{}
 	w.Add(len(tasks))
+	var errs []error
+	errLock := &sync.Mutex{}
 
 	for _, task := range tasks {
 		go func(t ClusterTask) {
@@ -230,17 +238,15 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
 
 			if err != nil {
 				glog.Error(err)
-				errCh <- err
+				errLock.Lock()
+				defer errLock.Unlock()
+				errs = append(errs, err)
 			}
 		}(task)
 	}
 
 	w.Wait()
 
-	errs := []error{}
-	for err := range errCh {
-		errs = append(errs, err)
-	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%v", errs)
 	}
@@ -248,52 +254,14 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
 	return nil
 }
 
-func cleanupKey(key *kubermaticv1.UserSSHKey, ctx *cleanupContext) {
+func cleanupKey(key *kubermaticv1.UserSSHKey, ctx *cleanupContext) error {
 	glog.Infof("Cleaning up SSHKey %s", key.Name)
-
-	tasks := []KeyTask{
-		migrateSSHKeyOwner,
-	}
-
-	w := sync.WaitGroup{}
-	w.Add(len(tasks))
-
-	for _, task := range tasks {
-		go func(t KeyTask) {
-			defer w.Done()
-			err := t(key, ctx)
-
-			if err != nil {
-				glog.Error(err)
-			}
-		}(task)
-	}
-
-	w.Wait()
+	return migrateSSHKeyOwner(key, ctx)
 }
 
-func cleanupUser(user *kubermaticv1.User, ctx *cleanupContext) {
+func cleanupUser(user *kubermaticv1.User, ctx *cleanupContext) error {
 	glog.Infof("Cleaning up User %s (%s)", user.Name, user.Spec.Email)
-
-	tasks := []UserTask{
-		migrateUserID,
-	}
-
-	w := sync.WaitGroup{}
-	w.Add(len(tasks))
-
-	for _, task := range tasks {
-		go func(t UserTask) {
-			defer w.Done()
-			err := t(user, ctx)
-
-			if err != nil {
-				glog.Error(err)
-			}
-		}(task)
-	}
-
-	w.Wait()
+	return migrateUserID(user, ctx)
 }
 
 func deleteResourceIgnoreNonExistent(namespace string, group string, version string, kind string, name string, ctx *cleanupContext) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds error handling to the migrations. The reason the initial PR (#3302) we reverted (#3305) sometimes blocked, is that I wrote the errors into a channel that was never read from until the WaitGroup the writer was part of finished, resulting in a deadlock.

In this PR I have replaced the channel with a simple `[]error` that is protected by a Mutex and appended to.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
