### PR TITLE
make max block duration in Prometheus configurable

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.0.1
+version: 2.0.2
 appVersion: v2.9.2
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -33,7 +33,15 @@ spec:
         - --config.file=/etc/prometheus/config/prometheus.yaml
         - --storage.tsdb.no-lockfile
         - --storage.tsdb.path=/var/prometheus/data
-        - --storage.tsdb.retention.time=360h
+        {{- with .Values.prometheus.tsdb.retentionTime }}
+        - --storage.tsdb.retention.time={{ . }}
+        {{- end }}
+        {{- with .Values.prometheus.tsdb.minBlockDuration }}
+        - --storage.tsdb.min-block-duration={{ . }}
+        {{- end }}
+        {{- with .Values.prometheus.tsdb.maxBlockDuration }}
+        - --storage.tsdb.max-block-duration={{ . }}
+        {{- end }}
         - --web.enable-lifecycle
         - --web.external-url=https://{{ .Values.prometheus.host | trim }}
         - --web.route-prefix=/

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -3,6 +3,11 @@ prometheus:
   host: ''
   storageSize: 100Gi
 
+  tsdb:
+    retentionTime: 15d
+    minBlockDuration: 2h
+    maxBlockDuration: 12h
+
   # If you install Prometheus using a different Helm release name,
   # you can override the name used for the resources, e.g. to have
   # multiple Prometheus installed into distinct namespaces but still


### PR DESCRIPTION
**What this PR does / why we need it**:
We often have issues with Prometheus not coming up and getting OOMKilled after an unclean shutdown. The OOMKill is likely caused by the fact that Prometheus needs to load the [entire WAL into memory](https://github.com/prometheus/prometheus/issues/4842#issuecomment-447793131) on the next startup. Another argument is that after removing everything from the `wal/` directory, Prometheus comes up with no issues and significantly lower memory usage.

To maybe, hopefully prevent this issue, this PR starts to make use of the max-block-duration flag, in the hope that this will flush more frequently and never leave huge WAL chunks laying around. The default value for this flag was "10% of the retention period", so 36h in our setup.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
