### PR TITLE
Add script to retag images coming from manifests supplied via stdin

### DIFF
--- a/api/hack/retag-images.sh
+++ b/api/hack/retag-images.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+TARGET_REGISTRY=${TARGET_REGISTRY:-127.0.0.1:5000}
+
+function retag {
+  local IMAGE=$1
+
+  TARGET_IMAGE="${TARGET_REGISTRY}/$(echo ${IMAGE} | cut -d / -f 2-)"
+  echo "Retagging ${IMAGE} to ${TARGET_IMAGE}"
+  docker pull ${IMAGE}
+  docker tag ${IMAGE} ${TARGET_IMAGE}
+  docker push ${TARGET_IMAGE}
+}
+
+IMAGES=$(cat /dev/stdin | grep "image: " | cut -d : -f 2,3)
+for IMAGE in ${IMAGES}
+do
+  # Make sure we strip all quotes
+  IMAGE="${IMAGE%\'}"
+  IMAGE="${IMAGE#\'}"
+  IMAGE="${IMAGE%\"}"
+  IMAGE="${IMAGE#\"}"
+  retag ${IMAGE}
+done


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a helper script which retags all images which are mentioned in manifests coming from stdin.
Useful when having to push all images from our helm charts to a custom registry.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @thetechnick 