### PR TITLE
Fix master controller deployment & startup error messages

### DIFF
--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -66,12 +66,12 @@ func main() {
 
 	config, err := clientcmd.BuildConfigFromFlags(ctrlCtx.runOptions.masterURL, ctrlCtx.runOptions.kubeconfig)
 	if err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Failed to create the config for the kubernetes client: %v", err)
 	}
 
 	selector, err := workerlabel.LabelSelector(ctrlCtx.runOptions.workerName)
 	if err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Failed to create the label selector for the given worker name '%s': %v", ctrlCtx.runOptions.workerName, err)
 	}
 
 	// register the global error metric. Ensures that runtime.HandleError() increases the error metric
@@ -92,12 +92,12 @@ func main() {
 
 	ctrlCtx.datacenters, err = provider.LoadDatacentersMeta(ctrlCtx.runOptions.dcFile)
 	if err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Failed to read the datacenters definition: %v", err)
 	}
 
 	ctrlCtx.kubeconfig, err = clientcmd.LoadFromFile(ctrlCtx.runOptions.kubeconfig)
 	if err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Failed to read the kubeconfig: %v", err)
 	}
 
 	{

--- a/config/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/master-controller-manager-dep.yaml
@@ -37,6 +37,9 @@ spec:
           - name: kubeconfig
             mountPath: "/opt/.kube/"
             readOnly: true
+          - name: datacenters
+            mountPath: "/opt/datacenter/"
+            readOnly: true
       containers:
       - name: master-controller
         command:
@@ -46,6 +49,7 @@ spec:
         - -v=4
         - -logtostderr
         - -kubeconfig=/opt/.kube/kubeconfig
+        - -datacenters=/opt/datacenter/datacenters.yaml
         {{- if .Values.kubermatic.worker_name }}
         - -worker-name={{ .Values.kubermatic.worker_name }}
         {{- end }}
@@ -63,6 +67,9 @@ spec:
       - name: kubeconfig
         secret:
           secretName: kubeconfig
+      - name: datacenters
+        secret:
+          secretName: datacenters
       nodeSelector:
 {{ toYaml .Values.kubermatic.masterController.nodeSelector | indent 8 }}
       affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds the missing datacenters.yaml to the master controllers helm deployment
- Adds some more infos to startup errors from the master controller

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
