### PR TITLE
do not deploy minio/s3-exporter on CI

### DIFF
--- a/api/hack/ci/ci-deploy-ci-kubermatic-io.sh
+++ b/api/hack/ci/ci-deploy-ci-kubermatic-io.sh
@@ -36,5 +36,5 @@ vault kv get -field=values.yaml dev/seed-clusters/ci.kubermatic.io > ${VALUES_FI
 echodate "Successfully got secrets for dev from Vault"
 
 echodate "Deploying Kubermatic to ci.kubermatic.io"
-TILLER_NAMESPACE=kubermatic DEPLOY_NODEPORT_PROXY=false DEPLOY_ALERTMANAGER=false ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+TILLER_NAMESPACE=kubermatic DEPLOY_NODEPORT_PROXY=false DEPLOY_ALERTMANAGER=false DEPLOY_MINIO=false ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
 echodate "Successfully deployed Kubermatic to ci.kubermatic.io"

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -22,6 +22,7 @@ else
 fi
 DEPLOY_NODEPORT_PROXY=${DEPLOY_NODEPORT_PROXY:-true}
 DEPLOY_ALERTMANAGER=${DEPLOY_ALERTMANAGER:-true}
+DEPLOY_MINIO=${DEPLOY_MINIO:-true}
 TILLER_NAMESPACE=${TILLER_NAMESPACE:-kubermatic}
 
 cd "$(dirname "$0")/../../"
@@ -59,8 +60,12 @@ if [[ "${1}" = "master" ]]; then
     deploy "iap" "iap" ./config/iap/ || true
 fi
 
-deploy "minio" "minio" ./config/minio/
-deploy "s3-exporter" "kube-system" ./config/s3-exporter/
+# CI has its own Minio deployment as a proxy for GCS, so we do not install the default Helm chart here.
+if [[ "${DEPLOY_MINIO}" = true ]]; then
+  deploy "minio" "minio" ./config/minio/
+  deploy "s3-exporter" "kube-system" ./config/s3-exporter/
+fi
+
 # The NodePort proxy is only relevant in cloud environments (Where LB services can be used)
 if [[ "${DEPLOY_NODEPORT_PROXY}" = true ]]; then
   deploy "nodeport-proxy" "nodeport-proxy" ./config/nodeport-proxy/


### PR DESCRIPTION
**What this PR does / why we need it**:
On CI we have a dedicated Minio deployment that works as a GCS proxy. This conflicts with our default chart because the chart defines a PVC that -- on Hetzner -- has a `WaitForFirstConsumer` flag and since the special Minio deployment does not use the PVC anymore, it gets stuck as Pending and Helm can never complete a chart update.
And since nobody is using the S3-Exporter metrics on CI anyway, we skip it as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
