### PR TITLE
improve authentication layer stability

### DIFF
--- a/config/iap/Chart.yaml
+++ b/config/iap/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: iap
-version: 1.1.0
+version: 1.1.1
 appVersion: 6.0.1
 description: A Helm to install Keycloak-Gatekeeper as an identity-aware proxy.
 keywords:

--- a/config/iap/templates/deployments.yaml
+++ b/config/iap/templates/deployments.yaml
@@ -8,7 +8,7 @@ metadata:
     app: iap
     target: {{ .name }}
 spec:
-  replicas: 1
+  replicas: {{ .replicas | default $.Values.iap.replicas | default 1 }}
   selector:
     matchLabels:
       app: iap

--- a/config/iap/templates/deployments.yaml
+++ b/config/iap/templates/deployments.yaml
@@ -69,7 +69,7 @@ spec:
       nodeSelector:
 {{ toYaml $.Values.iap.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml $.Values.iap.affinity | indent 8 }}
+{{ (tpl (toYaml $.Values.iap.affinity) (merge $ .)) | fromYaml | toYaml | indent 8 }}
       tolerations:
 {{ toYaml $.Values.iap.tolerations | indent 8 }}
 {{- end }}

--- a/config/iap/templates/pdbs.yaml
+++ b/config/iap/templates/pdbs.yaml
@@ -1,0 +1,13 @@
+{{- range .Values.iap.deployments }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: iap-{{ .name }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: {{ .name }}
+{{- end }}

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -1,7 +1,7 @@
 iap:
   # replicas per deployment; you can set this explicitly per deployment
   # to override this
-  replicas: 1
+  replicas: 2
 
   deployments:
     # alertmanager:

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -1,7 +1,12 @@
 iap:
+  # replicas per deployment; you can set this explicitly per deployment
+  # to override this
+  replicas: 1
+
   deployments:
     # alertmanager:
     #   name: alertmanager
+    #   replicas: 2 #
     #   client_id: alertmanager
     #   client_secret: xxx
     #   encryption_key: xxx

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -90,6 +90,18 @@ iap:
       cpu: 100m
       memory: 50Mi
 
-  affinity: {}
+  # You can use Go templating inside affinities and access
+  # the deployment's values directly (e.g. via .name or .client_id).
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: iap
+              target: '{{ .name }}'
+          topologyKey: kubernetes.io/hostname
+        weight: 10
+
   nodeSelector: {}
   tolerations: []

--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: oauth
-version: 1.0.2
+version: 1.0.3
 appVersion: v2.16.0
 description: Dex
 keywords:

--- a/config/oauth/templates/pdb.yaml
+++ b/config/oauth/templates/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: dex
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: dex

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -2,7 +2,7 @@ dex:
   image:
     repository: "quay.io/dexidp/dex"
     tag: "v2.16.0"
-  replicas: 1
+  replicas: 2
   ingress:
     host: ""
     path: "/dex"

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -45,5 +45,13 @@ dex:
       memory: 200Mi
 
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: dex
+          topologyKey: kubernetes.io/hostname
+        weight: 10
   tolerations: []


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR attempts to make our authentication layer (Dex + Keycloak-Gatekeeper) more stable by

* defining PDBs for both components
* allowing to specify the replica count for Keycloak deployments
* raising the default replica count to 2
* setting affinities to prevent two pods to be scheduled on the same node

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
