### PR TITLE
fixes the wrong volumeMount for the datacenters secret in the master controller

### DIFF
--- a/config/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/master-controller-manager-dep.yaml
@@ -37,9 +37,6 @@ spec:
           - name: kubeconfig
             mountPath: "/opt/.kube/"
             readOnly: true
-          - name: datacenters
-            mountPath: "/opt/datacenter/"
-            readOnly: true
       containers:
       - name: master-controller
         command:
@@ -58,6 +55,9 @@ spec:
         volumeMounts:
           - name: kubeconfig
             mountPath: "/opt/.kube/"
+            readOnly: true
+          - name: datacenters
+            mountPath: "/opt/datacenter/"
             readOnly: true
         resources:
 {{ toYaml .Values.kubermatic.masterController.resources | indent 10 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the wrong `volumeMount` for the datacenters secret in the master controller

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
