### PR TITLE
update Velero to 1.0.0

### DIFF
--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: velero
-version: 1.0.0
-appVersion: v0.11.0
+version: 1.0.1
+appVersion: v1.0.0
 description: A Helm chart for Heptio Velero
 keywords:
 - kubermatic

--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: velero
-version: 1.0.1
+version: 1.1.0
 appVersion: v1.0.0
 description: A Helm chart for Heptio Velero
 keywords:

--- a/config/backup/velero/templates/customresourcedefinitions.yaml
+++ b/config/backup/velero/templates/customresourcedefinitions.yaml
@@ -1,169 +1,177 @@
 # This file has been generated with Velero v1.0.0. Do not edit.
-apiVersion: v1
-items:
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: backups.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: Backup
-      plural: backups
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: backupstoragelocations.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: BackupStorageLocation
-      plural: backupstoragelocations
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: deletebackuprequests.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: DeleteBackupRequest
-      plural: deletebackuprequests
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: downloadrequests.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: DownloadRequest
-      plural: downloadrequests
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: podvolumebackups.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: PodVolumeBackup
-      plural: podvolumebackups
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: podvolumerestores.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: PodVolumeRestore
-      plural: podvolumerestores
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: resticrepositories.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: ResticRepository
-      plural: resticrepositories
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: restores.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: Restore
-      plural: restores
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: schedules.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: Schedule
-      plural: schedules
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: serverstatusrequests.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: ServerStatusRequest
-      plural: serverstatusrequests
-    scope: Namespaced
-    version: v1
-- apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    annotations:
-      helm.sh/hook: crd-install
-    labels:
-      component: velero
-    name: volumesnapshotlocations.velero.io
-  spec:
-    group: velero.io
-    names:
-      kind: VolumeSnapshotLocation
-      plural: volumesnapshotlocations
-    scope: Namespaced
-    version: v1
-kind: List
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: backups.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Backup
+    plural: backups
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: backupstoragelocations.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: BackupStorageLocation
+    plural: backupstoragelocations
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: deletebackuprequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: DeleteBackupRequest
+    plural: deletebackuprequests
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: downloadrequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: DownloadRequest
+    plural: downloadrequests
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: podvolumebackups.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: PodVolumeBackup
+    plural: podvolumebackups
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: podvolumerestores.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: PodVolumeRestore
+    plural: podvolumerestores
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: resticrepositories.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: ResticRepository
+    plural: resticrepositories
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: restores.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Restore
+    plural: restores
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: schedules.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Schedule
+    plural: schedules
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: serverstatusrequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: ServerStatusRequest
+    plural: serverstatusrequests
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/hook: crd-install
+  labels:
+    component: velero
+  name: volumesnapshotlocations.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: VolumeSnapshotLocation
+    plural: volumesnapshotlocations
+  scope: Namespaced
+  version: v1

--- a/config/backup/velero/templates/customresourcedefinitions.yaml
+++ b/config/backup/velero/templates/customresourcedefinitions.yaml
@@ -1,185 +1,169 @@
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: backups.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: backups
-    kind: Backup
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: schedules.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: schedules
-    kind: Schedule
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: restores.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: restores
-    kind: Restore
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: downloadrequests.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: downloadrequests
-    kind: DownloadRequest
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: deletebackuprequests.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: deletebackuprequests
-    kind: DeleteBackupRequest
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: podvolumebackups.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: podvolumebackups
-    kind: PodVolumeBackup
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: podvolumerestores.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: podvolumerestores
-    kind: PodVolumeRestore
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: resticrepositories.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: resticrepositories
-    kind: ResticRepository
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: backupstoragelocations.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: backupstoragelocations
-    kind: BackupStorageLocation
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: volumesnapshotlocations.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: volumesnapshotlocations
-    kind: VolumeSnapshotLocation
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: serverstatusrequests.velero.io
-  labels:
-    component: velero
-  annotations:
-    'helm.sh/hook': crd-install
-spec:
-  group: velero.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: serverstatusrequests
-    kind: ServerStatusRequest
+# This file has been generated with Velero v1.0.0. Do not edit.
+apiVersion: v1
+items:
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: backups.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: Backup
+      plural: backups
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: backupstoragelocations.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: BackupStorageLocation
+      plural: backupstoragelocations
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: deletebackuprequests.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: DeleteBackupRequest
+      plural: deletebackuprequests
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: downloadrequests.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: DownloadRequest
+      plural: downloadrequests
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: podvolumebackups.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: PodVolumeBackup
+      plural: podvolumebackups
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: podvolumerestores.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: PodVolumeRestore
+      plural: podvolumerestores
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: resticrepositories.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: ResticRepository
+      plural: resticrepositories
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: restores.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: Restore
+      plural: restores
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: schedules.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: Schedule
+      plural: schedules
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: serverstatusrequests.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: ServerStatusRequest
+      plural: serverstatusrequests
+    scope: Namespaced
+    version: v1
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      helm.sh/hook: crd-install
+    labels:
+      component: velero
+    name: volumesnapshotlocations.velero.io
+  spec:
+    group: velero.io
+    names:
+      kind: VolumeSnapshotLocation
+      plural: volumesnapshotlocations
+    scope: Namespaced
+    version: v1
+kind: List

