### PR TITLE
Cluster autoscaler

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -327,6 +327,7 @@ func getTemplateData(versions []*version.MasterVersion, requestedVersion string)
 		resources.MetricsServerKubeconfigSecretName,
 		resources.MachineControllerWebhookServingCertSecretName,
 		resources.InternalUserClusterAdminKubeconfigSecretName,
+		resources.ClusterAutoscalerKubeconfigSecretName,
 	})
 	objects := []runtime.Object{configMapList, secretList, serviceList}
 

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -185,7 +185,8 @@ func GetDeploymentCreators(data *resources.TemplateData, enableAPIserverOIDCAuth
 		metricsserver.DeploymentCreator(data),
 		usercluster.DeploymentCreator(data, false),
 	}
-	if data.Cluster().Spec.Version.Minor() > 13 {
+	if data.Cluster().Annotations[kubermaticv1.AnnotationNameClusterAutoscalerEnabled] != "" &&
+		data.Cluster().Spec.Version.Minor() > 13 {
 		deployments = append(deployments, clusterautoscaler.DeploymentCreator(data))
 	}
 

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/cloudconfig"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/clusterautoscaler"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/controllermanager"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/dns"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/etcd"
@@ -183,6 +184,7 @@ func GetDeploymentCreators(data *resources.TemplateData, enableAPIserverOIDCAuth
 		machinecontroller.WebhookDeploymentCreator(data),
 		metricsserver.DeploymentCreator(data),
 		usercluster.DeploymentCreator(data, false),
+		clusterautoscaler.DeploymentCreator(data),
 	}
 }
 
@@ -216,6 +218,7 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 		resources.GetInternalKubeconfigCreator(resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.MetricsServerKubeconfigSecretName, resources.MetricsServerCertUsername, nil, data),
 		resources.GetInternalKubeconfigCreator(resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data),
+		resources.GetInternalKubeconfigCreator(resources.ClusterAutoscalerKubeconfigSecretName, resources.ClusterAutoscalerCertUsername, nil, data),
 		resources.AdminKubeconfigCreator(data),
 		apiserver.TokenUsersCreator(data),
 	}

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/cloudconfig"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/clusterautoscaler"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/dns"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/etcd"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroller"
@@ -455,6 +456,7 @@ func (r *Reconciler) getAllSecretCreators(ctx context.Context, osData *openshift
 		resources.GetInternalKubeconfigCreator(resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, osData),
 		resources.GetInternalKubeconfigCreator(resources.MetricsServerKubeconfigSecretName, resources.MetricsServerCertUsername, nil, osData),
 		resources.GetInternalKubeconfigCreator(resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, osData),
+		resources.GetInternalKubeconfigCreator(resources.ClusterAutoscalerKubeconfigSecretName, resources.ClusterAutoscalerCertUsername, nil, osData),
 
 		//TODO: This is only needed because of the ServiceAccount Token needed for Openshift
 		//TODO: Streamline this by using it everywhere and use the clientprovider here or remove
@@ -530,7 +532,8 @@ func (r *Reconciler) getAllDeploymentCreators(ctx context.Context, osData *opens
 		openvpn.DeploymentCreator(osData),
 		dns.DeploymentCreator(osData),
 		machinecontroller.WebhookDeploymentCreator(osData),
-		usercluster.DeploymentCreator(osData, true)}
+		usercluster.DeploymentCreator(osData, true),
+		clusterautoscaler.DeploymentCreator(osData)}
 }
 
 func (r *Reconciler) deployments(ctx context.Context, osData *openshiftData) error {

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -526,14 +526,19 @@ func (r *Reconciler) configMaps(ctx context.Context, osData *openshiftData) erro
 }
 
 func (r *Reconciler) getAllDeploymentCreators(ctx context.Context, osData *openshiftData) []reconciling.NamedDeploymentCreatorGetter {
-	return []reconciling.NamedDeploymentCreatorGetter{openshiftresources.APIDeploymentCreator(ctx, osData),
+	creators := []reconciling.NamedDeploymentCreatorGetter{openshiftresources.APIDeploymentCreator(ctx, osData),
 		openshiftresources.ControllerManagerDeploymentCreator(ctx, osData),
 		openshiftresources.MachineController(osData),
 		openvpn.DeploymentCreator(osData),
 		dns.DeploymentCreator(osData),
 		machinecontroller.WebhookDeploymentCreator(osData),
-		usercluster.DeploymentCreator(osData, true),
-		clusterautoscaler.DeploymentCreator(osData)}
+		usercluster.DeploymentCreator(osData, true)}
+
+	if osData.Cluster().Annotations[kubermaticv1.AnnotationNameClusterAutoscalerEnabled] != "" {
+		creators = append(creators, clusterautoscaler.DeploymentCreator(osData))
+	}
+
+	return creators
 }
 
 func (r *Reconciler) deployments(ctx context.Context, osData *openshiftData) error {

--- a/api/pkg/controller/usercluster/reconciler.go
+++ b/api/pkg/controller/usercluster/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	openshiftresources "github.com/kubermatic/kubermatic/api/pkg/controller/openshift/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/clusterautoscaler"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/controller-manager"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/dnat-controller"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/kube-state-metrics"
@@ -95,6 +96,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context) error {
 	// kube-system
 	creators := []reconciling.NamedRoleCreatorGetter{
 		machinecontroller.KubeSystemRoleCreator(),
+		clusterautoscaler.KubeSystemRoleCreator(),
 	}
 
 	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
@@ -114,6 +116,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context) error {
 	// default
 	creators = []reconciling.NamedRoleCreatorGetter{
 		machinecontroller.EndpointReaderRoleCreator(),
+		clusterautoscaler.DefaultRoleCreator(),
 	}
 
 	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceDefault, r.Client); err != nil {
@@ -142,6 +145,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context) error {
 		metricsserver.RolebindingAuthReaderCreator(),
 		scheduler.RoleBindingAuthDelegator(),
 		controllermanager.RoleBindingAuthDelegator(),
+		clusterautoscaler.KubeSystemRoleBindingCreator(),
 	}
 	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in kube-system Namespace: %v", err)
