### PR TITLE
Ignore namespace in cluster reconcile requests

### DIFF
--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -120,6 +120,7 @@ func Add(
 			err := mgr.GetClient().Get(context.Background(), types.NamespacedName{Name: ownerRef.Name}, cluster)
 			if err != nil {
 				if kerrors.IsNotFound(err) {
+					glog.V(4).Infof("Couldn't find cluster %q", ownerRef.Name)
 					return nil
 				}
 				glog.Errorf("failed to get cluster %q: %v", ownerRef.Name, err)

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -172,8 +172,11 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	defer cancel()
 
 	cluster := &kubermaticv1.Cluster{}
+	// Ignore the namespace in the request
+	request.NamespacedName.Namespace = ""
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if kubeapierrors.IsNotFound(err) {
+			glog.V(4).Infof("Couldn't find cluster %q", request.NamespacedName.String())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -151,8 +151,11 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	defer cancel()
 
 	cluster := &kubermaticv1.Cluster{}
+	// Ignore the namespace in the request
+	request.NamespacedName.Namespace = ""
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if kubeapierrors.IsNotFound(err) {
+			glog.V(4).Infof("Couldn't find cluster %q", request.NamespacedName.String())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the reconcile triggering of clusters that get enqueued via `EnqueueRequestForOwner`. `EnqueueRequestForOwner` sets the `Namespace` of the `reconcile.Request` to the namespace of the triggering object.

This doesn't work for clusters as they are not namespaced.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
