### PR TITLE
do not create empty scrape targets

### DIFF
--- a/config/monitoring/prometheus/config/scraping/thanos-sidecar.yaml
+++ b/config/monitoring/prometheus/config/scraping/thanos-sidecar.yaml
@@ -24,4 +24,6 @@ relabel_configs:
   target_label: pod
   replacement: $1
   action: replace
+{{ else }}
+job_name: thanos-sidecar
 {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus does not like entirely empty scraping configs. When Thanos is disabled, we need to either not load the thanos-sidecar.yaml (via values.yaml, but it's tedious) or create a scraping config with just a name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
