### PR TITLE
Refactor alertmanager Chart

### DIFF
--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -312,7 +312,7 @@ alerting:
   alertmanagers:
   - dns_sd_configs:
     - names:
-      - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+      - 'alertmanager.monitoring.svc.cluster.local'
       type: A
       port: 9093
 `

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -234,7 +234,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -230,7 +230,7 @@ data:
       alertmanagers:
       - dns_sd_configs:
         - names:
-          - 'alertmanager-kubermatic.monitoring.svc.cluster.local'
+          - 'alertmanager.monitoring.svc.cluster.local'
           type: A
           port: 9093
   rules.yaml: |2

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -13,7 +13,7 @@ iap:
     #     - uri: "/*"
     #       groups:
     #       - "mygithuborg:mygroup"
-    #   upstream_service: alertmanager-kubermatic.monitoring.svc.cluster.local
+    #   upstream_service: alertmanager.monitoring.svc.cluster.local
     #   upstream_port: 9093
     #   ingress:
     #     host: "alertmanager.kubermatic.tld"

--- a/config/monitoring/alertmanager/Chart.yaml
+++ b/config/monitoring/alertmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: alertmanager
-version: 1.0.2
+version: 2.0.0
 appVersion: v0.17.0
 description: Alertmanager for Kubermatic
 keywords:

--- a/config/monitoring/alertmanager/kubermatic.tmpl
+++ b/config/monitoring/alertmanager/kubermatic.tmpl
@@ -1,4 +1,6 @@
-{* regular Slack alerts *}
+{* A nice, compact set of templates for pretty Slack Alerts. *}
+{* Capable of displaying the user-cluster from which alerts originate. *}
+{* Shows a pretty flag if the seed cluster name matches regex. *}
 
 {{ define "slack.kubermatic.pretty.runbook" }}{{ with .Annotations.runbook_url }}<{{ .}}|:notebook:>{{ end }}{{ end }}
 {{ define "slack.kubermatic.titlelink" }}{{ end }}

--- a/config/monitoring/alertmanager/templates/alertmanager-secret.yaml
+++ b/config/monitoring/alertmanager/templates/alertmanager-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: alertmanager-kubermatic
-type: Opaque
-data:
-  alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}
-  kubermatic.tmpl: {{ .Files.Get "kubermatic.tmpl" | b64enc | quote }}

--- a/config/monitoring/alertmanager/templates/service.yaml
+++ b/config/monitoring/alertmanager/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: alertmanager-kubermatic
+  name: {{ template "name" . }}
   labels:
-    app: alertmanager-kubermatic
+    app: {{ template "name" . }}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -17,4 +17,4 @@ spec:
     protocol: TCP
     targetPort: 6783
   selector:
-    app: alertmanager-kubermatic
+    app: {{ template "name" . }}

--- a/config/monitoring/alertmanager/templates/service.yaml
+++ b/config/monitoring/alertmanager/templates/service.yaml
@@ -18,3 +18,28 @@ spec:
     targetPort: 6783
   selector:
     app: {{ template "name" . }}
+
+---
+# This server is provided to retain backwards compatibility with
+# existing user clusters which have not yet been reconciled to
+# use the new default Alertmanager service name.
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-kubermatic
+  labels:
+    app: {{ template "name" . }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: web
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+  - name: mesh
+    port: 6783
+    protocol: TCP
+    targetPort: 6783
+  selector:
+    app: {{ template "name" . }}

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -105,7 +105,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.alertmanager.affinity | indent 8 }}
+{{ tpl (toYaml .Values.alertmanager.affinity) . | fromYaml | toYaml | indent 8 }}
       tolerations:
 {{ toYaml .Values.alertmanager.tolerations | indent 8 }}
   updateStrategy:

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -1,40 +1,43 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+  name: {{ template "name" . }}
   labels:
-    app: alertmanager-kubermatic
-  name: alertmanager-kubermatic
+    app: {{ template "name" . }}
 spec:
   replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: alertmanager-kubermatic
-  serviceName: alertmanager-kubermatic
+      app: {{ template "name" . }}
+  serviceName: {{ template "name" . }}
   template:
     metadata:
       labels:
-        app: alertmanager-kubermatic
+        app: {{ template "name" . }}
     spec:
       containers:
-      - args:
+      - name: alertmanager
+        image: '{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.version | default .Values.alertmanager.image.tag }}'
+        imagePullPolicy: {{ .Values.alertmanager.image.pullPolicy }}
+        args:
         - --config.file=/etc/alertmanager/config/alertmanager.yaml
         - --cluster.listen-address=$(POD_IP):6783
         - --storage.path=/alertmanager
         - --web.listen-address=:9093
         - --web.external-url=https://{{ .Values.alertmanager.host | trim }}
         - --web.route-prefix=/
-        - --cluster.peer=alertmanager-kubermatic-0.alertmanager-kubermatic.{{ .Release.Namespace }}.svc.cluster.local:6783
-        - --cluster.peer=alertmanager-kubermatic-1.alertmanager-kubermatic.{{ .Release.Namespace }}.svc.cluster.local:6783
-        - --cluster.peer=alertmanager-kubermatic-2.alertmanager-kubermatic.{{ .Release.Namespace }}.svc.cluster.local:6783
+        {{- if gt .Values.alertmanager.replicas 1.0 }}
+        {{- range (until (int .Values.alertmanager.replicas)) }}
+        - --cluster.peer={{ template "name" $ }}-{{ . }}.{{ template "name" $ }}.{{ $.Release.Namespace }}.svc.cluster.local:6783
+        {{- end }}
+        {{- end }}
         env:
         - name: POD_IP
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
-        image: '{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.version | default .Values.alertmanager.image.tag }}'
-        imagePullPolicy: {{ .Values.alertmanager.image.pullPolicy }}
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -44,7 +47,6 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 3
-        name: alertmanager
         ports:
         - containerPort: 9093
           name: web
@@ -70,8 +72,9 @@ spec:
         - mountPath: /etc/alertmanager/config
           name: config-volume
         - mountPath: /alertmanager
-          name: alertmanager-kubermatic-db
+          name: db
           subPath: alertmanager-db
+
       - name: reloader
         image: jimmidyson/configmap-reload
         imagePullPolicy: IfNotPresent
@@ -98,7 +101,7 @@ spec:
       - name: config-volume
         secret:
           defaultMode: 420
-          secretName: alertmanager-kubermatic
+          secretName: {{ template "name" . }}
       nodeSelector:
 {{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
       affinity:
@@ -109,22 +112,13 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
   - metadata:
-      creationTimestamp: null
-      name: alertmanager-kubermatic-db
+      name: db
     spec:
+      {{- with .Values.alertmanager.storageClass }}
+      storageClassName: {{ . }}
+      {{- end }}
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: {{ .Values.alertmanager.resources.storage }}
-      storageClassName: kubermatic-fast
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: alertmanager-kubermatic
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: alertmanager-kubermatic
+          storage: {{ .Values.alertmanager.resources.storage | default .Values.alertmanager.storageSize }}

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "name" . }}
 spec:
-  replicas: 3
+  replicas: {{ .Values.alertmanager.replicas }}
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -5,7 +5,7 @@ alertmanager:
     pullPolicy: IfNotPresent
   host: ""
   replicas: 3
-  storageSize: 1Gi
+  storageSize: 100Mi
   storageClass: kubermatic-fast
   config:
     global:

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -4,14 +4,17 @@ alertmanager:
     tag: v0.17.0
     pullPolicy: IfNotPresent
   host: ""
+  replicas: 3
+  storageSize: 1Gi
+  storageClass: kubermatic-fast
   config:
     global:
       slack_api_url: https://hooks.slack.com/services/YOUR_KEYS_HERE
     route:
-      receiver: 'default'
+      receiver: default
       repeat_interval: 1h
     receivers:
-    - name: 'default'
+    - name: default
       slack_configs:
       - channel: '#alerting'
         send_resolved: true
@@ -30,7 +33,14 @@ alertmanager:
       limits:
         cpu: 5m
         memory: 32Mi
-    storage: 100Mi
+    migration:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
   nodeSelector: {}
   affinity:
     podAntiAffinity:
@@ -38,7 +48,21 @@ alertmanager:
       - podAffinityTerm:
           labelSelector:
             matchLabels:
-              app: alertmanager-kubermatic
+              app: '{{ template "name" . }}'
           topologyKey: kubernetes.io/hostname
         weight: 100
   tolerations: []
+
+  # When upgrading the chart from 1.x => 2.0, the naming for volumes
+  # has changed and without a migration your existing Alertmanager database
+  # would not be used anymore. Set the enabled flag to true to let an
+  # init container copy the data over. A lockfile is created so that when
+  # the pod for whatever reason restarts the migration is not executed
+  # again.
+  # Once the migration has finished and you set the flag to false again,
+  # you can safely remove the old `alertmanager-kubermatic-db-...` PVCs.
+  migration:
+    enabled: false
+    image:
+      repository: quay.io/kubermatic/util
+      tag: 1.0.0-2

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.0.2
+version: 2.0.3
 appVersion: v2.9.2
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/config/alertmanagers/kubermatic.yaml
+++ b/config/monitoring/prometheus/config/alertmanagers/kubermatic.yaml
@@ -10,7 +10,7 @@ timeout: 10s
 relabel_configs:
 - source_labels: [__meta_kubernetes_service_name]
   separator: ;
-  regex: alertmanager-kubermatic
+  regex: alertmanager
   replacement: $1
   action: keep
 - source_labels: [__meta_kubernetes_endpoint_port_name]

--- a/config/monitoring/prometheus/rules/src/general/prometheus.yaml
+++ b/config/monitoring/prometheus/rules/src/general/prometheus.yaml
@@ -36,8 +36,8 @@ groups:
       severity: critical
     runbook:
       steps:
-      - Check Alertmanager pod's logs via `kubectl -n monitoring logs alertmanager-kubermatic-0`, `-1` and `-2`.
-      - Check the `alertmanager-kubermatic` secret via `kubectl -n monitoring get secret alertmanager-kubermatic -o yaml`.
+      - Check Alertmanager pod's logs via `kubectl -n monitoring logs alertmanager-0`, `-1` and `-2`.
+      - Check the `alertmanager` secret via `kubectl -n monitoring get secret alertmanager -o yaml`.
 
   - alert: PromAlertsFailed
     annotations:


### PR DESCRIPTION
**What this PR does / why we need it**:
This applies the same changes to the Alertmanager chart as we just did for Prometheus in #3347. To give user clusters time to reconcile a fallback service is provided and slated to be removed in the first follow-up release to 2.11. The fallback is installed unconditionally because it's such a short-term solution, even though it prevents the Chart from being installed multiple times inside the same namespace.

**Which issue(s) this PR fixes**:
Relates to #3238

**Does this PR introduce a user-facing change?**:
```release-note
BREAK: refactored Alertmanager Helm chart for master-cluster monitoring, see documentation for migration notes 
```
