### PR TITLE
use the canonical name for docker images inside the addon manifests

### DIFF
--- a/addons/canal/canal.yaml
+++ b/addons/canal/canal.yaml
@@ -130,7 +130,7 @@ spec:
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
         - name: set-mtu
-          image: '{{Registry "docker.io" }}/alpine:3.9'
+          image: '{{Registry "docker.io" }}/library/alpine:3.9'
           # We can not use the MTU of the flannel interface directly, because
           # it may not exist yet. Running this in parallel to the other containers
           # is a bad idea as well, as they may come up with a wrong configuration

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.16-dev1
+export TAG=v0.2.17
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.16
+export TAG=v0.2.16-dev1
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -80,7 +80,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.16"
+          tag: "v0.2.16-dev1"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -80,7 +80,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.16-dev1"
+          tag: "v0.2.17"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image


### PR DESCRIPTION
**What this PR does / why we need it**:
This will replace the short names for docker images, like `alpine` with the canonical name: `docker.io/library/alpine`.
This ensures that we can reliably detect the registry, org & name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
