### PR TITLE
update Grafana to 6.1.6

### DIFF
--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 1.0.2
-appVersion: 6.1.4
+version: 1.0.3
+appVersion: 6.1.6
 description: Grafana for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -4,7 +4,7 @@ grafana:
 
   image:
     repository: grafana/grafana
-    tag: 6.1.4
+    tag: 6.1.6
 
   resources:
     requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Grafana 6.1.6 contains ["urgent security fixes"](https://grafana.com/blog/2019/04/29/grafana-5.4.4-and-6.1.6-released-with-important-security-fix/).

**Does this PR introduce a user-facing change?**:
```release-note
update Grafana to 6.1.6
```
