### PR TITLE
Add ownerref to etcd backup secret

### DIFF
--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -275,10 +275,13 @@ func (r *Reconciler) ensureCronJobSecret(ctx context.Context, cluster *kubermati
 		getCA,
 	)()
 
+	wrappedCreator := reconciling.SecretObjectWrapper(creator)
+	wrappedCreator = reconciling.OwnerRefWrapper(resources.GetClusterRef(cluster))(wrappedCreator)
+
 	err := reconciling.EnsureNamedObject(
 		ctx,
 		types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: secretName},
-		reconciling.SecretObjectWrapper(creator), r.Client, &corev1.Secret{}, false)
+		wrappedCreator, r.Client, &corev1.Secret{}, false)
 	if err != nil {
 		return fmt.Errorf("failed to ensure Secret %q: %v", secretName, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the etcd secrets in the kube-system namespace created for allowing the backup cronjob to access the etcd never get cleaned up, because they have no ownerRef.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
