### PR TITLE
Cleanup: Remove PDBs and handle errNotFound gracefully

### DIFF
--- a/api/pkg/clusterdeletion/deletion_test.go
+++ b/api/pkg/clusterdeletion/deletion_test.go
@@ -110,11 +110,15 @@ func TestCleanUpPVUsingWorkloads(t *testing.T) {
 			name:    "Dont delete pod without PV",
 			objects: []runtime.Object{getPod("", "", false)},
 		},
+		{
+			name:                "No error when owner doesn't exist",
+			objects:             []runtime.Object{getPod("ReplicaSet", "my-rs", true)},
+			objDeletionExpected: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			client := fake.NewFakeClient(tc.objects...)
 			d := &Deletion{userClusterClient: client}
 			ctx := context.Background()


### PR DESCRIPTION
**What this PR does / why we need it**:

* Removes all PDBs before attempting to cleanup Pods to make sure we don't end up in a deadlock
* Gracefully handle ErrNotFound when an owner doesn't exist anymore

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3546

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 