### PR TITLE
test pull-kubermatic-api-e2e step

### DIFF
--- a/api/hack/ci/ci_run_api_e2e.sh
+++ b/api/hack/ci/ci_run_api_e2e.sh
@@ -25,6 +25,7 @@ dockerd > /dev/null 2> /dev/null &
 
 # Step 1: Build kubermatic docker image that will be used by the inner Kube cluster
 cd $(dirname $0)/../..
+make build
 make docker-build
 
 # Step 2: create a Kube cluster and deploy Kubermatic

--- a/api/hack/ci/ci_run_api_e2e.sh
+++ b/api/hack/ci/ci_run_api_e2e.sh
@@ -15,11 +15,13 @@ function cleanup {
 }
 trap cleanup EXIT
 
-echo $IMAGE_PULL_SECRET_DATA | base64 -d > /config.json
+# Step 0: Setup
 # An elegant hack that routes dex.oauth domain to localhost and then down to a dex service inside the inner Kube cluster
 # See also expose.sh script
+echo $IMAGE_PULL_SECRET_DATA | base64 -d > /config.json
 sed 's/localhost/localhost dex.oauth/' < /etc/hosts > /hosts
 cat /hosts > /etc/hosts
+dockerd > /dev/null 2> /dev/null &
 
 # Step 1: Build kubermatic docker image that will be used by the inner Kube cluster
 cd $(dirname $0)/../..

--- a/api/hack/ci/ci_run_api_e2e.sh
+++ b/api/hack/ci/ci_run_api_e2e.sh
@@ -25,15 +25,15 @@ dockerd > /dev/null 2> /dev/null &
 
 # Step 1: Build kubermatic docker image that will be used by the inner Kube cluster
 cd $(dirname $0)/../..
-make build
-make docker-build
+time make build
+time make docker-build
 
 # Step 2: create a Kube cluster and deploy Kubermatic
 # Note that latestbuild tag comes from running "make docker-build"
-deploy.sh latestbuild
+time deploy.sh latestbuild
 DOCKER_CONFIG=/ docker run --name controller -d -v /root/.kube/config:/inner -v /etc/kubeconfig/kubeconfig:/outer --network host --privileged ${CONTROLLER_IMAGE} --kubeconfig-inner "/inner" --kubeconfig-outer "/outer" --namespace "default" --build-id "$PROW_JOB_ID"
 docker logs -f controller &
-expose.sh
+time expose.sh
 
 # Step3: run e2e tests
 # TODO: run api e2e test

--- a/api/hack/ci/ci_run_api_e2e.sh
+++ b/api/hack/ci/ci_run_api_e2e.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# TODO: remove
+more /proc/cpuinfo
+
 CONTROLLER_IMAGE="quay.io/kubermatic/cluster-exposer:v1.0.0"
 # TODO: remove once we generate static clients from the tests
 export KUBERMATIC_DEX_DEV_E2E_USERNAME="roxy@loodse.com"

--- a/api/hack/ci/ci_run_api_e2e.sh
+++ b/api/hack/ci/ci_run_api_e2e.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# TODO: remove
-more /proc/cpuinfo
-
 CONTROLLER_IMAGE="quay.io/kubermatic/cluster-exposer:v1.0.0"
 # TODO: remove once we generate static clients from the tests
 export KUBERMATIC_DEX_DEV_E2E_USERNAME="roxy@loodse.com"


### PR DESCRIPTION
**What this PR does / why we need it**: updates `ci_run_api_e2e.sh` script so that it runs in the CI.

**Related issue**: #3315

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
