### PR TITLE
Remove unused OS field from PacketNodeSpec

### DIFF
--- a/api/cmd/conformance-tests/scenarios_packet.go
+++ b/api/cmd/conformance-tests/scenarios_packet.go
@@ -87,7 +87,6 @@ func (s *packetScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
 				Cloud: kubermaticapiv1.NodeCloudSpec{
 					Packet: &kubermaticapiv1.PacketNodeSpec{
 						InstanceType: "t1.small.x86",
-						OS:           "coreos",
 					},
 				},
 				Versions: kubermaticapiv1.NodeVersionInfo{

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -5106,19 +5106,13 @@
       "description": "PacketNodeSpec specifies packet specific node settings",
       "type": "object",
       "required": [
-        "instanceType",
-        "os"
+        "instanceType"
       ],
       "properties": {
         "instanceType": {
           "description": "InstanceType denotes the plan to which the device will be provisioned.",
           "type": "string",
           "x-go-name": "InstanceType"
-        },
-        "os": {
-          "description": "OS denotes the operating system with which the device will be provisioned.",
-          "type": "string",
-          "x-go-name": "OS"
         },
         "tags": {
           "description": "additional instance tags",

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -683,9 +683,6 @@ type PacketNodeSpec struct {
 	// InstanceType denotes the plan to which the device will be provisioned.
 	// required: true
 	InstanceType string `json:"instanceType"`
-	// OS denotes the operating system with which the device will be provisioned.
-	// required: true
-	OS string `json:"os"`
 	// additional instance tags
 	// required: false
 	Tags []string `json:"tags"`

--- a/api/pkg/machine/convert.go
+++ b/api/pkg/machine/convert.go
@@ -141,7 +141,6 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 		}
 		cloudSpec.Packet = &apiv1.PacketNodeSpec{
 			InstanceType: config.InstanceType.Value,
-			OS:           config.OS.Value,
 		}
 		for _, v := range config.Tags {
 			cloudSpec.Packet.Tags = append(cloudSpec.Packet.Tags, v.Value)

--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -228,7 +228,6 @@ func getDigitaloceanProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpe
 func getPacketProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc provider.DatacenterMeta) (*runtime.RawExtension, error) {
 	config := packet.RawConfig{
 		InstanceType: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Packet.InstanceType},
-		OS:           providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Packet.OS},
 	}
 
 	tags := sets.NewString(nodeSpec.Cloud.Packet.Tags...)


### PR DESCRIPTION
Related: https://github.com/kubermatic/machine-controller/pull/534

/cc @alvaroaleman @maciaszczykm 


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
