### PR TITLE
Exclude openshift clusters in the image-loader

### DIFF
--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/features"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/net"
@@ -107,7 +108,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.oidcIssuerClientSecret, "oidc-issuer-client-secret", "", "OpenID client secret")
 	flag.BoolVar(&c.log.Debug, "log-debug", false, "Enables debug logging")
 	flag.StringVar(&c.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
-	flag.StringVar(&c.kubermaticImage, "kubermatic-image", "quay.io/kubermatic/api", "The location from which to pull the Kubermatic image")
+	flag.StringVar(&c.kubermaticImage, "kubermatic-image", resources.DefaultKubermaticImage, "The location from which to pull the Kubermatic image")
 	flag.Parse()
 
 	featureGates, err := features.NewFeatures(rawFeatureGates)

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -280,6 +280,9 @@ const (
 	InternalUserClusterAdminKubeconfigSecretName = "internal-admin-kubeconfig"
 	// InternalUserClusterAdminKubeconfigCertUsername is the name of the user coming from kubeconfig cert
 	InternalUserClusterAdminKubeconfigCertUsername = "kubermatic-controllers"
+
+	// DefaultKubermaticImage defines the default image which contains the Kubermatic applications
+	DefaultKubermaticImage = "quay.io/kubermatic/api"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Exclude openshift clusters in the image-loader & fix the pushing of images.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
