### PR TITLE
remove ownerRef from VPA pointing to a cluster

### DIFF
--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -304,7 +304,7 @@ func (r *Reconciler) ensureVerticalPodAutoscalers(ctx context.Context, c *kuberm
 		return fmt.Errorf("failed to create the functions to handle VPA resources: %v", err)
 	}
 
-	return reconciling.ReconcileVerticalPodAutoscalers(ctx, creators, c.Status.NamespaceName, r.Client, reconciling.OwnerRefWrapper(resources.GetClusterRef(c)))
+	return reconciling.ReconcileVerticalPodAutoscalers(ctx, creators, c.Status.NamespaceName, r.Client)
 }
 
 func (r *Reconciler) ensureStatefulSets(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the cluster OwnerRef on VPA objects.
Its not needed because we only wan't to have the target of the VPA as owner set (Deployment/Statefulset).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
