### PR TITLE
[release/v2.10] disable insecure versions v1.13.6 & v1.14.2 (#3554)

### DIFF
--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -38,7 +38,14 @@ versions:
   default: false
 - version: "1.13.5"
   default: true
+# Insecure https://github.com/kubernetes/kubernetes/issues/78308
+#- version: "1.13.6"
+#  default: false
 - version: "v1.14.0"
   default: false
 - version: "v1.14.1"
   default: false
+# Insecure https://github.com/kubernetes/kubernetes/issues/78308
+#- version: "v1.14.2"
+#  default: false
+# OpenShift 3.11


### PR DESCRIPTION
(cherry picked from commit 696362919cfd49171d28b1b791add2942256f8a2)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
