### PR TITLE
fix forgotten nodePortProxy fallback

### DIFF
--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             cpu: {{ .Values.nodePortPoxy.resources.envoyManager.limits.cpu | default .Values.nodePortProxy.resources.envoyManager.limits.cpu }}
             memory: {{ .Values.nodePortPoxy.resources.envoyManager.limits.memory | default .Values.nodePortProxy.resources.envoyManager.limits.memory }}
       - name: envoy
-        image: '{{ .Values.nodePortPoxy.envoy.image.repository }}:{{ .Values.nodePortPoxy.envoy.image.tag }}'
+        image: '{{ .Values.nodePortPoxy.envoy.image.repository | default .Values.nodePortProxy.envoy.image.repository }}:{{ .Values.nodePortPoxy.envoy.image.tag | default .Values.nodePortProxy.envoy.image.tag }}'
         command:
         - /usr/local/bin/envoy
         args:


### PR DESCRIPTION
**What this PR does / why we need it**:
One more change even 8 eyes did not see and which I did not notice because without this, you could easily deploy the Chart, even though it would then later fail..

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