@@ -159,6 +163,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context) error {
 	// Default
 	creators = []reconciling.NamedRoleBindingCreatorGetter{
 		machinecontroller.DefaultRoleBindingCreator(),
+		clusterautoscaler.DefaultRoleBindingCreator(),
 	}
 	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceDefault, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in default Namespace: %v", err)
@@ -186,6 +191,7 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context) error {
 		machinecontroller.ClusterRoleCreator(),
 		dnatcontroller.ClusterRoleCreator(),
 		metricsserver.ClusterRoleCreator(),
+		clusterautoscaler.ClusterRoleCreator(),
 	}
 
 	if err := reconciling.ReconcileClusterRoles(ctx, creators, "", r.Client); err != nil {
@@ -207,6 +213,7 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context) error {
 		metricsserver.ClusterRoleBindingAuthDelegatorCreator(),
 		scheduler.ClusterRoleBindingAuthDelegatorCreator(),
 		controllermanager.ClusterRoleBindingAuthDelegator(),
+		clusterautoscaler.ClusterRoleBindingCreator(),
 	}
 
 	if err := reconciling.ReconcileClusterRoleBindings(ctx, creators, "", r.Client); err != nil {

--- a/api/pkg/controller/usercluster/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/controller/usercluster/resources/clusterautoscaler/clusterautoscaler.go
@@ -1,0 +1,178 @@
+package clusterautoscaler
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRole returns a cluster role for the clusterautoscaler
+func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return resources.ClusterAutoscalerClusterRoleName,
+			func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+				cr.Rules = []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{
+							"nodes",
+							"pods",
+							"services",
+							"persistentvolumeclaims",
+							"persistentvolumes",
+							"replicationcontrollers",
+						},
+						Verbs: []string{"list", "watch", "get"},
+					},
+					{
+						// Needed to taint nodes prior to scaling down
+						APIGroups: []string{""},
+						Resources: []string{"nodes"},
+						Verbs:     []string{"update"},
+					},
+					{
+						APIGroups: []string{"apps", "extensions"},
+						Resources: []string{
+							"deployments",
+							"replicasets",
+							"daemonsets",
+							"statefulsets",
+						},
+						Verbs: []string{"list", "watch", "get"},
+					},
+					{
+						APIGroups: []string{"policy"},
+						Resources: []string{"poddisruptionbudgets"},
+						Verbs:     []string{"list", "watch", "get"},
+					},
+					{
+						APIGroups: []string{"storage.k8s.io"},
+						Resources: []string{"storageclasses"},
+						Verbs:     []string{"list", "watch", "get"},
+					},
+					{
+						APIGroups: []string{"batch"},
+						Resources: []string{"jobs", "cronjobs"},
+						Verbs:     []string{"list", "watch", "get"},
+					},
+					{
+						APIGroups: []string{"cluster.k8s.io"},
+						Resources: []string{"machinedeployments", "machinesets", "machines"},
+						Verbs:     []string{"list", "watch", "get"},
+					},
+					{
+						// Needed on MachineDeployments to change replicaCount and on
+						// machines to set the scale down annotation
+						APIGroups: []string{"cluster.k8s.io"},
+						Resources: []string{"machinedeployments", "machines"},
+						Verbs:     []string{"update"},
+					},
+				}
+				return cr, nil
+			}
+	}
+}
+
+// ClusterRoleBinding returns a ClusterRoleBinding for clusterautoscaler
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return resources.ClusterAutoscalerClusterRoleBindingName,
+			func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+				crb.RoleRef = rbacv1.RoleRef{
+					Name:     resources.ClusterAutoscalerClusterRoleName,
+					Kind:     "ClusterRole",
+					APIGroup: rbacv1.GroupName,
+				}
+				crb.Subjects = []rbacv1.Subject{{
+					Kind:     "User",
+					Name:     resources.ClusterAutoscalerCertUsername,
+					APIGroup: rbacv1.GroupName,
+				}}
+				return crb, nil
+			}
+	}
+}
+
+func KubeSystemRoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
+		return resources.ClusterAutoscalerClusterRoleName,
+			func(r *rbacv1.Role) (*rbacv1.Role, error) {
+				r.Rules = []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"create", "patch"},
+					},
+					{
+						APIGroups:     []string{""},
+						Resources:     []string{"configmaps"},
+						ResourceNames: []string{"cluster-autoscaler-status", "cluster-autoscaler"},
+						Verbs:         []string{"get", "update", "delete"},
+					},
+				}
+				return r, nil
+			}
+	}
+}
+
+func KubeSystemRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
+		return resources.ClusterAutoscalerClusterRoleBindingName,
+			func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+				rb.RoleRef = rbacv1.RoleRef{
+					Name:     resources.ClusterAutoscalerClusterRoleName,
+					Kind:     "Role",
+					APIGroup: rbacv1.GroupName,
+				}
+				rb.Subjects = []rbacv1.Subject{{
+					Kind:     "User",
+					Name:     resources.ClusterAutoscalerCertUsername,
+					APIGroup: rbacv1.GroupName,
+				}}
+
+				return rb, nil
+			}
+	}
+}
+
+func DefaultRoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
+		return resources.ClusterAutoscalerClusterRoleName,
+			func(r *rbacv1.Role) (*rbacv1.Role, error) {
+				r.Rules = []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"patch", "create"},
+					},
+				}
+				return r, nil
+			}
+	}
+}
+
+func DefaultRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
+		return resources.ClusterAutoscalerClusterRoleBindingName,
+			func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+				rb.RoleRef = rbacv1.RoleRef{
+					Name:     resources.ClusterAutoscalerClusterRoleName,
+					Kind:     "Role",
+					APIGroup: rbacv1.GroupName,
+				}
+				rb.Subjects = []rbacv1.Subject{{
+					Kind:     "User",
+					Name:     resources.ClusterAutoscalerCertUsername,
+					APIGroup: rbacv1.GroupName,
+				}}
+
+				return rb, nil
+			}
+	}
+}

