### PR TITLE
set GODEBUG env to prevent excessive Prometheus memory usage

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.0.0
+version: 2.0.1
 appVersion: v2.9.2
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -40,6 +40,10 @@ spec:
         {{- if .Values.prometheus.backup.enabled }}
         - --web.enable-admin-api
         {{- end }}
+        env:
+        # prevent excessive memory usage until Prometheus 2.10
+        - name: GODEBUG
+          value: madvdontneed=1
         ports:
         - containerPort: 9090
           name: web


### PR DESCRIPTION
**What this PR does / why we need it**:
This works around the increased memory in Prometheus 2.9.x. See https://github.com/prometheus/prometheus/issues/5524 for more details. Version 2.10 is due in two weeks or so and that's more painful than doing a temporary fix on our side.

**Which issue(s) this PR fixes**:
https://github.com/prometheus/prometheus/issues/5524

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
