### PR TITLE
E2E tests: Don't delete nodelease namespace

### DIFF
--- a/api/cmd/conformance-tests/cleanup.go
+++ b/api/cmd/conformance-tests/cleanup.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	protectedNamespaces = sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic)
+	protectedNamespaces = sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic, corev1.NamespaceNodeLease)
 )
 
 func deleteAllNonDefaultNamespaces(log *logrus.Entry, client ctrlruntimeclient.Client) error {


### PR DESCRIPTION
**What this PR does / why we need it**

Avoids deleting the nodelease NS during e2e tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
/assign @mrIncompetent 