### PR TITLE
fix swagger

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -83,7 +83,6 @@ run-master-controller-manager:
 verify: gofmt
 		./hack/verify-codegen.sh
 		./hack/verify-swagger.sh
-		./hack/verify-api-client.sh
 
 check-dependencies:
 	# We need mercurial for bitbucket.org/ww/goautoneg, otherwise dep hangs forever

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -5796,17 +5796,5 @@
         "$ref": "#/definitions/ErrorDetails"
       }
     }
-  },
-  "securityDefinitions": {
-    "api_key": {
-      "type": "apiKey",
-      "name": "Authorization",
-      "in": "header"
-    }
-  },
-  "security": [
-    {
-      "api_key": []
-    }
-  ]
+  }
 }

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1,19 +1,3 @@
-// Kubermatic API.
-// Kubermatic API. This describes possible operations which can be made against the Kubermatic API.
-//
-//     Schemes: http, https
-//     Host: localhost
-//
-//     Security:
-//     - api_key:
-//
-//     SecurityDefinitions:
-//     api_key:
-//          type: apiKey
-//          name: Authorization
-//          in: header
-//
-// swagger:meta
 package handler
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**: remove swagger:meta to make go-swagger stable

```release-note
NONE
```
