### PR TITLE
Add containerRuntimeVersion and kernelVersion to NodeInfo

### DIFF
--- a/api/pkg/handler/v1/node/node.go
+++ b/api/pkg/handler/v1/node/node.go
@@ -774,6 +774,8 @@ func apiNodeStatus(status apiv1.NodeStatus, inputNode *corev1.Node, hideInitialN
 	status.NodeInfo.OperatingSystem = inputNode.Status.NodeInfo.OperatingSystem
 	status.NodeInfo.KubeletVersion = inputNode.Status.NodeInfo.KubeletVersion
 	status.NodeInfo.Architecture = inputNode.Status.NodeInfo.Architecture
+	status.NodeInfo.ContainerRuntimeVersion = inputNode.Status.NodeInfo.ContainerRuntimeVersion
+	status.NodeInfo.KernelVersion = inputNode.Status.NodeInfo.KernelVersion
 	return status
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add containerRuntimeVersion and kernelVersion to NodeInfo

**Special notes for your reviewer**:
Related dashboard PR https://github.com/kubermatic/dashboard-v2/pull/1216

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Added containerRuntimeVersion and kernelVersion to NodeInfo
```
