### PR TITLE
lower dex resource requests

### DIFF
--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -39,10 +39,10 @@ dex:
   resources:
     requests:
       cpu: 10m
-      memory: 128Mi
+      memory: 32Mi
     limits:
       cpu: 50m
-      memory: 200Mi
+      memory: 128Mi
 
   nodeSelector: {}
   affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
Dex does not need 128MB memory, let alone a limit of 200MB.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
