### PR TITLE
Add option to hide cluster type

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -172,7 +172,9 @@ kubermatic:
         "show_demo_info": false,
         "show_terms_of_service": false,
         "cleanup_cluster": false,
-        "custom_links": []
+        "custom_links": [],
+        "hide_kubernetes": false,
+        "hide_openshift": false
       }
     resources:
       requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add option to hide cluster type

Fixes https://github.com/kubermatic/kubermatic/issues/3560

**Special notes for your reviewer**:
Possibility to configure if type (Kubernetes or OpenShift) should be visible in ui wizard.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Added possibility to hide cluster type "kubernetes" or "openshift" via values.yaml. 
```
