### PR TITLE
Allow DefaultCloudSpec to work by taking a pointer

### DIFF
--- a/api/pkg/defaulting/cluster.go
+++ b/api/pkg/defaulting/cluster.go
@@ -23,7 +23,7 @@ func DefaultCreateClusterSpec(
 		return nil
 	}
 
-	if err := cloudProvider.DefaultCloudSpec(spec.Cloud); err != nil {
+	if err := cloudProvider.DefaultCloudSpec(&spec.Cloud); err != nil {
 		return fmt.Errorf("failed to default cloud spec: %v", err)
 	}
 

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -37,7 +37,7 @@ type amazonEc2 struct {
 	dcs map[string]provider.DatacenterMeta
 }
 
-func (a *amazonEc2) DefaultCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (a *amazonEc2) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/api/pkg/provider/cloud/azure/provider.go
+++ b/api/pkg/provider/cloud/azure/provider.go
@@ -613,7 +613,7 @@ func ensureAvailabilitySet(name, location string, cloud kubermaticv1.CloudSpec) 
 	return err
 }
 
-func (a *azure) DefaultCloudSpec(cloud kubermaticv1.CloudSpec) error {
+func (a *azure) DefaultCloudSpec(cloud *kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/api/pkg/provider/cloud/bringyourown/provider.go
+++ b/api/pkg/provider/cloud/bringyourown/provider.go
@@ -12,7 +12,7 @@ func NewCloudProvider() provider.CloudProvider {
 	return &bringyourown{}
 }
 
-func (b *bringyourown) DefaultCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (b *bringyourown) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/api/pkg/provider/cloud/digitalocean/provider.go
+++ b/api/pkg/provider/cloud/digitalocean/provider.go
@@ -20,7 +20,7 @@ func NewCloudProvider(dcs map[string]provider.DatacenterMeta) provider.CloudProv
 	}
 }
 
-func (do *digitalocean) DefaultCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (do *digitalocean) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/api/pkg/provider/cloud/fake/provider.go
+++ b/api/pkg/provider/cloud/fake/provider.go
@@ -17,7 +17,7 @@ func NewCloudProvider() provider.CloudProvider {
 	}
 }
 
-func (p *fakeCloudProvider) DefaultCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (p *fakeCloudProvider) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/api/pkg/provider/cloud/hetzner/provider.go
+++ b/api/pkg/provider/cloud/hetzner/provider.go
@@ -20,7 +20,7 @@ func NewCloudProvider(dcs map[string]provider.DatacenterMeta) provider.CloudProv
 }
 
 // DefaultCloudSpec
-func (h *hetzner) DefaultCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (h *hetzner) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -48,7 +48,7 @@ func NewCloudProvider(dcs map[string]provider.DatacenterMeta) provider.CloudProv
 }
 
 // DefaultCloudSpec adds defaults to the cloud spec
-func (os *Provider) DefaultCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (os *Provider) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/api/pkg/provider/cloud/packet/provider.go
+++ b/api/pkg/provider/cloud/packet/provider.go
@@ -23,7 +23,7 @@ func NewCloudProvider(dcs map[string]provider.DatacenterMeta) provider.CloudProv
 }
 
 // DefaultCloudSpec adds defaults to the CloudSpec.
-func (p *packet) DefaultCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (p *packet) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
 	return nil
 }
 

--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -185,7 +185,7 @@ func (v *Provider) GetNetworks(spec kubermaticv1.CloudSpec) ([]Network, error) {
 }
 
 // DefaultCloudSpec adds defaults to the cloud spec
-func (v *Provider) DefaultCloudSpec(spec kubermaticv1.CloudSpec) error {
+func (v *Provider) DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error {
 	dc, found := v.dcs[spec.DatacenterName]
 	if !found || dc.Spec.VSphere == nil {
 		return fmt.Errorf("invalid datacenter %q", spec.DatacenterName)

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -51,7 +51,7 @@ type ClusterUpdater func(string, func(*kubermaticv1.Cluster)) (*kubermaticv1.Clu
 type CloudSpecProvider interface {
 	InitializeCloudProvider(*kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
 	CleanUpCloudProvider(*kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
-	DefaultCloudSpec(spec kubermaticv1.CloudSpec) error
+	DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error
 	ValidateCloudSpec(spec kubermaticv1.CloudSpec) error
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, `DefaultCloudSpec` never does anything, because it takes a literal `kubermaticv1.CloudSpec` and only returns an error, meaning all changes to the `CloudSpec` will never leave the `DefaultCloudSpec` func.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

Cant unsee it now that you mentioned it :see_no_evil: 

/assign @nikhita 
CC @mrIncompetent 