### PR TITLE
Update Vault to 1.1.3

### DIFF
--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -175,7 +175,7 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "proxy",
-					Image:           "quay.io/kubermatic/util:1.0.0-2",
+					Image:           "quay.io/kubermatic/util:1.0.0-4",
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/bin/bash"},
 					Args:            []string{"-c", strings.TrimSpace(proxyScript)},

--- a/config/kubermatic/templates/hook-migration-crd-check.yaml
+++ b/config/kubermatic/templates/hook-migration-crd-check.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: kubermatic
       containers:
       - name: check-crd-migration
-        image: "quay.io/kubermatic/util:1.0.0-3"
+        image: "quay.io/kubermatic/util:1.0.0-4"
         command: ["/bin/bash"]
         args:
         - "-c"

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -16,7 +16,7 @@ logging:
     setupContainer:
       image:
         repository: quay.io/kubermatic/util
-        tag: 1.0.0-3
+        tag: 1.0.0-4
         pullPolicy: IfNotPresent
       resources:
         requests:

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -19,7 +19,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.0.0-3
+      tag: 1.0.0-4
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -65,4 +65,4 @@ alertmanager:
     enabled: false
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.0.0-3
+      tag: 1.0.0-4

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       {{ if .Values.grafana.provisioning.datasources.paths }}
       initContainers:
-      - image: quay.io/kubermatic/util:1.0.0-3
+      - image: quay.io/kubermatic/util:1.0.0-4
         name: datasource-assembler
         command: [/bin/bash]
         args:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -16,7 +16,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.0.0-3
+      tag: 1.0.0-4
     timeout: 60m
 
   # Specify additional external labels which will be added to all
@@ -167,7 +167,7 @@ prometheus:
     enabled: false
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.0.0-3
+      tag: 1.0.0-4
 
   containers:
     prometheus:

--- a/containers/conformance-tests/Dockerfile
+++ b/containers/conformance-tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:latest
+
 RUN apk --no-cache add ca-certificates curl bash
 COPY ./install-kube-tests.sh /opt/install-kube-tests.sh
 RUN /opt/install-kube-tests.sh
@@ -8,6 +9,7 @@ RUN rm -rf /opt/kube-test/*/platforms/darwin
 RUN rm -rf /opt/kube-test/*/platforms/windows
 
 FROM golang:1.11.4-stretch
+
 COPY --from=0 /opt/kube-test /opt/kube-test
 COPY start-docker.sh /usr/local/bin/start-docker.sh
 RUN apt update && apt install -y git-crypt curl apt-transport-https software-properties-common unzip jq && \
@@ -22,8 +24,8 @@ RUN apt update && apt install -y git-crypt curl apt-transport-https software-pro
   sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker && \
   echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
     tee --append /etc/default/docker && \
-  cd /tmp && curl -LO https://releases.hashicorp.com/vault/1.0.1/vault_1.0.1_linux_amd64.zip && unzip vault_*.zip && mv vault /usr/local/bin && \
-  curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.12.1-linux-amd64.tar.gz|tar -xvz && mv linux-amd64/helm /usr/local/bin && \
+  cd /tmp && curl -LO https://releases.hashicorp.com/vault/1.1.3/vault_1.1.3_linux_amd64.zip && unzip vault_*.zip && mv vault /usr/local/bin && \
+  curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-linux-amd64.tar.gz|tar -xvz && mv linux-amd64/helm /usr/local/bin && \
   curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin

--- a/containers/conformance-tests/install-kube-tests.sh
+++ b/containers/conformance-tests/install-kube-tests.sh
@@ -32,7 +32,7 @@ for VERSION in 1.{11..15}; do
         cd -
 
         # Delete all binaries for non amd64 architectures
-        # We keep the windows and darwin ones, in case someone want's to test locally
+        # We keep the windows and darwin ones, in case someone wants to test locally
         rm -rf ${DIRECTORY}/platforms/linux/arm
         rm -rf ${DIRECTORY}/platforms/linux/arm64
         rm -rf ${DIRECTORY}/platforms/linux/ppc64le

--- a/containers/conformance-tests/release.sh
+++ b/containers/conformance-tests/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=v0.9
+TAG=v0.9.1
 
 set -euox pipefail
 

--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker:18.09.0-dind
 
 RUN apk add --no-cache -U ca-certificates wget unzip jq bash
-RUN wget https://releases.hashicorp.com/vault/0.11.5/vault_0.11.5_linux_amd64.zip && \
-    unzip vault_0.11.5_linux_amd64.zip && \
-    rm vault_0.11.5_linux_amd64.zip && \
+RUN wget https://releases.hashicorp.com/vault/1.1.3/vault_1.1.3_linux_amd64.zip && \
+    unzip vault_1.1.3_linux_amd64.zip && \
+    rm vault_1.1.3_linux_amd64.zip && \
     mv vault /bin/

--- a/containers/docker/release.sh
+++ b/containers/docker/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-NUMBER=3
+NUMBER=4
 VERSION=18.09.0
 
 set -euox pipefail

--- a/containers/util/Dockerfile
+++ b/containers/util/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 
-ENV MC_VERSION=RELEASE.2019-06-11T00-44-33Z \
+ENV MC_VERSION=RELEASE.2019-06-07T00-01-32Z \
     KUBECTL_VERSION=v1.14.1 \
     HELM_VERSION=v2.13.1 \
     VAULT_VERSION=1.1.3
@@ -14,16 +14,20 @@ RUN apk add --no-cache -U \
     unzip
 
 RUN curl -Lo /usr/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} && \
-    chmod +x /usr/bin/mc
+    chmod +x /usr/bin/mc && \
+    mc --version
 
 RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
-    chmod +x /usr/bin/kubectl
+    chmod +x /usr/bin/kubectl && \
+    kubectl version --short --client
 
 RUN curl -L https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xvz && \
     mv linux-amd64/helm /usr/bin/helm && \
-    rm -rf linux-amd64
+    rm -rf linux-amd64 && \
+    helm version --client --short
 
 RUN curl -Lo vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
     unzip vault.zip && \
     rm vault.zip && \
-    mv vault /usr/bin/vault
+    mv vault /usr/bin/vault && \
+    vault version

--- a/containers/util/Dockerfile
+++ b/containers/util/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.9
 ENV MC_VERSION=RELEASE.2019-06-11T00-44-33Z \
     KUBECTL_VERSION=v1.14.1 \
     HELM_VERSION=v2.13.1 \
-    VAULT_VERSION=0.11.6
+    VAULT_VERSION=1.1.3
 
 RUN apk add --no-cache -U \
     bash \

--- a/containers/util/release.sh
+++ b/containers/util/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-NUMBER=3
+NUMBER=4
 VERSION=1.0.0
 
 set -euox pipefail


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates Vault to the latest stable version across all Docker images. The Helm version has also been bumped because we use 2.13 everywhere else already.

From my simple tests, using 1.1.3 locally works perfectly fine when using vault.loodse.com as the server.

This PR also downgrades mc because the current Minio release does not (yet?) have a companion mc release and our Minio deployments keep failing because they cannot init their backup container. To prevent future fuckups, I added explicit calls to print each app's version.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
