### PR TITLE
[WIP] Replace the metrics-server with the prometheus metrics-adapter

### DIFF
--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -231,6 +231,7 @@ func GetConfigMapCreators(data *resources.TemplateData) []reconciling.NamedConfi
 		cloudconfig.ConfigMapCreator(data),
 		openvpn.ServerClientConfigsConfigMapCreator(data),
 		dns.ConfigMapCreator(data),
+		metricsserver.ConfigMapCreator(),
 	}
 }
 

--- a/api/pkg/resources/metrics-server/configmap.go
+++ b/api/pkg/resources/metrics-server/configmap.go
@@ -1,0 +1,57 @@
+package metricsserver
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ConfigMapCreator returns a function to create the ConfigMap containing the cloud-config
+func ConfigMapCreator() reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return resources.MetricsServerConfigConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+
+			cm.Labels = resources.BaseAppLabel(name, nil)
+			cm.Data["config.yaml"] = cfg
+
+			return cm, nil
+		}
+	}
+}
+
+const cfg = `rules:
+resourceRules:
+  cpu:
+    containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[5m]))
+      by (<<.GroupBy>>)
+    nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[5m]))
+      by (<<.GroupBy>>)
+    resources:
+      overrides:
+        instance:
+          resource: node
+        namespace:
+          resource: namespace
+        pod_name:
+          resource: pod
+    containerLabel: container_name
+  memory:
+    containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by
+      (<<.GroupBy>>)
+    nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'})
+      by (<<.GroupBy>>)
+    resources:
+      overrides:
+        instance:
+          resource: node
+        namespace:
+          resource: namespace
+        pod_name:
+          resource: pod
+    containerLabel: container_name
+  window: 5m
+`

--- a/api/pkg/resources/metrics-server/service.go
+++ b/api/pkg/resources/metrics-server/service.go
@@ -21,7 +21,7 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 				{
 					Port:       443,
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(443),
+					TargetPort: intstr.FromInt(6443),
 				},
 			}
 

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -154,6 +154,8 @@ const (
 	ClusterInfoConfigMapName = "cluster-info"
 	//PrometheusConfigConfigMapName is the name for the configmap containing the prometheus config
 	PrometheusConfigConfigMapName = "prometheus"
+	// MetricsServerConfigConfigMapName is the name for the ConfigMap containing the metrics server config
+	MetricsServerConfigConfigMapName = "metrics-server-config"
 
 	//PrometheusServiceAccountName is the name for the Prometheus serviceaccount
 	PrometheusServiceAccountName = "prometheus"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         app: metrics-server
         cluster: de-test-01
-        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-config-configmap-revision: "123456"
         metrics-server-secret-revision: "123456"
-        openvpn-client-certificates-secret-revision: "123456"
     spec:
       affinity:
         podAntiAffinity:
@@ -41,24 +40,49 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
+        - --secure-port
+        - "6443"
+        - --logtostderr
+        - --v
+        - "2"
+        - --cert-dir
+        - /etc/adapter-certs
+        - --prometheus-url
+        - http://prometheus:9090/
+        - --metrics-relist-interval
+        - 1m
+        - --config
+        - /etc/adapter/config.yaml
+        - --lister-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
-        - "1"
-        - --logtostderr
         command:
-        - /metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
+        - /adapter
+        image: docker.io/directxman12/k8s-prometheus-adapter-amd64:v0.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
         name: metrics-server
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 6443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           limits:
             cpu: 150m
@@ -70,91 +94,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
-      - args:
-        - --client
-        - --proto
-        - tcp
-        - --dev
-        - tun
-        - --auth-nocache
-        - --remote
-        - openvpn-server.cluster-de-test-01.svc.cluster.local.
-        - "1194"
-        - --nobind
-        - --connect-timeout
-        - "5"
-        - --connect-retry
-        - "1"
-        - --ca
-        - /etc/openvpn/pki/client/ca.crt
-        - --cert
-        - /etc/openvpn/pki/client/client.crt
-        - --key
-        - /etc/openvpn/pki/client/client.key
-        - --remote-cert-tls
-        - server
-        - --link-mtu
-        - "1432"
-        - --cipher
-        - AES-256-GCM
-        - --auth
-        - SHA1
-        - --keysize
-        - "256"
-        - --script-security
-        - "2"
-        - --status
-        - /run/openvpn-status
-        - --log
-        - /dev/stdout
-        command:
-        - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
-        name: openvpn-client
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 5m
-            memory: 5Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /etc/openvpn/pki/client
-          name: openvpn-client-certificates
+        - mountPath: /etc/adapter
+          name: metrics-server-config
           readOnly: true
-      - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -node-access-network
-        - 192.0.2.0/24
-        - -v
-        - "4"
-        - -logtostderr
-        command:
-        - /usr/local/bin/kubeletdnat-controller
-        image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
-        name: dnat-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 512Mi
-          requests:
-            cpu: 5m
-            memory: 16Mi
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          procMount: Default
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: kubeletdnatcontroller-kubeconfig
-          readOnly: true
+        - mountPath: /etc/adapter-certs
+          name: cert-dir
       imagePullSecrets:
       - name: dockercfg
       initContainers:
@@ -181,12 +125,11 @@ spec:
         secret:
           defaultMode: 292
           secretName: metrics-server
-      - name: openvpn-client-certificates
-        secret:
-          defaultMode: 256
-          secretName: openvpn-client-certificates
-      - name: kubeletdnatcontroller-kubeconfig
-        secret:
+      - configMap:
           defaultMode: 292
-          secretName: kubeletdnatcontroller-kubeconfig
+          name: metrics-server-config
+        name: metrics-server-config
+      - emptyDir:
+          sizeLimit: 1Mi
+        name: cert-dir
 status: {}

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.10.6-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.11.1-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.12.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-aws-1.13.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.10.6-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.11.1-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.12.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-azure-1.13.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.10.6-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.11.1-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.12.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-bringyourown-1.13.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.10.6-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.11.1-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.12.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-digitalocean-1.13.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.10.6-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.11.1-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.12.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-openstack-1.13.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.10.6-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.11.1-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.12.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/fixtures/service-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/service-vsphere-1.13.0-metrics-server.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 6443
   selector:
     app: metrics-server
 status:

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -421,6 +421,13 @@ func TestLoadFiles(t *testing.T) {
 							Namespace:       cluster.Status.NamespaceName,
 						},
 					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.MetricsServerConfigConfigMapName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
 					&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      resources.ApiserverExternalServiceName,


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace the metrics-server with the prometheus metrics-adapter.

This PR has the following advantages:
- We have the cAdvisor metrics in Prometheus so we can utilize them (Dashboards / Alerts)
- With the cAdvisor metrics in Prometheus we avoid the overhead of the metrics-server own scraping(Scrapes the kubelet every 30sec). 
- Since the prometheus-metrics-adapter only talks to Prometheus, we can avoid having to run the OpenVPN sidecars - Reducing the number of containers per cluster by 4.

For concerns about stability/support:
RedHat uses it for OpenShift 4

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