--- a/config/backup/velero/templates/daemonset.yaml
+++ b/config/backup/velero/templates/daemonset.yaml
@@ -22,19 +22,16 @@ spec:
       - name: restic
         image: '{{ .Values.velero.image.repository }}:{{ .Values.velero.image.tag }}'
         imagePullPolicy: {{ .Values.velero.image.pullPolicy }}
-
         command:
         - /velero
         args:
         - restic
         - server
-
         {{- if .Values.velero.credentials.azure }}
         envFrom:
         - secretRef:
             name: azure-credentials
         {{- end }}
-
         env:
         - name: NODE_NAME
           valueFrom:
@@ -54,7 +51,6 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /credentials/gcp/creds
         {{- end }}
-
         volumeMounts:
         - name: host-pods
           mountPath: /host_pods
@@ -69,10 +65,8 @@ spec:
         - name: gcp-credentials
           mountPath: /credentials/gcp
         {{- end }}
-
         resources:
 {{ toYaml .Values.velero.restic.resources | indent 10 }}
-
       volumes:
       - name: host-pods
         hostPath:
@@ -89,7 +83,6 @@ spec:
         secret:
           secretName: gcp-credentials
       {{- end }}
-
       serviceAccountName: velero
       securityContext:
         runAsUser: 0

--- a/config/backup/velero/templates/deployment.yaml
+++ b/config/backup/velero/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: velero
@@ -27,7 +27,6 @@ spec:
       - name: velero
         image: '{{ .Values.velero.image.repository }}:{{ .Values.velero.image.tag }}'
         imagePullPolicy: {{ .Values.velero.image.pullPolicy }}
-
         command:
         - /velero
         args:
@@ -41,13 +40,11 @@ spec:
         {{- with .Values.velero.defaultVolumeSnapshotLocations }}
         - '--default-volume-snapshot-locations={{ . | join "," }}'
         {{- end }}
-
         {{- if .Values.velero.credentials.azure }}
         envFrom:
         - secretRef:
             name: azure-credentials
         {{- end }}
-
         env:
         - name: VELERO_SCRATCH_DIR
           value: /scratch
@@ -59,7 +56,6 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /credentials/gcp/creds
         {{- end }}
-
         volumeMounts:
         - name: plugins
           mountPath: /plugins
@@ -73,15 +69,12 @@ spec:
         - name: gcp-credentials
           mountPath: /credentials/gcp
         {{- end }}
-
         ports:
         - name: metrics
           containerPort: 8085
           protocol: TCP
-
         resources:
 {{ toYaml .Values.velero.resources | indent 10 }}
-
       volumes:
       - name: plugins
         emptyDir: {}
@@ -97,7 +90,6 @@ spec:
         secret:
           secretName: gcp-credentials
       {{- end }}
-
       serviceAccountName: velero
       nodeSelector:
 {{ toYaml .Values.velero.nodeSelector | indent 8 }}

