### PR TITLE
Add nodelocal-dns-cache addon

### DIFF
--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 
 LABEL maintainer "henrik@loodse.com"
 

--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -95,7 +95,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: {{ Registry "k8s.gcr.io" }}/k8s-dns-node-cache:1.15.2
+        image: {{ Registry "gcr.io" }}/google_containers/k8s-dns-node-cache:1.15.2
         resources:
           limits:
             memory: 30Mi

--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -95,7 +95,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.2
+        image: {{ Registry "k8s.gcr.io" }}/k8s-dns-node-cache:1.15.2
         resources:
           limits:
             memory: 30Mi

--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -25,7 +25,7 @@ data:
         reload
         loop
         bind 169.254.20.10
-        forward . 10.96.0.10 {
+        forward . {{.DNSClusterIP}} {
                 force_tcp
         }
         prometheus :9253
@@ -37,7 +37,7 @@ data:
         reload
         loop
         bind 169.254.20.10
-        forward . 10.96.0.10 {
+        forward . {{.DNSClusterIP}} {
                 force_tcp
         }
         prometheus :9253
@@ -48,7 +48,7 @@ data:
         reload
         loop
         bind 169.254.20.10
-        forward . 10.96.0.10 {
+        forward . {{.DNSClusterIP}} {
                 force_tcp
         }
         prometheus :9253
@@ -143,3 +143,6 @@ spec:
           items:
             - key: Corefile
               path: Corefile
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0

--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -1,0 +1,145 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind 169.254.20.10
+        forward . 10.96.0.10 {
+                force_tcp
+        }
+        prometheus :9253
+        health 169.254.20.10:8080
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 169.254.20.10
+        forward . 10.96.0.10 {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 169.254.20.10
+        forward . 10.96.0.10 {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind 169.254.20.10
+        forward . /etc/resolv.conf {
+                force_tcp
+        }
+        prometheus :9253
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  template:
+    metadata:
+      labels:
+         k8s-app: node-local-dns
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      hostNetwork: true
+      dnsPolicy: Default  # Don't use cluster DNS.
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      containers:
+      - name: node-cache
+        image: k8s.gcr.io/k8s-dns-node-cache:1.15.2
+        resources:
+          limits:
+            memory: 30Mi
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args:
+        - -localip
+        - 169.254.20.10
+        - -conf
+        - /etc/coredns/Corefile
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: 169.254.20.10
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - name: config-volume
+          mountPath: /etc/coredns
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: config-volume
+        configMap:
+          name: node-local-dns
+          items:
+            - key: Corefile
+              path: Corefile

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.10-dev
+export TAG=v0.2.10-dev-2
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.10-dev-3
+export TAG=v0.2.10-dev-4
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.10-dev-4
+export TAG=v0.2.10
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.9
+export TAG=v0.2.10-dev
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.10-dev-2
+export TAG=v0.2.10-dev-3
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -362,6 +362,7 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 		"",
 		"",
 		"",
+		true,
 	), nil
 }
 

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -111,6 +111,7 @@ func createClusterController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.oidcCAFile,
 		ctrlCtx.runOptions.oidcIssuerURL,
 		ctrlCtx.runOptions.oidcIssuerClientID,
+		strings.Contains(ctrlCtx.runOptions.kubernetesAddonsList, "nodelocal-dns-cache"),
 		cluster.Features{
 			VPA:                      ctrlCtx.runOptions.featureGates.Enabled(VerticalPodAutoscaler),
 			EtcdDataCorruptionChecks: ctrlCtx.runOptions.featureGates.Enabled(EtcdDataCorruptionChecks),
@@ -170,6 +171,7 @@ func createMonitoringController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.inClusterPrometheusDisableDefaultScrapingConfigs,
 		ctrlCtx.runOptions.inClusterPrometheusScrapingConfigsFile,
 		dockerPullConfigJSON,
+		strings.Contains(ctrlCtx.runOptions.kubernetesAddonsList, "nodelocal-dns-cache"),
 
 		monitoring.Features{
 			VPA: ctrlCtx.runOptions.featureGates.Enabled(VerticalPodAutoscaler),

--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -82,7 +82,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.nodeAccessNetwork, "node-access-network", "10.254.0.0/16", "A network which allows direct access to nodes via VPN. Uses CIDR notation.")
 	flag.StringVar(&c.kubernetesAddonsPath, "kubernetes-addons-path", "/opt/addons/kubernetes", "Path to addon manifests. Should contain sub-folders for each addon")
 	flag.StringVar(&c.openshiftAddonsPath, "openshift-addons-path", "/opt/addons/openshift", "Path to addon manifests. Should contain sub-folders for each addon")
-	flag.StringVar(&c.kubernetesAddonsList, "kubernetes-addons-list", "canal,dashboard,dns,kube-proxy,openvpn,rbac,kubelet-configmap,default-storage-class,node-exporter", "Comma separated list of Addons to install into every user-cluster")
+	flag.StringVar(&c.kubernetesAddonsList, "kubernetes-addons-list", "canal,dashboard,dns,kube-proxy,openvpn,rbac,kubelet-configmap,default-storage-class,node-exporter,nodelocal-dns-cache", "Comma separated list of Addons to install into every user-cluster")
 	flag.StringVar(&c.openshiftAddonsList, "openshift-addons-list", "networking,openvpn,rbac", "Comma separated list of addons to install into every openshift user cluster")
 	flag.StringVar(&c.backupContainerFile, "backup-container", "", fmt.Sprintf("[Required] Filepath of a backup container yaml. It must mount a volume named %s from which it reads the etcd backups", backupcontroller.SharedVolumeName))
 	flag.StringVar(&c.cleanupContainerFile, "cleanup-container", "", "[Required] Filepath of a cleanup container yaml. The container will be used to cleanup the backup directory for a cluster after it got deleted.")

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -78,6 +78,7 @@ type Reconciler struct {
 	inClusterPrometheusScrapingConfigsFile           string
 	monitoringScrapeAnnotationPrefix                 string
 	dockerPullConfigJSON                             []byte
+	nodeLocalDNSCacheEnabled                         bool
 
 	oidcCAFile         string
 	oidcIssuerURL      string
@@ -109,6 +110,7 @@ func Add(
 	oidcCAFile string,
 	oidcIssuerURL string,
 	oidcIssuerClientID string,
+	nodeLocalDNSCacheEnabled bool,
 	features Features) error {
 
 	if err := kubermaticscheme.AddToScheme(scheme.Scheme); err != nil {
@@ -132,6 +134,7 @@ func Add(
 		inClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
 		monitoringScrapeAnnotationPrefix:                 monitoringScrapeAnnotationPrefix,
 		dockerPullConfigJSON:                             dockerPullConfigJSON,
+		nodeLocalDNSCacheEnabled:                         nodeLocalDNSCacheEnabled,
 
 		externalURL: externalURL,
 		dc:          dc,

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -108,6 +108,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		r.oidcCAFile,
 		r.oidcIssuerURL,
 		r.oidcIssuerClientID,
+		r.nodeLocalDNSCacheEnabled,
 	), nil
 }
 

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -66,6 +66,7 @@ type Reconciler struct {
 	// Annotation prefix to discover user cluster resources
 	// example: kubermatic.io -> kubermatic.io/path,kubermatic.io/port
 	monitoringScrapeAnnotationPrefix string
+	nodeLocalDNSCacheEnabled         bool
 
 	features Features
 }
@@ -89,6 +90,7 @@ func Add(
 	inClusterPrometheusDisableDefaultScrapingConfigs bool,
 	inClusterPrometheusScrapingConfigsFile string,
 	dockerPullConfigJSON []byte,
+	nodeLocalDNSCacheEnabled bool,
 
 	features Features,
 ) error {
@@ -108,6 +110,7 @@ func Add(
 		inClusterPrometheusDisableDefaultScrapingConfigs: inClusterPrometheusDisableDefaultScrapingConfigs,
 		inClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
 		dockerPullConfigJSON:                             dockerPullConfigJSON,
+		nodeLocalDNSCacheEnabled:                         nodeLocalDNSCacheEnabled,
 
 		dc:  dc,
 		dcs: dcs,

--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -39,6 +39,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, client ctrlrunt
 		"",
 		"",
 		"",
+		r.nodeLocalDNSCacheEnabled,
 	), nil
 }
 

--- a/api/pkg/controller/openshift/data.go
+++ b/api/pkg/controller/openshift/data.go
@@ -248,3 +248,8 @@ func (od *openshiftData) HasEtcdOperatorService() (bool, error) {
 func (od *openshiftData) EtcdDiskSize() resource.Quantity {
 	return od.etcdDiskSize
 }
+
+// Openshift has its own DNS cache, so this is always false
+func (od *openshiftData) NodeLocalDNSCacheEnabled() bool {
+	return false
+}

--- a/api/pkg/controller/openshift/resources/interfaces.go
+++ b/api/pkg/controller/openshift/resources/interfaces.go
@@ -29,4 +29,5 @@ type openshiftData interface {
 	DC() *provider.DatacenterMeta
 	HasEtcdOperatorService() (bool, error)
 	EtcdDiskSize() resource.Quantity
+	NodeLocalDNSCacheEnabled() bool
 }

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -39,6 +39,7 @@ type TemplateData struct {
 	oidcCAFile                                       string
 	oidcIssuerURL                                    string
 	oidcIssuerClientID                               string
+	nodeLocalDNSCacheEnabled                         bool
 }
 
 // NewTemplateData returns an instance of TemplateData
@@ -59,7 +60,8 @@ func NewTemplateData(
 	inClusterPrometheusScrapingConfigsFile string,
 	oidcCAFile string,
 	oidcURL string,
-	oidcIssuerClientID string) *TemplateData {
+	oidcIssuerClientID string,
+	nodeLocalDNSCacheEnabled bool) *TemplateData {
 	return &TemplateData{
 		ctx:                                    ctx,
 		client:                                 client,
@@ -78,6 +80,7 @@ func NewTemplateData(
 		oidcCAFile:                                       oidcCAFile,
 		oidcIssuerURL:                                    oidcURL,
 		oidcIssuerClientID:                               oidcIssuerClientID,
+		nodeLocalDNSCacheEnabled:                         nodeLocalDNSCacheEnabled,
 	}
 }
 
@@ -244,4 +247,8 @@ func (d *TemplateData) GetOpenVPNServerPort() (int32, error) {
 	}
 
 	return service.Spec.Ports[0].NodePort, nil
+}
+
+func (d *TemplateData) NodeLocalDNSCacheEnabled() bool {
+	return d.nodeLocalDNSCacheEnabled
 }

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - -v
         - "4"
         - -cluster-dns
-        - 10.10.10.10
+        - 169.254.20.10
         - -internal-listen-address
         - 0.0.0.0:8085
         command:

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -528,6 +528,7 @@ func TestLoadFiles(t *testing.T) {
 					"test",
 					"https://dev.kubermatic.io/dex",
 					"kubermaticIssuer",
+					true,
 				)
 
 				var deploymentCreators []reconciling.NamedDeploymentCreatorGetter

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -69,7 +69,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.10-dev"
+          tag: "v0.2.10-dev-2"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -69,7 +69,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.10-dev-2"
+          tag: "v0.2.10-dev-3"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -69,7 +69,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.10-dev-4"
+          tag: "v0.2.10"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -69,7 +69,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.10-dev-3"
+          tag: "v0.2.10-dev-4"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -69,7 +69,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.9"
+          tag: "v0.2.10-dev"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -66,6 +66,7 @@ kubermatic:
         - kubelet-configmap
         - default-storage-class
         - node-exporter
+        - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
           tag: "v0.2.9"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the nodelocal-dns-cache addon which greatly improves resiliency of the DNS service on busy clusters

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The resiliency of in-cluster DNS was greatly improved by adding the nodelocal-dns-cache addon, which runs a DNS cache on each node, avoiding the need to use NAT for DNS queries
```
