### PR TITLE
update Alertmanager to 0.17.0

### DIFF
--- a/config/monitoring/alertmanager/Chart.yaml
+++ b/config/monitoring/alertmanager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: alertmanager
-version: 1.0.1
-appVersion: v0.16.2
+version: 1.0.2
+appVersion: v0.17.0
 description: Alertmanager for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -33,8 +33,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
-        image: quay.io/prometheus/alertmanager:{{ .Values.alertmanager.version }}
-        imagePullPolicy: IfNotPresent
+        image: '{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.version | default .Values.alertmanager.image.tag }}'
+        imagePullPolicy: {{ .Values.alertmanager.image.pullPolicy }}
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -1,5 +1,8 @@
 alertmanager:
-  version: v0.16.2
+  image:
+    repository: quay.io/prometheus/alertmanager
+    tag: v0.17.0
+    pullPolicy: IfNotPresent
   host: ""
   config:
     global:


### PR DESCRIPTION
**What this PR does / why we need it**:
Alertmanager 0.17 brings back an API for groups that could be useful for our master monitoring and the only breaking change is referring to the exporting of silences via `amtool`, which we never used.

This PR also changes the configuration to be in-sync with our other charts while still supporting the old `version` field.

**Does this PR introduce a user-facing change?**:
```release-note
update Alertmanager to 0.17.0, deprecate version field in favor of image.tag in Helm values.yaml
```
