### PR TITLE
add health port to nodeport-proxy

### DIFF
--- a/api/cmd/nodeport-proxy/lb-updater/main.go
+++ b/api/cmd/nodeport-proxy/lb-updater/main.go
@@ -111,6 +111,12 @@ func (u *LBUpdater) syncLB(s string) error {
 	}
 
 	var wantLBPorts []corev1.ServicePort
+	wantLBPorts = append(wantLBPorts, corev1.ServicePort{
+		Name:       "healthz",
+		Port:       1337, // FIXME use constant
+		TargetPort: 8002, // FIXME use constant
+		Protocol:   corev1.ProtocolTCP,
+	})
 	for _, service := range services.Items {
 		if service.Annotations[exposeAnnotationKey] != "true" {
 			glog.V(4).Infof("skipping service %s/%s as the annotation %s is not set to 'true'", service.Namespace, service.Name, exposeAnnotationKey)

--- a/api/cmd/nodeport-proxy/lb-updater/main.go
+++ b/api/cmd/nodeport-proxy/lb-updater/main.go
@@ -24,7 +24,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const defaultExposeAnnotationKey = "nodeport-proxy.k8s.io/expose"
+const (
+	defaultExposeAnnotationKey = "nodeport-proxy.k8s.io/expose"
+	healthCheckPort            = 8002
+)
 
 var (
 	lbName              string
@@ -113,8 +116,8 @@ func (u *LBUpdater) syncLB(s string) error {
 	var wantLBPorts []corev1.ServicePort
 	wantLBPorts = append(wantLBPorts, corev1.ServicePort{
 		Name:       "healthz",
-		Port:       1337, // FIXME use constant
-		TargetPort: 8002, // FIXME use constant
+		Port:       healthCheckPort,
+		TargetPort: intstr.FromInt(healthCheckPort),
 		Protocol:   corev1.ProtocolTCP,
 	})
 	for _, service := range services.Items {

--- a/config/nodeport-proxy/templates/lb.yaml
+++ b/config/nodeport-proxy/templates/lb.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     app: nodeport-proxy
   ports:
-  - name: keepalive
+  - name: healthz
     port: 1337
     targetPort: 8002
     protocol: TCP

--- a/config/nodeport-proxy/templates/lb.yaml
+++ b/config/nodeport-proxy/templates/lb.yaml
@@ -11,5 +11,6 @@ spec:
   ports:
   - name: keepalive
     port: 1337
+    targetPort: 8002
     protocol: TCP
   type: LoadBalancer

--- a/config/nodeport-proxy/templates/lb.yaml
+++ b/config/nodeport-proxy/templates/lb.yaml
@@ -10,7 +10,7 @@ spec:
     app: nodeport-proxy
   ports:
   - name: healthz
-    port: 1337
+    port: 8002
     targetPort: 8002
     protocol: TCP
   type: LoadBalancer


### PR DESCRIPTION
**What this PR does / why we need it**:

While the nodeport-proxy chart creates an initial "keepalive" port to the `nodeport-lb` Service, this is replaced with the first sync of the `lb-updater`. (It is assumed that this keepalive port was only added to have a least one port.)

This PR makes sure the `nodeport-lb` will always have that first port pointing at the envoys' healthz endpoints.

NB: Envoy is running as a deployment so the pods are not necessarily bound to specific nodes, so there is actually no correct relation between the used /healthz endpoint and the represented node (from the AWS LB health-check point of view). But the actually kube-proxy behaviour on the receiving node is checked so to some degree it is a valid health check for the cloud-lb.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3657

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
