### PR TITLE
Show controller-manager logs when tests fail

### DIFF
--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -29,6 +29,9 @@ function cleanup {
     echodate "tests failed, describing cluster"
     # TODO: If this runs on something other than AWS, we need to adjust the egrep expression
     kubectl describe cluster -l worker-name=$BUILD_ID|egrep -vi 'Secret Access Key|Access Key Id'
+
+    echodate "Getting controllre manager logs"
+    kubectl logs -n $NAMESPACE  $(kubectl get pod -n $NAMESPACE -l role=controller-manager |tail -n 1|awk '{print $1}')
   fi
 
   # Delete addons from all clusters that have our worker-name label


### PR DESCRIPTION
**What this PR does / why we need it**:

Shows the ckubermatic-ontroller-manager logs on failure to aid in debugging

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
