### PR TITLE
rename nodePortPoxy to nodePortProxy

### DIFF
--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nodeport-proxy
-version: 1.0.0
+version: 1.1.0
 appVersion: v2.0.0
 description: Kubermatic nodeport-proxy
 keywords:

--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: envoy
 spec:
-  replicas: {{ .Values.nodePortPoxy.replicas }}
+  replicas: {{ .Values.nodePortPoxy.replicas | default .Values.nodePortProxy.replicas  }}
   selector:
     matchLabels:
       app: nodeport-proxy
@@ -23,7 +23,7 @@ spec:
     spec:
       initContainers:
       - name: copy-envoy-config
-        image: '{{ .Values.nodePortPoxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag }}'
+        image: '{{ .Values.nodePortPoxy.image.repository | default .Values.nodePortProxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag | default .Values.nodePortProxy.image.tag }}'
         command:
         - /bin/cp
         args:
@@ -34,7 +34,7 @@ spec:
           name: envoy-config
       containers:
       - name: envoy-manager
-        image: '{{ .Values.nodePortPoxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag }}'
+        image: '{{ .Values.nodePortPoxy.image.repository | default .Values.nodePortProxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag | default .Values.nodePortProxy.image.tag }}'
         command:
         - /envoy-manager
         args:
@@ -47,7 +47,12 @@ spec:
           name: grpc
           protocol: TCP
         resources:
-{{ toYaml .Values.nodePortPoxy.resources.envoyManager | indent 10 }}
+          requests:
+            cpu: {{ .Values.nodePortPoxy.resources.envoyManager.requests.cpu | default .Values.nodePortProxy.resources.envoyManager.requests.cpu }}
+            memory: {{ .Values.nodePortPoxy.resources.envoyManager.requests.memory | default .Values.nodePortProxy.resources.envoyManager.requests.memory }}
+          limits:
+            cpu: {{ .Values.nodePortPoxy.resources.envoyManager.limits.cpu | default .Values.nodePortProxy.resources.envoyManager.limits.cpu }}
+            memory: {{ .Values.nodePortPoxy.resources.envoyManager.limits.memory | default .Values.nodePortProxy.resources.envoyManager.limits.memory }}
       - name: envoy
         image: '{{ .Values.nodePortPoxy.envoy.image.repository }}:{{ .Values.nodePortPoxy.envoy.image.tag }}'
         command:
@@ -83,7 +88,12 @@ spec:
         - mountPath: /etc/envoy
           name: envoy-config
         resources:
-{{ toYaml .Values.nodePortPoxy.resources.envoy | indent 10 }}
+          requests:
+            cpu: {{ .Values.nodePortPoxy.resources.envoy.requests.cpu | default .Values.nodePortProxy.resources.envoy.requests.cpu }}
+            memory: {{ .Values.nodePortPoxy.resources.envoy.requests.memory | default .Values.nodePortProxy.resources.envoy.requests.memory }}
+          limits:
+            cpu: {{ .Values.nodePortPoxy.resources.envoy.limits.cpu | default .Values.nodePortProxy.resources.envoy.limits.cpu }}
+            memory: {{ .Values.nodePortPoxy.resources.envoy.limits.memory | default .Values.nodePortProxy.resources.envoy.limits.memory }}
       imagePullSecrets:
       - name: quay
       restartPolicy: Always
@@ -92,11 +102,26 @@ spec:
       - emptyDir: {}
         name: envoy-config
       nodeSelector:
-{{ toYaml .Values.nodePortPoxy.nodeSelector | indent 8 }}
+{{ toYaml (.Values.nodePortPoxy.nodeSelector | default .Values.nodePortProxy.nodeSelector) | indent 8 }}
       affinity:
