### PR TITLE
Make every image in our charts configurable via the values.yaml

### DIFF
--- a/config/iap/Chart.yaml
+++ b/config/iap/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: iap
-version: 1.1.1
+version: 1.1.2
 appVersion: 6.0.1
 description: A Helm to install Keycloak-Gatekeeper as an identity-aware proxy.
 keywords:

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -78,7 +78,7 @@ iap:
   port: 3000
 
   image:
-    repository: keycloak/keycloak-gatekeeper
+    repository: docker.io/keycloak/keycloak-gatekeeper
     tag: 6.0.1
     pullPolicy: IfNotPresent
 

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.0
+version: 1.0.1
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/templates/hook-migration-crd-check.yaml
+++ b/config/kubermatic/templates/hook-migration-crd-check.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: kubermatic
       containers:
       - name: check-crd-migration
-        image: "quay.io/kubermatic/util:1.0.0-4"
+        image: "{{ .Values.kubermatic.checks.crd.image.repository }}:{{ .Values.kubermatic.checks.crd.image.tag }}"
         command: ["/bin/bash"]
         args:
         - "-c"

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -39,7 +39,7 @@ kubermatic:
       helmVersion: "v2.11.0"
       image:
         repository: "quay.io/kubermatic/util"
-        tag: "1.0.0-3"
+        tag: "1.0.0-4"
 
   etcd:
     # PV size for the etcd StatefulSet of new clusters

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -37,6 +37,9 @@ kubermatic:
     crd:
       disable: false
       helmVersion: "v2.11.0"
+      image:
+        repository: "quay.io/kubermatic/util"
+        tag: "1.0.0-3"
 
   etcd:
     # PV size for the etcd StatefulSet of new clusters
@@ -301,7 +304,7 @@ kubermatic:
   vpa:
     updater:
       image:
-        repository: k8s.gcr.io/vpa-updater
+        repository: gcr.io/google_containers/vpa-updater
         tag: 0.5.0
       resources:
         requests:
@@ -316,7 +319,7 @@ kubermatic:
 
     recommender:
       image:
-        repository: k8s.gcr.io/vpa-recommender
+        repository: gcr.io/google_containers/vpa-recommender
         tag: 0.5.0
       resources:
         requests:
@@ -331,7 +334,7 @@ kubermatic:
 
     admissioncontroller:
       image:
-        repository: k8s.gcr.io/vpa-admission-controller
+        repository: gcr.io/google_containers/vpa-admission-controller
         tag: 0.5.0
       resources:
         requests:

--- a/config/logging/elasticsearch/Chart.yaml
+++ b/config/logging/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 1.0.2
+version: 1.0.3
 appVersion: 6.7.1
 description: Chart to deploy Elasticsearch master and data nodes.
 keywords:

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -74,7 +74,7 @@ logging:
 
     exporter:
       image:
-        repository: justwatch/elasticsearch_exporter
+        repository: docker.io/justwatch/elasticsearch_exporter
         tag: "1.1.0rc1"
         pullPolicy: IfNotPresent
 
@@ -98,7 +98,7 @@ logging:
 
     cerebro:
       image:
-        repository: lmenezes/cerebro
+        repository: docker.io/lmenezes/cerebro
         tag: "0.8.3"
         pullPolicy: IfNotPresent
       deploy: false

--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.1.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -1,7 +1,7 @@
 logging:
   fluentbit:
     image:
-      repository: fluent/fluent-bit
+      repository: docker.io/fluent/fluent-bit
       tag: 1.1.2
       pullPolicy: IfNotPresent
     configuration:

--- a/config/minio/Chart.yaml
+++ b/config/minio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minio
-version: 1.0.2
+version: 1.0.3
 appVersion: RELEASE.2019-06-11T00-44-33Z
 description: minio
 keywords:

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -1,6 +1,6 @@
 minio:
   image:
-    repository: minio/minio
+    repository: docker.io/minio/minio
     tag: RELEASE.2019-06-11T00-44-33Z
   storeSize: 100Gi
   credentials:

--- a/config/monitoring/alertmanager/Chart.yaml
+++ b/config/monitoring/alertmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: alertmanager
-version: 2.0.0
+version: 2.0.1
 appVersion: v0.17.0
 description: Alertmanager for Kubermatic
 keywords:

--- a/config/monitoring/alertmanager/templates/statefulset.yaml
+++ b/config/monitoring/alertmanager/templates/statefulset.yaml
@@ -77,8 +77,8 @@ spec:
           subPath: alertmanager-db
 
       - name: reloader
-        image: jimmidyson/configmap-reload
-        imagePullPolicy: IfNotPresent
+        image: '{{ .Values.alertmanager.configReloaderImage.repository }}:{{ .Values.alertmanager.configReloaderImage.tag }}'
+        imagePullPolicy: {{ .Values.alertmanager.configReloaderImage.pullPolicy }}
         args:
         - -webhook-url=http://localhost:9093/-/reload
         - -volume-dir=/etc/alertmanager/config

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -3,6 +3,10 @@ alertmanager:
     repository: quay.io/prometheus/alertmanager
     tag: v0.17.0
     pullPolicy: IfNotPresent
+  configReloaderImage:
+    repository: docker.io/jimmidyson/configmap-reload
+    tag: v0.2.2
+    pullPolicy: IfNotPresent
   host: ""
   replicas: 3
   storageSize: 100Mi

--- a/config/monitoring/blackbox-exporter/Chart.yaml
+++ b/config/monitoring/blackbox-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: blackbox-exporter
-version: 1.0.0
+version: 1.0.1
 appVersion: v0.14.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:

--- a/config/monitoring/blackbox-exporter/values.yaml
+++ b/config/monitoring/blackbox-exporter/values.yaml
@@ -1,6 +1,6 @@
 blackboxExporter:
   image:
-    repository: prom/blackbox-exporter
+    repository: docker.io/prom/blackbox-exporter
     tag: v0.14.0
     pullPolicy: IfNotPresent
 

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.0.5
+version: 1.0.6
 appVersion: 6.2.1
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       {{ if .Values.grafana.provisioning.datasources.paths }}
       initContainers:
-      - image: quay.io/kubermatic/util:1.0.0-4
+      - image: '{{ .Values.grafana.utilImage.repository }}:{{ .Values.grafana.utilImage.tag }}'
         name: datasource-assembler
         command: [/bin/bash]
         args:

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -4,9 +4,11 @@ grafana:
 
   replicas: 1
   image:
-    repository: grafana/grafana
+    repository: docker.io/grafana/grafana
     tag: 6.2.1
-
+  utilImage:
+    repository: quay.io/kubermatic/util
+    tag: 1.0.0-3
   resources:
     requests:
       cpu: 100m

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -8,7 +8,7 @@ grafana:
     tag: 6.2.1
   utilImage:
     repository: quay.io/kubermatic/util
-    tag: 1.0.0-3
+    tag: 1.0.0-4
   resources:
     requests:
       cpu: 100m

--- a/config/monitoring/helm-exporter/Chart.yaml
+++ b/config/monitoring/helm-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: helm-exporter
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.4.0
 description: Exports Helm release information to Prometheus
 keywords:

--- a/config/monitoring/helm-exporter/values.yaml
+++ b/config/monitoring/helm-exporter/values.yaml
@@ -2,7 +2,7 @@ helmExporter:
   replicas: 1
   tillerNamespace: kubermatic-installer
   image:
-    repository: sstarcher/helm-exporter
+    repository: docker.io/sstarcher/helm-exporter
     tag: 0.4.0
     pullPolicy: IfNotPresent
   nameOverride: ''

--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-state-metrics
-version: 1.0.1
+version: 1.0.2
 appVersion: v1.6.0
 description: Kube-State-Metrics for Kubermatic
 keywords:

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -12,7 +12,7 @@ kubeStateMetrics:
 
   resizer:
     image:
