### PR TITLE
Avoid enqueuing the same cluster twice

### DIFF
--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -8,6 +8,7 @@ import (
 
 	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	"github.com/kubermatic/kubermatic/api/pkg/clusterdeletion"
+	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticscheme "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/scheme"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -144,8 +145,6 @@ func Add(
 		return err
 	}
 
-	ownerHandler := &handler.EnqueueRequestForOwner{IsController: true, OwnerType: &kubermaticv1.Cluster{}}
-
 	typesToWatch := []runtime.Object{
 		&corev1.Service{},
 		&corev1.ConfigMap{},
@@ -159,7 +158,7 @@ func Add(
 	}
 
 	for _, t := range typesToWatch {
-		if err := c.Watch(&source.Kind{Type: t}, ownerHandler); err != nil {
+		if err := c.Watch(&source.Kind{Type: t}, controllerutil.EnqueueClusterForNamespacedObject(mgr.GetClient())); err != nil {
 			return fmt.Errorf("failed to create watcher for %T: %v", t, err)
 		}
 	}
@@ -172,8 +171,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	defer cancel()
 
 	cluster := &kubermaticv1.Cluster{}
-	// Ignore the namespace in the request
-	request.NamespacedName.Namespace = ""
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if kubeapierrors.IsNotFound(err) {
 			glog.V(4).Infof("Couldn't find cluster %q", request.NamespacedName.String())

--- a/api/pkg/controller/util/util.go
+++ b/api/pkg/controller/util/util.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// EnqueueClusterForNamespacedObject enqueues the cluster that owns a namespaced object, if any
+// It is used by various controllers to react to changes in the resources in the cluster namespace
+func EnqueueClusterForNamespacedObject(client ctrlruntimeclient.Client) *handler.EnqueueRequestsFromMapFunc {
+	return &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
+		clusterList := &kubermaticv1.ClusterList{}
+		if err := client.List(context.Background(), &ctrlruntimeclient.ListOptions{}, clusterList); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to list Clusters: %v", err))
+			return []reconcile.Request{}
+		}
+		for _, cluster := range clusterList.Items {
+			if cluster.Status.NamespaceName == a.Meta.GetNamespace() {
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: cluster.Name}}}
+			}
+		}
+		return []reconcile.Request{}
+	})}
+}


### PR DESCRIPTION
`handler.EnqueueRequestForOwner` enqueues the owning object with the
triggering objects namespace, which doesn't work if the owning object
is non-namespaced.

We worked around this by removing the namespace from clusters in the
`Reconcile`. The problem is that we still have two possible queue keys
for the cluster, allowing two workers to concurrently work on the same
cluster, causing a lot of errors.

This PR changes the whole logic to not use the ownerreference but the
namespace of the objects to find the corresponding cluster.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/cherrypick release/v2.10
/assign @mrIncompetent 