### PR TITLE
unify finalizer handling

### DIFF
--- a/api/pkg/clusterdeletion/deletion.go
+++ b/api/pkg/clusterdeletion/deletion.go
@@ -183,8 +183,8 @@ func (d *Deletion) cleanupInClusterResources(ctx context.Context, cluster *kuber
 	}
 
 	return d.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, kubermaticapiv1.InClusterLBCleanupFinalizer)
-		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, kubermaticapiv1.InClusterPVCleanupFinalizer)
+		kuberneteshelper.RemoveFinalizer(c, kubermaticapiv1.InClusterLBCleanupFinalizer)
+		kuberneteshelper.RemoveFinalizer(c, kubermaticapiv1.InClusterPVCleanupFinalizer)
 	})
 }
 
@@ -269,7 +269,7 @@ func (d *Deletion) deletingNodeCleanup(ctx context.Context, cluster *kubermaticv
 	}
 
 	return d.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-		c.Finalizers = kuberneteshelper.RemoveFinalizer(c.Finalizers, kubermaticapiv1.NodeDeletionFinalizer)
+		kuberneteshelper.RemoveFinalizer(c, kubermaticapiv1.NodeDeletionFinalizer)
 	})
 }
 

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -52,7 +52,7 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 		// Otherwise we fail to delete the nodes and are stuck in a loop
 		if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer) {
 			err = r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-				c.Finalizers = append(c.Finalizers, kubermaticapiv1.NodeDeletionFinalizer)
+				kuberneteshelper.AddFinalizer(c, kubermaticapiv1.NodeDeletionFinalizer)
 			})
 			if err != nil {
 				return nil, err

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -281,7 +281,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	// Otherwise we fail to delete the nodes and are stuck in a loop
 	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer) {
 		err = r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-			c.Finalizers = append(c.Finalizers, kubermaticapiv1.NodeDeletionFinalizer)
+			kuberneteshelper.AddFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer)
 		})
 		if err != nil {
 			return nil, err

--- a/api/pkg/controller/user-project-binding/user_project_binding_controller.go
+++ b/api/pkg/controller/user-project-binding/user_project_binding_controller.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -136,10 +136,8 @@ func (r *reconcileSyncProjectBinding) ensureNotProjectOwnerForBinding(projectBin
 }
 
 func (r *reconcileSyncProjectBinding) removeFinalizerFromBinding(projectBinding *kubermaticv1.UserProjectBinding) error {
-	if sets.NewString(projectBinding.Finalizers...).Has(rbac.CleanupFinalizerName) {
-		finalizers := sets.NewString(projectBinding.Finalizers...)
-		finalizers.Delete(rbac.CleanupFinalizerName)
-		projectBinding.Finalizers = finalizers.List()
+	if kuberneteshelper.HasFinalizer(projectBinding, rbac.CleanupFinalizerName) {
+		kuberneteshelper.RemoveFinalizer(projectBinding, rbac.CleanupFinalizerName)
 		return r.Update(r.ctx, projectBinding)
 
 	}

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -326,10 +326,10 @@ func DeleteEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 			if req.DeleteLoadBalancers {
-				existingCluster.Finalizers = kuberneteshelper.AddFinalizer(existingCluster.Finalizers, apiv1.InClusterLBCleanupFinalizer)
+				kuberneteshelper.AddFinalizer(existingCluster, apiv1.InClusterLBCleanupFinalizer)
 			}
 			if req.DeleteVolumes {
-				existingCluster.Finalizers = kuberneteshelper.AddFinalizer(existingCluster.Finalizers, apiv1.InClusterPVCleanupFinalizer)
+				kuberneteshelper.AddFinalizer(existingCluster, apiv1.InClusterPVCleanupFinalizer)
 			}
 
 			if _, err = clusterProvider.Update(userInfo, existingCluster); err != nil {

--- a/api/pkg/kubernetes/helper.go
+++ b/api/pkg/kubernetes/helper.go
@@ -13,18 +13,18 @@ func HasFinalizer(o metav1.Object, name string) bool {
 	return sets.NewString(o.GetFinalizers()...).Has(name)
 }
 
-// RemoveFinalizer removes the given finalizer and returns the cleaned list
-func RemoveFinalizer(finalizers []string, toRemove string) []string {
-	set := sets.NewString(finalizers...)
+// RemoveFinalizer removes the given finalizer from the object
+func RemoveFinalizer(obj metav1.Object, toRemove string) {
+	set := sets.NewString(obj.GetFinalizers()...)
 	set.Delete(toRemove)
-	return set.List()
+	obj.SetFinalizers(set.List())
 }
 
 // AddFinalizer will add the given finalizer to the object. It uses a StringSet to avoid duplicates
-func AddFinalizer(finalizers []string, toAdd string) []string {
-	set := sets.NewString(finalizers...)
-	set.Insert(toAdd)
-	return set.List()
+func AddFinalizer(obj metav1.Object, finalizer string) {
+	set := sets.NewString(obj.GetFinalizers()...)
+	set.Insert(finalizer)
+	obj.SetFinalizers(set.List())
 }
 
 // GenerateToken generates a new, random token that can be used

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -496,7 +496,7 @@ func (a *amazonEc2) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 			return nil, fmt.Errorf("createSecurityGroup for cluster %s did not return sg id", cluster.Name)
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = append(cluster.Finalizers, securityGroupCleanupFinalizer)
+			kuberneteshelper.AddFinalizer(cluster, securityGroupCleanupFinalizer)
 			cluster.Spec.Cloud.AWS.SecurityGroupID = securityGroupID
 		})
 		if err != nil {
@@ -515,7 +515,7 @@ func (a *amazonEc2) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 			return nil, fmt.Errorf("failed to create instance profile: %v", err)
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = append(cluster.Finalizers, instanceProfileCleanupFinalizer)
+			kuberneteshelper.AddFinalizer(cluster, instanceProfileCleanupFinalizer)
 			cluster.Spec.Cloud.AWS.RoleName = *role.RoleName
 			cluster.Spec.Cloud.AWS.InstanceProfileName = *instanceProfile.InstanceProfileName
 		})
@@ -542,7 +542,7 @@ func (a *amazonEc2) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 			return nil, err
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = append(cluster.Finalizers, tagCleanupFinalizer)
+			kuberneteshelper.AddFinalizer(cluster, tagCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -597,7 +597,7 @@ func (a *amazonEc2) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 			}
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kuberneteshelper.RemoveFinalizer(cluster.Finalizers, securityGroupCleanupFinalizer)
+			kuberneteshelper.RemoveFinalizer(cluster, securityGroupCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -646,7 +646,7 @@ func (a *amazonEc2) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 			}
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kuberneteshelper.RemoveFinalizer(cluster.Finalizers, instanceProfileCleanupFinalizer)
+			kuberneteshelper.RemoveFinalizer(cluster, instanceProfileCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -658,7 +658,7 @@ func (a *amazonEc2) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 			return nil, err
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kuberneteshelper.RemoveFinalizer(cluster.Finalizers, tagCleanupFinalizer)
+			kuberneteshelper.RemoveFinalizer(cluster, tagCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err

--- a/api/pkg/provider/cloud/azure/provider.go
+++ b/api/pkg/provider/cloud/azure/provider.go
@@ -165,7 +165,7 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 			}
 		}
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerSecurityGroup)
+			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerSecurityGroup)
 		})
 		if err != nil {
 			return nil, err
@@ -180,7 +180,7 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 			}
 		}
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerRouteTable)
+			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerRouteTable)
 		})
 		if err != nil {
 			return nil, err
@@ -195,7 +195,7 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 			}
 		}
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerSubnet)
+			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerSubnet)
 		})
 		if err != nil {
 			return nil, err
@@ -211,7 +211,7 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 		}
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerVNet)
+			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerVNet)
 		})
 		if err != nil {
 			return nil, err
@@ -227,7 +227,7 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 		}
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerResourceGroup)
+			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerResourceGroup)
 		})
 		if err != nil {
 			return nil, err
@@ -243,7 +243,7 @@ func (a *azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provi
 		}
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
-			updatedCluster.Finalizers = kuberneteshelper.RemoveFinalizer(updatedCluster.Finalizers, FinalizerAvailabilitySet)
+			kuberneteshelper.RemoveFinalizer(updatedCluster, FinalizerAvailabilitySet)
 		})
 		if err != nil {
 			return nil, err
@@ -496,7 +496,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.ResourceGroup = cluster.Spec.Cloud.Azure.ResourceGroup
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerResourceGroup)
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerResourceGroup)
 		})
 		if err != nil {
 			return nil, err
@@ -513,7 +513,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.VNetName = cluster.Spec.Cloud.Azure.VNetName
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerVNet)
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerVNet)
 		})
 		if err != nil {
 			return nil, err
@@ -530,7 +530,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.SubnetName = cluster.Spec.Cloud.Azure.SubnetName
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerSubnet)
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSubnet)
 		})
 		if err != nil {
 			return nil, err
@@ -547,7 +547,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.RouteTableName = cluster.Spec.Cloud.Azure.RouteTableName
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerRouteTable)
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerRouteTable)
 		})
 		if err != nil {
 			return nil, err
@@ -564,7 +564,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.SecurityGroup = cluster.Spec.Cloud.Azure.SecurityGroup
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerSecurityGroup)
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerSecurityGroup)
 		})
 		if err != nil {
 			return nil, err
@@ -581,7 +581,7 @@ func (a *azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update pr
 
 		cluster, err = update(cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.AvailabilitySet = asName
-			updatedCluster.Finalizers = append(updatedCluster.Finalizers, FinalizerAvailabilitySet)
+			kuberneteshelper.AddFinalizer(updatedCluster, FinalizerAvailabilitySet)
 		})
 		if err != nil {
 			return nil, err

--- a/api/pkg/provider/cloud/gcp/provider.go
+++ b/api/pkg/provider/cloud/gcp/provider.go
@@ -69,7 +69,7 @@ func (g *gcp) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update prov
 
 	if !kuberneteshelper.HasFinalizer(cluster, firewallCleanupFinalizer) {
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = append(cluster.Finalizers, firewallCleanupFinalizer)
+			kuberneteshelper.AddFinalizer(cluster, firewallCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -107,7 +107,7 @@ func (g *gcp) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provide
 		}
 
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kuberneteshelper.RemoveFinalizer(cluster.Finalizers, firewallCleanupFinalizer)
+			kuberneteshelper.RemoveFinalizer(cluster, firewallCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to remove %s finalizer: %v", firewallCleanupFinalizer, err)

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -154,7 +154,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.Openstack.SecurityGroups = g.Name
-			cluster.Finalizers = kubernetes.AddFinalizer(cluster.Finalizers, SecurityGroupCleanupFinalizer)
+			kubernetes.AddFinalizer(cluster, SecurityGroupCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -168,7 +168,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.Openstack.Network = network.Name
-			cluster.Finalizers = kubernetes.AddFinalizer(cluster.Finalizers, NetworkCleanupFinalizer)
+			kubernetes.AddFinalizer(cluster, NetworkCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -188,7 +188,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.Openstack.SubnetID = subnet.ID
-			cluster.Finalizers = kubernetes.AddFinalizer(cluster.Finalizers, SubnetCleanupFinalizer)
+			kubernetes.AddFinalizer(cluster, SubnetCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -207,7 +207,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 				}
 				cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 					cluster.Spec.Cloud.Openstack.RouterID = router.ID
-					cluster.Finalizers = kubernetes.AddFinalizer(cluster.Finalizers, RouterCleanupFinalizer)
+					kubernetes.AddFinalizer(cluster, RouterCleanupFinalizer)
 				})
 				if err != nil {
 					return nil, err
@@ -234,7 +234,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 		}
 
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kubernetes.AddFinalizer(cluster.Finalizers, RouterSubnetLinkCleanupFinalizer)
+			kubernetes.AddFinalizer(cluster, RouterSubnetLinkCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -260,7 +260,7 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 		}
 
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kubernetes.RemoveFinalizer(cluster.Finalizers, SecurityGroupCleanupFinalizer)
+			kubernetes.RemoveFinalizer(cluster, SecurityGroupCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -274,7 +274,7 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 			}
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kubernetes.RemoveFinalizer(cluster.Finalizers, RouterSubnetLinkCleanupFinalizer)
+			kubernetes.RemoveFinalizer(cluster, RouterSubnetLinkCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -286,7 +286,7 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 			return nil, fmt.Errorf("failed to delete subnet '%s': %v", cluster.Spec.Cloud.Openstack.SubnetID, err)
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kubernetes.RemoveFinalizer(cluster.Finalizers, SubnetCleanupFinalizer)
+			kubernetes.RemoveFinalizer(cluster, SubnetCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -301,7 +301,7 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 		}
 
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kubernetes.RemoveFinalizer(cluster.Finalizers, NetworkCleanupFinalizer)
+			kubernetes.RemoveFinalizer(cluster, NetworkCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -316,7 +316,7 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 		}
 
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kubernetes.RemoveFinalizer(cluster.Finalizers, RouterCleanupFinalizer)
+			kubernetes.RemoveFinalizer(cluster, RouterCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -325,7 +325,7 @@ func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update p
 
 	if kubernetes.HasFinalizer(cluster, OldNetworkCleanupFinalizer) {
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kubernetes.RemoveFinalizer(cluster.Finalizers, OldNetworkCleanupFinalizer)
+			kubernetes.RemoveFinalizer(cluster, OldNetworkCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err

--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -111,7 +111,7 @@ func (v *Provider) createVMFolderForCluster(cluster *kubermaticv1.Cluster, updat
 
 	if !kuberneteshelper.HasFinalizer(cluster, folderCleanupFinalizer) {
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = append(cluster.Finalizers, folderCleanupFinalizer)
+			kuberneteshelper.AddFinalizer(cluster, folderCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -245,7 +245,7 @@ func (v *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update pr
 		}
 		// Folder is not there anymore, maybe someone deleted it manually
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Finalizers = kuberneteshelper.RemoveFinalizer(cluster.Finalizers, folderCleanupFinalizer)
+			kuberneteshelper.RemoveFinalizer(cluster, folderCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err
@@ -262,7 +262,7 @@ func (v *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update pr
 	}
 
 	cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-		cluster.Finalizers = kuberneteshelper.RemoveFinalizer(cluster.Finalizers, folderCleanupFinalizer)
+		kuberneteshelper.RemoveFinalizer(cluster, folderCleanupFinalizer)
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR unifies the finalizer handling across all controllers.
Instead of doing:
```golang
set := strings.NewSet(obj.Finalizers...)
set.Insert("myFancyFinalizer")
obj.Finalizers = set.List()
```
we now have helper functions which do all that:
```golang
kuberneteshelper.AddFinalizer(project, "myFancyFinalizer")
```

The helper functions use `metav1.Object` interface which makes the function applicable for all Kubernetes related objects.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
