### PR TITLE
fix IAP generating invalid ingresses pointing to other namespaces

### DIFF
--- a/config/iap/templates/ingresses.yaml
+++ b/config/iap/templates/ingresses.yaml
@@ -23,12 +23,12 @@ spec:
   - host: {{ .ingress.host | trim }}
     http:
       paths:
-      {{- $upstream_service := .upstream_service }}
+      {{- $name := .name }}
       {{- $upstream_port := .upstream_port }}
       {{- range .passthrough }}
       - path: "{{ . }}"
         backend:
-          serviceName: {{ $upstream_service }}
+          serviceName: {{ $name }}-upstream
           servicePort: {{ $upstream_port }}
       {{- end }}
       - path: "/"

--- a/config/iap/templates/services.yaml
+++ b/config/iap/templates/services.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: iap
     target: {{ .name }}
+    kind: proxy
 spec:
   type: ClusterIP
   ports:
@@ -17,4 +18,22 @@ spec:
   selector:
     app: iap
     target: {{ .name }}
+
+{{- if .passthrough }}
+---
+# This service is used to allow the ingress to access services in other namespaces.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .name }}-upstream
+  labels:
+    app: iap
+    target: {{ .name }}
+    kind: upstream
+spec:
+  type: ExternalName
+  externalName: {{ .upstream_service }}
+  ports:
+  - port: {{ .upstream_port }}
+{{- end }}
 {{- end }}

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -39,7 +39,7 @@ iap:
     #   ingress:
     #     host: "grafana.kubermatic.tld"
     #     annotations: {}
-    #   annotations:
+    #   passthrough:
     #   - /api/health # exposes Grafana version and Git hash
     # kibana:
     #   name: kibana


### PR DESCRIPTION
**What this PR does / why we need it**:
It turns out that Ingresses cannot have backends in other namespaces, which is sad for our attempt to passthrough paths directly to the services.

"This one weird trick" fixes it by creating an alias ExternalName service that points to the upstream service.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
