### PR TITLE
Add Antiaffinity & PDBs to dns-resolver, Kubermatic and the monitoring components

### DIFF
--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -257,6 +257,7 @@ func GetPodDisruptionBudgetCreators(data *resources.TemplateData) []reconciling.
 		etcd.PodDisruptionBudgetCreator(data),
 		apiserver.PodDisruptionBudgetCreator(),
 		metricsserver.PodDisruptionBudgetCreator(),
+		dns.PodDisruptionBudgetCreator(),
 	}
 }
 

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -563,6 +563,7 @@ func GetPodDisruptionBudgetCreators(osData *openshiftData) []reconciling.NamedPo
 	return []reconciling.NamedPodDisruptionBudgetCreatorGetter{
 		etcd.PodDisruptionBudgetCreator(osData),
 		apiserver.PodDisruptionBudgetCreator(),
+		dns.PodDisruptionBudgetCreator(),
 	}
 }
 

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -10,6 +10,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -205,6 +206,23 @@ func ConfigMapCreator(data configMapCreatorData) reconciling.NamedConfigMapCreat
 `, seedClusterNamespaceDNS, data.Cluster().Spec.ClusterNetwork.DNSDomain, dnsIP)
 
 			return cm, nil
+		}
+	}
+}
+
+// PodDisruptionBudgetCreator returns a func to create/update the apiserver PodDisruptionBudget
+func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGetter {
+	return func() (string, reconciling.PodDisruptionBudgetCreator) {
+		return resources.DNSResolverPodDisruptionBudetName, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
+			minAvailable := intstr.FromInt(1)
+			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil),
+				},
+				MinAvailable: &minAvailable,
+			}
+
+			return pdb, nil
 		}
 	}
 }

--- a/api/pkg/resources/metrics-server/pdb.go
+++ b/api/pkg/resources/metrics-server/pdb.go
@@ -13,12 +13,12 @@ import (
 func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGetter {
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
 		return resources.MetricsServerPodDisruptionBudgetName, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
-			maxUnavailable := intstr.FromInt(1)
+			minAvailable := intstr.FromInt(1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: resources.BaseAppLabel(name, nil),
 				},
-				MaxUnavailable: &maxUnavailable,
+				MinAvailable: &minAvailable,
 			}
 			return pdb, nil
 		}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -58,6 +58,8 @@ const (
 	DNSResolverConfigMapName = "dns-resolver"
 	//DNSResolverServiceName is the name of the dns resolvers service
 	DNSResolverServiceName = "dns-resolver"
+	//DNSResolverPodDisruptionBudetName is the name of the dns resolvers pdb
+	DNSResolverPodDisruptionBudetName = "dns-resolver"
 	//DNSResolverVPAName is the name of the dns resolvers VerticalPodAutoscaler
 	KubeStateMetricsDeploymentName = "kube-state-metrics"
 	// UserClusterControllerDeploymentName is the name of the usercluster-controller deployment

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.6-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.10.6-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.1-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.11.1-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.12.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.12.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.13.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.13.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.6-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.10.6-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.1-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.11.1-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.12.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.12.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.13.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.13.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.6-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.10.6-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.1-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.11.1-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.12.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.12.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.13.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.13.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.6-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.10.6-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.1-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.11.1-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.12.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.12.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.13.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.13.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.6-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.10.6-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.1-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.11.1-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.12.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.12.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.13.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.13.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.6-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.10.6-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.1-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.11.1-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.12.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.12.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.13.0-dns-resolver.yaml
@@ -1,0 +1,12 @@
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.13.0-metrics-server.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       app: metrics-server

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -87,4 +87,14 @@ spec:
 {{ toYaml .Values.kubermatic.api.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.kubermatic.api.tolerations | indent 8 }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kubermatic-api
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      role: kubermatic-api
 {{ end }}

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -173,3 +173,13 @@ spec:
 {{ toYaml .Values.kubermatic.controller.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.kubermatic.controller.tolerations | indent 8 }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: controller-manager-v1
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      role: controller-manager

--- a/config/kubermatic/templates/kubermatic-ui-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-ui-dep.yaml
@@ -38,4 +38,14 @@ spec:
 {{ toYaml .Values.kubermatic.ui.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.kubermatic.ui.tolerations | indent 8 }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kubermatic-ui-v2
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      role: kubermatic-ui
 {{ end }}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -100,6 +100,14 @@ kubermatic:
               operator: In
               values:
               - stable
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                role: controller-manager
+            topologyKey: kubernetes.io/hostname
+          weight: 10
     nodeSelector: {}
     tolerations:
     - key: only_critical
@@ -130,6 +138,14 @@ kubermatic:
               operator: In
               values:
               - stable
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                role: kubermatic-api
+            topologyKey: kubernetes.io/hostname
+          weight: 10
     nodeSelector: {}
     tolerations:
     - key: only_critical
@@ -169,6 +185,14 @@ kubermatic:
               operator: In
               values:
               - stable
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                role: kubermatic-ui
+            topologyKey: kubernetes.io/hostname
+          weight: 10
     nodeSelector: {}
     tolerations:
     - key: only_critical

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -118,3 +118,13 @@ spec:
         requests:
           storage: {{ .Values.alertmanager.resources.storage }}
       storageClassName: kubermatic-fast
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: alertmanager-kubermatic
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: alertmanager-kubermatic

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -29,5 +29,13 @@ alertmanager:
         memory: 32Mi
     storage: 100Mi
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: alertmanager-kubermatic
+          topologyKey: kubernetes.io/hostname
+        weight: 100
   tolerations: []

--- a/config/monitoring/blackbox-exporter/templates/deployment.yaml
+++ b/config/monitoring/blackbox-exporter/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: blackbox-exporter
 spec:
+  replicas: 1
   strategy:
     type: Recreate
   template:
@@ -36,3 +37,13 @@ spec:
 {{ toYaml .Values.blackboxExporter.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.blackboxExporter.tolerations | indent 8 }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: blackbox-exporter
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter

--- a/config/monitoring/blackbox-exporter/values.yaml
+++ b/config/monitoring/blackbox-exporter/values.yaml
@@ -15,7 +15,15 @@ blackboxExporter:
           memory: 32Mi
 
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: blackbox-exporter
+          topologyKey: kubernetes.io/hostname
+        weight: 100
   tolerations: []
 
   modules:

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -149,3 +149,13 @@ spec:
 {{ toYaml .Values.grafana.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.grafana.tolerations | indent 8 }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: grafana
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: grafana

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -15,7 +15,15 @@ grafana:
       memory: 128Mi
 
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: grafana
+          topologyKey: kubernetes.io/hostname
+        weight: 100
   tolerations: []
 
   # Control where the provisioning files are located.

--- a/config/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/config/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -60,3 +60,13 @@ spec:
 {{ toYaml .Values.kubeStateMetrics.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.kubeStateMetrics.tolerations | indent 8 }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-state-metrics
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -23,5 +23,13 @@ kubeStateMetrics:
         memory: 48Mi
 
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: kube-state-metrics
+          topologyKey: kubernetes.io/hostname
+        weight: 100
   tolerations: []

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -169,3 +169,13 @@ spec:
         requests:
           storage: {{ .Values.prometheus.storageSize }}
       storageClassName: kubermatic-fast
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: prometheus-kubermatic
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: prometheus-kubermatic

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -109,5 +109,13 @@ prometheus:
           memory: 32Mi
 
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: prometheus-kubermatic
+          topologyKey: kubernetes.io/hostname
+        weight: 100
   tolerations: []


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Pod Antiaffinity and PDBs to the dns-resolver, the Kubermatic control plane and the monitoring components.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Pod AntiAffinity and PDBs were added to the Kubermatic control plane components and the monitoring stack to spread them out if possible and reduce the chance of unavailability
```

