### PR TITLE
deploy s3 exporter in kube-system

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -60,7 +60,7 @@ if [[ "${1}" = "master" ]]; then
 fi
 
 deploy "minio" "minio" ./config/minio/
-deploy "s3-exporter" "s3-exporter" ./config/s3-exporter/
+deploy "s3-exporter" "kube-system" ./config/s3-exporter/
 # The NodePort proxy is only relevant in cloud environments (Where LB services can be used)
 if [[ "${DEPLOY_NODEPORT_PROXY}" = true ]]; then
   deploy "nodeport-proxy" "nodeport-proxy" ./config/nodeport-proxy/


### PR DESCRIPTION
**What this PR does / why we need it**:
Deploy s3 exporter in kube-system

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
