### PR TITLE
Avoid initial `externalIP is unset` reconciling error

### DIFF
--- a/api/pkg/resources/address/address.go
+++ b/api/pkg/resources/address/address.go
@@ -60,7 +60,7 @@ func SyncClusterAddress(ctx context.Context,
 	if err := client.Get(ctx, serviceKey, service); err != nil {
 		if kerrors.IsNotFound(err) {
 			glog.V(4).Infof("Skipping URL setting for cluster %s as no external apiserver service exists yet. Will retry later", cluster.Name)
-			return nil, nil
+			return modifiers, nil
 		}
 		return nil, err
 	}


### PR DESCRIPTION
`SyncAddress` currently doesn't update any part of the address if the
apiserver service doesn't exist, even thought it can already update the
IP which is needed to not get the above-mentioned error when creating
the apiservers serving cert secret


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
