### PR TITLE
update fluent-bit to 1.1.1

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: fluentbit
-version: 1.0.1
-appVersion: 1.0.6
-description: fluentbit
+version: 1.0.2
+appVersion: 1.1.1
+description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:
 - kubermatic
 - logging

--- a/config/logging/fluentbit/templates/clusterrole.yaml
+++ b/config/logging/fluentbit/templates/clusterrole.yaml
@@ -2,9 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: fluent-bit-read
+  labels:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/version: '{{ .Values.logging.fluentbit.image.tag }}'
+    app.kubernetes.io/managed-by: helm
 rules:
-- apiGroups: [""]
-  resources:
-  - namespaces
-  - pods
-  verbs: ["get", "list", "watch"]
+- apiGroups: ['']
+  resources: [namespaces, pods]
+  verbs: [get, list, watch]

--- a/config/logging/fluentbit/templates/clusterrolebinding.yaml
+++ b/config/logging/fluentbit/templates/clusterrolebinding.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: fluent-bit-read
+  labels:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/version: '{{ .Values.logging.fluentbit.image.tag }}'
+    app.kubernetes.io/managed-by: helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -1,9 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluent-bit-config
+  name: fluent-bit
   labels:
-    k8s-app: fluent-bit
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/version: '{{ .Values.logging.fluentbit.image.tag }}'
+    app.kubernetes.io/managed-by: helm
 data:
   # Configuration files: server, input, filters and output
   # ======================================================

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -1,23 +1,21 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
   labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/version: '{{ .Values.logging.fluentbit.image.tag }}'
+    app.kubernetes.io/managed-by: helm
 spec:
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
+        app.kubernetes.io/name: fluent-bit
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '2020'
         prometheus.io/path: /api/v1/metrics/prometheus
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
@@ -30,16 +28,16 @@ spec:
         - containerPort: 2020
         env:
         - name: FLUENT_ELASTICSEARCH_HOST
-          value: "es-data"
+          value: es-data
         - name: FLUENT_ELASTICSEARCH_PORT
-          value: "9200"
+          value: '9200'
         volumeMounts:
         - name: varlog
           mountPath: /var/log
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-        - name: fluent-bit-config
+        - name: config
           mountPath: /fluent-bit/etc/
         resources:
 {{ toYaml .Values.logging.fluentbit.resources | indent 10 }}
@@ -51,9 +49,9 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
-      - name: fluent-bit-config
+      - name: config
         configMap:
-          name: fluent-bit-config
+          name: fluent-bit
       nodeSelector:
 {{ toYaml .Values.logging.fluentbit.nodeSelector | indent 8 }}
       affinity:

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -7,12 +7,23 @@ metadata:
     app.kubernetes.io/version: '{{ .Values.logging.fluentbit.image.tag }}'
     app.kubernetes.io/managed-by: helm
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
+      version: v1
+      kubernetes.io/cluster-service: "true"
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: fluent-bit
+        # TODO: Be bold at some point and adjust these labels to the same
+        # labels used by the DaemonSet. It's not possible without re-creating
+        # the entire DaemonSet, so it's a somewhat breaking change for little
+        # wins, but still worth it for the cleanup itself.
+        k8s-app: fluent-bit-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '2020'

--- a/config/logging/fluentbit/templates/serviceaccount.yaml
+++ b/config/logging/fluentbit/templates/serviceaccount.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fluent-bit
+  labels:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/version: '{{ .Values.logging.fluentbit.image.tag }}'
+    app.kubernetes.io/managed-by: helm

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -2,7 +2,7 @@ logging:
   fluentbit:
     image:
       repository: fluent/fluent-bit
-      tag: 1.0.6
+      tag: 1.1.1
       pullPolicy: IfNotPresent
     configuration:
       containerRuntimeParser: docker


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates fluent-bit to its latest stable version. I wish I could have also updated the pod labels and selector to the new format (especially since the cluster-service label is [deprecated](https://github.com/kubernetes/kubernetes/issues/72757)), but this would cause upgrade issues because the labels are basically immutable.

I did a canary deployment on dev and v1.1.1 seems to work just fine.

**Does this PR introduce a user-facing change?**:
```release-note
update fluent-bit to 1.1.1
```
