### PR TITLE
extend versions and updates

### DIFF
--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -627,7 +627,7 @@ func (r Routing) getMasterVersions() http.Handler {
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
 		)(cluster.GetMasterVersionsEndpoint(r.updateManager)),
-		decodeEmptyReq,
+		cluster.DecodeClusterTypeReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -17,11 +17,11 @@ import (
 
 // UpdateManager specifies a set of methods to handle cluster versions & updates
 type UpdateManager interface {
-	GetVersion(string) (*version.MasterVersion, error)
-	GetMasterVersions() ([]*version.MasterVersion, error)
+	GetVersion(from, clusterType string) (*version.MasterVersion, error)
+	GetMasterVersions(clusterType string) ([]*version.MasterVersion, error)
 	GetDefault() (*version.MasterVersion, error)
-	AutomaticUpdate(from string) (*version.MasterVersion, error)
-	GetPossibleUpdates(from string) ([]*version.MasterVersion, error)
+	AutomaticUpdate(from, clusterType string) (*version.MasterVersion, error)
+	GetPossibleUpdates(from, clusterType string) ([]*version.MasterVersion, error)
 }
 
 // Routing represents an object which binds endpoints to http handlers.

--- a/api/pkg/handler/v1/cluster/upgrade_test.go
+++ b/api/pkg/handler/v1/cluster/upgrade_test.go
@@ -62,12 +62,15 @@ func TestGetClusterUpgrades(t *testing.T) {
 			versions: []*version.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.6.1"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.7.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 			},
 			updates: []*version.MasterUpdate{
@@ -75,11 +78,13 @@ func TestGetClusterUpgrades(t *testing.T) {
 					From:      "1.6.0",
 					To:        "1.6.1",
 					Automatic: false,
+					Type:      apiv1.KubernetesClusterType,
 				},
 				{
 					From:      "1.6.x",
 					To:        "1.7.0",
 					Automatic: false,
+					Type:      apiv1.KubernetesClusterType,
 				},
 			},
 		},
@@ -112,12 +117,15 @@ func TestGetClusterUpgrades(t *testing.T) {
 			versions: []*version.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.6.1"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.7.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 			},
 			updates: []*version.MasterUpdate{
@@ -125,11 +133,13 @@ func TestGetClusterUpgrades(t *testing.T) {
 					From:      "1.6.0",
 					To:        "1.6.1",
 					Automatic: false,
+					Type:      apiv1.KubernetesClusterType,
 				},
 				{
 					From:      "1.6.x",
 					To:        "1.7.0",
 					Automatic: false,
+					Type:      apiv1.KubernetesClusterType,
 				},
 			},
 		},
@@ -148,9 +158,87 @@ func TestGetClusterUpgrades(t *testing.T) {
 			versions: []*version.MasterVersion{
 				{
 					Version: semver.MustParse("1.6.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 			},
 			updates: []*version.MasterUpdate{},
+		},
+		{
+			name: "upgrade available for OpenShift",
+			cluster: func() *kubermaticv1.Cluster {
+				c := test.GenCluster("foo", "foo", "project", time.Now())
+				c.Labels = map[string]string{"user": test.UserName}
+				c.Annotations = map[string]string{"kubermatic.io/openshift": "true"}
+				c.Spec.Version = *ksemver.NewSemverOrDie("5.1")
+				return c
+			}(),
+			existingKubermaticObjs:     test.GenDefaultKubermaticObjects(),
+			existingMachineDeployments: []*clusterv1alpha1.MachineDeployment{},
+			apiUser:                    *test.GenDefaultAPIUser(),
+			wantUpdates: []*apiv1.MasterVersion{
+				{
+					Version: semver.MustParse("5.2"),
+				},
+			},
+			versions: []*version.MasterVersion{
+				{
+					Version: semver.MustParse("1.6.0"),
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("1.6.1"),
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("1.7.0"),
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.1"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.2"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("5.1"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("5.2"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			},
+			updates: []*version.MasterUpdate{
+				{
+					From:      "1.6.0",
+					To:        "1.6.1",
+					Automatic: false,
+					Type:      apiv1.KubernetesClusterType,
+				},
+				{
+					From:      "1.6.x",
+					To:        "1.7.0",
+					Automatic: false,
+					Type:      apiv1.KubernetesClusterType,
+				},
+				{
+					From:      "5.1.0",
+					To:        "5.2.0",
+					Automatic: true,
+					Type:      apiv1.OpenShiftClusterType,
+				},
+			},
 		},
 	}
 	for _, testStruct := range tests {
@@ -307,39 +395,51 @@ func TestGetNodeUpgrades(t *testing.T) {
 			existingVersions: []*version.MasterVersion{
 				{
 					Version: semver.MustParse("0.0.1"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("0.1.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.0.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.4.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.4.1"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.5.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.5.1"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.6.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.6.1"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.7.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("1.7.1"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 				{
 					Version: semver.MustParse("2.0.0"),
+					Type:    apiv1.KubernetesClusterType,
 				},
 			},
 			expectedOutput: []*apiv1.MasterVersion{
@@ -367,6 +467,154 @@ func TestGetNodeUpgrades(t *testing.T) {
 	for _, testStruct := range tests {
 		t.Run(testStruct.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/upgrades/node?control_plane_version=%s", testStruct.controlPlaneVersion), nil)
+			res := httptest.NewRecorder()
+			ep, err := test.CreateTestEndpoint(testStruct.apiUser, nil, testStruct.existingKubermaticObjs,
+				testStruct.existingVersions, testStruct.existingUpdates, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create testStruct endpoint due to %v", err)
+			}
+			ep.ServeHTTP(res, req)
+			if res.Code != http.StatusOK {
+				t.Fatalf("Expected status code to be 200, got %d\nResponse body: %q", res.Code, res.Body.String())
+			}
+
+			var response []*apiv1.MasterVersion
+			err = json.Unmarshal(res.Body.Bytes(), &response)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := deep.Equal(response, testStruct.expectedOutput); diff != nil {
+				t.Fatalf("got different versions response than expected. Diff: %v", diff)
+			}
+		})
+	}
+}
+
+func TestGetMasterVersionsEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                   string
+		clusterType            string
+		apiUser                apiv1.User
+		existingUpdates        []*version.MasterUpdate
+		existingVersions       []*version.MasterVersion
+		expectedOutput         []*apiv1.MasterVersion
+		existingKubermaticObjs []runtime.Object
+	}{
+		{
+			name:                   "get all OpenShift versions",
+			clusterType:            apiv1.OpenShiftClusterType,
+			apiUser:                *test.GenDefaultAPIUser(),
+			existingKubermaticObjs: []runtime.Object{test.GenDefaultUser()},
+			existingUpdates:        []*version.MasterUpdate{},
+			existingVersions: []*version.MasterVersion{
+				{
+					Version: semver.MustParse("1.13.5"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11.5"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.1"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.2"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.3"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			},
+			expectedOutput: []*apiv1.MasterVersion{
+				{
+					Version: semver.MustParse("3.11"),
+					Default: false,
+				},
+				{
+					Version: semver.MustParse("4.1"),
+					Default: true,
+				},
+				{
+					Version: semver.MustParse("4.2"),
+					Default: true,
+				},
+				{
+					Version: semver.MustParse("4.3"),
+					Default: true,
+				},
+			},
+		},
+		{
+			name:                   "get default only kubernetes versions",
+			clusterType:            "",
+			apiUser:                *test.GenDefaultAPIUser(),
+			existingKubermaticObjs: []runtime.Object{test.GenDefaultUser()},
+			existingUpdates:        []*version.MasterUpdate{},
+			existingVersions: []*version.MasterVersion{
+				{
+					Version: semver.MustParse("1.13.5"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11.5"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.1"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.2"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.3"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			},
+			expectedOutput: []*apiv1.MasterVersion{
+				{
+					Version: semver.MustParse("1.13.5"),
+					Default: true,
+				},
+				{
+					Version: semver.MustParse("3.11.5"),
+					Default: true,
+				},
+			},
+		},
+	}
+	for _, testStruct := range tests {
+		t.Run(testStruct.name, func(t *testing.T) {
+			if len(testStruct.clusterType) > 0 {
+				testStruct.clusterType = fmt.Sprintf("?type=%s", testStruct.clusterType)
+			}
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/upgrades/cluster%s", testStruct.clusterType), nil)
 			res := httptest.NewRecorder()
 			ep, err := test.CreateTestEndpoint(testStruct.apiUser, nil, testStruct.existingKubermaticObjs,
 				testStruct.existingVersions, testStruct.existingUpdates, hack.NewTestRouting)

--- a/api/pkg/handler/v1/cluster/upgrade_test.go
+++ b/api/pkg/handler/v1/cluster/upgrade_test.go
@@ -240,6 +240,59 @@ func TestGetClusterUpgrades(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "upgrade not available for OpenShift (versions 3.11.*)",
+			cluster: func() *kubermaticv1.Cluster {
+				c := test.GenCluster("foo", "foo", "project", time.Now())
+				c.Labels = map[string]string{"user": test.UserName}
+				c.Annotations = map[string]string{"kubermatic.io/openshift": "true"}
+				c.Spec.Version = *ksemver.NewSemverOrDie("3.11.0")
+				return c
+			}(),
+			existingKubermaticObjs:     test.GenDefaultKubermaticObjects(),
+			existingMachineDeployments: []*clusterv1alpha1.MachineDeployment{},
+			apiUser:                    *test.GenDefaultAPIUser(),
+			wantUpdates:                []*apiv1.MasterVersion{},
+			versions: []*version.MasterVersion{
+				{
+					Version: semver.MustParse("1.7.0"),
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11.0"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11.1"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11.2"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11.3"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("5.2"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			},
+			updates: []*version.MasterUpdate{
+				{
+					From:      "3.11.0",
+					To:        "3.11.*",
+					Automatic: true,
+					Type:      apiv1.OpenShiftClusterType,
+				},
+			},
+		},
 	}
 	for _, testStruct := range tests {
 		t.Run(testStruct.name, func(t *testing.T) {

--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -28,11 +28,11 @@ type OIDCConfiguration struct {
 
 // UpdateManager specifies a set of methods to handle cluster versions & updates
 type UpdateManager interface {
-	GetVersion(string) (*version.MasterVersion, error)
-	GetMasterVersions() ([]*version.MasterVersion, error)
+	GetVersion(from, clusterType string) (*version.MasterVersion, error)
+	GetMasterVersions(string) ([]*version.MasterVersion, error)
 	GetDefault() (*version.MasterVersion, error)
-	AutomaticUpdate(from string) (*version.MasterVersion, error)
-	GetPossibleUpdates(from string) ([]*version.MasterVersion, error)
+	AutomaticUpdate(from, clusterType string) (*version.MasterVersion, error)
+	GetPossibleUpdates(from, clusterType string) ([]*version.MasterVersion, error)
 }
 
 // ServerMetrics defines metrics used by the API.

--- a/api/pkg/version/manager.go
+++ b/api/pkg/version/manager.go
@@ -3,9 +3,11 @@ package version
 import (
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/Masterminds/semver"
 	"github.com/golang/glog"
+	"github.com/kubermatic/kubermatic/api/pkg/api/v1"
 )
 
 var (
@@ -23,6 +25,7 @@ type Manager struct {
 type MasterVersion struct {
 	Version *semver.Version `json:"version"`
 	Default bool            `json:"default"`
+	Type    string          `json:"type"`
 }
 
 // MasterUpdate represents an update option for K8s master components
@@ -30,6 +33,7 @@ type MasterUpdate struct {
 	From      string `json:"from"`
 	To        string `json:"to"`
 	Automatic bool   `json:"automatic"`
+	Type      string `json:"type"`
 }
 
 // New returns a instance of Manager
@@ -46,9 +50,32 @@ func NewFromFiles(versionsFilename, updatesFilename string) (*Manager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load updates from %s: %v", updatesFilename, err)
 	}
+	for _, update := range updates {
+		// set default type if empty
+		if len(update.Type) == 0 {
+			update.Type = v1.KubernetesClusterType
+		}
+		// sanity check if OpenShift update from version 3.11 or 3.11.*
+		if update.Type == v1.OpenShiftClusterType {
+			forbiddenUpdate, err := regexp.MatchString(`^3\.11(\.(\*|\d+))?$`, update.From)
+			if err != nil {
+				return nil, fmt.Errorf("failed to validate version %s: %v", update.From, err)
+			}
+			if forbiddenUpdate {
+				return nil, fmt.Errorf("the OpenShift can not be updated from version 3.11")
+			}
+
+		}
+	}
+
 	versions, err := LoadVersions(versionsFilename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load versions from %s: %v", versionsFilename, err)
+	}
+	for _, version := range versions {
+		if len(version.Type) == 0 {
+			version.Type = v1.KubernetesClusterType
+		}
 	}
 
 	return New(versions, updates), nil
@@ -65,14 +92,14 @@ func (m *Manager) GetDefault() (*MasterVersion, error) {
 }
 
 // GetVersion returns the MasterVersions for s
-func (m *Manager) GetVersion(s string) (*MasterVersion, error) {
+func (m *Manager) GetVersion(s, t string) (*MasterVersion, error) {
 	sv, err := semver.NewVersion(s)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %v", s, err)
 	}
 
 	for _, v := range m.versions {
-		if v.Version.Equal(sv) {
+		if v.Version.Equal(sv) && v.Type == t {
 			return v, nil
 		}
 	}
@@ -80,24 +107,26 @@ func (m *Manager) GetVersion(s string) (*MasterVersion, error) {
 }
 
 // GetMasterVersions returns all MasterVersions which don't result in automatic updates
-func (m *Manager) GetMasterVersions() ([]*MasterVersion, error) {
+func (m *Manager) GetMasterVersions(clusterType string) ([]*MasterVersion, error) {
 	var masterVersions []*MasterVersion
 	for _, v := range m.versions {
-		autoUpdate, err := m.AutomaticUpdate(v.Version.String())
-		if err != nil {
-			glog.Errorf("Failed to get AutomaticUpdate for version %s: %v", v.Version.String(), err)
-			continue
+		if v.Type == clusterType {
+			autoUpdate, err := m.AutomaticUpdate(v.Version.String(), clusterType)
+			if err != nil {
+				glog.Errorf("Failed to get AutomaticUpdate for version %s: %v", v.Version.String(), err)
+				continue
+			}
+			if autoUpdate != nil {
+				continue
+			}
+			masterVersions = append(masterVersions, v)
 		}
-		if autoUpdate != nil {
-			continue
-		}
-		masterVersions = append(masterVersions, v)
 	}
 	return masterVersions, nil
 }
 
 // AutomaticUpdate returns a version if an automatic update can be found for version sfrom
-func (m *Manager) AutomaticUpdate(sfrom string) (*MasterVersion, error) {
+func (m *Manager) AutomaticUpdate(sfrom, ctype string) (*MasterVersion, error) {
 	from, err := semver.NewVersion(sfrom)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %v", sfrom, err)
@@ -105,23 +134,25 @@ func (m *Manager) AutomaticUpdate(sfrom string) (*MasterVersion, error) {
 
 	var toVersions []string
 	for _, u := range m.updates {
-		if !u.Automatic {
-			continue
-		}
+		if u.Type == ctype {
+			if !u.Automatic {
+				continue
+			}
 
-		uFrom, err := semver.NewConstraint(u.From)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse from constraint %s: %v", u.From, err)
-		}
-		if !uFrom.Check(from) {
-			continue
-		}
+			uFrom, err := semver.NewConstraint(u.From)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse from constraint %s: %v", u.From, err)
+			}
+			if !uFrom.Check(from) {
+				continue
+			}
 
-		// Automatic updates must not be a constraint. They must be version.
-		if _, err = semver.NewVersion(u.To); err != nil {
-			return nil, fmt.Errorf("failed to parse to version %s: %v", u.To, err)
+			// Automatic updates must not be a constraint. They must be version.
+			if _, err = semver.NewVersion(u.To); err != nil {
+				return nil, fmt.Errorf("failed to parse to version %s: %v", u.To, err)
+			}
+			toVersions = append(toVersions, u.To)
 		}
-		toVersions = append(toVersions, u.To)
 	}
 
 	if len(toVersions) == 0 {
@@ -132,7 +163,7 @@ func (m *Manager) AutomaticUpdate(sfrom string) (*MasterVersion, error) {
 		return nil, fmt.Errorf("more than one automatic update found for version. Not allowed. Automatic updates to: %v", toVersions)
 	}
 
-	mVersion, err := m.GetVersion(toVersions[0])
+	mVersion, err := m.GetVersion(toVersions[0], ctype)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get MasterVersion for %s: %v", toVersions[0], err)
 	}
@@ -140,7 +171,7 @@ func (m *Manager) AutomaticUpdate(sfrom string) (*MasterVersion, error) {
 }
 
 // GetPossibleUpdates returns possible updates for the version sfrom
-func (m *Manager) GetPossibleUpdates(sfrom string) ([]*MasterVersion, error) {
+func (m *Manager) GetPossibleUpdates(sfrom, ctype string) ([]*MasterVersion, error) {
 	from, err := semver.NewVersion(sfrom)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %v", sfrom, err)
@@ -148,25 +179,27 @@ func (m *Manager) GetPossibleUpdates(sfrom string) ([]*MasterVersion, error) {
 
 	var toConstraints []*semver.Constraints
 	for _, u := range m.updates {
-		uFrom, err := semver.NewConstraint(u.From)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse from constraint %s: %v", u.From, err)
-		}
-		if !uFrom.Check(from) {
-			continue
-		}
+		if u.Type == ctype {
+			uFrom, err := semver.NewConstraint(u.From)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse from constraint %s: %v", u.From, err)
+			}
+			if !uFrom.Check(from) {
+				continue
+			}
 
-		uTo, err := semver.NewConstraint(u.To)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse to constraint %s: %v", u.To, err)
+			uTo, err := semver.NewConstraint(u.To)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse to constraint %s: %v", u.To, err)
+			}
+			toConstraints = append(toConstraints, uTo)
 		}
-		toConstraints = append(toConstraints, uTo)
 	}
 
 	var possibleVersions []*MasterVersion
 	for _, c := range toConstraints {
 		for _, v := range m.versions {
-			if c.Check(v.Version) && !from.Equal(v.Version) {
+			if c.Check(v.Version) && !from.Equal(v.Version) && v.Type == ctype {
 				possibleVersions = append(possibleVersions, v)
 			}
 		}

--- a/api/pkg/version/version_test.go
+++ b/api/pkg/version/version_test.go
@@ -4,60 +4,252 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
+	"github.com/go-test/deep"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 )
 
-func TestBestAutomaticUpdate(t *testing.T) {
-	manager := New([]*MasterVersion{
-		{
-			Version: semver.MustParse("1.10.0"),
-			Default: false,
-		},
-		{
-			Version: semver.MustParse("1.10.1"),
-			Default: true,
-		},
-	}, []*MasterUpdate{
-		{
-			From:      "1.10.0",
-			To:        "1.10.1",
-			Automatic: true,
-		},
-	})
+func TestAutomaticUpdate(t *testing.T) {
+	t.Parallel()
 
-	updateVersion, err := manager.AutomaticUpdate("1.10.0")
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	tests := []struct {
+		name            string
+		manager         *Manager
+		clusterType     string
+		versionFrom     string
+		expectedVersion string
+		expectedError   string
+	}{
+		{
+			name:            "test best automatic update for kubernetes cluster",
+			versionFrom:     "1.10.0",
+			expectedVersion: "1.10.1",
+			clusterType:     apiv1.KubernetesClusterType,
+			manager: New([]*MasterVersion{
+				{
+					Version: semver.MustParse("1.10.0"),
+					Default: false,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("1.10.1"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+			}, []*MasterUpdate{
+				{
+					From:      "1.10.0",
+					To:        "1.10.1",
+					Automatic: true,
+					Type:      apiv1.KubernetesClusterType,
+				},
+			}),
+		},
+		{
+			name:            "test Kubernetes best automatic update with wild card for kubernetes cluster",
+			versionFrom:     "1.10.0",
+			expectedVersion: "1.10.1",
+			clusterType:     apiv1.KubernetesClusterType,
+			manager: New([]*MasterVersion{
+				{
+					Version: semver.MustParse("1.10.0"),
+					Default: false,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("1.10.1"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+			}, []*MasterUpdate{
+				{
+					From:      "1.10.*",
+					To:        "1.10.1",
+					Automatic: true,
+					Type:      apiv1.KubernetesClusterType,
+				},
+			}),
+		},
+		{
+			name:          "test required update for kubernetes cluster type doesn't exist",
+			versionFrom:   "1.10.0",
+			expectedError: "failed to get MasterVersion for 1.10.1: version not found",
+			clusterType:   apiv1.KubernetesClusterType,
+			manager: New([]*MasterVersion{
+				{
+					Version: semver.MustParse("1.10.0"),
+					Default: false,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("1.10.1"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			}, []*MasterUpdate{
+				{
+					From:      "1.10.0",
+					To:        "1.10.1",
+					Automatic: true,
+					Type:      apiv1.KubernetesClusterType,
+				},
+			}),
+		},
 	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 
-	if updateVersion.Version.String() != "1.10.1" {
-		t.Fatalf("Unexpected update version to be 1.10.1. Got=%v", updateVersion)
+			updateVersion, err := tc.manager.AutomaticUpdate(tc.versionFrom, tc.clusterType)
+
+			if len(tc.expectedError) > 0 {
+				if err == nil {
+					t.Fatalf("Epected error")
+				}
+				if tc.expectedError != err.Error() {
+					t.Fatalf("Expected error: %s got %v", tc.expectedError, err)
+				}
+
+			} else {
+
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if updateVersion.Version.String() != tc.expectedVersion {
+					t.Fatalf("Unexpected update version to be %s. Got=%v", tc.expectedVersion, updateVersion)
+				}
+			}
+		})
 	}
 }
 
-func TestBestAutomaticUpdateWildCard(t *testing.T) {
-	manager := New([]*MasterVersion{
-		{
-			Version: semver.MustParse("1.10.0"),
-			Default: false,
-		},
-		{
-			Version: semver.MustParse("1.10.1"),
-			Default: true,
-		},
-	}, []*MasterUpdate{
-		{
-			From:      "1.10.*",
-			To:        "1.10.1",
-			Automatic: true,
-		},
-	})
+func TestGetMasterVersions(t *testing.T) {
+	t.Parallel()
 
-	updateVersion, err := manager.AutomaticUpdate("1.10.0")
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	tests := []struct {
+		name             string
+		manager          *Manager
+		expectedVersions []*MasterVersion
+	}{
+		{
+			name: "test OpenShift versions without automatic updates",
+			manager: New([]*MasterVersion{
+				{
+					Version: semver.MustParse("1.13.5"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11.5"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.1"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.2"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.3"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			}, []*MasterUpdate{},
+			),
+			expectedVersions: []*MasterVersion{
+				{
+					Version: semver.MustParse("3.11"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.1"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.2"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.3"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			},
+		},
+		{
+			name: "test OpenShift versions with automatic updates",
+			manager: New([]*MasterVersion{
+				{
+					Version: semver.MustParse("1.13.5"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11.5"),
+					Default: true,
+					Type:    apiv1.KubernetesClusterType,
+				},
+				{
+					Version: semver.MustParse("3.11"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.1"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.2"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+				{
+					Version: semver.MustParse("4.3"),
+					Default: true,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			}, []*MasterUpdate{
+				{
+					From:      "4.*",
+					To:        "4.1",
+					Automatic: true,
+					Type:      apiv1.OpenShiftClusterType,
+				},
+			}),
+			expectedVersions: []*MasterVersion{
+				{
+					Version: semver.MustParse("3.11"),
+					Default: false,
+					Type:    apiv1.OpenShiftClusterType,
+				},
+			},
+		},
 	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 
-	if updateVersion.Version.String() != "1.10.1" {
-		t.Fatalf("Unexpected update version to be 1.10.1. Got=%v", updateVersion)
+			versions, err := tc.manager.GetMasterVersions(apiv1.OpenShiftClusterType)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// equality.Semantic.DeepEqual panic comparing version.MasterVersion types
+			if diff := deep.Equal(versions, tc.expectedVersions); diff != nil {
+				t.Fatalf("version list %v is not the same as expected %v", versions, tc.expectedVersions)
+			}
+		})
 	}
 }

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -42,3 +42,7 @@ versions:
   default: false
 - version: "v1.14.1"
   default: false
+# OpenShift 3.11
+- version: "v3.11"
+  default: true
+  type: "openshift"


### PR DESCRIPTION
**What this PR does / why we need it**: extend versions and updates to support OpenShift cluster type

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2421

```release-note
extend versions and updates to support OpenShift cluster type.
The optional `type` field was added in `updates.yaml` and `versions.yaml`. By default, the `type` field is set to `kubernetes`  
```
