### PR TITLE
downgrade Elastic Stack to 6.7 to allow rolling upgrades later

### DIFF
--- a/config/logging/elasticsearch/Chart.yaml
+++ b/config/logging/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 version: 1.0.2
-appVersion: 6.7.0
+appVersion: 6.7.1
 description: Chart to deploy Elasticsearch master and data nodes.
 keywords:
 - kubermatic

--- a/config/logging/elasticsearch/Chart.yaml
+++ b/config/logging/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
-version: 1.0.1
-appVersion: 7.0.0
+version: 1.0.2
+appVersion: 6.7.0
 description: Chart to deploy Elasticsearch master and data nodes.
 keywords:
 - kubermatic

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -2,7 +2,7 @@ logging:
   elasticsearch:
     image:
       repository: docker.elastic.co/elasticsearch/elasticsearch-oss
-      tag: "6.7.0"
+      tag: "6.7.1"
       pullPolicy: IfNotPresent
 
     cluster:

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -2,7 +2,7 @@ logging:
   elasticsearch:
     image:
       repository: docker.elastic.co/elasticsearch/elasticsearch-oss
-      tag: "7.0.0"
+      tag: "6.7.0"
       pullPolicy: IfNotPresent
 
     cluster:

--- a/config/logging/kibana/Chart.yaml
+++ b/config/logging/kibana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kibana
-version: 1.0.1
-appVersion: 7.0.0
+version: 1.0.2
+appVersion: 6.7.0
 description: kibana
 keywords:
 - kubermatic

--- a/config/logging/kibana/Chart.yaml
+++ b/config/logging/kibana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kibana
 version: 1.0.2
-appVersion: 6.7.0
+appVersion: 6.7.1
 description: kibana
 keywords:
 - kubermatic

--- a/config/logging/kibana/config/ensure-index-pattern.sh
+++ b/config/logging/kibana/config/ensure-index-pattern.sh
@@ -18,7 +18,7 @@ ensure_index_pattern() {
 
    # Check if the index pattern already exists.
    patterns=$(kibana "${KIBANA_URL}/api/saved_objects/_find?type=index-pattern&search_fields=title&search=logstash-\\*" | jq '.total')
-   if [ "$patterns" -eq 1 ]; then
+   if [ "$patterns" -ge 1 ]; then
       return 0
    fi
 

--- a/config/logging/kibana/templates/deployment.yaml
+++ b/config/logging/kibana/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         resources:
 {{ toYaml .Values.logging.kibana.resources | indent 10 }}
         env:
-        - name: ELASTICSEARCH_URL
+        - name: ELASTICSEARCH_HOSTS
           value: http://es-data:9200
         ports:
         - containerPort: 5601
@@ -40,7 +40,7 @@ spec:
         resources:
 {{ toYaml .Values.logging.kibana.setupContainer.resources | indent 10 }}
         env:
-        - name: ELASTICSEARCH_URL
+        - name: ELASTICSEARCH_HOSTS
           value: http://es-data:9200
         - name: KIBANA_URL
           value: http://127.0.0.1:5601

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -2,7 +2,7 @@ logging:
   kibana:
     image:
       repository: docker.elastic.co/kibana/kibana-oss
-      tag: "6.7.0"
+      tag: "6.7.1"
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -2,7 +2,7 @@ logging:
   kibana:
     image:
       repository: docker.elastic.co/kibana/kibana-oss
-      tag: "7.0.0"
+      tag: "6.7.0"
       pullPolicy: IfNotPresent
     resources:
       requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Performing rolling upgrades to 7.0 from anything but 6.7 is [not supported](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html). To not force customers to restart their logging cluster, we postpone our 7.0 upgrade to Kubermatic 2.11 and instead ship 2.11 with 6.7 (i.e. this PR is supposed to be cherry-picked into 2.10).

This PR also improves the index-pattern setup logic to not run into an endless loop and replaces the old deprecated `elasticsearch.url` property with the new `elasticsearch.hosts`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cherry-pick release/v2.10