-{{ toYaml .Values.nodePortPoxy.affinity | indent 8 }}
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+{{ toYaml (.Values.nodePortPoxy.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution) | indent 12 }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+{{ toYaml (.Values.nodePortPoxy.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms | default .Values.nodePortProxy.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms) | indent 14 }}
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+{{ toYaml (.Values.nodePortPoxy.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution) | indent 12 }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+{{ toYaml (.Values.nodePortPoxy.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution) | indent 12 }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+{{ toYaml (.Values.nodePortPoxy.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution) | indent 12 }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+{{ toYaml (.Values.nodePortPoxy.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution) | indent 12 }}
       tolerations:
-{{ toYaml .Values.nodePortPoxy.tolerations | indent 8 }}
+{{ toYaml (.Values.nodePortPoxy.tolerations | default .Values.nodePortProxy.tolerations) | indent 8 }}
 
 ---
 apiVersion: apps/v1
@@ -116,7 +141,7 @@ spec:
       serviceAccountName: nodeport-proxy
       containers:
       - name: lb-updater
-        image: '{{ .Values.nodePortPoxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag }}'
+        image: '{{ .Values.nodePortPoxy.image.repository | default .Values.nodePortProxy.image.repository }}:{{ .Values.nodePortPoxy.image.tag | default .Values.nodePortProxy.image.tag }}'
         command:
         - /lb-updater
         args:
@@ -129,12 +154,17 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         resources:
-{{ toYaml .Values.nodePortPoxy.resources.lbUpdater | indent 10 }}
+          requests:
+            cpu: {{ .Values.nodePortPoxy.resources.lbUpdater.requests.cpu | default .Values.nodePortProxy.resources.lbUpdater.requests.cpu }}
+            memory: {{ .Values.nodePortPoxy.resources.lbUpdater.requests.memory | default .Values.nodePortProxy.resources.lbUpdater.requests.memory }}
+          limits:
+            cpu: {{ .Values.nodePortPoxy.resources.lbUpdater.limits.cpu | default .Values.nodePortProxy.resources.lbUpdater.limits.cpu }}
+            memory: {{ .Values.nodePortPoxy.resources.lbUpdater.limits.memory | default .Values.nodePortProxy.resources.lbUpdater.limits.memory }}
       imagePullSecrets:
       - name: quay
       nodeSelector:
-{{ toYaml .Values.nodePortPoxy.lbUpdater.nodeSelector | indent 8 }}
+{{ toYaml (.Values.nodePortPoxy.lbUpdater.nodeSelector | default .Values.nodePortProxy.lbUpdater.nodeSelector) | indent 8 }}
       affinity:
-{{ toYaml .Values.nodePortPoxy.lbUpdater.affinity | indent 8 }}
+{{ toYaml (.Values.nodePortPoxy.lbUpdater.affinity | default .Values.nodePortProxy.lbUpdater.affinity) | indent 8 }}
       tolerations:
-{{ toYaml .Values.nodePortPoxy.lbUpdater.tolerations | indent 8 }}
+{{ toYaml (.Values.nodePortPoxy.lbUpdater.tolerations | default .Values.nodePortProxy.lbUpdater.tolerations) | indent 8 }}

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -1,15 +1,25 @@
-nodePortPoxy:
+nodePortProxy:
   replicas: 3
+  image:
+    repository: "quay.io/kubermatic/nodeport-proxy"
+    tag: "v2.0.0"
   envoy:
     image:
       repository: "envoyproxy/envoy-alpine"
       tag: "v1.10.0"
-  image:
-    repository: "quay.io/kubermatic/nodeport-proxy"
-    tag: "v2.0.0"
 
   nodeSelector: {}
+
+  # The only reason all these fields are defined explicitly is so that
+  # we can properly merge any potential overwrites.
   affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution: []
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms: []
+    podAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution: []
+      requiredDuringSchedulingIgnoredDuringExecution: []
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
       - podAffinityTerm:
@@ -18,6 +28,7 @@ nodePortPoxy:
               app: envoy
           topologyKey: kubernetes.io/hostname
         weight: 100
+      requiredDuringSchedulingIgnoredDuringExecution: []
   tolerations: []
 
   resources:
@@ -43,6 +54,33 @@ nodePortPoxy:
         cpu: 10m
         memory: 32Mi
 
+  lbUpdater:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+
+# stub to make templating easier
+nodePortPoxy:
+  image: {}
+  envoy:
+    image: {}
+  nodeSelector: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution: {}
+    podAffinity: {}
+    podAntiAffinity: {}
+  tolerations: []
+  resources:
+    envoy:
+      requests: {}
+      limits: {}
+    envoyManager:
+      requests: {}
+      limits: {}
+    lbUpdater:
+      requests: {}
+      limits: {}
   lbUpdater:
     nodeSelector: {}
     affinity: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is another attempt at fixing ye ol' `nodePortPoxy` typo. Previous PRs simply renamed the root key, but because this could bring customers into trouble when updating, the PR had been rejected.

This PR however goes the extra mile and uses a `poxy.value | default proxy.value` stanza everywhere. By defining a stub for the old `nodePortPoxy` root key, this is not entire madness, just ... slight madness. It would look okay if we didn't define an affinity for envoy itself, but because we do and want to properly handle all cases where customers might have defined some other affinity options, it got a bit out of hand.

**Does this PR introduce a user-facing change?**:
```release-note
nodePortPoxy Helm values has been renamed to nodePortProxy, old root key is now deprecated; please update your Helm values
```