-      repository: k8s.gcr.io/addon-resizer
+      repository: gcr.io/google_containers/addon-resizer
       tag: '1.8.4'
     resources:
       requests:

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.1.1
+version: 2.1.2
 appVersion: v2.10.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: '{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.version }}'
+        image: '{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.version | default .Values.prometheus.image.tag }}'
         command: [/bin/sh]
         args:
         - -c

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: 'quay.io/prometheus/prometheus:{{ .Values.prometheus.version }}'
+        image: '{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.version }}'
         command: [/bin/sh]
         args:
         - -c
@@ -131,7 +131,8 @@ spec:
 
       {{- if not .Values.prometheus.thanos.enabled }}
       - name: reloader
-        image: jimmidyson/configmap-reload
+        image: '{{ .Values.prometheus.configReloaderImage.repository }}:{{ .Values.prometheus.configReloaderImage.tag }}'
+        imagePullPolicy: {{ .Values.prometheus.configReloaderImage.pullPolicy }}
         args:
         - --volume-dir=/etc/prometheus/config
         - --volume-dir=/etc/prometheus/rules

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,7 +1,9 @@
 prometheus:
   image:
     repository: quay.io/prometheus/prometheus
-  version: v2.10.0
+    tag: v2.10.0
+    pullPolicy: IfNotPresent
+
   host: ''
   storageSize: 100Gi
 

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,10 +1,17 @@
 prometheus:
+  image:
+    repository: quay.io/prometheus/prometheus
   version: v2.10.0
   host: ''
   storageSize: 100Gi
 
   tsdb:
     retentionTime: 15d
+
+  configReloaderImage:
+    repository: docker.io/jimmidyson/configmap-reload
+    tag: v0.2.2
+    pullPolicy: IfNotPresent
 
   # If you install Prometheus using a different Helm release name,
   # you can override the name used for the resources, e.g. to have

--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nodeport-proxy
-version: 1.1.0
-appVersion: v2.0.0
+version: 1.2.0
+appVersion: v2.1.1
 description: Kubermatic nodeport-proxy
 keywords:
 - kubermatic

--- a/config/nodeport-proxy/templates/quay-secret.yaml
+++ b/config/nodeport-proxy/templates/quay-secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: quay
 data:
-  .dockerconfigjson: {{ .Values.kubermatic.imagePullSecretData | quote }}
+  .dockerconfigjson: {{ with .Values.kubermatic }}{{ .imagePullSecretData | default "" | quote }}{{ else }}""{{ end }}
 type: kubernetes.io/dockerconfigjson

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -1,3 +1,8 @@
+# Required to make the templating pass without a valid values.yaml
+# Unfortunately we reuse the kubermatic ImagePullSecret here - Changing it would be a breaking change
+# and would duplicate the ImagePullSecret in the "master" values.yaml.
+kubermatic:
+  imagePullSecretData: ""
 nodePortProxy:
   replicas: 3
   image:
@@ -5,7 +10,7 @@ nodePortProxy:
     tag: v2.1.1
   envoy:
     image:
-      repository: "envoyproxy/envoy-alpine"
+      repository: "docker.io/envoyproxy/envoy-alpine"
       tag: "v1.10.0"
 
   nodeSelector: {}

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -1,8 +1,3 @@
-# Required to make the templating pass without a valid values.yaml
-# Unfortunately we reuse the kubermatic ImagePullSecret here - Changing it would be a breaking change
-# and would duplicate the ImagePullSecret in the "master" values.yaml.
-kubermatic:
-  imagePullSecretData: ""
 nodePortProxy:
   replicas: 3
   image:


### PR DESCRIPTION
**What this PR does / why we need it**:
This change does 2 things:
- Ensure we always specify the registry (Required by our retagging for offline setups)
- Ensures every image repository can be overwritten via the values.yaml (Required for offline setups)

All changes should be backwards compatible

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
