### PR TITLE
specify leaderelection lock name for the user cluster controller manager

### DIFF
--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -132,7 +132,12 @@ func main() {
 
 	log.SetLogger(log.ZapLogger(false))
 
-	mgr, err := manager.New(cfg, manager.Options{LeaderElection: true, LeaderElectionNamespace: metav1.NamespaceSystem, MetricsBindAddress: runOp.metricsListenAddr})
+	mgr, err := manager.New(cfg, manager.Options{
+		LeaderElection:          true,
+		LeaderElectionNamespace: metav1.NamespaceSystem,
+		LeaderElectionID:        "user-cluster-controller-leader-lock",
+		MetricsBindAddress:      runOp.metricsListenAddr,
+	})
 	if err != nil {
 		glog.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Specify leaderelection lock name for the user cluster controller manager.
Otherwise `controller-leader-election-helper` gets used & can potentially conflict with user written controllers.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
