### PR TITLE
Dont try to migrate clusters that have no namespace

### DIFF
--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -154,6 +154,7 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 					if err := migrations.RunAll(ctrlCtx.mgr.GetConfig(), ctrlCtx.runOptions.workerName); err != nil {
 						glog.Errorf("failed to run migrations: %v", err)
 						stopLeaderElection()
+						return
 					}
 					glog.Info("Migrations executed successfully")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we try to migrate clusters without namespace, which leads to errors because the underlying `deleteResourceIgnoreNonExistent` can not cope with that.

Also we continued to start the manager if the migration failed, we just canceled the leader election which caused weird errors during mgr startup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
