### PR TITLE
add custom credential support for providers endpoints

### DIFF
--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -20,6 +20,7 @@ type serverRunOptions struct {
 	workerName      string
 	versionsFile    string
 	updatesFile     string
+	credentialFile  string
 	domain          string
 	log             kubermaticlog.Options
 
@@ -53,6 +54,7 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&s.workerName, "worker-name", "", "Create clusters only processed by worker-name cluster controller")
 	flag.StringVar(&s.versionsFile, "versions", "versions.yaml", "The versions.yaml file path")
 	flag.StringVar(&s.updatesFile, "updates", "updates.yaml", "The updates.yaml file path")
+	flag.StringVar(&s.credentialFile, "credentials", "", "The optional credential file path")
 	flag.StringVar(&s.oidcURL, "oidc-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
 	flag.BoolVar(&s.oidcSkipTLSVerify, "oidc-skip-tls-verify", false, "Skip TLS verification for the token issuer")
 	flag.StringVar(&s.oidcAuthenticatorClientID, "oidc-authenticator-client-id", "", "Authenticator client ID")

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2916,6 +2916,52 @@
         }
       }
     },
+    "/api/v1/providers/aws/credentials": {
+      "get": {
+        "description": "Lists credential names for AWS",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "aws"
+        ],
+        "operationId": "listAWSCredentials",
+        "responses": {
+          "200": {
+            "description": "CredentialList",
+            "schema": {
+              "$ref": "#/definitions/CredentialList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/providers/azure/credentials": {
+      "get": {
+        "description": "Lists credential names for Azure",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "azure"
+        ],
+        "operationId": "listAzureCredentials",
+        "responses": {
+          "200": {
+            "description": "CredentialList",
+            "schema": {
+              "$ref": "#/definitions/CredentialList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/providers/azure/sizes": {
       "get": {
         "description": "Lists available VM sizes in an Azure region",
@@ -2939,6 +2985,29 @@
         }
       }
     },
+    "/api/v1/providers/digitalocean/credentials": {
+      "get": {
+        "description": "Lists credential names for DigitalOcean",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "digitalocean"
+        ],
+        "operationId": "listDigitaloceanCredentials",
+        "responses": {
+          "200": {
+            "description": "CredentialList",
+            "schema": {
+              "$ref": "#/definitions/CredentialList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/providers/digitalocean/sizes": {
       "get": {
         "description": "Lists sizes from digitalocean",
@@ -2954,6 +3023,75 @@
             "description": "DigitaloceanSizeList",
             "schema": {
               "$ref": "#/definitions/DigitaloceanSizeList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/providers/gcp/credentials": {
+      "get": {
+        "description": "Lists credential names for GCP",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "gcp"
+        ],
+        "operationId": "listGCPCredentials",
+        "responses": {
+          "200": {
+            "description": "CredentialList",
+            "schema": {
+              "$ref": "#/definitions/CredentialList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/providers/hetzner/credentials": {
+      "get": {
+        "description": "Lists credential names for hetzner",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "hetzner"
+        ],
+        "operationId": "listHetznerCredentials",
+        "responses": {
+          "200": {
+            "description": "CredentialList",
+            "schema": {
+              "$ref": "#/definitions/CredentialList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/providers/openstack/credentials": {
+      "get": {
+        "description": "Lists credential names for Openstack",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "openstack"
+        ],
+        "operationId": "listOpenstackCredentials",
+        "responses": {
+          "200": {
+            "description": "CredentialList",
+            "schema": {
+              "$ref": "#/definitions/CredentialList"
             }
           },
           "default": {
@@ -3116,6 +3254,52 @@
               "items": {
                 "$ref": "#/definitions/OpenstackTenant"
               }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/providers/packet/credentials": {
+      "get": {
+        "description": "Lists credential names for Packet",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "packet"
+        ],
+        "operationId": "listPacketCredentials",
+        "responses": {
+          "200": {
+            "description": "CredentialList",
+            "schema": {
+              "$ref": "#/definitions/CredentialList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/providers/vsphere/credentials": {
+      "get": {
+        "description": "Lists credential names for Vsphere",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "vsphere"
+        ],
+        "operationId": "listVsphereCredentials",
+        "responses": {
+          "200": {
+            "description": "CredentialList",
+            "schema": {
+              "$ref": "#/definitions/CredentialList"
             }
           },
           "default": {
@@ -3890,6 +4074,20 @@
         },
         "nodeDeployment": {
           "$ref": "#/definitions/NodeDeployment"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "CredentialList": {
+      "type": "object",
+      "title": "CredentialList represents a object for provider credential names.",
+      "properties": {
+        "names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Names"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -134,6 +134,12 @@ type DigitaloceanSizeList struct {
 	Optimized []DigitaloceanSize `json:"optimized"`
 }
 
+// CredentialList represents a object for provider credential names.
+// swagger:model CredentialList
+type CredentialList struct {
+	Names []string `json:"names,omitempty"`
+}
+
 // DigitaloceanSize is the object representing digitalocean sizes.
 // swagger:model DigitaloceanSize
 type DigitaloceanSize struct {

--- a/api/pkg/credentials/manager.go
+++ b/api/pkg/credentials/manager.go
@@ -1,0 +1,130 @@
+package credentials
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ghodss/yaml"
+)
+
+// Credentials specifies custom credentials for supported provider
+type Credentials struct {
+	Digitalocean []DigitaloceanCredentials `json:"digitalocean,omitempty"`
+	Hetzner      []HetznerCredentials      `json:"hetzner,omitempty"`
+	Azure        []AzureCredentials        `json:"azure,omitempty"`
+	VSphere      []VSphereCredentials      `json:"vsphere,omitempty"`
+	AWS          []AWSCredentials          `json:"aws,omitempty"`
+	Openstack    []OpenstackCredentials    `json:"openstack,omitempty"`
+	Packet       []PacketCredentials       `json:"packet,omitempty"`
+	GCP          []GCPCredentials          `json:"gcp,omitempty"`
+}
+
+// DigitaloceanCredential defines Digitalocean credential
+type DigitaloceanCredentials struct {
+	Name  string `json:"name"`
+	Token string `json:"token"` // Token is used to authenticate with the DigitalOcean API.
+}
+
+type HetznerCredentials struct {
+	Name  string `json:"name"`
+	Token string `json:"token"` // Token is used to authenticate with the Hetzner API.
+}
+
+type AzureCredentials struct {
+	Name           string `json:"name"`
+	TenantID       string `json:"tenantId"`
+	SubscriptionID string `json:"subscriptionId"`
+	ClientID       string `json:"clientId"`
+	ClientSecret   string `json:"clientSecret"`
+}
+
+// VSphereCredentials credentials represents a credential for accessing vSphere
+type VSphereCredentials struct {
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type AWSCredentials struct {
+	Name            string `json:"name"`
+	AccessKeyID     string `json:"accessKeyId"`
+	SecretAccessKey string `json:"secretAccessKey"`
+}
+
+// OpenstackCredentials specifies access data to an openstack cloud.
+type OpenstackCredentials struct {
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Tenant   string `json:"tenant"`
+	Domain   string `json:"domain"`
+}
+
+// PacketCredentials specifies access data to a Packet cloud.
+type PacketCredentials struct {
+	Name      string `json:"name"`
+	APIKey    string `json:"apiKey"`
+	ProjectID string `json:"projectId"`
+}
+
+// GCPCredentials specifies access data to GCP.
+type GCPCredentials struct {
+	Name           string `json:"name"`
+	ServiceAccount string `json:"serviceAccount"`
+}
+
+// loadCredentials loads the custom credentials for supported providers
+func loadCredentials(path string) (*Credentials, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := ioutil.ReadAll(bufio.NewReader(f))
+	if err != nil {
+		return nil, err
+	}
+
+	s := struct {
+		Credentials *Credentials `json:"credentials"`
+	}{}
+
+	err = yaml.Unmarshal(bytes, &s)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Credentials, nil
+}
+
+// Manager is a object to handle credentials from a predefined config
+type Manager struct {
+	credentials *Credentials
+}
+
+func New() *Manager {
+	credentials := &Credentials{}
+	return &Manager{credentials: credentials}
+}
+
+// NewFromFiles returns a instance of manager with the credentials loaded from the given paths
+func NewFromFiles(credentialsFilename string) (*Manager, error) {
+	var credentials *Credentials
+	var err error
+	if len(credentialsFilename) > 0 {
+		credentials, err = loadCredentials(credentialsFilename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load credentials from %s: %v", credentialsFilename, err)
+		}
+	}
+	if credentials == nil {
+		credentials = &Credentials{}
+	}
+	return &Manager{credentials: credentials}, nil
+}
+
+func (m *Manager) GetCredentials() *Credentials {
+	return m.credentials
+}

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -78,6 +78,38 @@ func (r Routing) RegisterV1(mux *mux.Router, metrics common.ServerMetrics) {
 		Path("/providers/vsphere/networks").
 		Handler(r.listVSphereNetworks())
 
+	mux.Methods(http.MethodGet).
+		Path("/providers/digitalocean/credentials").
+		Handler(r.listDigitaloceanCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/providers/azure/credentials").
+		Handler(r.listAzureCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/providers/vsphere/credentials").
+		Handler(r.listVsphereCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/providers/openstack/credentials").
+		Handler(r.listOpenstackCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/providers/hetzner/credentials").
+		Handler(r.listHetznerCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/providers/aws/credentials").
+		Handler(r.listAWSCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/providers/packet/credentials").
+		Handler(r.listPacketCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/providers/gcp/credentials").
+		Handler(r.listGCPCredentials())
+
 	//
 	// Defines a set of HTTP endpoints for project resource
 	mux.Methods(http.MethodGet).
@@ -388,6 +420,182 @@ func (r Routing) deleteSSHKey() http.Handler {
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(ssh.DeleteEndpoint(r.sshKeyProvider, r.projectProvider)),
 		ssh.DecodeDeleteReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/digitalocean/credentials digitalocean listDigitaloceanCredentials
+//
+// Lists credential names for DigitalOcean
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: CredentialList
+func (r Routing) listDigitaloceanCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.DigitaloceanCredentialEndpoint(r.credentialManager)),
+		decodeEmptyReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/azure/credentials azure listAzureCredentials
+//
+// Lists credential names for Azure
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: CredentialList
+func (r Routing) listAzureCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.AzureCredentialEndpoint(r.credentialManager)),
+		decodeEmptyReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/openstack/credentials openstack listOpenstackCredentials
+//
+// Lists credential names for Openstack
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: CredentialList
+func (r Routing) listOpenstackCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.OpenstackCredentialEndpoint(r.credentialManager)),
+		decodeEmptyReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/vsphere/credentials vsphere listVsphereCredentials
+//
+// Lists credential names for Vsphere
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: CredentialList
+func (r Routing) listVsphereCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.VsphereCredentialEndpoint(r.credentialManager)),
+		decodeEmptyReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/hetzner/credentials hetzner listHetznerCredentials
+//
+// Lists credential names for hetzner
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: CredentialList
+func (r Routing) listHetznerCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.HetznerCredentialEndpoint(r.credentialManager)),
+		decodeEmptyReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/packet/credentials packet listPacketCredentials
+//
+// Lists credential names for Packet
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: CredentialList
+func (r Routing) listPacketCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.PacketCredentialEndpoint(r.credentialManager)),
+		decodeEmptyReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/aws/credentials aws listAWSCredentials
+//
+// Lists credential names for AWS
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: CredentialList
+func (r Routing) listAWSCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.AWSCredentialEndpoint(r.credentialManager)),
+		decodeEmptyReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/gcp/credentials gcp listGCPCredentials
+//
+// Lists credential names for GCP
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: CredentialList
+func (r Routing) listGCPCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.GCPCredentialEndpoint(r.credentialManager)),
+		decodeEmptyReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -46,6 +46,7 @@ type Routing struct {
 	saTokenAuthenticator        serviceaccount.TokenAuthenticator
 	saTokenGenerator            serviceaccount.TokenGenerator
 	eventRecorderProvider       provider.EventRecorderProvider
+	credentialManager           common.CredentialManager
 }
 
 // NewRouting creates a new Routing.
@@ -69,6 +70,7 @@ func NewRouting(
 	saTokenAuthenticator serviceaccount.TokenAuthenticator,
 	saTokenGenerator serviceaccount.TokenGenerator,
 	eventRecorderProvider provider.EventRecorderProvider,
+	credentialManager common.CredentialManager,
 ) Routing {
 	return Routing{
 		datacenters:                 datacenters,
@@ -91,6 +93,7 @@ func NewRouting(
 		saTokenAuthenticator:        saTokenAuthenticator,
 		saTokenGenerator:            saTokenGenerator,
 		eventRecorderProvider:       eventRecorderProvider,
+		credentialManager:           credentialManager,
 	}
 }
 

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -38,7 +38,8 @@ func NewTestRouting(
 	updates []*version.MasterUpdate,
 	saTokenAuthenticator serviceaccount.TokenAuthenticator,
 	saTokenGenerator serviceaccount.TokenGenerator,
-	eventRecorderProvider provider.EventRecorderProvider) http.Handler {
+	eventRecorderProvider provider.EventRecorderProvider,
+	credentialManager common.CredentialManager) http.Handler {
 
 	updateManager := version.New(versions, updates)
 	r := handler.NewRouting(
@@ -61,6 +62,7 @@ func NewTestRouting(
 		saTokenAuthenticator,
 		saTokenGenerator,
 		eventRecorderProvider,
+		credentialManager,
 	)
 
 	mainRouter := mux.NewRouter()

--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -1,10 +1,12 @@
 package common
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/credentials"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // OIDCConfiguration is a struct that holds
@@ -33,6 +35,11 @@ type UpdateManager interface {
 	GetDefault() (*version.MasterVersion, error)
 	AutomaticUpdate(from, clusterType string) (*version.MasterVersion, error)
 	GetPossibleUpdates(from, clusterType string) ([]*version.MasterVersion, error)
+}
+
+// UpdateManager specifies a set of methods to handle credentials for specific provider
+type CredentialManager interface {
+	GetCredentials() *credentials.Credentials
 }
 
 // ServerMetrics defines metrics used by the API.

--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+)
+
+// AWSCredentialEndpoint returns custom credential list name for AWS provider
+func AWSCredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		credentials := apiv1.CredentialList{}
+		names := make([]string, 0)
+		if credentialManager.GetCredentials().AWS != nil {
+			for _, do := range credentialManager.GetCredentials().AWS {
+				names = append(names, do.Name)
+			}
+		}
+		credentials.Names = names
+		return credentials, nil
+	}
+}

--- a/api/pkg/handler/v1/provider/azure.go
+++ b/api/pkg/handler/v1/provider/azure.go
@@ -153,6 +153,21 @@ func AzureSizeEndpoint() endpoint.Endpoint {
 	}
 }
 
+// AzureCredentialEndpoint returns custom credential list name for Azure provider
+func AzureCredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		credentials := apiv1.CredentialList{}
+		names := make([]string, 0)
+		if credentialManager.GetCredentials().Azure != nil {
+			for _, do := range credentialManager.GetCredentials().Azure {
+				names = append(names, do.Name)
+			}
+		}
+		credentials.Names = names
+		return credentials, nil
+	}
+}
+
 func azureSize(ctx context.Context, subscriptionID, clientID, clientSecret, tenantID, location string) (apiv1.AzureSizeList, error) {
 	sizesClient, err := NewAzureClientSet(subscriptionID, clientID, clientSecret, tenantID)
 	if err != nil {

--- a/api/pkg/handler/v1/provider/digitalocean.go
+++ b/api/pkg/handler/v1/provider/digitalocean.go
@@ -49,6 +49,21 @@ func DigitaloceanSizeEndpoint() endpoint.Endpoint {
 	}
 }
 
+// DigitaloceanCredentialEndpoint returns custom credential list name for DigitalOcean provider
+func DigitaloceanCredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		credentials := apiv1.CredentialList{}
+		names := make([]string, 0)
+		if credentialManager.GetCredentials().Digitalocean != nil {
+			for _, do := range credentialManager.GetCredentials().Digitalocean {
+				names = append(names, do.Name)
+			}
+		}
+		credentials.Names = names
+		return credentials, nil
+	}
+}
+
 func digitaloceanSize(ctx context.Context, token string) (apiv1.DigitaloceanSizeList, error) {
 	static := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	client := godo.NewClient(oauth2.NewClient(context.Background(), static))

--- a/api/pkg/handler/v1/provider/digitalocean_test.go
+++ b/api/pkg/handler/v1/provider/digitalocean_test.go
@@ -1,0 +1,64 @@
+package provider_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+)
+
+func TestDigitaloceanCredentialEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name             string
+		credentials      []credentials.DigitaloceanCredentials
+		httpStatus       int
+		expectedResponse string
+	}{
+		{
+			name:             "test no credentials for Digitalocean",
+			httpStatus:       http.StatusOK,
+			expectedResponse: "{}",
+		},
+		{
+			name: "test list of credential names for Digitalocean",
+			credentials: []credentials.DigitaloceanCredentials{
+				{Name: "first"},
+				{Name: "second"},
+			},
+			httpStatus:       http.StatusOK,
+			expectedResponse: `{"names":["first","second"]}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := httptest.NewRequest("GET", "/api/v1/providers/digitalocean/credentials", strings.NewReader(""))
+
+			credentialsManager := credentials.New()
+			cred := credentialsManager.GetCredentials()
+			cred.Digitalocean = tc.credentials
+
+			res := httptest.NewRecorder()
+			router, err := test.CreateCredentialTestEndpoint(credentialsManager, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v\n", err)
+			}
+			router.ServeHTTP(res, req)
+
+			// validate
+			assert.Equal(t, tc.httpStatus, res.Code)
+
+			if res.Code == http.StatusOK {
+				compareJSON(t, res, tc.expectedResponse)
+			}
+		})
+	}
+}

--- a/api/pkg/handler/v1/provider/gcp.go
+++ b/api/pkg/handler/v1/provider/gcp.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+)
+
+// GCPCredentialEndpoint returns custom credential list name for GCP provider
+func GCPCredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		credentials := apiv1.CredentialList{}
+		names := make([]string, 0)
+		if credentialManager.GetCredentials().GCP != nil {
+			for _, do := range credentialManager.GetCredentials().GCP {
+				names = append(names, do.Name)
+			}
+		}
+		credentials.Names = names
+		return credentials, nil
+	}
+}

--- a/api/pkg/handler/v1/provider/gcp_test.go
+++ b/api/pkg/handler/v1/provider/gcp_test.go
@@ -1,0 +1,64 @@
+package provider_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+)
+
+func TestGCPCredentialEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name             string
+		credentials      []credentials.GCPCredentials
+		httpStatus       int
+		expectedResponse string
+	}{
+		{
+			name:             "test no credentials for GCP",
+			httpStatus:       http.StatusOK,
+			expectedResponse: "{}",
+		},
+		{
+			name: "test list of credential names for GCP",
+			credentials: []credentials.GCPCredentials{
+				{Name: "first"},
+				{Name: "second"},
+			},
+			httpStatus:       http.StatusOK,
+			expectedResponse: `{"names":["first","second"]}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := httptest.NewRequest("GET", "/api/v1/providers/gcp/credentials", strings.NewReader(""))
+
+			credentialsManager := credentials.New()
+			cred := credentialsManager.GetCredentials()
+			cred.GCP = tc.credentials
+
+			res := httptest.NewRecorder()
+			router, err := test.CreateCredentialTestEndpoint(credentialsManager, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v\n", err)
+			}
+			router.ServeHTTP(res, req)
+
+			// validate
+			assert.Equal(t, tc.httpStatus, res.Code)
+
+			if res.Code == http.StatusOK {
+				compareJSON(t, res, tc.expectedResponse)
+			}
+		})
+	}
+}

--- a/api/pkg/handler/v1/provider/hetzner.go
+++ b/api/pkg/handler/v1/provider/hetzner.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+)
+
+// HetznerCredentialEndpoint returns custom credential list name for Hetzner provider
+func HetznerCredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		credentials := apiv1.CredentialList{}
+		names := make([]string, 0)
+		if credentialManager.GetCredentials().Hetzner != nil {
+			for _, do := range credentialManager.GetCredentials().Hetzner {
+				names = append(names, do.Name)
+			}
+		}
+		credentials.Names = names
+		return credentials, nil
+	}
+}

--- a/api/pkg/handler/v1/provider/hetzner_test.go
+++ b/api/pkg/handler/v1/provider/hetzner_test.go
@@ -1,0 +1,64 @@
+package provider_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+)
+
+func TestHetznerCredentialEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name             string
+		credentials      []credentials.HetznerCredentials
+		httpStatus       int
+		expectedResponse string
+	}{
+		{
+			name:             "test no credentials for Hetzner",
+			httpStatus:       http.StatusOK,
+			expectedResponse: "{}",
+		},
+		{
+			name: "test list of credential names for Hetzner",
+			credentials: []credentials.HetznerCredentials{
+				{Name: "first"},
+				{Name: "second"},
+			},
+			httpStatus:       http.StatusOK,
+			expectedResponse: `{"names":["first","second"]}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := httptest.NewRequest("GET", "/api/v1/providers/hetzner/credentials", strings.NewReader(""))
+
+			credentialsManager := credentials.New()
+			cred := credentialsManager.GetCredentials()
+			cred.Hetzner = tc.credentials
+
+			res := httptest.NewRecorder()
+			router, err := test.CreateCredentialTestEndpoint(credentialsManager, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v\n", err)
+			}
+			router.ServeHTTP(res, req)
+
+			// validate
+			assert.Equal(t, tc.httpStatus, res.Code)
+
+			if res.Code == http.StatusOK {
+				compareJSON(t, res, tc.expectedResponse)
+			}
+		})
+	}
+}

--- a/api/pkg/handler/v1/provider/openstack.go
+++ b/api/pkg/handler/v1/provider/openstack.go
@@ -53,6 +53,21 @@ func OpenstackSizeNoCredentialsEndpoint(projectProvider provider.ProjectProvider
 	}
 }
 
+// OpenstackCredentialEndpoint returns custom credential list name for OpenStack provider
+func OpenstackCredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		credentials := apiv1.CredentialList{}
+		names := make([]string, 0)
+		if credentialManager.GetCredentials().Openstack != nil {
+			for _, do := range credentialManager.GetCredentials().Openstack {
+				names = append(names, do.Name)
+			}
+		}
+		credentials.Names = names
+		return credentials, nil
+	}
+}
+
 func getOpenstackSizes(providers provider.CloudRegistry, username, passowrd, tenant, domain, datacenterName string, datacenter provider.DatacenterMeta) ([]apiv1.OpenstackSize, error) {
 	osProviderInterface, ok := providers[provider.OpenstackCloudProvider]
 	if !ok {

--- a/api/pkg/handler/v1/provider/openstack_test.go
+++ b/api/pkg/handler/v1/provider/openstack_test.go
@@ -3,6 +3,8 @@ package provider_test
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/stretchr/testify/assert"
 	"html/template"
 	"io/ioutil"
 	"net/http"
@@ -321,6 +323,56 @@ func TestMeetsOpentackNodeSizeRequirement(t *testing.T) {
 		t.Run(testToRun.name, func(t *testing.T) {
 			if providerv1.MeetsOpenstackNodeSizeRequirement(testToRun.apiSize, testToRun.nodeSizeRequirement) != testToRun.meetsRequirement {
 				t.Errorf("expected result to be %v, but got %v", testToRun.meetsRequirement, !testToRun.meetsRequirement)
+			}
+		})
+	}
+}
+
+func TestOpenstackCredentialEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name             string
+		credentials      []credentials.OpenstackCredentials
+		httpStatus       int
+		expectedResponse string
+	}{
+		{
+			name:             "test no credentials for OpenStack",
+			httpStatus:       http.StatusOK,
+			expectedResponse: "{}",
+		},
+		{
+			name: "test list of credential names for OpenStack",
+			credentials: []credentials.OpenstackCredentials{
+				{Name: "first"},
+				{Name: "second"},
+			},
+			httpStatus:       http.StatusOK,
+			expectedResponse: `{"names":["first","second"]}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := httptest.NewRequest("GET", "/api/v1/providers/openstack/credentials", strings.NewReader(""))
+
+			credentialsManager := credentials.New()
+			cred := credentialsManager.GetCredentials()
+			cred.Openstack = tc.credentials
+
+			res := httptest.NewRecorder()
+			router, err := test.CreateCredentialTestEndpoint(credentialsManager, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v\n", err)
+			}
+			router.ServeHTTP(res, req)
+
+			// validate
+			assert.Equal(t, tc.httpStatus, res.Code)
+
+			if res.Code == http.StatusOK {
+				compareJSON(t, res, tc.expectedResponse)
 			}
 		})
 	}

--- a/api/pkg/handler/v1/provider/packet.go
+++ b/api/pkg/handler/v1/provider/packet.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+)
+
+// PacketCredentialEndpoint returns custom credential list name for Packet provider
+func PacketCredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		credentials := apiv1.CredentialList{}
+		names := make([]string, 0)
+		if credentialManager.GetCredentials().Packet != nil {
+			for _, do := range credentialManager.GetCredentials().Packet {
+				names = append(names, do.Name)
+			}
+		}
+		credentials.Names = names
+		return credentials, nil
+	}
+}

--- a/api/pkg/handler/v1/provider/packet_test.go
+++ b/api/pkg/handler/v1/provider/packet_test.go
@@ -1,0 +1,64 @@
+package provider_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+)
+
+func TestPacketCredentialEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name             string
+		credentials      []credentials.PacketCredentials
+		httpStatus       int
+		expectedResponse string
+	}{
+		{
+			name:             "test no credentials for Packet",
+			httpStatus:       http.StatusOK,
+			expectedResponse: "{}",
+		},
+		{
+			name: "test list of credential names for Packet",
+			credentials: []credentials.PacketCredentials{
+				{Name: "first"},
+				{Name: "second"},
+			},
+			httpStatus:       http.StatusOK,
+			expectedResponse: `{"names":["first","second"]}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := httptest.NewRequest("GET", "/api/v1/providers/packet/credentials", strings.NewReader(""))
+
+			credentialsManager := credentials.New()
+			cred := credentialsManager.GetCredentials()
+			cred.Packet = tc.credentials
+
+			res := httptest.NewRecorder()
+			router, err := test.CreateCredentialTestEndpoint(credentialsManager, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v\n", err)
+			}
+			router.ServeHTTP(res, req)
+
+			// validate
+			assert.Equal(t, tc.httpStatus, res.Code)
+
+			if res.Code == http.StatusOK {
+				compareJSON(t, res, tc.expectedResponse)
+			}
+		})
+	}
+}

--- a/api/pkg/handler/v1/provider/vsphere.go
+++ b/api/pkg/handler/v1/provider/vsphere.go
@@ -50,6 +50,21 @@ func VsphereNetworksNoCredentialsEndpoint(projectProvider provider.ProjectProvid
 	}
 }
 
+// VsphereCredentialEndpoint returns custom credential list name for Vsphere provider
+func VsphereCredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		credentials := apiv1.CredentialList{}
+		names := make([]string, 0)
+		if credentialManager.GetCredentials().VSphere != nil {
+			for _, do := range credentialManager.GetCredentials().VSphere {
+				names = append(names, do.Name)
+			}
+		}
+		credentials.Names = names
+		return credentials, nil
+	}
+}
+
 func getVsphereNetworks(providers provider.CloudRegistry, username, password, datacenterName string) ([]apiv1.VSphereNetwork, error) {
 	vsProviderInterface, ok := providers[provider.VSphereCloudProvider]
 	if !ok {

--- a/api/pkg/handler/v1/provider/vsphere_test.go
+++ b/api/pkg/handler/v1/provider/vsphere_test.go
@@ -1,8 +1,11 @@
 package provider_test
 
 import (
+	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,6 +72,56 @@ func TestVsphereNetworksEndpoint(t *testing.T) {
 	}
 
 	test.CompareWithResult(t, res, `[{"name":"VM Network"}]`)
+}
+
+func TestVsphereCredentialEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name             string
+		credentials      []credentials.VSphereCredentials
+		httpStatus       int
+		expectedResponse string
+	}{
+		{
+			name:             "test no credentials for VSphere",
+			httpStatus:       http.StatusOK,
+			expectedResponse: "{}",
+		},
+		{
+			name: "test list of credential names for VSphere",
+			credentials: []credentials.VSphereCredentials{
+				{Name: "first"},
+				{Name: "second"},
+			},
+			httpStatus:       http.StatusOK,
+			expectedResponse: `{"names":["first","second"]}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := httptest.NewRequest("GET", "/api/v1/providers/vsphere/credentials", strings.NewReader(""))
+
+			credentialsManager := credentials.New()
+			cred := credentialsManager.GetCredentials()
+			cred.VSphere = tc.credentials
+
+			res := httptest.NewRecorder()
+			router, err := test.CreateCredentialTestEndpoint(credentialsManager, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v\n", err)
+			}
+			router.ServeHTTP(res, req)
+
+			// validate
+			assert.Equal(t, tc.httpStatus, res.Code)
+
+			if res.Code == http.StatusOK {
+				compareJSON(t, res, tc.expectedResponse)
+			}
+		})
+	}
 }
 
 func (v *vSphereMock) buildVSphereDatacenterMeta() map[string]provider.DatacenterMeta {


### PR DESCRIPTION
**What this PR does / why we need it**: add endpoints for all providers to get name list of credentials

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3570

```release-note
new endpoints to get name list of provider credentials
[Action required] to get credentials for the given provider the configuration file must be set in the kubermatic API server: `-credentials=/path/to/credential/file`

The credential file example:
credentials:
  digitalocean:
    - name: default
      token:
  hetzner:
    - name: default
      token:
  azure:
    - name: default
      tenantId:
      subscriptionId:
      clientId:
      clientSecret:
  vsphere:
    - name: default
      username:
      password:
  aws:
    - name: default
      accessKeyId:
      secretAccessKey:
  openstack:
    - name: default
      username:
      password:
      tenant:
      domain:
  packet:
    - name: default
      apiKey:
      projectId:
  gcp:
    - name: default
      serviceAccount:

```
