### PR TITLE
restore Elasticsearch compatibility with Kubermatic 2.9

### DIFF
--- a/config/logging/elasticsearch/templates/es-data-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-data-stateful.yaml
@@ -10,7 +10,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
   serviceName: es-data
-  replicas: {{ .Values.logging.elasticsearch.data.replicas }}
+  replicas: {{ .Values.logging.elasticsearch.dataReplicas | default .Values.logging.elasticsearch.data.replicas }}
   selector:
     matchLabels:
       component: elasticsearch
@@ -118,7 +118,7 @@ spec:
               - /bin/bash
               - /post-start-hook.sh
         resources:
-{{ toYaml .Values.logging.elasticsearch.data.resources | indent 10 }}
+{{ toYaml (.Values.logging.elasticsearch.resources.data | default .Values.logging.elasticsearch.data.resources) | indent 10 }}
         volumeMounts:
         - name: storage
           mountPath: /usr/share/elasticsearch/data
@@ -154,4 +154,4 @@ spec:
       accessModes: [ ReadWriteOnce ]
       resources:
         requests:
-          storage: {{ .Values.logging.elasticsearch.data.storageSize }}
+          storage: {{ .Values.logging.elasticsearch.storageSize | default .Values.logging.elasticsearch.data.storageSize }}

--- a/config/logging/elasticsearch/templates/es-master-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-master-stateful.yaml
@@ -10,7 +10,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
   serviceName: es-master
-  replicas: {{ .Values.logging.elasticsearch.master.replicas }}
+  replicas: {{ .Values.logging.elasticsearch.masterReplicas | default .Values.logging.elasticsearch.master.replicas }}
   selector:
     matchLabels:
       component: elasticsearch
@@ -119,7 +119,7 @@ spec:
               - /bin/bash
               - /post-start-hook.sh
         resources:
-{{ toYaml .Values.logging.elasticsearch.master.resources | indent 10 }}
+{{ toYaml (.Values.logging.elasticsearch.resources.master | default .Values.logging.elasticsearch.master.resources) | indent 10 }}
         volumeMounts:
         - name: storage
           mountPath: /usr/share/elasticsearch/data
@@ -155,4 +155,4 @@ spec:
       accessModes: [ ReadWriteOnce ]
       resources:
         requests:
-          storage: {{ .Values.logging.elasticsearch.master.storageSize }}
+          storage: {{ .Values.logging.elasticsearch.masterStorageSize | default .Values.logging.elasticsearch.master.storageSize }}

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -107,3 +107,7 @@ logging:
       nodeSelector: {}
       affinity: {}
       tolerations: []
+
+    # this key is only used to make templating easier and should
+    # be removed once we switch to Elasticsearch 7.0
+    resources: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
In #3062 I updated the values.yaml structure to accomodate the new ES version, cerebro and stuff. This broke backwards compatibility with Kubermatic 2.9 and lead to the situation where our own cluster is now using the (smallish) default volume size of 10Gi instead of what we actually configured in our secrets repo.

This PR adds extra code to allow Kubermatic 2.9 configuration to still work, so we can then remove the compat stuff in Kubermatic 2.11 (when we also finally switch to ES 7.0).

Thankfully the renamed config keys were in fact [documented](https://docs.kubermatic.io/upgrading/2.9_to_2.10/#explicit-resource-requests-limits), but we should still use 2.10 as a transition period.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
