### PR TITLE
fix user-cluster Prometheus not scraping kube-state-metrics

### DIFF
--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -53,6 +53,11 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 				Labels: podLabels,
+				Annotations: map[string]string{
+					// do not specify a port so that Prometheus automatically
+					// scrapes both the metrics and the telemetry endpoints
+					"prometheus.io/scrape": "true",
+				},
 			}
 
 			dep.Spec.Template.Spec.Volumes = volumes

--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -323,6 +323,14 @@ groups:
     labels:
       severity: critical
 
+  - alert: KubeStateMetricsDown
+    annotations:
+      message: Kube-state-metrics has disappeared from Prometheus target discovery.
+    expr: absent(up{job="kube-state-metrics"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+
   - alert: EtcdDown
     annotations:
       message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -561,6 +561,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -557,6 +557,14 @@ data:
         labels:
           severity: critical
 
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: EtcdDown
         annotations:
           message: Etcd has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: kube-state-metrics


### PR DESCRIPTION
**What this PR does / why we need it**:
During refactorings we removed the Service for kube-state-metrics. As the service was the only element that contained Prometheus scraping annotations, we have since then not scraped it anymore.

This PR restores the annotation directly on the Deployment's spec. It also defines a new alert so that we notice the missing scrape target earlier.

**Does this PR introduce a user-facing change?**:
```release-note
fixed kube-state-metrics in user-clusters not being scraped
```
