### PR TITLE
Fix nodeport proxy

### DIFF
--- a/api/cmd/nodeport-proxy/envoy-manager/controller.go
+++ b/api/cmd/nodeport-proxy/envoy-manager/controller.go
@@ -165,7 +165,8 @@ func (c *reconciler) getInitialResources() (listeners []envoycache.Resource, clu
 	return listeners, clusters, nil
 }
 
-func (c reconciler) Reconcile(_ reconcile.Request) (reconcile.Result, error) {
+func (c *reconciler) Reconcile(_ reconcile.Request) (reconcile.Result, error) {
+	c.log.Debug("Got reconcile request")
 	err := c.sync()
 	if err != nil {
 		c.log.WithError(err).Print("Failed to reconcile")

--- a/api/cmd/nodeport-proxy/envoy-manager/main.go
+++ b/api/cmd/nodeport-proxy/envoy-manager/main.go
@@ -86,7 +86,7 @@ func main() {
 		mainLog.Fatal(err)
 	}
 
-	r := reconciler{
+	r := &reconciler{
 		Client:              mgr.GetClient(),
 		envoySnapshotCache:  snapshotCache,
 		log:                 mainLog.WithField("annotation", exposeAnnotationKey),

--- a/api/cmd/nodeport-proxy/release.sh
+++ b/api/cmd/nodeport-proxy/release.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-TAG=v2.1.0
+TAG=v2.1.1
 export TAG
 make docker

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -2,7 +2,7 @@ nodePortProxy:
   replicas: 3
   image:
     repository: "quay.io/kubermatic/nodeport-proxy"
-    tag: "v2.0.0"
+    tag: v2.1.1
   envoy:
     image:
       repository: "envoyproxy/envoy-alpine"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the nodeport proxy. I've manually deployed this on dev and checked that access still works after one of the apiserver pods got deleted.

Cause seems to be:

* reconciler is a literal
* reconciler.envoySnapshotCache is a pointer so that is not an issue
* reconciler.lastAppliedSnapshot is a literal
* We construct a new cache version on every iteration, but since `lastAppliedSnapshot` is a literal we never update it, hence always use `1.0.0` as version there (We start out with `0.0.0`, then do `IncMajor()`
* Then we call `reconciler.envoySnapshotCache.SetSnapshot`
* That in turn only removes watches for which the version changed, which doesn't happen after the first iteration

Also TIL: You can call a pointer receiver from a value receiver (reconciler.Reconcile was a value receiver, r.sync() was and is a pointer receiver)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 
