### PR TITLE
Avoid re-creating addon resources when cluster was deleted

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -179,6 +179,11 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addo
 		return nil
 	}
 
+	if cluster.DeletionTimestamp != nil {
+		log.Debug("Skipping addon because cluster is deleted")
+		return nil
+	}
+
 	if cluster.Spec.Pause {
 		log.Debug("Skipping because the cluster is paused")
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Otherwise addons may re-create LB/PV resoruces we are trying to cleanup

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3488

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 
/CC @kron4eg 
