### PR TITLE
Fix validation methods to work with Packet clouds

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ issues:
   exclude:
   - cyclomatic complexity 43 of func `main` is high
   - cyclomatic complexity 37 of func `migrateToProject` is high
+  - cyclomatic complexity 31 of func `ValidateCloudSpec` is high
   - 'CleanUpCloudProvider` is high'
   - string `get` has 6 occurrences, make it a constant
   - struct of size 536 bytes could be of size 520 bytes

--- a/api/pkg/validation/cluster.go
+++ b/api/pkg/validation/cluster.go
@@ -265,9 +265,18 @@ func ValidateCloudSpec(spec kubermaticv1.CloudSpec, dc provider.DatacenterMeta) 
 		}
 
 		if spec.VSphere.Password == "" {
-			return errors.New("no password provided")
+			return errors.New("no password specified")
 		}
+		return nil
+	}
 
+	if spec.Packet != nil {
+		if spec.Packet.APIKey == "" {
+			return errors.New("no API key specified")
+		}
+		if spec.Packet.ProjectID == "" {
+			return errors.New("no project ID specified")
+		}
 		return nil
 	}
 

--- a/api/pkg/validation/cluster.go
+++ b/api/pkg/validation/cluster.go
@@ -122,6 +122,9 @@ func ValidateCloudChange(newSpec, oldSpec kubermaticv1.CloudSpec) error {
 	if newSpec.VSphere == nil && oldSpec.VSphere != nil {
 		return ErrCloudChangeNotAllowed
 	}
+	if newSpec.Packet == nil && oldSpec.Packet != nil {
+		return ErrCloudChangeNotAllowed
+	}
 	if newSpec.DatacenterName != oldSpec.DatacenterName {
 		return errors.New("changing the datacenter is not allowed")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes ValidateCloudSpec method to accept PacketCloudSpec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Related to #3419.

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
