### PR TITLE
adds ci_run_api_e2e scrip for running API E2E test

### DIFF
--- a/api/hack/ci/ci_run_api_e2e.sh
+++ b/api/hack/ci/ci_run_api_e2e.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTROLLER_IMAGE="quay.io/kubermatic/cluster-exposer:v1.0.0"
+# TODO: remove once we generate static clients from the tests
+export KUBERMATIC_DEX_DEV_E2E_USERNAME="roxy@loodse.com"
+export KUBERMATIC_DEX_DEV_E2E_USERNAME_2="roxy2@loodse.com"
+export KUBERMATIC_DEX_DEV_E2E_PASSWORD="password"
+
+function cleanup {
+	kubectl delete service -l "prow.k8s.io/id=$PROW_JOB_ID"
+
+	# Kill all descendant processes
+	pkill -P $$
+}
+trap cleanup EXIT
+
+echo $IMAGE_PULL_SECRET_DATA | base64 -d > /config.json
+# An elegant hack that routes dex.oauth domain to localhost and then down to a dex service inside the inner Kube cluster
+# See also expose.sh script
+sed 's/localhost/localhost dex.oauth/' < /etc/hosts > /hosts
+cat /hosts > /etc/hosts
+
+# Step 1: Build kubermatic docker image that will be used by the inner Kube cluster
+cd $(dirname $0)/../..
+make docker-build
+
+# Step 2: create a Kube cluster and deploy Kubermatic
+# Note that latestbuild tag comes from running "make docker-build"
+deploy.sh latestbuild
+DOCKER_CONFIG=/ docker run --name controller -d -v /root/.kube/config:/inner -v /etc/kubeconfig/kubeconfig:/outer --network host --privileged ${CONTROLLER_IMAGE} --kubeconfig-inner "/inner" --kubeconfig-outer "/outer" --namespace "default" --build-id "$PROW_JOB_ID"
+docker logs -f controller &
+expose.sh
+
+# Step3: run e2e tests
+# TODO: run api e2e test


### PR DESCRIPTION
**What this PR does / why we need it**: the script is meant to be run in the CI.
It requires `e2e-kind` image that provides deployment and cluster creation scripts.

The script essentially builds a local image that has `Kubermatic` binaries from the current branch.
Pushes the image to the inner `Kubernetes` cluster and uses it to install `Kubermatic`.
Finally, it runs E2E test for the `API`.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #3315 


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
