### PR TITLE
allow restic on all nodes

### DIFF
--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: velero
-version: 1.1.0
+version: 1.1.1
 appVersion: v1.0.0
 description: A Helm chart for Heptio Velero
 keywords:

--- a/config/backup/velero/values.yaml
+++ b/config/backup/velero/values.yaml
@@ -28,7 +28,11 @@ velero:
 
     affinity: {}
     nodeSelector: {}
-    tolerations: []
+    tolerations:
+    - effect: NoExecute
+      operator: Exists
+    - effect: NoSchedule
+      operator: Exists
 
   # configure the credentials used to make snapshots (when using
   # persistentVolumeProvider) and to store backups; you can enable


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we moved Prometheus on the stable node pool, backups are failing because there are no local restic pods running on the stable pool by default. This PR adjusts the default tolerations to have Restic available everywhere.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
