### PR TITLE
update to official keycloak-gatekeeper 6.0.1

### DIFF
--- a/config/iap/Chart.yaml
+++ b/config/iap/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 name: iap
-version: 1.0.0
-appVersion: v2.3.0
-description: A Helm to install Keycloak-Proxy as an identity-aware proxy.
+version: 1.1.0
+appVersion: 6.0.1
+description: A Helm to install Keycloak-Gatekeeper as an identity-aware proxy.
 keywords:
 - kubermatic
-- keycloak-proxy
+- keycloak-gatekeeper
 - iap
 home: https://github.com/keycloak/keycloak-gatekeeper
 maintainers:

--- a/config/iap/templates/deployments.yaml
+++ b/config/iap/templates/deployments.yaml
@@ -23,7 +23,7 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") $ | sha256sum }}
     spec:
       containers:
-      - name: keycloak-proxy
+      - name: keycloak-gatekeeper
         image: "{{ $.Values.iap.image.repository }}:{{ $.Values.iap.image.tag }}"
         imagePullPolicy: {{ $.Values.iap.image.pullPolicy }}
         args:

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -5,7 +5,7 @@ iap:
     #   client_id: alertmanager
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: ## see https://github.com/gambol99/keycloak-proxy#configuration
+    #   config: ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
     #   ## example configuration allowing access only to the mygroup from mygithuborg organization
     #     scopes:
     #     - "groups"
@@ -23,7 +23,7 @@ iap:
     #   client_id: grafana
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: {} ## see https://github.com/gambol99/keycloak-proxy#configuration
+    #   config: {} ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
     #   upstream_service: grafana.monitoring.svc.cluster.local
     #   upstream_port: 3000
     #   ingress:
@@ -34,7 +34,7 @@ iap:
     #   client_id: kibana
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: {} ## see https://github.com/gambol99/keycloak-proxy#configuration
+    #   config: {} ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
     #   upstream_service: kibana.logging.svc.cluster.local
     #   upstream_port: 5601
     #   ingress:
@@ -45,7 +45,7 @@ iap:
     #   client_id: prometheus
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: {} ## see https://github.com/gambol99/keycloak-proxy#configuration
+    #   config: {} ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
     #   upstream_service: prometheus-kubermatic.monitoring.svc.cluster.local
     #   upstream_port: 9090
     #   ingress:
@@ -57,8 +57,8 @@ iap:
   port: 3000
 
   image:
-    repository: quay.io/gambol99/keycloak-proxy
-    tag: v2.3.0
+    repository: keycloak/keycloak-gatekeeper
+    tag: 6.0.1
     pullPolicy: IfNotPresent
 
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
The old keycloak-proxy has been migrated to be the official keycloak-gatekeeper a long time ago and since then new releases have occured (not sure why they are not featured more prominently on GitHub). This PR switches the repo over and updates some references. A canary deployment on dev worked without issues, all services were still accessible as before.

**Does this PR introduce a user-facing change?**:
```release-note
replace gambol99/keycloak-proxy 2.3.0 with official keycloak-gatekeeper 6.0.1
```
