### PR TITLE
split deployment process into stacks: kubermatic, monitoring, logging

### DIFF
--- a/api/hack/ci/ci-deploy-cloud-asia.sh
+++ b/api/hack/ci/ci-deploy-cloud-asia.sh
@@ -1,23 +1,16 @@
 #!/usr/bin/env bash
 
+DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
+
 set -euo pipefail
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 
 source ./api/hack/lib.sh
 
-echodate "Logging into Quay"
-docker ps &>/dev/null || start-docker.sh
-retry 5 docker login -u ${QUAY_IO_USERNAME} -p ${QUAY_IO_PASSWORD} quay.io
-echodate "Successfully logged into Quay"
-
-echodate "Building binaries"
-time make -C api build
-echodate "Successfully finished building binaries"
-
-echodate "Building and pushing quay images"
-retry 5 ./api/hack/push_image.sh $GIT_HEAD_HASH $(git tag -l --points-at HEAD) "latest"
-echodate "Sucessfully finished building and pushing quay images"
+if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
+  ./ci-push-images.sh
+fi
 
 echodate "Getting secrets from Vault"
 export VAULT_ADDR=https://vault.loodse.com/
@@ -37,6 +30,6 @@ vault kv get -field=asia-east1-a-1-values.yaml dev/seed-clusters/cloud.kubermati
 kubectl config use-context asia-east1-a-1
 echodate "Successfully got secrets for cloud-asia from Vault"
 
-echodate "Deploying Kubermatic to cloud-asia"
+echodate "Deploying ${DEPLOY_STACK} stack to cloud-asia"
 TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh seed ${VALUES_FILE} ${HELM_EXTRA_ARGS}
-echodate "Successfully deployed Kubermatic to cloud-asia"
+echodate "Successfully deployed ${DEPLOY_STACK} stack to cloud-asia"

--- a/api/hack/ci/ci-deploy-cloud-asia.sh
+++ b/api/hack/ci/ci-deploy-cloud-asia.sh
@@ -8,7 +8,7 @@ cd $(dirname $0)/../../..
 source ./api/hack/lib.sh
 
 if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
-  ./ci-push-images.sh
+  ./api/hack/ci/ci-push-images.sh
 fi
 
 echodate "Getting secrets from Vault"

--- a/api/hack/ci/ci-deploy-cloud-asia.sh
+++ b/api/hack/ci/ci-deploy-cloud-asia.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
-
 set -euo pipefail
+export DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 

--- a/api/hack/ci/ci-deploy-cloud-eu.sh
+++ b/api/hack/ci/ci-deploy-cloud-eu.sh
@@ -8,7 +8,7 @@ cd $(dirname $0)/../../..
 source ./api/hack/lib.sh
 
 if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
-  ./ci-push-images.sh
+  ./api/hack/ci/ci-push-images.sh
 fi
 
 echodate "Getting secrets from Vault"

--- a/api/hack/ci/ci-deploy-cloud-eu.sh
+++ b/api/hack/ci/ci-deploy-cloud-eu.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
-
 set -euo pipefail
+export DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 

--- a/api/hack/ci/ci-deploy-cloud-us.sh
+++ b/api/hack/ci/ci-deploy-cloud-us.sh
@@ -1,23 +1,16 @@
 #!/usr/bin/env bash
 
+DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
+
 set -euo pipefail
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 
 source ./api/hack/lib.sh
 
-echodate "Logging into Quay"
-docker ps &>/dev/null || start-docker.sh
-retry 5 docker login -u ${QUAY_IO_USERNAME} -p ${QUAY_IO_PASSWORD} quay.io
-echodate "Successfully logged into Quay"
-
-echodate "Building binaries"
-time make -C api build
-echodate "Successfully finished building binaries"
-
-echodate "Building and pushing quay images"
-retry 5 ./api/hack/push_image.sh $GIT_HEAD_HASH $(git tag -l --points-at HEAD) "latest"
-echodate "Sucessfully finished building and pushing quay images"
+if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
+  ./ci-push-images.sh
+fi
 
 echodate "Getting secrets from Vault"
 export VAULT_ADDR=https://vault.loodse.com/
@@ -37,6 +30,6 @@ vault kv get -field=us-central1-c-1-values.yaml dev/seed-clusters/cloud.kubermat
 kubectl config use-context us-central1-c-1
 echodate "Successfully got secrets for cloud-us from Vault"
 
-echodate "Deploying Kubermatic to cloud-us"
+echodate "Deploying ${DEPLOY_STACK} stack to cloud-us"
 TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh seed ${VALUES_FILE} ${HELM_EXTRA_ARGS}
-echodate "Successfully deployed Kubermatic to cloud-us"
+echodate "Successfully deployed ${DEPLOY_STACK} stack to cloud-us"

--- a/api/hack/ci/ci-deploy-cloud-us.sh
+++ b/api/hack/ci/ci-deploy-cloud-us.sh
@@ -8,7 +8,7 @@ cd $(dirname $0)/../../..
 source ./api/hack/lib.sh
 
 if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
-  ./ci-push-images.sh
+  ./api/hack/ci/ci-push-images.sh
 fi
 
 echodate "Getting secrets from Vault"

