### PR TITLE
Allow filtering of OpenStack node flavors by minimum CPU and memory

### DIFF
--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -452,7 +452,7 @@ func (r Routing) listOpenstackSizes() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-		)(provider.OpenstackSizeEndpoint(r.cloudProviders)),
+		)(provider.OpenstackSizeEndpoint(r.cloudProviders, r.datacenters)),
 		provider.DecodeOpenstackReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
@@ -1660,7 +1660,7 @@ func (r Routing) listOpenstackSizesNoCredentials() http.Handler {
 			middleware.UserSaver(r.userProvider),
 			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
 			middleware.UserInfoExtractor(r.userProjectMapper),
-		)(provider.OpenstackSizeNoCredentialsEndpoint(r.projectProvider, r.cloudProviders)),
+		)(provider.OpenstackSizeNoCredentialsEndpoint(r.projectProvider, r.cloudProviders, r.datacenters)),
 		provider.DecodeOpenstackNoCredentialsReq,
 		encodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -46,7 +46,15 @@ type OpenstackSpec struct {
 	ManageSecurityGroups *bool `yaml:"manage_security_groups"`
 	// Gets mapped to the "trust-device-path" setting in the cloud config.
 	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage
-	TrustDevicePath *bool `yaml:"trust_device_path"`
+	TrustDevicePath      *bool                         `yaml:"trust_device_path"`
+	NodeSizeRequirements OpenstackNodeSizeRequirements `yaml:"node_size_requirements"`
+}
+
+type OpenstackNodeSizeRequirements struct {
+	// VCPUs is the minimum required amount of (virtual) CPUs
+	MinimumVCPUs int `yaml:"minimum_vcpus"`
+	// MinimumMemory is the minimum required amount of memory, measured in MB
+	MinimumMemory int `yaml:"minimum_memory"`
 }
 
 // AzureSpec describes an Azure cloud datacenter


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows vendor to configure per datacenter the minimum required node
CPU and memory size for customer clusters, to prevent customers to create
nodes on which the deployed addons would not fit.

**Documentation**:
Will be provided by @mrIncompetent.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Openstack: datacenter can be configured with minimum required CPU and memory for nodes
```
