### PR TITLE
E2E tests: consolidate distribution exclusion logic

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -324,7 +324,7 @@ func getScenarios(opts Opts, log *logrus.Entry) []testScenario {
 	var scenarios []testScenario
 	if opts.providers.Has("aws") {
 		log.Info("Adding AWS scenarios")
-		scenarios = append(scenarios, getAWSScenarios(opts.excludeSelector, opts.versions)...)
+		scenarios = append(scenarios, getAWSScenarios(opts.versions)...)
 	}
 	if opts.providers.Has("digitalocean") {
 		log.Info("Adding Digitalocean scenarios")
@@ -346,9 +346,28 @@ func getScenarios(opts Opts, log *logrus.Entry) []testScenario {
 		log.Info("Adding Azure scenarios")
 		scenarios = append(scenarios, getAzureScenarios(opts.versions)...)
 	}
+
+	var filteredScenarios []testScenario
+	for _, scenario := range scenarios {
+		nd := scenario.Nodes(1)
+		if nd.Spec.Template.OperatingSystem.Ubuntu != nil {
+			if !opts.excludeSelector.Distributions[providerconfig.OperatingSystemUbuntu] {
+				filteredScenarios = append(filteredScenarios, scenario)
+			}
+		}
+		if nd.Spec.Template.OperatingSystem.ContainerLinux != nil {
+			if !opts.excludeSelector.Distributions[providerconfig.OperatingSystemCoreos] {
+				filteredScenarios = append(filteredScenarios, scenario)
+			}
+		}
+		if nd.Spec.Template.OperatingSystem.CentOS != nil {
+			if !opts.excludeSelector.Distributions[providerconfig.OperatingSystemCentOS] {
+				filteredScenarios = append(filteredScenarios, scenario)
+			}
+		}
+	}
 	// Shuffle scenarios - avoids timeouts caused by quota issues
-	scenarios = shuffle(scenarios)
-	return scenarios
+	return shuffle(filteredScenarios)
 }
 
 func setupHomeDir(log *logrus.Entry) (string, []byte, error) {

--- a/api/cmd/conformance-tests/scenarios_aws.go
+++ b/api/cmd/conformance-tests/scenarios_aws.go
@@ -6,46 +6,39 @@ import (
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
-	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Returns a matrix of (version x operating system)
-func getAWSScenarios(es excludeSelector, versions []*semver.Semver) []testScenario {
+func getAWSScenarios(versions []*semver.Semver) []testScenario {
 	var scenarios []testScenario
 	for _, v := range versions {
 		// Ubuntu
-		if _, ok := es.Distributions[providerconfig.OperatingSystemUbuntu]; !ok {
-			scenarios = append(scenarios, &awsScenario{
-				version: v,
-				nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-					Ubuntu: &kubermaticapiv1.UbuntuSpec{},
-				},
-			})
-		}
+		scenarios = append(scenarios, &awsScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				Ubuntu: &kubermaticapiv1.UbuntuSpec{},
+			},
+		})
 		// CoreOS
-		if _, ok := es.Distributions[providerconfig.OperatingSystemCoreos]; !ok {
-			scenarios = append(scenarios, &awsScenario{
-				version: v,
-				nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
-					ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
-						// Otherwise the nodes restart directly after creation - bad for tests
-						DisableAutoUpdate: true,
-					},
+		scenarios = append(scenarios, &awsScenario{
+			version: v,
+			nodeOsSpec: kubermaticapiv1.OperatingSystemSpec{
+				ContainerLinux: &kubermaticapiv1.ContainerLinuxSpec{
+					// Otherwise the nodes restart directly after creation - bad for tests
+					DisableAutoUpdate: true,
 				},
-			})
-		}
+			},
+		})
 		// CentOS
 		//TODO: Fix
-		// if _, ok := es.Distributions[providerconfig.OperatingSystemCentos]; !ok {
 		//scenarios = append(scenarios, &awsScenario{
 		//	version: v,
 		//	nodeOsSpec: kubermaticapiv2.OperatingSystemSpec{
 		//		CentOS: &kubermaticapiv2.CentOSSpec{},
 		//	},
 		//})
-		//}
 	}
 	return scenarios
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Consolidates the distribution exclusion logic, right now it works for AWS only :grimacing: 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
