### PR TITLE
allow to set GCP network, subnet & zone for conformance tests

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -103,6 +103,9 @@ type secrets struct {
 	}
 	GCP struct {
 		ServiceAccount string
+		Network        string
+		Subnetwork     string
+		Zone           string
 	}
 }
 
@@ -180,6 +183,9 @@ func main() {
 	flag.StringVar(&opts.secrets.Packet.APIKey, "packet-api-key", "", "Packet: APIKey")
 	flag.StringVar(&opts.secrets.Packet.ProjectID, "packet-project-id", "", "Packet: ProjectID")
 	flag.StringVar(&opts.secrets.GCP.ServiceAccount, "gcp-service-account", "", "GCP: Service Account")
+	flag.StringVar(&opts.secrets.GCP.Zone, "gcp-zone", "europe-west3-c", "GCP: Zone")
+	flag.StringVar(&opts.secrets.GCP.Network, "gcp-network", "", "GCP: Network")
+	flag.StringVar(&opts.secrets.GCP.Subnetwork, "gcp-subnetwork", "", "GCP: Subnetwork")
 
 	flag.Parse()
 
@@ -375,7 +381,7 @@ func getScenarios(opts Opts, log *logrus.Entry) []testScenario {
 
 	var filteredScenarios []testScenario
 	for _, scenario := range scenarios {
-		nd := scenario.Nodes(1)
+		nd := scenario.Nodes(1, secrets{})
 		if nd.Spec.Template.OperatingSystem.Ubuntu != nil {
 			if !opts.excludeSelector.Distributions[providerconfig.OperatingSystemUbuntu] {
 				filteredScenarios = append(filteredScenarios, scenario)

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -53,7 +53,7 @@ var (
 type testScenario interface {
 	Name() string
 	Cluster(secrets secrets) *kubermaticv1.Cluster
-	Nodes(num int) *kubermaticapiv1.NodeDeployment
+	Nodes(num int, secrets secrets) *kubermaticapiv1.NodeDeployment
 }
 
 func newRunner(scenarios []testScenario, opts *Opts) *testRunner {
@@ -294,7 +294,7 @@ func (r *testRunner) executeScenario(log *logrus.Entry, scenario testScenario) (
 		return nil, fmt.Errorf("failed to get the client for the cluster: %v", err)
 	}
 
-	nodeDeployment := scenario.Nodes(r.nodeCount)
+	nodeDeployment := scenario.Nodes(r.nodeCount, r.secrets)
 	if err := r.setupNodes(log, scenario.Name(), cluster, userClusterClient, nodeDeployment, dc); err != nil {
 		return nil, fmt.Errorf("failed to setup nodes: %v", err)
 	}

--- a/api/cmd/conformance-tests/scenarios_aws.go
+++ b/api/cmd/conformance-tests/scenarios_aws.go
@@ -77,7 +77,7 @@ func (s *awsScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *awsScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
+func (s *awsScenario) Nodes(num int, _ secrets) *kubermaticapiv1.NodeDeployment {
 	return &kubermaticapiv1.NodeDeployment{
 		Spec: kubermaticapiv1.NodeDeploymentSpec{
 			Replicas: int32(num),

--- a/api/cmd/conformance-tests/scenarios_azure.go
+++ b/api/cmd/conformance-tests/scenarios_azure.go
@@ -80,7 +80,7 @@ func (s *azureScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *azureScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
+func (s *azureScenario) Nodes(num int, _ secrets) *kubermaticapiv1.NodeDeployment {
 	return &kubermaticapiv1.NodeDeployment{
 		Spec: kubermaticapiv1.NodeDeploymentSpec{
 			Replicas: int32(num),

--- a/api/cmd/conformance-tests/scenarios_digitalocean.go
+++ b/api/cmd/conformance-tests/scenarios_digitalocean.go
@@ -78,7 +78,7 @@ func (s *digitaloceanScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *digitaloceanScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
+func (s *digitaloceanScenario) Nodes(num int, _ secrets) *kubermaticapiv1.NodeDeployment {
 	return &kubermaticapiv1.NodeDeployment{
 		Spec: kubermaticapiv1.NodeDeploymentSpec{
 			Replicas: int32(num),

--- a/api/cmd/conformance-tests/scenarios_gcp.go
+++ b/api/cmd/conformance-tests/scenarios_gcp.go
@@ -73,20 +73,22 @@ func (s *gcpScenario) Cluster(secrets secrets) *v1.Cluster {
 				DatacenterName: "gcp-westeurope",
 				GCP: &v1.GCPCloudSpec{
 					ServiceAccount: secrets.GCP.ServiceAccount,
+					Network:        secrets.GCP.Network,
+					Subnetwork:     secrets.GCP.Subnetwork,
 				},
 			},
 		},
 	}
 }
 
-func (s *gcpScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
+func (s *gcpScenario) Nodes(num int, secrets secrets) *kubermaticapiv1.NodeDeployment {
 	return &kubermaticapiv1.NodeDeployment{
 		Spec: kubermaticapiv1.NodeDeploymentSpec{
 			Replicas: int32(num),
 			Template: kubermaticapiv1.NodeSpec{
 				Cloud: kubermaticapiv1.NodeCloudSpec{
 					GCP: &kubermaticapiv1.GCPNodeSpec{
-						Zone:        "europe-west3-c",
+						Zone:        secrets.GCP.Zone,
 						MachineType: "n1-standard-2",
 						DiskType:    "pd-standard",
 						DiskSize:    50,

--- a/api/cmd/conformance-tests/scenarios_hetzner.go
+++ b/api/cmd/conformance-tests/scenarios_hetzner.go
@@ -68,7 +68,7 @@ func (s *hetznerScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *hetznerScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
+func (s *hetznerScenario) Nodes(num int, _ secrets) *kubermaticapiv1.NodeDeployment {
 	return &kubermaticapiv1.NodeDeployment{
 		Spec: kubermaticapiv1.NodeDeploymentSpec{
 			Replicas: int32(num),

--- a/api/cmd/conformance-tests/scenarios_openstack.go
+++ b/api/cmd/conformance-tests/scenarios_openstack.go
@@ -81,7 +81,7 @@ func (s *openStackScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *openStackScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
+func (s *openStackScenario) Nodes(num int, _ secrets) *kubermaticapiv1.NodeDeployment {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
 	return &kubermaticapiv1.NodeDeployment{
 		Spec: kubermaticapiv1.NodeDeploymentSpec{

--- a/api/cmd/conformance-tests/scenarios_packet.go
+++ b/api/cmd/conformance-tests/scenarios_packet.go
@@ -79,7 +79,7 @@ func (s *packetScenario) Cluster(secrets secrets) *v1.Cluster {
 	}
 }
 
-func (s *packetScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
+func (s *packetScenario) Nodes(num int, _ secrets) *kubermaticapiv1.NodeDeployment {
 	return &kubermaticapiv1.NodeDeployment{
 		Spec: kubermaticapiv1.NodeDeploymentSpec{
 			Replicas: int32(num),

--- a/api/cmd/conformance-tests/scenarios_vsphere.go
+++ b/api/cmd/conformance-tests/scenarios_vsphere.go
@@ -83,7 +83,7 @@ func (s *vSphereScenario) Cluster(secrets secrets) *kubermaticv1.Cluster {
 	}
 }
 
-func (s *vSphereScenario) Nodes(num int) *kubermaticapiv1.NodeDeployment {
+func (s *vSphereScenario) Nodes(num int, _ secrets) *kubermaticapiv1.NodeDeployment {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
 	return &kubermaticapiv1.NodeDeployment{
 		Spec: kubermaticapiv1.NodeDeploymentSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow to set GCP network, subnet & zone for conformance tests

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
