### PR TITLE
replace __KUBERMATIC__TAG__ when deploying via Prow

### DIFF
--- a/api/hack/ci/ci-deploy-dev-cloud.sh
+++ b/api/hack/ci/ci-deploy-dev-cloud.sh
@@ -31,6 +31,8 @@ export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
     --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
     --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH}"
 
+sed -i "s/__KUBERMATIC_TAG__/$GIT_HEAD_HASH/g" ./config/kubermatic/Chart.yaml
+
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
 vault kv get -field=values.yaml dev/seed-clusters/dev.kubermatic.io > ${VALUES_FILE}

--- a/api/hack/ci/ci-deploy-dev-cloud.sh
+++ b/api/hack/ci/ci-deploy-dev-cloud.sh
@@ -31,8 +31,6 @@ export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
     --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
     --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH}"
 
-sed -i "s/__KUBERMATIC_TAG__/$GIT_HEAD_HASH/g" ./config/kubermatic/Chart.yaml
-
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
 vault kv get -field=values.yaml dev/seed-clusters/dev.kubermatic.io > ${VALUES_FILE}

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -37,6 +37,8 @@ function deploy {
   retry 5 helm --tiller-namespace ${TILLER_NAMESPACE} upgrade --install --atomic ${MASTER_FLAG} ${HELM_EXTRA_ARGS} --values ${VALUES_FILE} --namespace ${namespace} ${name} ${path}
 }
 
+sed -i "s/__KUBERMATIC_TAG__/$GIT_HEAD_HASH/g" ./config/kubermatic/Chart.yaml
+
 echodate "Initializing Tiller in namespace ${TILLER_NAMESPACE}"
 # In clusters which have not been initialized yet, this will fail
 helm version --tiller-namespace ${TILLER_NAMESPACE} || true


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes it so that when Prow deployed Kubermatic, we can see the exact version via `helm ls`. The chart-sync script already takes care of that for publicly relased versions, but it's nice to have this for our dev versions as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
