### PR TITLE
update Grafana to 6.2.1

### DIFF
--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 1.0.4
-appVersion: 6.1.6
+version: 1.0.5
+appVersion: 6.2.0
 description: Grafana for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
 version: 1.0.5
-appVersion: 6.2.0
+appVersion: 6.2.1
 description: Grafana for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -1,11 +1,11 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: grafana
   labels:
     app: grafana
-  name: grafana
 spec:
-  replicas: 1
+  replicas: {{ .Values.grafana.replicas }}
   selector:
     matchLabels:
       app: grafana
@@ -149,13 +149,3 @@ spec:
 {{ toYaml .Values.grafana.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.grafana.tolerations | indent 8 }}
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: grafana
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: grafana

--- a/config/monitoring/grafana/templates/pdb.yaml
+++ b/config/monitoring/grafana/templates/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: grafana
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: grafana

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -5,7 +5,7 @@ grafana:
   replicas: 1
   image:
     repository: grafana/grafana
-    tag: 6.2.0
+    tag: 6.2.1
 
   resources:
     requests:

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -2,9 +2,10 @@ grafana:
   user: YWRtaW4= # admin
   password: bG9vZHNlMTIz # loodse123
 
+  replicas: 1
   image:
     repository: grafana/grafana
-    tag: 6.1.6
+    tag: 6.2.0
 
   resources:
     requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates Grafana to the latest stable version with many improvements, none of which are really critical for us. There are no backwards incompatible changes.

**Does this PR introduce a user-facing change?**:
```release-note
update Grafana to 6.2.1
```
