### PR TITLE
Fix check-dependencies to use dep check

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -88,7 +88,7 @@ check-dependencies:
 	# We need mercurial for bitbucket.org/ww/goautoneg, otherwise dep hangs forever
 	which hg >/dev/null 2>&1 || apt update && apt install -y mercurial
 	dep version || go get -u github.com/golang/dep/cmd/dep
-	dep status
+	dep check
 	git diff --exit-code
 
 license-validation:


### PR DESCRIPTION
**What this PR does / why we need it**:

`check-dependencies` should fail when vendor is directly updated without updating `Gopkg.toml`. It doesn't fail in https://github.com/kubermatic/kubermatic/pull/3419. To have that, we should be using `dep check` instead of `dep status`.

Ref:
- https://golang.github.io/dep/docs/daily-dep.html#key-takeaways
- https://golang.github.io/dep/docs/ensure-mechanics.html#staying-in-sync

With `dep check`:

```
➜  api git:(packet-support-01) ✗ make check-dependencies
# We need mercurial for bitbucket.org/ww/goautoneg, otherwise dep hangs forever
# which hg >/dev/null 2>&1 || apt update && apt install -y mercurial
dep version || go get -u github.com/golang/dep/cmd/dep
dep:
 version     : devel
 build date  : 
 git hash    : 
 go version  : go1.10.2
 go compiler : gc
 platform    : linux/amd64
 features    : ImportDuringSolve=false
dep check
# vendor is out of sync:
github.com/kubermatic/machine-controller: hash of vendored tree not equal to digest in Gopkg.lock
make: *** [Makefile:91: check-dependencies] Error 1
```

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @alvaroaleman 