--- a/api/pkg/controller/usercluster/resources/machine-controller/clusterrolebinding.go
+++ b/api/pkg/controller/usercluster/resources/machine-controller/clusterrolebinding.go
@@ -11,7 +11,6 @@ import (
 
 // ClusterRoleBinding returns a ClusterRoleBinding for the machine-controller.
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
-	// TemplateData actually not needed, no ownerrefs set in user-cluster
 	return createClusterRoleBindingCreator("controller",
 		resources.MachineControllerClusterRoleName, rbacv1.Subject{
 			Kind:     "User",

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -17,6 +17,11 @@ const (
 
 	// ClusterKindName represents "Kind" defined in Kubernetes
 	ClusterKindName = "Cluster"
+
+	// AnnotationNameClusterAutoscalerEnabled is the name of the annotation that is being
+	// used to determine if the cluster-autoscaler is enabled for this cluster. It is
+	// enabled when this Annotation is set with any value
+	AnnotationNameClusterAutoscalerEnabled = "kubermatic.io/cluster-autoscaler-enabled"
 )
 
 // ClusterPhase is the life cycle phase of a cluster.

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -28,7 +28,7 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 			var tag string
 			switch data.Cluster().Spec.Version.Minor() {
 			case 14:
-				tag = "vertical-pod-autoscaler-0.3.0-439-g7ce0c1ada-dirty"
+				tag = "fe5bee817ad9d37c8ce5e473af201c2f3fdf5b94-1"
 			}
 			if tag == "" {
 				return nil, fmt.Errorf("No matching autoscaler tag found for version %d", data.Cluster().Spec.Version.Minor())
@@ -92,7 +92,7 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.ClusterAutoscalerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryDocker) + "/alvaroaleman/cluster-autoscaler:" + tag,
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/kubernetes-cluster-autoscaler:" + tag,
 					Command: []string{"/cluster-autoscaler"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
@@ -102,6 +102,8 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 						// because the DS pods on them alone manage to get the utilization above the 0.5 threshold.
 						"--scale-down-utilization-threshold", "0.7",
 					},
+					// This likely won't be enough for bigger clusters, see https://github.com/kubermatic/kubermatic/issues/3568
+					// for details on how we want to fix this: https://github.com/kubermatic/kubermatic/issues/3568
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("32Mi"),

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -1,0 +1,142 @@
+package clusterautoscaler
+
+import (
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type clusterautoscalerData interface {
+	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
+	ImageRegistry(string) string
+	Cluster() *kubermaticv1.Cluster
+}
+
+// DeploymentCreator returns the function to create and update the cluster-autoscaler deployment
+func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
+		return resources.ClusterAutoscalerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			var tag string
+			switch data.Cluster().Spec.Version.Minor() {
+			case 14:
+				tag = "vertical-pod-autoscaler-0.3.0-439-g7ce0c1ada-dirty"
+			}
+			if tag == "" {
+				return nil, fmt.Errorf("No matching autoscaler tag found for version %d", data.Cluster().Spec.Version.Minor())
+			}
+
+			dep.Name = resources.ClusterAutoscalerDeploymentName
+			dep.Labels = resources.BaseAppLabel(resources.ClusterAutoscalerDeploymentName, nil)
+
+			dep.Spec.Replicas = resources.Int32(1)
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(resources.ClusterAutoscalerDeploymentName, nil),
+			}
+			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
+			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+				MaxSurge: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+				},
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 0,
+				},
+			}
+
+			volumes := []corev1.Volume{
+				{
+					Name: resources.ClusterAutoscalerKubeconfigSecretName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: resources.ClusterAutoscalerKubeconfigSecretName,
+							// We have to make the secret readable for all for now because owner/group cannot be changed.
+							// ( upstream proposal: https://github.com/kubernetes/kubernetes/pull/28733 )
+							DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+						},
+					},
+				},
+			}
+			podLabels, err := data.GetPodTemplateLabels(resources.ClusterAutoscalerDeploymentName,
+				volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %v", err)
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+				Annotations: map[string]string{
+					"prometheus.io/scrape": "true",
+					"prometheus.io/path":   "/metrics",
+					"prometheus.io/port":   "8085",
+				},
+			}
+
+			dep.Spec.Template.Spec.Volumes = volumes
+
+			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
+			if err != nil {
+				return nil, err
+			}
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:    resources.ClusterAutoscalerDeploymentName,
+					Image:   data.ImageRegistry(resources.RegistryDocker) + "/alvaroaleman/cluster-autoscaler:" + tag,
+					Command: []string{"/cluster-autoscaler"},
+					Args: []string{
+						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
+						"--leader-elect-resource-lock", "configmaps",
+						// PercentageUsed treshold. If the current utilization of a node is above this, the CA will never
+						// scale it down. Default is 0.5. Increased, because otherwise small nodes never get scaled down
+						// because the DS pods on them alone manage to get the utilization above the 0.5 threshold.
+						"--scale-down-utilization-threshold", "0.7",
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+							corev1.ResourceCPU:    resource.MustParse("25m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/health-check",
+								Port:   intstr.FromInt(8085),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						FailureThreshold:    3,
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.ClusterAutoscalerKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
+						},
+					},
+				},
+			}
+
+			return dep, nil
+		}
+	}
+}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -223,6 +223,10 @@ const (
 	PrometheusClusterRoleBindingName = "system:external-prometheus"
 	//MetricsServerResourceReaderClusterRoleBindingName is the name for the metrics server ClusterRoleBinding
 	MetricsServerResourceReaderClusterRoleBindingName = "system:metrics-server"
+	// ClusterAutoscalerClusterRoleName is the name of the clusterrole for the cluster autoscaler
+	ClusterAutoscalerClusterRoleName = "system:kubermatic-cluster-autoscaler"
+	// ClusterAutoscalerClusterRoleBindingName is the name of the clusterrolebinding for the CA
+	ClusterAutoscalerClusterRoleBindingName = "system:kubermatic-cluster-autoscaler"
 
 	// EtcdPodDisruptionBudgetName is the name of the PDB for the etcd StatefulSet
 	EtcdPodDisruptionBudgetName = "etcd"

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -64,6 +64,8 @@ const (
 	KubeStateMetricsDeploymentName = "kube-state-metrics"
 	// UserClusterControllerDeploymentName is the name of the usercluster-controller deployment
 	UserClusterControllerDeploymentName = "usercluster-controller"
+	// ClusterAutoscalerDeploymentName is the name of the cluster-autoscaler depoyment
+	ClusterAutoscalerDeploymentName = "cluster-autoscaler"
 
 	//PrometheusStatefulSetName is the name for the prometheus StatefulSet
 	PrometheusStatefulSetName = "prometheus"
@@ -113,6 +115,9 @@ const (
 	MachineControllerWebhookServingCertKeyKeyName = "key.pem"
 	//PrometheusApiserverClientCertificateSecretName is the name for the secret containing the client certificate used by prometheus to access the apiserver
 	PrometheusApiserverClientCertificateSecretName = "prometheus-apiserver-certificate"
+	// ClusterAutoscalerKubeconfigSecretName is the name of the kubeconfig secret used for
+	// the cluster-autoscaler
+	ClusterAutoscalerKubeconfigSecretName = "cluster-autoscaler-kubeconfig"
 
 	// ImagePullSecretName specifies the name of the dockercfg secret used to access the private repo.
 	ImagePullSecretName = "dockercfg"
@@ -184,6 +189,8 @@ const (
 	KubeletDnatControllerCertUsername = "kubermatic:kubeletdnat-controller"
 	// PrometheusCertUsername is the name of the user coming from kubeconfig cert
 	PrometheusCertUsername = "prometheus"
+	// ClusterAutoscalerCertUsername is the name of the user coming from the CA kubeconfig cert
+	ClusterAutoscalerCertUsername = "kubermatic:cluster-autoscaler"
 
 	// KubeletDnatControllerClusterRoleName is the name for the KubeletDnatController cluster role
 	KubeletDnatControllerClusterRoleName = "system:kubermatic-kubeletdnat-controller"

--- a/config/test/autoscaler-scaleup.yaml
+++ b/config/test/autoscaler-scaleup.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: autoscaler-scaleup
+  name: autoscaler-scaleup
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: autoscaler-scaleup
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: autoscaler-scaleup
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        resources:
+          requests:
+            cpu: 300m


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces support for autoscaling for Kubernetes > 1.13 or openshift, by adding the following annotations like this on the MachineDeployment:

```
 cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: "10"
 cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3370 

**Special notes for your reviewer**:

requires a new machine-controller release first.

/hold
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
