### PR TITLE
increase the default resources for the master controller

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -209,10 +209,10 @@ kubermatic:
     resources:
       requests:
         cpu: 50m
-        memory: 32Mi
+        memory: 128Mi
       limits:
         cpu: 100m
-        memory: 64Mi
+        memory: 256Mi
     affinity: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the default resources for the master controller to avoid OOM kills.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
