### PR TITLE
Enable -race flag for go tests

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -34,7 +34,7 @@ showenv:
 check: gofmt lint
 
 test:
-	$(GO) test ./...
+	CGO_ENABLED=1 $(GO) test -race ./...
 
 test-update:
 	-$(GO) test ./... -update

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -26,6 +26,11 @@ import (
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
+func init() {
+	// Mock timezone to keep creation timestamp always the same.
+	time.Local = time.UTC
+}
+
 func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {
@@ -826,8 +831,6 @@ func TestGetClusterHealth(t *testing.T) {
 func TestPatchCluster(t *testing.T) {
 	t.Parallel()
 
-	// Mock timezone to keep creation timestamp always the same.
-	time.Local = time.UTC
 	cluster := test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 	cluster.Spec.Cloud.DatacenterName = "us-central1"
 

--- a/api/pkg/handler/v1/node/node_test.go
+++ b/api/pkg/handler/v1/node/node_test.go
@@ -28,6 +28,11 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func init() {
+	// Mock timezone to keep creation timestamp always the same.
+	time.Local = time.UTC
+}
+
 func TestDeleteNodeForCluster(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {
@@ -1018,9 +1023,6 @@ func TestPatchNodeDeployment(t *testing.T) {
 	var replicas int32 = 1
 	var replicasUpdated int32 = 3
 	var kubeletVerUpdated = "v9.8.0"
-
-	// Mock timezone to keep creation timestamp always the same.
-	time.Local = time.UTC
 
 	testcases := []struct {
 		Name                       string


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables the `-race` flag for `go test` to make sure our tests cache races

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
