### PR TITLE
Scrape cAdvisor metrics for user clusters & disable the graceful termination of Prometheus

### DIFF
--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -134,6 +134,31 @@ scrape_configs:
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}/proxy/metrics
 
+- job_name: cadvisor
+  scheme: https
+  tls_config:
+    ca_file: /etc/kubernetes/ca.crt
+    cert_file: /etc/kubernetes/prometheus-client.crt
+    key_file: /etc/kubernetes/prometheus-client.key
+
+  kubernetes_sd_configs:
+  - role: node
+    api_server: 'https://{{ .APIServerURL }}'
+    tls_config:
+      ca_file: /etc/kubernetes/ca.crt
+      cert_file: /etc/kubernetes/prometheus-client.crt
+      key_file: /etc/kubernetes/prometheus-client.key
+
+  relabel_configs:
+  - action: labelmap
+    regex: __meta_kubernetes_node_label_(.+)
+  - target_label: __address__
+    replacement: '{{ .APIServerURL }}'
+  - source_labels: [__meta_kubernetes_node_name]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
 - job_name: 'kubernetes-control-plane'
   kubernetes_sd_configs:
   - role: pod

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -74,7 +74,9 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 			}
 			set.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 			set.Spec.Template.Spec.ServiceAccountName = resources.PrometheusServiceAccountName
-			set.Spec.Template.Spec.TerminationGracePeriodSeconds = resources.Int64(600)
+			// We don't persist data, so there's no need for a graceful shutdown.
+			// The faster restart time is preferable
+			set.Spec.Template.Spec.TerminationGracePeriodSeconds = resources.Int64(0)
 			resourceRequirements := defaultResourceRequirements
 			if data.Cluster().Spec.ComponentsOverride.Prometheus.Resources != nil {
 				resourceRequirements = *data.Cluster().Spec.ComponentsOverride.Prometheus.Resources

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -60,6 +60,31 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.:30000'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
     - job_name: 'kubernetes-control-plane'
       kubernetes_sd_configs:
       - role: pod

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       serviceAccountName: prometheus
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
           defaultMode: 256


### PR DESCRIPTION
**What this PR does / why we need it**:
Scrape cAdvisor metrics for user clusters & disable the graceful termination of Prometheus

**Does this PR introduce a user-facing change?**:
```release-note
cAdvisor metrics are now being scraped for user clusters
```
