### PR TITLE
Fix cert-manager CRDs

### DIFF
--- a/config/cert-manager/templates/crd.yaml
+++ b/config/cert-manager/templates/crd.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "helm.sh/hook": "crd-install"
   labels:
     controller-tools.k8s.io: "1.0"
   name: certificates.certmanager.k8s.io
@@ -202,6 +204,8 @@ status:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "helm.sh/hook": "crd-install"
   labels:
     controller-tools.k8s.io: "1.0"
   name: challenges.certmanager.k8s.io
@@ -355,6 +359,8 @@ status:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "helm.sh/hook": "crd-install"
   labels:
     controller-tools.k8s.io: "1.0"
   name: clusterissuers.certmanager.k8s.io
@@ -613,6 +619,8 @@ status:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "helm.sh/hook": "crd-install"
   labels:
     controller-tools.k8s.io: "1.0"
   name: issuers.certmanager.k8s.io
@@ -871,6 +879,8 @@ status:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "helm.sh/hook": "crd-install"
   labels:
     controller-tools.k8s.io: "1.0"
   name: orders.certmanager.k8s.io


### PR DESCRIPTION
**What this PR does / why we need it**:
The CRDs require the Helm hooks to be installed before any other resource. Otherwise Kubermatic 2.9 -> 2.10 upgrades will fail.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cherrypick release/v2.10