### PR TITLE
lower default Prometheus resource requirements

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.1.2
+version: 2.1.3
 appVersion: v2.10.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -267,7 +267,9 @@ spec:
       resources:
         requests:
           storage: {{ .Values.prometheus.storageSize }}
-      storageClassName: kubermatic-fast
+      {{- with .Values.prometheus.storageClass }}
+      storageClassName: {{ . }}
+      {{- end }}
 {{ end }}
 
 ---

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -6,6 +6,7 @@ prometheus:
 
   host: ''
   storageSize: 100Gi
+  storageClass: kubermatic-fast
 
   tsdb:
     retentionTime: 15d
@@ -182,11 +183,11 @@ prometheus:
     prometheus:
       resources:
         requests:
-          cpu: 1
-          memory: 2Gi
+          cpu: 150m
+          memory: 1Gi
         limits:
-          cpu: 2
-          memory: 10Gi
+          cpu: 500m
+          memory: 3Gi
     backup:
       resources:
         requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
For smaller test setups and POCs it's nice if Prometheus by default does not tons of resources and might even be unschedulable. We override the resources for all our systems anyway and I expect most customers do as well (though we can note this in the release notes to prevent accidental downscaling).

The configurable storage class also helps for quick setups where no custom storage class is setup or required.

**Which issue(s) this PR fixes**:
Relates to #3588

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
