### PR TITLE
Dont re-build binaries and docker image if they already exist

### DIFF
--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -90,20 +90,23 @@ echodate "Successfully got secrets from Vault"
 
 
 # Build kubermatic binaries and push the image to quay
-docker ps &>/dev/null || start-docker.sh
-echodate "Logging into quay"
-docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io
-echodate "Successfully logged into quay"
-
-echodate "Building binaries"
-time make -C api build
-cd api
-echodate "Building quay image"
-time docker build -t quay.io/kubermatic/api:${GIT_HEAD_HASH} .
-echodate "Pushing quay image"
-time retry 5 docker push quay.io/kubermatic/api:${GIT_HEAD_HASH}
-echodate "Finished building and pushing quay image"
-cd -
+if ! curl --fail "https://${QUAY_IO_USERNAME}:${QUAY_IO_PASSWORD}@quay.io/v1/repositories/kubermatic/api/tags/${GIT_HEAD_HASH}"; then
+  docker ps &>/dev/null || start-docker.sh
+  echodate "Logging into quay"
+  docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io
+  echodate "Successfully logged into quay"
+  echodate "Building binaries"
+  time make -C api build
+  cd api
+  echodate "Building quay image"
+  time docker build -t quay.io/kubermatic/api:${GIT_HEAD_HASH} .
+  echodate "Pushing quay image"
+  time retry 5 docker push quay.io/kubermatic/api:${GIT_HEAD_HASH}
+  echodate "Finished building and pushing quay image"
+  cd -
+else
+  echodate "Omitting building of binaries and docker image, as tag ${GIT_HEAD_HASH} already exists on quay"
+fi
 
 INITIAL_MANIFESTS=$(cat <<EOF
 apiVersion: v1

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -90,7 +90,8 @@ echodate "Successfully got secrets from Vault"
 
 
 # Build kubermatic binaries and push the image to quay
-if ! curl --fail "https://${QUAY_IO_USERNAME}:${QUAY_IO_PASSWORD}@quay.io/v1/repositories/kubermatic/api/tags/${GIT_HEAD_HASH}"; then
+if ! curl -Ss --fail \
+    "https://${QUAY_IO_USERNAME}:${QUAY_IO_PASSWORD}@quay.io/v1/repositories/kubermatic/api/tags/${GIT_HEAD_HASH}" &>/dev/null; then
   docker ps &>/dev/null || start-docker.sh
   echodate "Logging into quay"
   docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoids building the binaries and docker image if the tag we want to build already exists. This speeds up re-tests significantly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
