### PR TITLE
fix broken caller log

### DIFF
--- a/api/pkg/log/zap.go
+++ b/api/pkg/log/zap.go
@@ -81,7 +81,6 @@ func New(debug bool, format Format) *zap.Logger {
 
 	opts := []zap.Option{
 		zap.AddCaller(),
-		zap.AddCallerSkip(1),
 		zap.ErrorOutput(sink),
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the broken caller field in our logs.
Before:
```
{"level":"info","time":"2019-05-15T16:17:25.172Z","caller":"run/group.go:38","msg":"Starting the internal HTTP server: 0.0.0.0:8085\n"}
{"level":"info","time":"2019-05-15T16:17:42.638Z","caller":"runtime/asm_amd64.s:1337","msg":"Acquired the leader lease"}
{"level":"info","time":"2019-05-15T16:17:42.639Z","caller":"runtime/asm_amd64.s:1337","msg":"Executing migrations..."}
```

After:
```
{"level":"debug","time":"2019-05-15T19:45:57.627+0200","caller":"kubermatic-controller-manager/main.go:105","msg":"Starting clusters collector"}
{"level":"info","time":"2019-05-15T19:45:57.627+0200","caller":"kubermatic-controller-manager/main.go:138","msg":"Starting the internal HTTP server: 127.0.0.1:8082\n"}
{"level":"info","time":"2019-05-15T19:45:57.697+0200","caller":"kubermatic-controller-manager/main.go:156","msg":"Acquired the leader lease"}
{"level":"info","time":"2019-05-15T19:45:57.697+0200","caller":"kubermatic-controller-manager/main.go:158","msg":"Executing migrations..."}
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