--- a/api/hack/ci/ci-deploy-cloud-us.sh
+++ b/api/hack/ci/ci-deploy-cloud-us.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
-
 set -euo pipefail
+export DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 

--- a/api/hack/ci/ci-deploy-dev.sh
+++ b/api/hack/ci/ci-deploy-dev.sh
@@ -1,23 +1,16 @@
 #!/usr/bin/env bash
 
+DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
+
 set -euo pipefail
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 
 source ./api/hack/lib.sh
 
-echodate "Logging into Quay"
-docker ps &>/dev/null || start-docker.sh
-retry 5 docker login -u ${QUAY_IO_USERNAME} -p ${QUAY_IO_PASSWORD} quay.io
-echodate "Successfully logged into Quay"
-
-echodate "Building binaries"
-time make -C api build
-echodate "Successfully finished building binaries"
-
-echodate "Building and pushing quay images"
-retry 5 ./api/hack/push_image.sh $GIT_HEAD_HASH $(git tag -l --points-at HEAD) "latest"
-echodate "Sucessfully finished building and pushing quay images"
+if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
+  ./ci-push-images.sh
+fi
 
 echodate "Getting secrets from Vault"
 export VAULT_ADDR=https://vault.loodse.com/
@@ -36,6 +29,6 @@ vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFI
 vault kv get -field=values.yaml dev/seed-clusters/dev.kubermatic.io > ${VALUES_FILE}
 echodate "Successfully got secrets for dev from Vault"
 
-echodate "Deploying Kubermatic to dev"
+echodate "Deploying ${DEPLOY_STACK} stack to dev"
 TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
-echodate "Successfully deployed Kubermatic to dev"
+echodate "Successfully deployed ${DEPLOY_STACK} stack to dev"

--- a/api/hack/ci/ci-deploy-dev.sh
+++ b/api/hack/ci/ci-deploy-dev.sh
@@ -8,7 +8,7 @@ cd $(dirname $0)/../../..
 source ./api/hack/lib.sh
 
 if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
-  ./ci-push-images.sh
+  ./api/hack/ci/ci-push-images.sh
 fi
 
 echodate "Getting secrets from Vault"

--- a/api/hack/ci/ci-deploy-dev.sh
+++ b/api/hack/ci/ci-deploy-dev.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
-
 set -euo pipefail
+export DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 

--- a/api/hack/ci/ci-deploy-run.sh
+++ b/api/hack/ci/ci-deploy-run.sh
@@ -8,7 +8,7 @@ cd $(dirname $0)/../../..
 source ./api/hack/lib.sh
 
 if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
-  ./ci-push-images.sh
+  ./api/hack/ci/ci-push-images.sh
 fi
 
 echodate "Getting secrets from Vault"

--- a/api/hack/ci/ci-deploy-run.sh
+++ b/api/hack/ci/ci-deploy-run.sh
@@ -1,23 +1,16 @@
 #!/usr/bin/env bash
 
+DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
+
 set -euo pipefail
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 
 source ./api/hack/lib.sh
 
-echodate "Logging into Quay"
-docker ps &>/dev/null || start-docker.sh
-retry 5 docker login -u ${QUAY_IO_USERNAME} -p ${QUAY_IO_PASSWORD} quay.io
-echodate "Successfully logged into Quay"
-
-echodate "Building binaries"
-time make -C api build
-echodate "Successfully finished building binaries"
-
-echodate "Building and pushing quay images"
-retry 5 ./api/hack/push_image.sh $GIT_HEAD_HASH $(git tag -l --points-at HEAD)
-echodate "Sucessfully finished building and pushing quay images"
+if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
+  ./ci-push-images.sh
+fi
 
 echodate "Getting secrets from Vault"
 export VAULT_ADDR=https://vault.loodse.com/
@@ -36,6 +29,6 @@ vault kv get -field=kubeconfig dev/seed-clusters/run.kubermatic.io > ${KUBECONFI
 vault kv get -field=values.yaml dev/seed-clusters/run.kubermatic.io > ${VALUES_FILE}
 echodate "Successfully got secrets for run from Vault"
 
-echodate "Deploying Kubermatic to run.kubermatic.io"
+echodate "Deploying ${DEPLOY_STACK} stack to run.kubermatic.io"
 TILLER_NAMESPACE=kube-system ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
-echodate "Successfully deployed Kubermatic to run.kubermatic.io"
+echodate "Successfully deployed ${DEPLOY_STACK} stack to run.kubermatic.io"

--- a/api/hack/ci/ci-deploy-run.sh
+++ b/api/hack/ci/ci-deploy-run.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
-
 set -euo pipefail
+export DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 cd $(dirname $0)/../../..
 


### PR DESCRIPTION
**What this PR does / why we need it**:
To make it easier to distinguish between core product and misc software stacks when deployments fail and we're getting notified, this PR splits the deployment into three distinct "stacks": kubermatic, monitoring and logging. By setting the `DEPLOY_STACK` variable (default: kubermatic) users can choose to install different charts.

Kubermatic is only built and pushed when the kubermatic stack is deployed.

PR that duplicates the Prow job follows.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
