### PR TITLE
Add missing cluster roles for new kube-state-metrics version

### DIFF
--- a/api/pkg/controller/usercluster/resources/kube-state-metrics/clusterrole.go
+++ b/api/pkg/controller/usercluster/resources/kube-state-metrics/clusterrole.go
@@ -42,12 +42,16 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 						"daemonsets",
 						"deployments",
 						"replicasets",
+						"ingresses",
 					},
 					Verbs: []string{"list", "watch"},
 				},
 				{
 					APIGroups: []string{"apps"},
 					Resources: []string{
+						"daemonsets",
+						"deployments",
+						"replicasets",
 						"statefulsets",
 					},
 					Verbs: []string{"list", "watch"},
@@ -71,6 +75,13 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 					APIGroups: []string{"policy"},
 					Resources: []string{
 						"poddisruptionbudgets",
+					},
+					Verbs: []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{"certificates.k8s.io"},
+					Resources: []string{
+						"certificatesigningrequests",
 					},
 					Verbs: []string{"list", "watch"},
 				},

--- a/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -45,3 +45,7 @@ rules:
   resources:
   - poddisruptionbudgets
   verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+    - certificatesigningrequests
+  verbs: ["list", "watch"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing cluster roles for new kube-state-metrics version

Errors in seed kube-state-metrics:

```
E0611 16:10:45.970446       1 reflector.go:126] k8s.io/kube-state-metrics/internal/collector/builder.go:482: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io^C
```

Errors in customer cluster kube-state-metrics:

```
E0611 19:04:01.222323       1 reflector.go:126] k8s.io/kube-state-metrics/internal/collector/builder.go:482: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "kube-state-metrics" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0611 19:04:01.235364       1 reflector.go:126] k8s.io/kube-state-metrics/internal/collector/builder.go:482: Failed to list *v1.Deployment: deployments.apps is forbidden: User "kube-state-metrics" cannot list resource "deployments" in API group "apps" at the cluster scope
E0611 19:04:01.235362       1 reflector.go:126] k8s.io/kube-state-metrics/internal/collector/builder.go:482: Failed to list *v1beta1.Ingress: ingresses.extensions is forbidden: User "kube-state-metrics" cannot list resource "ingresses" in API group "extensions" at the cluster scope
E0611 19:04:01.236736       1 reflector.go:126] k8s.io/kube-state-metrics/internal/collector/builder.go:482: Failed to list *v1.DaemonSet: daemonsets.apps is forbidden: User "kube-state-metrics" cannot list resource "daemonsets" in API group "apps" at the cluster scope
```

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
