### PR TITLE
allow ICMP traffic on Openstack, Azure and AWS

### DIFF
--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -334,6 +334,22 @@ func createSecurityGroup(client *ec2.EC2, vpcID, clusterName string) (string, er
 				SetIpRanges([]*ec2.IpRange{
 					{CidrIp: aws.String("0.0.0.0/0")},
 				}),
+			(&ec2.IpPermission{}).
+				// ICMP from/to everywhere
+				SetIpProtocol("icmp").
+				SetFromPort(-1). // any port
+				SetToPort(-1).   // any port
+				SetIpRanges([]*ec2.IpRange{
+					{CidrIp: aws.String("0.0.0.0/0")},
+				}),
+			(&ec2.IpPermission{}).
+				// ICMPv6 from/to everywhere
+				SetIpProtocol("icmpv6").
+				SetFromPort(-1). // any port
+				SetToPort(-1).   // any port
+				SetIpRanges([]*ec2.IpRange{
+					{CidrIp: aws.String("0.0.0.0/0")},
+				}),
 		},
 	})
 	if err != nil {

--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -199,6 +199,20 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 			PortRangeMax: provider.DefaultKubeletPort,
 			Protocol:     osecruritygrouprules.ProtocolTCP,
 		},
+		{
+			// Allows ICMP traffic
+			Direction:  osecruritygrouprules.DirIngress,
+			EtherType:  osecruritygrouprules.EtherType4,
+			SecGroupID: g.ID,
+			Protocol:   osecruritygrouprules.ProtocolICMP,
+		},
+		{
+			// Allows ICMPv6 traffic
+			Direction:  osecruritygrouprules.DirIngress,
+			EtherType:  osecruritygrouprules.EtherType6,
+			SecGroupID: g.ID,
+			Protocol:   osecruritygrouprules.ProtocolIPv6ICMP,
+		},
 	}
 
 	for _, opts := range rules {


### PR DESCRIPTION
**What this PR does / why we need it**:
#3562

**Special notes for your reviewer**:
/meow network

```release-note
ICMP traffic to clusters is now always permitted to allow MTU discovery
```

/assign @alvaroaleman 