### PR TITLE
update to kube-state-metrics 1.6.0

### DIFF
--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -29,7 +29,7 @@ var (
 
 const (
 	name    = "kube-state-metrics"
-	version = "v1.5.0"
+	version = "v1.6.0"
 )
 
 // DeploymentCreator returns the function to create and update the kube-state-metrics deployment

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         - "8081"
         command:
         - /kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube-state-metrics
-version: 1.0.0
-appVersion: v1.5.0
+version: 1.0.1
+appVersion: v1.6.0
 description: Kube-State-Metrics for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.5.0
+    tag: v1.6.0
   resources:
     requests:
       cpu: 50m
@@ -13,7 +13,7 @@ kubeStateMetrics:
   resizer:
     image:
       repository: k8s.gcr.io/addon-resizer
-      tag: '1.7'
+      tag: '1.8.4'
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates to the just released v1.6.0.

**Does this PR introduce a user-facing change?**:
```release-note
update kube-state-metrics to 1.6.0
```
