### PR TITLE
do not create StatefulSet when migration is enabled

### DIFF
--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.alertmanager.migration.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -122,3 +123,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.alertmanager.resources.storage | default .Values.alertmanager.storageSize }}
+{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
One more leftover from the latest Alertmanager renaming PR. Thankfully it seems that deploying the migration job and the StatefulSet at the same time did not cause any issues in the migration itself.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
