### PR TITLE
Cherry-pick of update machine controller to v1.1.17

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -778,7 +778,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:4a18c7cd27270416e89b30e3afe4f1b0dd9289ce855c5d081c7556f11776ce12"
+  digest = "1:6c13cdb225527113e1a09ba3cdc1e770eef75546154e95ce287df1c96f14d033"
   name = "github.com/kubermatic/machine-controller"
   packages = [
     "pkg/apis/plugin",
@@ -804,8 +804,8 @@
     "pkg/userdata/ubuntu",
   ]
   pruneopts = "NUT"
-  revision = "8f9bbf5209cd6ca767e80eec220d991f01b81e4b"
-  version = "v1.1.6"
+  revision = "baf02a6c95d73585093188378d7336c983770ead"
+  version = "v1.1.7"
 
 [[projects]]
   digest = "1:0dbba7d4d4f3eeb01acd81af338ff4a3c4b0bb814d87368ea536e616f383240d"

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -125,7 +125,7 @@ required = [
 
 [[override]]
   name = "github.com/kubermatic/machine-controller"
-  version = "v1.1.6"
+  version = "v1.1.7"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -32,7 +32,7 @@ var (
 const (
 	Name = "machine-controller"
 
-	tag = "v1.1.6"
+	tag = "v1.1.7"
 )
 
 type machinecontrollerData interface {

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.6
+        image: docker.io/kubermatic/machine-controller:v1.1.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/machine-vsphere.yaml
+++ b/api/pkg/resources/test/fixtures/machine-vsphere.yaml
@@ -14,6 +14,7 @@ spec:
         cpus: 2
         datacenter: vsphere-datacenter
         datastore: vsphere-datastore
+        diskSizeGB: null
         folder: vsphere-1a2b3c4d5e
         memoryMB: 2048
         password: ""

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/provider.go
@@ -48,6 +48,13 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
+const (
+	// We set this field on the virtual machine to the name of
+	// the machine to indicate creation succeeded.
+	// If this is not set correctly, .Get will delete the instance
+	creationCompleteFieldName = "kubernetes-worker-complete"
+)
+
 type provider struct {
 	configVarResolver *providerconfig.ConfigVarResolver
 }
@@ -75,6 +82,7 @@ type RawConfig struct {
 	Datastore       providerconfig.ConfigVarString `json:"datastore"`
 	CPUs            int32                          `json:"cpus"`
 	MemoryMB        int64                          `json:"memoryMB"`
+	DiskSizeGB      *int64                         `json:"diskSizeGB"`
 	AllowInsecure   providerconfig.ConfigVarBool   `json:"allowInsecure"`
 }
 
@@ -92,6 +100,7 @@ type Config struct {
 	AllowInsecure   bool
 	CPUs            int32
 	MemoryMB        int64
+	DiskSizeGB      *int64
 }
 
 type Server struct {
@@ -277,6 +286,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfig.
 
 	c.CPUs = rawConfig.CPUs
 	c.MemoryMB = rawConfig.MemoryMB
+	c.DiskSizeGB = rawConfig.DiskSizeGB
 
 	return &c, &pconfig, &rawConfig, nil
 }
@@ -318,6 +328,25 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 
 	if _, err := finder.ClusterComputeResource(ctx, config.Cluster); err != nil {
 		return fmt.Errorf("failed to get cluster: %s: %v", config.Cluster, err)
+	}
+
+	templateVM, err := finder.VirtualMachine(ctx, config.TemplateVMName)
+	if err != nil {
+		return fmt.Errorf("failed to get template vm %q: %v", config.TemplateVMName, err)
+	}
+
+	disks, err := getDisksFromVM(ctx, templateVM)
+	if err != nil {
+		return fmt.Errorf("failed to get disks from VM: %v", err)
+	}
+	if diskLen := len(disks); diskLen != 1 {
+		return fmt.Errorf("expected vm to have exactly one disk, had %d", diskLen)
+	}
+
+	if config.DiskSizeGB != nil {
+		if err := validateDiskResizing(disks, *config.DiskSizeGB); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -385,6 +414,14 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDelet
 		}()
 
 		if err := uploadAndAttachISO(ctx, finder, virtualMachine, localUserdataIsoFilePath, config.Datastore); err != nil {
+			// Destroy VM to avoid a leftover.
+			destroyTask, vmErr := virtualMachine.Destroy(ctx)
+			if vmErr != nil {
+				return nil, fmt.Errorf("failed to destroy vm %s after failing upload and attach userdata iso: %v / %v", virtualMachine.Name(), err, vmErr)
+			}
+			if vmErr := destroyTask.Wait(ctx); vmErr != nil {
+				return nil, fmt.Errorf("failed to destroy vm %s after failing upload and attach userdata iso: %v / %v", virtualMachine.Name(), err, vmErr)
+			}
 			return nil, machineInvalidConfigurationTerminalError(fmt.Errorf("failed to upload and attach userdata iso: %v", err))
 		}
 	}
@@ -396,6 +433,24 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDelet
 
 	if err := powerOnTask.Wait(ctx); err != nil {
 		return nil, fmt.Errorf("error when waiting for vm powerOn task: %v", err)
+	}
+
+	// Add a custom field to indicate to our Get that creation succeeded
+	// If the field is not set, Get will delete the instance
+	customFieldManager, err := object.GetCustomFieldsManager(client.Client)
+	key, err := customFieldManager.FindKey(ctx, creationCompleteFieldName)
+	if err != nil {
+		if !strings.Contains(err.Error(), "key name not found") {
+			return nil, fmt.Errorf("error trying to get field with key %q: %v", creationCompleteFieldName, err)
+		}
+		field, err := customFieldManager.Add(ctx, creationCompleteFieldName, "VirtualMachine", nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add field %q: %v", creationCompleteFieldName, err)
+		}
+		key = field.Key
+	}
+	if err := customFieldManager.Set(ctx, virtualMachine.Reference(), key, machine.Spec.Name); err != nil {
+		return nil, fmt.Errorf("failed to set field %q to value %q: %v", creationCompleteFieldName, machine.Spec.Name, err)
 	}
 
 	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value}, nil
@@ -502,6 +557,9 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloud.MachineCreateD
 		filemanager := datastore.NewFileManager(dc, false)
 
 		if err := filemanager.Delete(ctx, virtualMachine.Name()); err != nil {
+			if err.Error() == fmt.Sprintf("File [%s] %s was not found", datastore.Name(), virtualMachine.Name()) {
+				return true, nil
+			}
 			return false, fmt.Errorf("failed to delete storage of deleted instance %s: %v", virtualMachine.Name(), err)
 		}
 	}
