### PR TITLE
containers/util: Add iproute2, iptables, socat.

### DIFF
--- a/containers/util/Dockerfile
+++ b/containers/util/Dockerfile
@@ -9,8 +9,11 @@ RUN apk add --no-cache -U \
     bash \
     ca-certificates \
     curl \
+    iproute2 \
+    iptables \
     jq \
     rsync \
+    socat \
     unzip
 
 RUN curl -Lo /usr/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} && \

--- a/containers/util/release.sh
+++ b/containers/util/release.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-NUMBER=5
-VERSION=1.0.0
+SUFFIX=""
+VERSION=1.1.0
 
 set -euox pipefail
 
-docker build --no-cache --pull -t quay.io/kubermatic/util:${VERSION}-${NUMBER} .
-docker push quay.io/kubermatic/util:${VERSION}-${NUMBER}
+docker build --no-cache --pull -t quay.io/kubermatic/util:${VERSION}${SUFFIX} .
+docker push quay.io/kubermatic/util:${VERSION}${SUFFIX}


### PR DESCRIPTION
Version bump to: kubermatic/util-1.1.0

```release-note
NONE
```
