### PR TITLE
Disable insecure versions v1.13.6 & v1.14.2

### DIFF
--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -38,12 +38,16 @@ versions:
   default: false
 - version: "1.13.5"
   default: true
+# Insecure https://github.com/kubernetes/kubernetes/issues/78308
+#- version: "1.13.6"
+#  default: false
 - version: "v1.14.0"
   default: false
 - version: "v1.14.1"
   default: false
-- version: "v1.14.2"
-  default: false
+# Insecure https://github.com/kubernetes/kubernetes/issues/78308
+#- version: "v1.14.2"
+#  default: false
 # OpenShift 3.11
 - version: "v3.11"
   default: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Both versions are insecure: https://github.com/kubernetes/kubernetes/issues/78308

Keeping both versions commented out will avoid that users manually add those versions.

**Does this PR introduce a user-facing change?**:
```release-note
Insecure Kubernetes versions v1.13.6 and v1.14.2 have been disabled.
```
