### PR TITLE
add helm-exporter and Prometheus alarm if a release is stuck/failed

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -71,6 +71,7 @@ deploy "prometheus" "monitoring" ./config/monitoring/prometheus/
 deploy "node-exporter" "monitoring" ./config/monitoring/node-exporter/
 deploy "kube-state-metrics" "monitoring" ./config/monitoring/kube-state-metrics/
 deploy "grafana" "monitoring" ./config/monitoring/grafana/
+deploy "helm-exporter" "monitoring" ./config/monitoring/helm-exporter/
 if [[ "${DEPLOY_ALERTMANAGER}" = true ]]; then
   deploy "alertmanager" "monitoring" ./config/monitoring/alertmanager/
 fi

--- a/config/monitoring/helm-exporter/Chart.yaml
+++ b/config/monitoring/helm-exporter/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+name: helm-exporter
+version: 1.0.0
+appVersion: 0.4.0
+description: Exports Helm release information to Prometheus
+keywords:
+- kubermatic
+- monitoring
+- helm
+- helm-exporter
+home: https://github.com/sstarcher/helm-exporter
+sources:
+- https://github.com/sstarcher/helm-exporter
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/monitoring/helm-exporter/templates/_helpers.tpl
+++ b/config/monitoring/helm-exporter/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "name" -}}
+{{- default .Release.Name .Values.helmExporter.nameOverride -}}
+{{- end }}

--- a/config/monitoring/helm-exporter/templates/deployment.yaml
+++ b/config/monitoring/helm-exporter/templates/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '{{ template "name" . }}'
+  labels:
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/instance: '{{ template "name" . }}'
+    app.kubernetes.io/managed-by: helm
+spec:
+  replicas: {{ .Values.helmExporter.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: '{{ .Chart.Name }}'
+      app.kubernetes.io/instance: '{{ template "name" . }}'
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: '{{ .Chart.Name }}'
+        app.kubernetes.io/instance: '{{ template "name" . }}'
+      annotations:
+        kubermatic/scrape: 'true'
+        kubermatic/scrape_port: '9571'
+    spec:
+      containers:
+      - name: '{{ .Chart.Name }}'
+        image: '{{ .Values.helmExporter.image.repository }}:{{ .Values.helmExporter.image.tag }}'
+        imagePullPolicy: {{ .Values.helmExporter.image.pullPolicy }}
+        args:
+        - '-tiller-namespaces={{ .Values.helmExporter.tillerNamespace }}'
+        ports:
+        - name: http
+          containerPort: 9571
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+        resources:
+{{ toYaml .Values.helmExporter.resources | indent 10 }}
+      serviceAccountName: '{{ template "name" . }}'
+      nodeSelector:
+{{ toYaml .Values.helmExporter.nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml .Values.helmExporter.affinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.helmExporter.tolerations | indent 8 }}

--- a/config/monitoring/helm-exporter/templates/serviceaccount.yaml
+++ b/config/monitoring/helm-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: '{{ template "name" . }}'
+  labels:
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/instance: '{{ template "name" . }}'
+    app.kubernetes.io/managed-by: helm

--- a/config/monitoring/helm-exporter/values.yaml
+++ b/config/monitoring/helm-exporter/values.yaml
@@ -1,0 +1,13 @@
+helmExporter:
+  replicas: 1
+  tillerNamespace: kubermatic-installer
+  image:
+    repository: sstarcher/helm-exporter
+    tag: 0.4.0
+    pullPolicy: IfNotPresent
+  nameOverride: ''
+
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/config/monitoring/prometheus/rules/general-helm-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-helm-exporter.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, do not edit.
+groups:
+- name: helm-exporter
+  rules:
+  - alert: HelmReleaseNotDeployed
+    annotations:
+      message: The Helm release `{{ $labels.release }}` (`{{ $labels.chart }}` chart
+        in namespace `{{ $labels.exported_namespace }}`) in version {{ $labels.version
+        }} has not been ready for more than 15 minutes.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-helmreleasenotdeployed
+    expr: helm_chart_info != 1
+    for: 15m
+    labels:
+      severity: warning

--- a/config/monitoring/prometheus/rules/src/general/helm-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/helm-exporter.yaml
@@ -1,0 +1,20 @@
+groups:
+- name: helm-exporter
+  rules:
+  - alert: HelmReleaseNotDeployed
+    annotations:
+      message:
+        The Helm release `{{ $labels.release }}` (`{{ $labels.chart }}` chart in namespace `{{ $labels.exported_namespace }}`)
+        in version {{ $labels.version }} has not been ready for more than 15 minutes.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-helmreleasenotdeployed
+    expr: helm_chart_info != 1
+    for: 15m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check the installed Helm releases via `helm --tiller-namespace kubermtic-installer ls`.
+      - If all releases are status `DEPLOYED`, make sure the helme-exporter is looking at the correct Tiller by checking
+        the `values.yaml` flag `helmExporter.tillerNamespace`.
+      - If Helm cannot repair the chart automatically, delete/purge the chart (`helm delete --purge [RELEASE]`) and
+        re-install the chart again. Re-installing charts will not affect any existing data in existing PersistentVolumeClaims.


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new monitoring chart for the Helm-Exporter. It can provide us with release-related information and serves as the basis for a simple alert that fires after 15 minutes if a release is not in status `DEPLOYED`.

**Which issue(s) this PR fixes**
Fixes #3031

**Does this PR introduce a user-facing change?**:
```release-note
Added Helm-Exporter to fire alarms if a chart is stuck/failed
```
