### PR TITLE
fix handling of boolean flags on the kubernetes controller manager

### DIFF
--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -226,27 +226,27 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 	if cluster.Spec.Cloud.AWS != nil {
 		flags = append(flags, "--cloud-provider", "aws")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes", "false")
+		flags = append(flags, "--configure-cloud-routes=false")
 	}
 	if cluster.Spec.Cloud.Openstack != nil {
 		flags = append(flags, "--cloud-provider", "openstack")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes", "false")
+		flags = append(flags, "--configure-cloud-routes=false")
 	}
 	if cluster.Spec.Cloud.VSphere != nil {
 		flags = append(flags, "--cloud-provider", "vsphere")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes", "false")
+		flags = append(flags, "--configure-cloud-routes=false")
 	}
 	if cluster.Spec.Cloud.Azure != nil {
 		flags = append(flags, "--cloud-provider", "azure")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes", "false")
+		flags = append(flags, "--configure-cloud-routes=false")
 	}
 	if cluster.Spec.Cloud.GCP != nil {
 		flags = append(flags, "--cloud-provider", "gce")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes", "true")
+		flags = append(flags, "--configure-cloud-routes=true")
 	}
 
 	if cluster.Spec.Version.Semver().Minor() >= 12 {
@@ -266,7 +266,7 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 		if cluster.Spec.Version.Semver().Patch() > 0 {
 			// Force the authentication lookup to succeed, otherwise if it fails all requests will be treated as anonymous and thus fail
 			// Both the flag and the issue only exist in 1.13.1 and above
-			flags = append(flags, "--authentication-tolerate-lookup-failure", "false")
+			flags = append(flags, "--authentication-tolerate-lookup-failure=false")
 		}
 	}
 

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --client-ca-file

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - aws
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --client-ca-file

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --client-ca-file

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - azure
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --client-ca-file

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --client-ca-file

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - openstack
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --client-ca-file

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         command:
         - /hyperkube
         - controller-manager

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --client-ca-file

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -124,8 +124,7 @@ spec:
         - vsphere
         - --cloud-config
         - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes
-        - "false"
+        - --configure-cloud-routes=false
         - --authentication-kubeconfig
         - /etc/kubernetes/kubeconfig/kubeconfig
         - --client-ca-file


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix handling of boolean flags on the kubernetes controller manager.
The old code activated the route controller for all clusters, which leads to AWS nodes to flap between `Ready` & `NotReady`.

For boolean flags the value must be passed within the flag itself and not as an additional arg.

Reference: https://stackoverflow.com/questions/27411691/how-to-pass-boolean-arguments-to-go-flags

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
