### PR TITLE
reduce helm history size to 10

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -44,7 +44,7 @@ echodate "Initializing Tiller in namespace ${TILLER_NAMESPACE}"
 helm version --tiller-namespace ${TILLER_NAMESPACE} || true
 kubectl create serviceaccount -n ${TILLER_NAMESPACE} tiller-sa || true
 kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=${TILLER_NAMESPACE}:tiller-sa  || true
-retry 5 helm --tiller-namespace ${TILLER_NAMESPACE} init --service-account tiller-sa --replicas 3 --history-max 100 --force-upgrade --wait
+retry 5 helm --tiller-namespace ${TILLER_NAMESPACE} init --service-account tiller-sa --replicas 3 --history-max 10 --force-upgrade --wait
 echodate "Tiller initialized successfully"
 
 echo "Deploying the CRD's..."


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reduces the history size for Helm from 100 to 10.

We used 100 before to have sufficient valid releases we could rollback to.
This was required as helm would create a new failed release for each failed deployment - eventually deleting the last valid release, which results in a very bad state (Helm has no idea what is actually deployed...)

Since we now use the `--atomic` flag we can safely reduce that number. 
`--atomic` instructs helm to do a rollback if a deployment fails (Leaving us with a valid release in the end).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
