### PR TITLE
[release/v2.10] Avoid re-creating addon resources when cluster was deleted (#3505)

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -178,6 +178,11 @@ func (r *Reconciler) reconcile(ctx context.Context, addon *kubermaticv1.Addon) e
 		return nil
 	}
 
+	if cluster.DeletionTimestamp != nil {
+		glog.V(4).Infof("Skipping addon %q because cluster is deleted", addon.Name)
+		return nil
+	}
+
 	if cluster.Spec.Pause {
 		glog.V(4).Infof("skipping paused cluster %s", cluster.Name)
 		return nil


### PR DESCRIPTION
This is a manual cherry-pick of #3505

/assign alvaroaleman

```release-note
none
```