### PR TITLE
Fix prometheus readiness endpoint

### DIFF
--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -150,7 +150,7 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 						SuccessThreshold:    1,
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/-/healthy",
+								Path:   "/-/ready",
 								Port:   intstr.FromString("web"),
 								Scheme: corev1.URISchemeHTTP,
 							},

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -58,7 +58,7 @@ spec:
         readinessProbe:
           failureThreshold: 6
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
             scheme: HTTP
           initialDelaySeconds: 5

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -67,7 +67,7 @@ spec:
         readinessProbe:
           failureThreshold: 120
           httpGet:
-            path: /-/healthy
+            path: /-/ready
             port: web
           initialDelaySeconds: 15
           periodSeconds: 5


### PR DESCRIPTION
Up to this point prometheus used the healthy endpoint as readiness
probe check, this results in the prometheus endpoints being marked
as ready way too early and a rolling update bringing the whole
prometheus cluster down.

Signed-off-by: Christian Beneke <c.beneke@syseleven.de>

**What this PR does / why we need it**: (See above)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
```release-note
NONE
```
