### PR TITLE
update node-exporter to 0.18.0

### DIFF
--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: v0.17.0
+    app.kubernetes.io/version: v0.18.0
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: node-exporter
       containers:
       - name: node-exporter
-        image: '{{ Registry "quay.io" }}/prometheus/node-exporter:v0.17.0'
+        image: '{{ Registry "quay.io" }}/prometheus/node-exporter:v0.18.0'
         args:
         - '--path.procfs=/host/proc'
         - '--path.sysfs=/host/sys'

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.10
+export TAG=v0.2.11-rc
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.11-rc
+export TAG=v0.2.11
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -69,7 +69,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.10"
+          tag: "v0.2.11-rc"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -69,7 +69,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.11-rc"
+          tag: "v0.2.11"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/monitoring/node-exporter/Chart.yaml
+++ b/config/monitoring/node-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: node-exporter
-version: 1.0.0
-appVersion: v0.17.0
+version: 1.0.1
+appVersion: v0.18.0
 description: Prometheus Node Exporter for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/node-exporter/values.yaml
+++ b/config/monitoring/node-exporter/values.yaml
@@ -1,7 +1,7 @@
 nodeExporter:
   image:
     repository: quay.io/prometheus/node-exporter
-    tag: v0.17.0
+    tag: v0.18.0
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
**What this PR does / why we need it**:
This simply updates node-exporter to the most recent version. None of the breaking changes in this version seem to affect us.

**Does this PR introduce a user-facing change?**:
```release-note
update node-exporter to 0.18.0
```