--- a/config/backup/velero/update.sh
+++ b/config/backup/velero/update.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+crds=templates/customresourcedefinitions.yaml
+version=$(velero version --client-only | grep Version | cut -d' ' -f2)
+
+echo "# This file has been generated with Velero $version. Do not edit." > $crds
+
+# extract CRDs by calling Velero with dummy values
+velero install --bucket does-not-matter --use-restic --provider gcp --secret-file Chart.yaml --dry-run -o json | \
+  jq '.items=(.items | map(select(.kind=="CustomResourceDefinition")) | sort_by(.metadata.name))' | \
+  jq 'del(.items[].metadata.creationTimestamp)' | \
+  jq -S '.items[].metadata.annotations["helm.sh/hook"] = "crd-install"' | \
+  yq r - \
+  >> $crds

--- a/config/backup/velero/update.sh
+++ b/config/backup/velero/update.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 
-crds=templates/customresourcedefinitions.yaml
+crdfile=templates/customresourcedefinitions.yaml
 version=$(velero version --client-only | grep Version | cut -d' ' -f2)
 
-echo "# This file has been generated with Velero $version. Do not edit." > $crds
+echo "# This file has been generated with Velero $version. Do not edit." > $crdfile
 
 # extract CRDs by calling Velero with dummy values
-velero install --bucket does-not-matter --use-restic --provider gcp --secret-file Chart.yaml --dry-run -o json | \
-  jq '.items=(.items | map(select(.kind=="CustomResourceDefinition")) | sort_by(.metadata.name))' | \
-  jq 'del(.items[].metadata.creationTimestamp)' | \
-  jq -S '.items[].metadata.annotations["helm.sh/hook"] = "crd-install"' | \
-  yq r - \
-  >> $crds
+crds=$(
+  velero install --bucket does-not-matter --use-restic --provider gcp --secret-file Chart.yaml --dry-run -o json | \
+  jq -c '.items | map(select(.kind=="CustomResourceDefinition")) | sort_by(.metadata.name) | .[]'
+)
+
+while IFS= read -r crd; do
+  crd=$(
+    echo "$crd" | \
+    jq 'del(.metadata.creationTimestamp)' | \
+    jq -S '.metadata.annotations["helm.sh/hook"] = "crd-install"' | \
+    yq r -
+  )
+
+  echo -e "---\n$crd" >> $crdfile
+done <<< "$crds"

--- a/config/backup/velero/values.yaml
+++ b/config/backup/velero/values.yaml
@@ -4,7 +4,7 @@ velero:
   # that also contains the restic binary
   image:
     repository: gcr.io/heptio-images/velero
-    tag: v0.11.0
+    tag: v1.0.0
     pullPolicy: IfNotPresent
 
   # CLI flags to pass to velero server; note that the two flags

--- a/config/monitoring/prometheus/rules/general-velero.yaml
+++ b/config/monitoring/prometheus/rules/general-velero.yaml
@@ -16,6 +16,6 @@ groups:
       message: There has not been a successful backup for schedule {{ $labels.schedule
         }} in the last 24 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-veleronorecentbackup
-    expr: changes(velero_backup_success_total{schedule!=""}[25h]) < 1
+    expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 3600*25
     labels:
       severity: warning

--- a/config/monitoring/prometheus/rules/src/general/velero.yaml
+++ b/config/monitoring/prometheus/rules/src/general/velero.yaml
@@ -19,7 +19,7 @@ groups:
     annotations:
       message: There has not been a successful backup for schedule {{ $labels.schedule }} in the last 24 hours.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-veleronorecentbackup
-    expr: changes(velero_backup_success_total{schedule!=""}[25h]) < 1
+    expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 3600*25
     labels:
       severity: warning
     runbook:


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates Velero to the new stable version. Since the manifests have been removed from the upstream distribution and been replaced with `velero install`, I added a tiny script to at least automatically extract the CRDs in the hopes of never having useless diffs because someone manually copies them over into our chart.

Upgrades from 0.11 are supposed to be easy and require no user interaction. As documented in Kubermatic 2.10, users are strongly supposed to replace Ark 0.x with Velero 0.11, so we have a good basis to update to Velero 1.0 in Kubermatic 2.11.

**Does this PR introduce a user-facing change?**:
```release-note
update Velero to 1.0
```
