### PR TITLE
fix bad YAML when defining multiple Grafana datasources

### DIFF
--- a/config/monitoring/grafana/provisioning/datasources/prometheus.yaml
+++ b/config/monitoring/grafana/provisioning/datasources/prometheus.yaml
@@ -1,3 +1,5 @@
+apiVersion: 1
+datasources:
 {{ range .Values.grafana.provisioning.datasources.prometheusServices }}
 {{ $name := . }}
 {{ $ns := $.Release.Namespace }}
@@ -10,8 +12,6 @@
 {{ $ns = (split "." $name)._1 }}
 {{ $name = (split "." $name)._0 }}
 {{ end }}
-apiVersion: 1
-datasources:
 - name: {{ $name }}
   type: prometheus
   access: proxy


### PR DESCRIPTION
**What this PR does / why we need it**:
Grafana expects a single document with a list of items for configuring datasources.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
