### PR TITLE
Better error reporting in addon controller

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -333,7 +333,7 @@ func (r *Reconciler) getAddonManifests(addon *kubermaticv1.Addon, cluster *kuber
 				if err == io.EOF {
 					break
 				}
-				return nil, fmt.Errorf("failed reading from YAML reader: %v", err)
+				return nil, fmt.Errorf("failed reading from YAML reader for file %s: %v", filename, err)
 			}
 			b = bytes.TrimSpace(b)
 			if len(b) == 0 {
@@ -342,7 +342,7 @@ func (r *Reconciler) getAddonManifests(addon *kubermaticv1.Addon, cluster *kuber
 			decoder := kyaml.NewYAMLToJSONDecoder(bytes.NewBuffer(b))
 			raw := runtime.RawExtension{}
 			if err := decoder.Decode(&raw); err != nil {
-				return nil, fmt.Errorf("decoding failed: %v", err)
+				return nil, fmt.Errorf("decoding failed for file %s: %v", filename, err)
 			}
 			if len(raw.Raw) == 0 {
 				// This can happen if the manifest contains only comments, e.G. because it comes from Helm


### PR DESCRIPTION
**What this PR does / why we need it**:
This improves the error reporting in the addon controller. If there is an error parsing the YAML content of a file, the filename is now also printed, to make it easier to debug in which file of an addon there is invalid yaml or if you have any files in an addon folder that should not be there to begin with (e.g. `.DS_Store`).

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
