### PR TITLE
adjust user-cluster alerting rules to work with OpenShift

### DIFF
--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -302,7 +302,7 @@ groups:
   - alert: KubernetesControllerManagerDown
     annotations:
       message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-    expr: absent(up{job="controller-manager"} == 1)
+    expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
     for: 15m
     labels:
       severity: critical
@@ -310,7 +310,7 @@ groups:
   - alert: KubernetesSchedulerDown
     annotations:
       message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-    expr: absent(up{job="scheduler"} == 1)
+    expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
     for: 15m
     labels:
       severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -540,7 +540,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -548,7 +548,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -536,7 +536,7 @@ data:
       - alert: KubernetesControllerManagerDown
         annotations:
           message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
-        expr: absent(up{job="controller-manager"} == 1)
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -544,7 +544,7 @@ data:
       - alert: KubernetesSchedulerDown
         annotations:
           message: Kubernetes scheduler has disappeared from Prometheus target discovery.
-        expr: absent(up{job="scheduler"} == 1)
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:
This adjusts the alerting rules to only fire if both the Kubernetes and OpenShift equivalent of a service are not available. This is done because we don't have any proper metric to detect the cluster type.

**Which issue(s) this PR fixes**:
Fixes #2947, fixes #2412, fixes #2420

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
