### PR TITLE
pass through proxy & image settings from the datacenters.yaml

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -2026,6 +2026,7 @@
     "github.com/gorilla/securecookie",
     "github.com/heptiolabs/healthcheck",
     "github.com/hetznercloud/hcloud-go/hcloud",
+    "github.com/kubermatic/machine-controller/pkg/apis/plugin",
     "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws",
     "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure",
     "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean",

--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -813,7 +813,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:11100cc3b768ae71140c2e38ddc9ae7a61645e720449d0cf524952f6178140cb"
+  digest = "1:b20927cae605cb8e33021e9b69f4334e8e96f0ed246f4835e7c3e45094b40644"
   name = "github.com/kubermatic/machine-controller"
   packages = [
     "pkg/apis/plugin",
@@ -841,8 +841,8 @@
     "pkg/userdata/ubuntu",
   ]
   pruneopts = "NUT"
-  revision = "44919d7c387fce1ff4972c56479230ff1f5fa783"
-  version = "v1.1.10"
+  revision = "33efce2c39dbcdd2786ffc11b2ec3664c6638a98"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:0dbba7d4d4f3eeb01acd81af338ff4a3c4b0bb814d87368ea536e616f383240d"

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -125,7 +125,7 @@ required = [
 
 [[override]]
   name = "github.com/kubermatic/machine-controller"
-  version = "v1.1.10"
+  version = "v1.2.0"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -122,6 +122,20 @@ type DatacenterSpec struct {
 	GCP          *GCPSpec          `yaml:"gcp,omitempty"`
 }
 
+// NodeSettings are node specific which can be configured on datacenter level
+type NodeSettings struct {
+	// If set, this proxy will be configured on all nodes.
+	HTTPProxy string `yaml:"http_proxy,omitempty"`
+	// If set this will be set as NO_PROXY on the node
+	NoProxy string `yaml:"no_proxy,omitempty"`
+	// If set, this image registry will be used for pulling all required images on the node
+	InsecureRegistries []string `yaml:"insecure_registries,omitempty"`
+	// Translates to --pod-infra-container-image on the kubelet. If not set, the kubelet will default it
+	PauseImage string `yaml:"pause_image,omitempty"`
+	// The hyperkube image to use. Currently only Container Linux uses it
+	HyperkubeImage string `yaml:"hyperkube_image,omitempty"`
+}
+
 // DatacenterMeta describes a Kubermatic datacenter.
 type DatacenterMeta struct {
 	Location         string         `yaml:"location"`
@@ -131,6 +145,7 @@ type DatacenterMeta struct {
 	Private          bool           `yaml:"private"`
 	IsSeed           bool           `yaml:"is_seed"`
 	SeedDNSOverwrite *string        `yaml:"seed_dns_overwrite,omitempty"`
+	Node             NodeSettings   `yaml:"node,omitempty"`
 }
 
 // datacentersMeta describes a number of Kubermatic datacenters.

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -128,7 +128,7 @@ type NodeSettings struct {
 	HTTPProxy string `yaml:"http_proxy,omitempty"`
 	// If set this will be set as NO_PROXY on the node
 	NoProxy string `yaml:"no_proxy,omitempty"`
-	// If set, this image registry will be used for pulling all required images on the node
+	// If set, this image registry will be configured as insecure on the container runtime.
 	InsecureRegistries []string `yaml:"insecure_registries,omitempty"`
 	// Translates to --pod-infra-container-image on the kubelet. If not set, the kubelet will default it
 	PauseImage string `yaml:"pause_image,omitempty"`

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -2,6 +2,7 @@ package machinecontroller
 
 import (
 	"fmt"
+	"strings"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -100,18 +101,13 @@ func DeploymentCreator(data machinecontrollerData) reconciling.NamedDeploymentCr
 					return nil, err
 				}
 			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:    Name,
-					Image:   data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
-					Command: []string{"/usr/local/bin/machine-controller"},
-					Args: []string{
-						"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-						"-logtostderr",
-						"-v", "4",
-						"-cluster-dns", clusterDNSIP,
-						"-internal-listen-address", "0.0.0.0:8085",
-					},
+					Name:      Name,
+					Image:     data.ImageRegistry(resources.RegistryDocker) + "/kubermatic/machine-controller:" + tag,
+					Command:   []string{"/usr/local/bin/machine-controller"},
+					Args:      getFlags(clusterDNSIP, data.DC().Node),
 					Env:       getEnvVars(data),
 					Resources: controllerResourceRequirements,
 					LivenessProbe: &corev1.Probe{
@@ -189,4 +185,31 @@ func getEnvVars(data machinecontrollerData) []corev1.EnvVar {
 		vars = append(vars, corev1.EnvVar{Name: "GOOGLE_SERVICE_ACCOUNT", Value: data.Cluster().Spec.Cloud.GCP.ServiceAccount})
 	}
 	return vars
+}
+
+func getFlags(clusterDNSIP string, nodeSettings provider.NodeSettings) []string {
+	flags := []string{
+		"-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
+		"-logtostderr",
+		"-v", "4",
+		"-cluster-dns", clusterDNSIP,
+		"-internal-listen-address", "0.0.0.0:8085",
+	}
+	if len(nodeSettings.InsecureRegistries) > 0 {
+		flags = append(flags, "-node-insecure-registries", strings.Join(nodeSettings.InsecureRegistries, ","))
+	}
+	if nodeSettings.HTTPProxy != "" {
+		flags = append(flags, "-node-http-proxy", nodeSettings.HTTPProxy)
+	}
+	if nodeSettings.NoProxy != "" {
+		flags = append(flags, "-node-no-proxy", nodeSettings.NoProxy)
+	}
+	if nodeSettings.PauseImage != "" {
+		flags = append(flags, "-node-pause-image", nodeSettings.PauseImage)
+	}
+	if nodeSettings.HyperkubeImage != "" {
+		flags = append(flags, "-node-hyperkube-image", nodeSettings.HyperkubeImage)
+	}
+
+	return flags
 }

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -33,7 +33,7 @@ var (
 const (
 	Name = "machine-controller"
 
-	tag = "v1.1.10"
+	tag = "v1.2.0"
 
 	nodeLocalDNSCacheAddress = "169.254.20.10"
 )

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -44,7 +44,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
           value: openstack-domain
         - name: OS_TENANT_NAME
           value: openstack-tenant
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.1.10
+        image: docker.io/kubermatic/machine-controller:v1.2.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/userdata/openshift/userdata_test.go
+++ b/api/pkg/userdata/openshift/userdata_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/kubermatic/machine-controller/pkg/apis/plugin"
 	"github.com/pmezard/go-difflib/difflib"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,12 +54,21 @@ func TestUserdataGeneration(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			p := Provider{}
-			userdata, err := p.UserData(test.spec,
-				kubeconfig,
-				"dummy-cloud-config",
-				test.cloudProviderName,
-				[]net.IP{net.ParseIP("8.8.8.8")},
-				false)
+
+			req := plugin.UserDataRequest{
+				MachineSpec:           test.spec,
+				Kubeconfig:            kubeconfig,
+				CloudConfig:           "dummy-cloud-config",
+				CloudProviderName:     test.cloudProviderName,
+				DNSIPs:                []net.IP{net.ParseIP("8.8.8.8")},
+				ExternalCloudProvider: false,
+				HTTPProxy:             "",
+				NoProxy:               "",
+				InsecureRegistries:    []string{},
+				PauseImage:            "",
+			}
+
+			userdata, err := p.UserData(req)
 			if err != nil {
 				t.Fatalf("failed to call p.Userdata: %v", err)
 			}

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/apis/plugin/plugin.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/apis/plugin/plugin.go
@@ -40,11 +40,16 @@ const (
 // UserDataRequest requests user data with the given arguments.
 type UserDataRequest struct {
 	MachineSpec           clusterv1alpha1.MachineSpec
-	KubeConfig            *clientcmdapi.Config
+	Kubeconfig            *clientcmdapi.Config
 	CloudProviderName     string
 	CloudConfig           string
 	DNSIPs                []net.IP
 	ExternalCloudProvider bool
+	HTTPProxy             string
+	NoProxy               string
+	InsecureRegistries    []string
+	PauseImage            string
+	HyperkubeImage        string
 }
 
 // UserDataResponse contains the responded user data.

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/convert/ignition-converter.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/convert/ignition-converter.go
@@ -19,14 +19,11 @@ package convert
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 
 	ctconfig "github.com/coreos/container-linux-config-transpiler/config"
 
+	pluginapi "github.com/kubermatic/machine-controller/pkg/apis/plugin"
 	"github.com/kubermatic/machine-controller/pkg/userdata/plugin"
-
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 func NewIgnition(p plugin.Provider) *Ignition {
@@ -37,14 +34,8 @@ type Ignition struct {
 	p plugin.Provider
 }
 
-func (j *Ignition) UserData(
-	spec clusterv1alpha1.MachineSpec,
-	kubeconfig *clientcmdapi.Config,
-	cloudConfig, cloudProviderName string,
-	clusterDNSIPs []net.IP,
-	externalCloudProvider bool,
-) (string, error) {
-	before, err := j.p.UserData(spec, kubeconfig, cloudConfig, cloudProviderName, clusterDNSIPs, externalCloudProvider)
+func (j *Ignition) UserData(req pluginapi.UserDataRequest) (string, error) {
+	before, err := j.p.UserData(req)
 	if err != nil {
 		return "", err
 	}

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/coreos/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/coreos/provider.go
@@ -23,14 +23,12 @@ package coreos
 import (
 	"bytes"
 	"fmt"
-	"net"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/semver"
 
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
+	"github.com/kubermatic/machine-controller/pkg/apis/plugin"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	userdatahelper "github.com/kubermatic/machine-controller/pkg/userdata/helper"
 )
@@ -39,32 +37,25 @@ import (
 type Provider struct{}
 
 // UserData renders user-data template to string.
-func (p Provider) UserData(
-	spec clusterv1alpha1.MachineSpec,
-	kubeconfig *clientcmdapi.Config,
-	cloudConfig string,
-	cloudProviderName string,
-	clusterDNSIPs []net.IP,
-	externalCloudProvider bool,
-) (string, error) {
+func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 
 	tmpl, err := template.New("user-data").Funcs(userdatahelper.TxtFuncMap()).Parse(userDataTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse user-data template: %v", err)
 	}
 
-	kubeletVersion, err := semver.NewVersion(spec.Versions.Kubelet)
+	kubeletVersion, err := semver.NewVersion(req.MachineSpec.Versions.Kubelet)
 	if err != nil {
 		return "", fmt.Errorf("invalid kubelet version: %v", err)
 	}
 
-	pconfig, err := providerconfig.GetConfig(spec.ProviderSpec)
+	pconfig, err := providerconfig.GetConfig(req.MachineSpec.ProviderSpec)
 	if err != nil {
 		return "", fmt.Errorf("failed to get provider config: %v", err)
 	}
 
 	if pconfig.OverwriteCloudConfig != nil {
-		cloudConfig = *pconfig.OverwriteCloudConfig
+		req.CloudConfig = *pconfig.OverwriteCloudConfig
 	}
 
 	coreosConfig, err := LoadConfig(pconfig.OperatingSystemSpec)
@@ -72,40 +63,40 @@ func (p Provider) UserData(
 		return "", fmt.Errorf("failed to get coreos config from provider config: %v", err)
 	}
 
-	kubeconfigString, err := userdatahelper.StringifyKubeconfig(kubeconfig)
+	kubeconfigString, err := userdatahelper.StringifyKubeconfig(req.Kubeconfig)
 	if err != nil {
 		return "", err
 	}
 
-	kubernetesCACert, err := userdatahelper.GetCACert(kubeconfig)
+	kubernetesCACert, err := userdatahelper.GetCACert(req.Kubeconfig)
 	if err != nil {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
+	// We need to reconfigure rkt to allow insecure registries in case the hyperkube image comes from an insecure registry
+	var insecureHyperkubeImage bool
+	for _, registry := range req.InsecureRegistries {
+		if strings.Contains(req.HyperkubeImage, registry) {
+			insecureHyperkubeImage = true
+		}
+	}
+
 	data := struct {
-		MachineSpec       clusterv1alpha1.MachineSpec
-		ProviderSpec      *providerconfig.Config
-		CoreOSConfig      *Config
-		Kubeconfig        string
-		CloudProvider     string
-		CloudConfig       string
-		HyperkubeImageTag string
-		ClusterDNSIPs     []net.IP
-		KubernetesCACert  string
-		KubeletVersion    string
-		IsExternal        bool
+		plugin.UserDataRequest
+		ProviderSpec           *providerconfig.Config
+		CoreOSConfig           *Config
+		Kubeconfig             string
+		KubernetesCACert       string
+		KubeletVersion         string
+		InsecureHyperkubeImage bool
 	}{
-		MachineSpec:       spec,
-		ProviderSpec:      pconfig,
-		CoreOSConfig:      coreosConfig,
-		Kubeconfig:        kubeconfigString,
-		CloudProvider:     cloudProviderName,
-		CloudConfig:       cloudConfig,
-		HyperkubeImageTag: fmt.Sprintf("v%s", kubeletVersion.String()),
-		ClusterDNSIPs:     clusterDNSIPs,
-		KubernetesCACert:  kubernetesCACert,
-		KubeletVersion:    kubeletVersion.String(),
-		IsExternal:        externalCloudProvider,
+		UserDataRequest:        req,
+		ProviderSpec:           pconfig,
+		CoreOSConfig:           coreosConfig,
+		Kubeconfig:             kubeconfigString,
+		KubernetesCACert:       kubernetesCACert,
+		KubeletVersion:         kubeletVersion.String(),
+		InsecureHyperkubeImage: insecureHyperkubeImage,
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -155,6 +146,15 @@ systemd:
     - name: docker.service
       enabled: true
 
+{{- if .HTTPProxy }}
+    - name: update-engine.service
+      dropins:
+        - name: 50-proxy.conf
+          contents: |
+            [Service]
+            Environment=ALL_PROXY={{ .HTTPProxy }}
+{{- end }}
+
     - name: download-healthcheck-script.service
       enabled: true
       contents: |
@@ -163,6 +163,7 @@ systemd:
         After=network-online.target
         [Service]
         Type=oneshot
+        EnvironmentFile=-/etc/environment
         ExecStart=/opt/bin/download.sh
         [Install]
         WantedBy=multi-user.target
@@ -200,9 +201,13 @@ systemd:
         TimeoutStartSec=5min
         CPUAccounting=true
         MemoryAccounting=true
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:{{ .HyperkubeImageTag }}
+{{- if .HTTPProxy }}
+        Environment=KUBELET_IMAGE=docker://{{ .HyperkubeImage }}:v{{ .KubeletVersion }}
+{{- else }}
+        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v{{ .KubeletVersion }}
+{{- end }}
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --insecure-options=image \
+          --insecure-options=image{{if .InsecureHyperkubeImage }},http{{ end }} \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
           --volume cni-bin,kind=host,source=/opt/cni/bin \
@@ -222,15 +227,32 @@ systemd:
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
         ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-{{ kubeletFlags .KubeletVersion .CloudProvider .MachineSpec.Name .ClusterDNSIPs .IsExternal | indent 10 }}
+{{ kubeletFlags .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 10 }}
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
         [Install]
         WantedBy=multi-user.target
 
+    - name: docker.service
+      enabled: true
+      dropins:
+      - name: 10-environment.conf
+        contents: |
+          [Service]
+          EnvironmentFile=-/etc/environment
+
 storage:
   files:
+{{- if .HTTPProxy }}
+    - path: /etc/environment
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+{{ proxyEnvironment .HTTPProxy .NoProxy | indent 10 }}
+{{- end }}
+
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       filesystem: root
       mode: 0644
@@ -293,7 +315,7 @@ storage:
       contents:
         inline: |
 {{ .KubernetesCACert | indent 10 }}
-{{ if ne .CloudProvider "aws" }}
+{{ if ne .CloudProviderName "aws" }}
     - path: /etc/hostname
       filesystem: root
       mode: 0600
@@ -320,13 +342,12 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
-    - path: /etc/systemd/system/docker.service.d/10-storage.conf
+    - path: /etc/docker/daemon.json
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          [Service]
-          Environment=DOCKER_OPTS=--storage-driver=overlay2
+{{ dockerConfig .InsecureRegistries | indent 10 }}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/helper.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helper
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -89,4 +90,32 @@ func JournalDConfig() string {
 	return `[Journal]
 SystemMaxUse=5G
 `
+}
+
+type dockerConfig struct {
+	StorageDriver      string   `json:"storage-driver"`
+	InsecureRegistries []string `json:"insecure-registries"`
+}
+
+// DockerConfig returns the docker daemon.json
+func DockerConfig(registries []string) (string, error) {
+	cfg := dockerConfig{
+		StorageDriver:      "overlay2",
+		InsecureRegistries: registries,
+	}
+	if registries == nil {
+		cfg.InsecureRegistries = []string{}
+	}
+
+	b, err := json.Marshal(cfg)
+	return string(b), err
+}
+
+func ProxyEnvironment(proxy, noProxy string) string {
+	return fmt.Sprintf(`HTTP_PROXY=%s
+http_proxy=%s
+HTTPS_PROXY=%s
+https_proxy=%s
+NO_PROXY=%s
+no_proxy=%s`, proxy, proxy, proxy, proxy, noProxy, noProxy)
 }

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/template_functions.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/template_functions.go
@@ -36,6 +36,8 @@ func TxtFuncMap() template.FuncMap {
 	funcMap["journalDConfig"] = JournalDConfig
 	funcMap["kubeletHealthCheckSystemdUnit"] = KubeletHealthCheckSystemdUnit
 	funcMap["containerRuntimeHealthCheckSystemdUnit"] = ContainerRuntimeHealthCheckSystemdUnit
+	funcMap["dockerConfig"] = DockerConfig
+	funcMap["proxyEnvironment"] = ProxyEnvironment
 
 	return funcMap
 }

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/plugin/plugin.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/plugin/plugin.go
@@ -26,11 +26,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
-
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/plugin"
 )
@@ -38,14 +34,7 @@ import (
 // Provider defines the interface each plugin has to implement
 // for the retrieval of the userdata based on the given arguments.
 type Provider interface {
-	UserData(
-		spec clusterv1alpha1.MachineSpec,
-		kubeconfig *clientcmdapi.Config,
-		cloudConfig string,
-		cloudProviderName string,
-		clusterDNSIPs []net.IP,
-		externalCloudProvider bool,
-	) (string, error)
+	UserData(req plugin.UserDataRequest) (string, error)
 }
 
 // Plugin implements a convenient helper to map the request to the given
@@ -78,14 +67,7 @@ func (p *Plugin) Run() error {
 	if err != nil {
 		return err
 	}
-	userData, err := p.provider.UserData(
-		req.MachineSpec,
-		req.KubeConfig,
-		req.CloudConfig,
-		req.CloudProviderName,
-		req.DNSIPs,
-		req.ExternalCloudProvider,
-	)
+	userData, err := p.provider.UserData(req)
 	var resp plugin.UserDataResponse
 	if err != nil {
 		resp.Err = err.Error()

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/ubuntu/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/ubuntu/provider.go
@@ -24,14 +24,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"net"
 	"text/template"
 
 	"github.com/Masterminds/semver"
 
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
+	"github.com/kubermatic/machine-controller/pkg/apis/plugin"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	userdatahelper "github.com/kubermatic/machine-controller/pkg/userdata/helper"
 )
@@ -40,32 +37,25 @@ import (
 type Provider struct{}
 
 // UserData renders user-data template to string.
-func (p Provider) UserData(
-	spec clusterv1alpha1.MachineSpec,
-	kubeconfig *clientcmdapi.Config,
-	cloudConfig string,
-	cloudProviderName string,
-	clusterDNSIPs []net.IP,
-	externalCloudProvider bool,
-) (string, error) {
+func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 
 	tmpl, err := template.New("user-data").Funcs(userdatahelper.TxtFuncMap()).Parse(userDataTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse user-data template: %v", err)
 	}
 
-	kubeletVersion, err := semver.NewVersion(spec.Versions.Kubelet)
+	kubeletVersion, err := semver.NewVersion(req.MachineSpec.Versions.Kubelet)
 	if err != nil {
 		return "", fmt.Errorf("invalid kubelet version: %v", err)
 	}
 
-	pconfig, err := providerconfig.GetConfig(spec.ProviderSpec)
+	pconfig, err := providerconfig.GetConfig(req.MachineSpec.ProviderSpec)
 	if err != nil {
 		return "", fmt.Errorf("failed to get providerSpec: %v", err)
 	}
 
 	if pconfig.OverwriteCloudConfig != nil {
-		cloudConfig = *pconfig.OverwriteCloudConfig
+		req.CloudConfig = *pconfig.OverwriteCloudConfig
 	}
 
 	if pconfig.Network != nil {
@@ -77,45 +67,37 @@ func (p Provider) UserData(
 		return "", fmt.Errorf("failed to get ubuntu config from provider config: %v", err)
 	}
 
-	serverAddr, err := userdatahelper.GetServerAddressFromKubeconfig(kubeconfig)
+	serverAddr, err := userdatahelper.GetServerAddressFromKubeconfig(req.Kubeconfig)
 	if err != nil {
 		return "", fmt.Errorf("error extracting server address from kubeconfig: %v", err)
 	}
 
-	kubeconfigString, err := userdatahelper.StringifyKubeconfig(kubeconfig)
+	kubeconfigString, err := userdatahelper.StringifyKubeconfig(req.Kubeconfig)
 	if err != nil {
 		return "", err
 	}
 
-	kubernetesCACert, err := userdatahelper.GetCACert(kubeconfig)
+	kubernetesCACert, err := userdatahelper.GetCACert(req.Kubeconfig)
 	if err != nil {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
 	data := struct {
-		MachineSpec      clusterv1alpha1.MachineSpec
+		plugin.UserDataRequest
 		ProviderSpec     *providerconfig.Config
 		OSConfig         *Config
-		CloudProvider    string
-		CloudConfig      string
-		ClusterDNSIPs    []net.IP
 		ServerAddr       string
 		KubeletVersion   string
 		Kubeconfig       string
 		KubernetesCACert string
-		IsExternal       bool
 	}{
-		MachineSpec:      spec,
+		UserDataRequest:  req,
 		ProviderSpec:     pconfig,
 		OSConfig:         ubuntuConfig,
-		CloudProvider:    cloudProviderName,
-		CloudConfig:      cloudConfig,
-		ClusterDNSIPs:    clusterDNSIPs,
 		ServerAddr:       serverAddr,
 		KubeletVersion:   kubeletVersion.String(),
 		Kubeconfig:       kubeconfigString,
 		KubernetesCACert: kubernetesCACert,
-		IsExternal:       externalCloudProvider,
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -127,7 +109,7 @@ func (p Provider) UserData(
 
 // UserData template.
 const userDataTemplate = `#cloud-config
-{{ if ne .CloudProvider "aws" }}
+{{ if ne .CloudProviderName "aws" }}
 hostname: {{ .MachineSpec.Name }}
 {{- /* Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name */}}
 {{ end }}
@@ -142,6 +124,13 @@ ssh_authorized_keys:
 {{- end }}
 
 write_files:
+{{- if .HTTPProxy }}
+- path: "/etc/environment"
+  content: |
+    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
+{{ proxyEnvironment .HTTPProxy .NoProxy | indent 4 }}
+{{- end }}
+
 - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
   content: |
 {{ journalDConfig | indent 4 }}
@@ -263,7 +252,7 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
-      ipvsadm{{ if eq .CloudProvider "vsphere" }} \
+      ipvsadm{{ if eq .CloudProviderName "vsphere" }} \
       open-vm-tools{{ end }}
 
 {{- /* If something failed during package installation but docker got installed, we need to put it on hold */}}
@@ -295,7 +284,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .KubeletVersion .CloudProvider .MachineSpec.Name .ClusterDNSIPs .IsExternal | indent 4 }}
+{{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 4 }}
 
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |
@@ -327,6 +316,7 @@ write_files:
     [Service]
     Type=oneshot
     RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
 
 - path: "/etc/profile.d/opt-bin-path.sh"
@@ -334,12 +324,10 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
+- path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
+{{ dockerConfig .InsecureRegistries | indent 4 }}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
@@ -350,6 +338,12 @@ write_files:
   permissions: "0644"
   content: |
 {{ containerRuntimeHealthCheckSystemdUnit | indent 4 }}
+
+- path: /etc/systemd/system/docker.service.d/environment.conf
+  permissions: "0644"
+  content: |
+    [Service]
+    EnvironmentFile=-/etc/environment
 
 runcmd:
 - systemctl enable --now setup.service


### PR DESCRIPTION
**What this PR does / why we need it**:
Pass through proxy & image settings from the datacenters.yaml.

**Does this PR introduce a user-facing change?**:
```release-note
Kubermatic now supports running in environments where the Internet can only be accessed via a http proxy
```
