### PR TITLE
Stop setting openVPN link mtu and set mss on the underlying connection instead

### DIFF
--- a/api/pkg/controller/usercluster/resources/openvpn/configmap.go
+++ b/api/pkg/controller/usercluster/resources/openvpn/configmap.go
@@ -34,7 +34,6 @@ cert '/etc/openvpn/certs/client.crt'
 key '/etc/openvpn/certs/client.key'
 remote-cert-tls server
 script-security 2
-link-mtu 1432
 cipher AES-256-GCM
 auth SHA1
 keysize 256

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -231,8 +231,8 @@ iptables -A INPUT -i tun0 -j DROP
 						"-c",
 						// Always set IP forwarding as a CNI plugin might reset this to 0 (Like Calico 3).
 						`while true; do sysctl -w net.ipv4.ip_forward=1;
-  if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-   iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+  if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+   iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
   fi
   sleep 30;
 done`,

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -120,8 +120,8 @@ spec:
         - -c
         - |-
           while true; do sysctl -w net.ipv4.ip_forward=1;
-            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
-             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
             fi
             sleep 30;
           done

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -49,8 +49,6 @@ spec:
         - /etc/openvpn/clients
         - --status
         - /run/openvpn-status
-        - --link-mtu
-        - "1432"
         - --cipher
         - AES-256-GCM
         - --auth
@@ -120,11 +118,17 @@ spec:
           readOnly: true
       - args:
         - -c
-        - while true; do sysctl -w net.ipv4.ip_forward=1; sleep 30; done
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
         command:
         - /bin/bash
         image: quay.io/kubermatic/openvpn:v0.5
-        name: ip-forward
+        name: ip-fixup
         resources:
           limits:
             cpu: 10m


### PR DESCRIPTION
**What this PR does / why we need it**:

Stops setting the openVPN link MTU and instead sets mss for connections to the openVPN server to make sure we don't run into issues due to some MTU on our route.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #3611

**Special notes for your reviewer**:

I manually checked that logs and exec still work, for the former with enough logs to make sure it doesn't fit in one packet

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

CC @bashofmann 
/assign @thz 
