### PR TITLE
allow to define passthrough paths for IAP

### DIFF
--- a/config/iap/templates/ingresses.yaml
+++ b/config/iap/templates/ingresses.yaml
@@ -23,6 +23,14 @@ spec:
   - host: {{ .ingress.host | trim }}
     http:
       paths:
+      {{- $upstream_service := .upstream_service }}
+      {{- $upstream_port := .upstream_port }}
+      {{- range .passthrough }}
+      - path: "{{ . }}"
+        backend:
+          serviceName: {{ $upstream_service }}
+          servicePort: {{ $upstream_port }}
+      {{- end }}
       - path: "/"
         backend:
           serviceName: {{ .name }}-iap

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -18,6 +18,16 @@ iap:
     #   ingress:
     #     host: "alertmanager.kubermatic.tld"
     #     annotations: {}
+    #   # List of URL prefixes for which nginx should be configured to route requests
+    #   # directly to the upstream service instead of to the Keycloak Proxy;
+    #   # this can be useful for health check which should not generate load on the
+    #   # identity aware proxy (Dex for example creates AuthRequest CRDs for each
+    #   # opened session).
+    #   # Be careful to not accidentally expose a health endpoint that in case of errors
+    #   # or bad configuration can respond with confidential data (error messages,
+    #   # stack traces, configuration, ...).
+    #   passthrough:
+    #   - /-/healthy # exposes nothing
     # grafana:
     #   name: grafana
     #   client_id: grafana
@@ -29,6 +39,8 @@ iap:
     #   ingress:
     #     host: "grafana.kubermatic.tld"
     #     annotations: {}
+    #   annotations:
+    #   - /api/health # exposes Grafana version and Git hash
     # kibana:
     #   name: kibana
     #   client_id: kibana
@@ -40,6 +52,8 @@ iap:
     #   ingress:
     #     host: "kibana.kubermatic.tld"
     #     annotations: {}
+    #   passthrough:
+    #   - /ui/favicons/favicon.ico # exposes nothing
     # prometheus:
     #   name: prometheus
     #   client_id: prometheus
@@ -52,6 +66,8 @@ iap:
     #     host: "prometheus.kubermatic.tld"
     #     annotations:
     #       ingress.kubernetes.io/upstream-hash-by: "ip_hash" ## needed for prometheus federations
+    #   passthrough:
+    #   - /-/healthy # exposes nothing
 
   discovery_url: https://kubermatic.tld/dex/.well-known/openid-configuration
   port: 3000


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently discovered an enormous amount (~22k) of AuthRequest resources created by Dex. After a bit of testing this seems to be caused by the blackbox-exporter hitting Kibana/Prometheus/Alertmanager and thereby "opening" a new session. This makes Dex create one AuthRequest resource per scrape and target, i.e. in our setup 4 resources every 30 seconds.
This slows down Dex' startup and puts load on the API server without any real need.

This PR makes it so that we can configure paths that are passed through directly to the application, circumventing the IAP entirely. It's possible that we thereby expose a few bits of information here and there, but maybe it's a worthwhile tradeoff. Plus this is not a default config that we install for customers, so there is little danger of accidentally exposing stuff.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
