### PR TITLE
fix upgrading from Helm 2.13 to 2.14

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -47,7 +47,7 @@ echodate "Initializing Tiller in namespace ${TILLER_NAMESPACE}"
 helm version --tiller-namespace ${TILLER_NAMESPACE} || true
 kubectl create serviceaccount -n ${TILLER_NAMESPACE} tiller-sa || true
 kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=${TILLER_NAMESPACE}:tiller-sa  || true
-retry 5 helm --tiller-namespace ${TILLER_NAMESPACE} init --service-account tiller-sa --replicas 3 --history-max 10 --force-upgrade --wait
+retry 5 helm --tiller-namespace ${TILLER_NAMESPACE} init --service-account tiller-sa --replicas 3 --history-max 10 --upgrade --force-upgrade --wait
 echodate "Tiller initialized successfully"
 
 echodate "Deploying ${DEPLOY_STACK} stack..."


### PR DESCRIPTION
**What this PR does / why we need it**:
For some reason Helm does not like upgrading 2.13 to 2.14 without being super ultra specific and not just hacving `--force-upgrade`, but also `--upgrade`. Go figure.

Without `--upgrade`:

```
$HELM_HOME has been configured at /root/.helm.
Warning: Tiller is already installed in the cluster.
(Use --client-only to suppress this message, or --upgrade to upgrade Tiller to the current version.)
Error: tiller was not found. polling deadline exceeded
```

With `--upgrade`:

```
$HELM_HOME has been configured at /root/.helm.
Tiller (the Helm server-side component) has been upgraded to the current version.
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
