### PR TITLE
fix nodeport-proxy nodeAffinity dummy

### DIFF
--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -105,16 +105,9 @@ spec:
 {{ toYaml (.Values.nodePortPoxy.nodeSelector | default .Values.nodePortProxy.nodeSelector) | indent 8 }}
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-{{ toYaml (.Values.nodePortPoxy.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution) | indent 12 }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-{{ toYaml (.Values.nodePortPoxy.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms | default .Values.nodePortProxy.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms) | indent 14 }}
+{{ toYaml (.Values.nodePortPoxy.affinity.nodeAffinity | default .Values.nodePortProxy.affinity.nodeAffinity) | indent 10 }}
         podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-{{ toYaml (.Values.nodePortPoxy.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution) | indent 12 }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-{{ toYaml (.Values.nodePortPoxy.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution) | indent 12 }}
+{{ toYaml (.Values.nodePortPoxy.affinity.podAffinity | default .Values.nodePortProxy.affinity.podAffinity) | indent 10 }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
 {{ toYaml (.Values.nodePortPoxy.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution | default .Values.nodePortProxy.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution) | indent 12 }}

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -13,13 +13,8 @@ nodePortProxy:
   # The only reason all these fields are defined explicitly is so that
   # we can properly merge any potential overwrites.
   affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution: []
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms: []
-    podAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution: []
-      requiredDuringSchedulingIgnoredDuringExecution: []
+    nodeAffinity: {}
+    podAffinity: {}
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
       - podAffinityTerm:
@@ -66,9 +61,6 @@ nodePortPoxy:
     image: {}
   nodeSelector: {}
   affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution: {}
-    podAffinity: {}
     podAntiAffinity: {}
   tolerations: []
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
When a `requiredDuringSchedulingIgnoredDuringExecution` field is set, it must contain at least one node selector term. Thankfully we only ever defined a podAntiAffinity, so we can reduce the amount ot boilerplate for the other affinities to a bare minimum and work around this.

Customers who set their own nodeAffinity will continue to use theirs and everyone else, like us, will get an empty nodeAffinity with *no child nodes* in the YAML.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
