### PR TITLE
more realistic resource requests for Elasticsearch

### DIFF
--- a/config/logging/elasticsearch/templates/es-data-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-data-stateful.yaml
@@ -78,14 +78,14 @@ spec:
         - name: NODE_DATA
           value: "true"
         - name: ES_JAVA_OPTS
-          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.logging.elasticsearch.data.heapSize }} -Xmx{{ .Values.logging.elasticsearch.data.heapSize }} {{ .Values.logging.elasticsearch.cluster.additionalJavaOpts }} {{ .Values.logging.elasticsearch.data.additionalJavaOpts }}"
+          value: "-Djava.net.preferIPv4Stack=true {{ .Values.logging.elasticsearch.cluster.additionalJavaOpts }} {{ .Values.logging.elasticsearch.data.additionalJavaOpts }}"
         - name: DISCOVERY_SERVICE
           value: es-master
         - name: PROCESSORS
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        {{- range $key, $value :=  .Values.logging.elasticsearch.cluster.env }}
+        {{- range $key, $value := .Values.logging.elasticsearch.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}

--- a/config/logging/elasticsearch/templates/es-master-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-master-stateful.yaml
@@ -79,14 +79,14 @@ spec:
         - name: NODE_DATA
           value: "false"
         - name: ES_JAVA_OPTS
-          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.logging.elasticsearch.master.heapSize }} -Xmx{{ .Values.logging.elasticsearch.master.heapSize }} {{ .Values.logging.elasticsearch.cluster.additionalJavaOpts }} {{ .Values.logging.elasticsearch.master.additionalJavaOpts }}"
+          value: "-Djava.net.preferIPv4Stack=true {{ .Values.logging.elasticsearch.cluster.additionalJavaOpts }} {{ .Values.logging.elasticsearch.master.additionalJavaOpts }}"
         - name: DISCOVERY_SERVICE
           value: es-master
         - name: PROCESSORS
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        {{- range $key, $value :=  .Values.logging.elasticsearch.cluster.env }}
+        {{- range $key, $value := .Values.logging.elasticsearch.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -86,8 +86,8 @@ logging:
 
       resources:
         requests:
-          cpu: 100m
-          memory: 128Mi
+          cpu: 50m
+          memory: 32Mi
         limits:
           cpu: 100m
           memory: 128Mi

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -21,7 +21,7 @@ logging:
       resources:
         requests:
           cpu: 75m
-          memory: 350Mi
+          memory: 512Mi
       nodeSelector: {}
       affinity:
         podAntiAffinity:
@@ -34,7 +34,7 @@ logging:
                   role: master
               topologyKey: kubernetes.io/hostname
       tolerations: []
-      storageSize: 1Gi
+      storageSize: 5Gi
 
     data:
       replicas: 5
@@ -43,7 +43,7 @@ logging:
       resources:
         requests:
           cpu: 200m
-          memory: 1536Mi
+          memory: 2560Mi
       nodeSelector: {}
       affinity:
         podAntiAffinity:
@@ -56,7 +56,7 @@ logging:
                   role: data
               topologyKey: kubernetes.io/hostname
       tolerations: []
-      storageSize: 10Gi
+      storageSize: 50Gi
 
     curator:
       # Amount of days after which the indicies should be killed

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -6,7 +6,7 @@ logging:
       pullPolicy: IfNotPresent
 
     cluster:
-      additionalJavaOpts: ""
+      additionalJavaOpts: "-XX:MaxRAMPercentage=80"
       config: {}
       env:
         # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes
@@ -16,12 +16,14 @@ logging:
 
     master:
       replicas: 3
-      heapSize: "256m"
-      # additionalJavaOpts: "-XX:MaxRAM=512m"
+      # additionalJavaOpts: ""
       resources:
         requests:
           cpu: 75m
           memory: 512Mi
+        limits:
+          cpu: 200m
+          memory: 1536Mi
       nodeSelector: {}
       affinity:
         podAntiAffinity:
@@ -38,12 +40,14 @@ logging:
 
     data:
       replicas: 5
-      heapSize: "1024m"
-      # additionalJavaOpts: "-XX:MaxRAM=1536m"
+      # additionalJavaOpts: ""
       resources:
         requests:
           cpu: 200m
           memory: 2560Mi
+        limits:
+          cpu: 200m
+          memory: 4Gi
       nodeSelector: {}
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
Judging from our dev cluster, the default resource usage for Elasticsearch is higher than what we define. This leads to bad scheduling decisions.

Starting with Java 10, more container-centric options are available. The newest is `-XX:+UseContainerSupport`, which supersedes `-XX:+UseCGroupMemory*`. With this the JVM is smart enough to figure out the resources the container is assigned. The only thing we then set is the percentage of memory to use for the heap, which we set to 80% (determined using a 12-sided dice, thrown 17 times and then averaged).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
