### PR TITLE
add support to set node taints during NodeDeployment creation

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -4787,6 +4787,14 @@
         "operatingSystem": {
           "$ref": "#/definitions/OperatingSystemSpec"
         },
+        "taints": {
+          "description": "List of taints to set on new nodes",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TaintSpec"
+          },
+          "x-go-name": "Taints"
+        },
         "versions": {
           "$ref": "#/definitions/NodeVersionInfo"
         }
@@ -5571,6 +5579,25 @@
           "description": "Token the JWT token",
           "type": "string",
           "x-go-name": "Token"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "TaintSpec": {
+      "description": "TaintSpec defines a node taint",
+      "type": "object",
+      "properties": {
+        "effect": {
+          "type": "string",
+          "x-go-name": "Effect"
+        },
+        "key": {
+          "type": "string",
+          "x-go-name": "Key"
+        },
+        "value": {
+          "type": "string",
+          "x-go-name": "Value"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -602,6 +602,13 @@ type NodeVersionInfo struct {
 	Kubelet string `json:"kubelet"`
 }
 
+// TaintSpec defines a node taint
+type TaintSpec struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Effect string `json:"effect"`
+}
+
 // NodeSpec node specification
 // swagger:model NodeSpec
 type NodeSpec struct {
@@ -615,6 +622,8 @@ type NodeSpec struct {
 	// It will be applied to Nodes allowing users run their apps on specific Node using labelSelector.
 	// required: false
 	Labels map[string]string `json:"labels,omitempty"`
+	// List of taints to set on new nodes
+	Taints []TaintSpec `json:"taints,omitempty"`
 }
 
 // DigitaloceanNodeSpec digitalocean node settings

--- a/api/pkg/handler/v1/node/node.go
+++ b/api/pkg/handler/v1/node/node.go
@@ -145,6 +145,15 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 		return nil, fmt.Errorf("failed to get node cloud spec from machine deployment: %v", err)
 	}
 
+	taints := make([]apiv1.TaintSpec, len(md.Spec.Template.Spec.Taints))
+	for i, taint := range md.Spec.Template.Spec.Taints {
+		taints[i] = apiv1.TaintSpec{
+			Effect: string(taint.Effect),
+			Key:    taint.Key,
+			Value:  taint.Value,
+		}
+	}
+
 	return &apiv1.NodeDeployment{
 		ObjectMeta: apiv1.ObjectMeta{
 			ID:                md.Name,
@@ -156,6 +165,7 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 			Replicas: *md.Spec.Replicas,
 			Template: apiv1.NodeSpec{
 				Labels: md.Spec.Template.Spec.Labels,
+				Taints: taints,
 				Versions: apiv1.NodeVersionInfo{
 					Kubelet: md.Spec.Template.Spec.Versions.Kubelet,
 				},

--- a/api/pkg/handler/v1/node/node_test.go
+++ b/api/pkg/handler/v1/node/node_test.go
@@ -510,6 +510,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(true)),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
+
 		// scenario 5
 		{
 			Name:                   "scenario 5: set taints",

--- a/api/pkg/handler/v1/node/node_test.go
+++ b/api/pkg/handler/v1/node/node_test.go
@@ -510,6 +510,29 @@ func TestCreateNodeDeployment(t *testing.T) {
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(true)),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
+		// scenario 5
+		{
+			Name:                   "scenario 5: set taints",
+			Body:                   `{"spec":{"replicas":1,"template":{"taints": [{"key":"foo","value":"bar","effect":"NoExecute"}],"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"}}}}`,
+			ExpectedResponse:       `{"name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"taints":[{"key":"foo","value":"bar","effect":"NoExecute"}]},"paused":false},"status":{}}`,
+			HTTPStatus:             http.StatusCreated,
+			ProjectID:              test.GenDefaultProject().Name,
+			ClusterID:              test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+		},
+
+		// scenario 6
+		{
+			Name:                   "scenario 6: invalid taint",
+			Body:                   `{"spec":{"replicas":1,"template":{"taints": [{"key":"foo","value":"bar","effect":"BAD_EFFECT"}],"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"}}}}`,
+			ExpectedResponse:       `{"error":{"code":400,"message":"node deployment validation failed: taint effect 'BAD_EFFECT' not allowed. Allowed: NoExecute, NoSchedule, PreferNoSchedule"}}`,
+			HTTPStatus:             http.StatusBadRequest,
+			ProjectID:              test.GenDefaultProject().Name,
+			ClusterID:              test.GenDefaultCluster().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(genTestCluster(true)),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to set node taints during NodeDeployment creation.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