@@ -511,8 +569,9 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloud.MachineCreateD
 }
 
 func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+	ctx := context.Background()
 
-	config, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	config, pc, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config: %v", err)
 	}
@@ -522,7 +581,7 @@ func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
 		return nil, fmt.Errorf("failed to get vsphere client: '%v'", err)
 	}
 	defer func() {
-		if lerr := client.Logout(context.TODO()); lerr != nil {
+		if lerr := client.Logout(ctx); lerr != nil {
 			utilruntime.HandleError(fmt.Errorf("vsphere client failed to logout: %s", lerr))
 		}
 	}()
@@ -531,7 +590,7 @@ func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get datacenter finder: %v", err)
 	}
-	virtualMachine, err := finder.VirtualMachine(context.TODO(), machine.Spec.Name)
+	virtualMachine, err := finder.VirtualMachine(ctx, machine.Spec.Name)
 	if err != nil {
 		if err.Error() == fmt.Sprintf("vm '%s' not found", machine.Spec.Name) {
 			return nil, cloudprovidererrors.ErrInstanceNotFound
@@ -539,9 +598,64 @@ func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
 		return nil, fmt.Errorf("failed to get server: %v", err)
 	}
 
-	powerState, err := virtualMachine.PowerState(context.TODO())
+	powerState, err := virtualMachine.PowerState(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get powerstate: %v", err)
+	}
+
+	// Check if the creationCompleteFieldName is set to machine.Spec.Name.
+	// If that is not the case, the creation didn't complete successfully and
+	// we must delete the instance so it gets recreated
+	fieldValue, err := getValueForField(ctx, virtualMachine, creationCompleteFieldName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get value for field: %v", err)
+	}
+	if fieldValue != machine.Spec.Name {
+		// TODO: This should leverage .Cleanup, but we can currently not do that,
+		// because .Cleanup needs cloud.MachineCreateDeleteData which we don't have here
+		if powerState == types.VirtualMachinePowerStatePoweredOn {
+			powerOffTask, err := virtualMachine.PowerOff(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to power off instance %q whose creation didn't complete: %v",
+					virtualMachine.Name(), err)
+			}
+			if err := powerOffTask.Wait(ctx); err != nil {
+				return nil, fmt.Errorf("failed to wait for instance %q whose creation didn't complete to be powered off: %v",
+					virtualMachine.Name(), err)
+			}
+		}
+		destroyTask, err := virtualMachine.Destroy(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to delete instance %q whose creation didn't complete: %v",
+				virtualMachine.Name(), err)
+		}
+		if err := destroyTask.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("failed to wait for deletion of instance %q whose creation didn't complete: %v",
+				virtualMachine.Name(), err)
+		}
+		if pc.OperatingSystem != providerconfig.OperatingSystemCoreos {
+			datastore, err := finder.Datastore(ctx, config.Datastore)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get datastore %s for instance %q whose creation didn't complete: %v",
+					config.Datastore, virtualMachine.Name(), err)
+			}
+			dc, err := finder.Datacenter(ctx, config.Datacenter)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get vsphere datacenter for instance %q whose creation didn't complete: %v",
+					virtualMachine.Name(), err)
+			}
+			finder.SetDatacenter(dc)
+			filemanager := datastore.NewFileManager(dc, false)
+
+			if err := filemanager.Delete(ctx, virtualMachine.Name()); err != nil {
+				if err.Error() == fmt.Sprintf("File [%s] %s was not found", datastore.Name(), virtualMachine.Name()) {
+					return nil, cloudprovidererrors.ErrInstanceNotFound
+				}
+				return nil, fmt.Errorf("failed to delete storage of deleted instance %q whose cretion didn't complete: %v",
+					virtualMachine.Name(), err)
+			}
+		}
+		return nil, cloudprovidererrors.ErrInstanceNotFound
 	}
 
 	var status instance.Status
@@ -552,28 +666,31 @@ func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
 		status = instance.StatusUnknown
 	}
 
-	isGuestToolsRunning, err := virtualMachine.IsToolsRunning(context.TODO())
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if guest utils are running: %v", err)
-	}
+	// virtualMachine.IsToolsRunning panics when executed on a VM that is not powered on
 	addresses := []string{}
-	if isGuestToolsRunning {
-		var moVirtualMachine mo.VirtualMachine
-		pc := property.DefaultCollector(client.Client)
-		if err := pc.RetrieveOne(context.TODO(), virtualMachine.Reference(), []string{"guest"}, &moVirtualMachine); err != nil {
-			return nil, fmt.Errorf("failed to retrieve guest info: %v", err)
+	if powerState == types.VirtualMachinePowerStatePoweredOn {
+		isGuestToolsRunning, err := virtualMachine.IsToolsRunning(context.TODO())
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if guest utils are running: %v", err)
 		}
+		if isGuestToolsRunning {
+			var moVirtualMachine mo.VirtualMachine
+			pc := property.DefaultCollector(client.Client)
+			if err := pc.RetrieveOne(context.TODO(), virtualMachine.Reference(), []string{"guest"}, &moVirtualMachine); err != nil {
+				return nil, fmt.Errorf("failed to retrieve guest info: %v", err)
+			}
 
-		for _, nic := range moVirtualMachine.Guest.Net {
-			for _, address := range nic.IpAddress {
-				// Exclude ipv6 link-local addresses and default Docker bridge
-				if !strings.HasPrefix(address, "fe80:") && !strings.HasPrefix(address, "172.17.") {
-					addresses = append(addresses, address)
+			for _, nic := range moVirtualMachine.Guest.Net {
+				for _, address := range nic.IpAddress {
+					// Exclude ipv6 link-local addresses and default Docker bridge
+					if !strings.HasPrefix(address, "fe80:") && !strings.HasPrefix(address, "172.17.") {
+						addresses = append(addresses, address)
+					}
 				}
 			}
+		} else {
+			glog.V(3).Infof("vmware guest utils for machine %s are not running, can't match it to a node!", machine.Spec.Name)
 		}
-	} else {
-		glog.V(3).Infof("vmware guest utils for machine %s are not running, can't match it to a node!", machine.Spec.Name)
 	}
 
 	return Server{name: virtualMachine.Name(), status: status, addresses: addresses, id: virtualMachine.Reference().Value}, nil


### PR DESCRIPTION
This is a cherry-pick of #3472. This is needed because the release contains bug fixes. See https://github.com/kubermatic/machine-controller/releases/tag/v1.1.7 for more details.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
vSphere VMs are cleaned up on ISO failure. 
```

/assign @alvaroaleman 