### PR TITLE
override jvm.options for Elasticsearch

### DIFF
--- a/config/logging/elasticsearch/Chart.yaml
+++ b/config/logging/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 1.0.4
+version: 1.0.5
 appVersion: 6.7.1
 description: Chart to deploy Elasticsearch master and data nodes.
 keywords:

--- a/config/logging/elasticsearch/templates/es-configmap.yaml
+++ b/config/logging/elasticsearch/templates/es-configmap.yaml
@@ -6,11 +6,6 @@ data:
   elasticsearch.yml: |-
     cluster.name: log-data
 
-    node.data: ${NODE_DATA:true}
-    node.master: ${NODE_MASTER:true}
-    node.ingest: ${NODE_INGEST:true}
-    node.name: ${HOSTNAME}
-
     # bind to both interfaces so Kubernetes port-forwardings work as expected
     network.bind_host: [_site_, _local_]
 
@@ -20,11 +15,27 @@ data:
     # see https://github.com/kubernetes/kubernetes/issues/3595
     bootstrap.memory_lock: ${BOOTSTRAP_MEMORY_LOCK:false}
 
-    discovery.zen.ping.unicast.hosts: ${DISCOVERY_SERVICE:}
-    discovery.zen.minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
-
     # see https://github.com/elastic/elasticsearch-definitive-guide/pull/679
     processors: ${PROCESSORS:}
+
+    {{ with .Values.logging.elasticsearch }}
+    {{- if eq (add .master.replicas .data.replicas) 1 }}
+    # configure a single-node deployment where one pod is both master and data node
+    node.data: true
+    node.master: true
+    node.ingest: true
+    node.name: ${HOSTNAME}
+
+    discovery.type: single-node
+    {{- else }}
+    # configure a dedicated master or data node inside a cluster
+    node.data: ${NODE_DATA:true}
+    node.master: ${NODE_MASTER:true}
+    node.ingest: ${NODE_INGEST:true}
+    node.name: ${HOSTNAME}
+
+    discovery.zen.ping.unicast.hosts: ${DISCOVERY_SERVICE:}
+    discovery.zen.minimum_master_nodes: ${MINIMUM_MASTER_NODES:2}
 
     # avoid split-brain w/ a minimum consensus of two masters plus a data node
     gateway.expected_master_nodes: ${EXPECTED_MASTER_NODES:2}
@@ -32,6 +43,9 @@ data:
     gateway.recover_after_time: ${RECOVER_AFTER_TIME:5m}
     gateway.recover_after_master_nodes: ${RECOVER_AFTER_MASTER_NODES:2}
     gateway.recover_after_data_nodes: ${RECOVER_AFTER_DATA_NODES:1}
+    {{- end }}
+    {{ end }}
+
 {{- with .Values.logging.elasticsearch.cluster.config }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/config/logging/elasticsearch/templates/es-configmap.yaml
+++ b/config/logging/elasticsearch/templates/es-configmap.yaml
@@ -47,6 +47,135 @@ data:
     logger.searchguard.name = com.floragunn
     logger.searchguard.level = info
 
+  # Overwrite JVM options to get rid of explicit heap sizes (-Xms and -Xmx)
+  # and tweak some other settings, like disabling heap dumps
+  jvm.options: |-
+    ## JVM configuration
+
+    ################################################################
+    ## IMPORTANT: JVM heap size
+    ################################################################
+    ##
+    ## You should always set the min and max JVM heap
+    ## size to the same value. For example, to set
+    ## the heap to 4 GB, set:
+    ##
+    ## -Xms4g
+    ## -Xmx4g
+    ##
+    ## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+    ## for more information
+    ##
+    ################################################################
+
+    # Xms represents the initial size of total heap space
+    # Xmx represents the maximum size of total heap space
+
+    # disabled for Kubermatic
+    #-Xms1g
+    #-Xmx1g
+
+    ################################################################
+    ## Expert settings
+    ################################################################
+    ##
+    ## All settings below this section are considered
+    ## expert settings. Don't tamper with them unless
+    ## you understand what you are doing
+    ##
+    ################################################################
+
+    ## GC configuration
+    -XX:+UseConcMarkSweepGC
+    -XX:CMSInitiatingOccupancyFraction=75
+    -XX:+UseCMSInitiatingOccupancyOnly
+
+    ## G1GC Configuration
+    # NOTE: G1GC is only supported on JDK version 10 or later.
+    # To use G1GC uncomment the lines below.
+    # 10-:-XX:-UseConcMarkSweepGC
+    # 10-:-XX:-UseCMSInitiatingOccupancyOnly
+    # 10-:-XX:+UseG1GC
+    # 10-:-XX:InitiatingHeapOccupancyPercent=75
+
+    ## DNS cache policy
+    # cache ttl in seconds for positive DNS lookups noting that this overrides the
+    # JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+    # changed for Kubermatic
+    #-Des.networkaddress.cache.ttl=60
+    -Des.networkaddress.cache.ttl=10
+    # cache ttl in seconds for negative DNS lookups noting that this overrides the
+    # JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+    # forever
+    -Des.networkaddress.cache.negative.ttl=10
+
+    ## optimizations
+
+    # pre-touch memory pages used by the JVM during initialization
+    -XX:+AlwaysPreTouch
+
+    ## basic
+
+    # explicitly set the stack size
+    -Xss1m
+
+    # set to headless, just in case
+    -Djava.awt.headless=true
+
+    # ensure UTF-8 encoding by default (e.g. filenames)
+    -Dfile.encoding=UTF-8
+
+    # use our provided JNA always versus the system one
+    -Djna.nosys=true
+
+    # turn off a JDK optimization that throws away stack traces for common
+    # exceptions because stack traces are important for debugging
+    # disabled for Kubermatic
+    #-XX:-OmitStackTraceInFastThrow
+
+    # flags to configure Netty
+    -Dio.netty.noUnsafe=true
+    -Dio.netty.noKeySetOptimization=true
+    -Dio.netty.recycler.maxCapacityPerThread=0
+
+    # log4j 2
+    -Dlog4j.shutdownHookEnabled=false
+    -Dlog4j2.disable.jmx=true
+
+    -Djava.io.tmpdir=${ES_TMPDIR}
+
+    # generate a heap dump when an allocation from the Java heap fails
+    # heap dumps are created in the working directory of the JVM
+    # disabled for Kubermatic
+    #-XX:+HeapDumpOnOutOfMemoryError
+
+    # specify an alternative path for heap dumps; ensure the directory exists and
+    # has sufficient space
+    -XX:HeapDumpPath=data
+
+    # specify an alternative path for JVM fatal error logs
+    -XX:ErrorFile=logs/hs_err_pid%p.log
+
+    ## JDK 8 GC logging
+
+    8:-XX:+PrintGCDetails
+    8:-XX:+PrintGCDateStamps
+    8:-XX:+PrintTenuringDistribution
+    8:-XX:+PrintGCApplicationStoppedTime
+    8:-Xloggc:logs/gc.log
+    8:-XX:+UseGCLogFileRotation
+    8:-XX:NumberOfGCLogFiles=32
+    8:-XX:GCLogFileSize=64m
+
+    # JDK 9+ GC logging
+    9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+    # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+    # time/date parsing will break in an incompatible way for some date patterns and locals
+    9-:-Djava.locale.providers=COMPAT
+
+    # temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+    10-:-XX:UseAVX=2
+
   pre-stop-hook.sh: |-
     #!/usr/bin/env bash
     set -xeuo pipefail

--- a/config/logging/elasticsearch/templates/es-configmap.yaml
+++ b/config/logging/elasticsearch/templates/es-configmap.yaml
@@ -99,18 +99,20 @@ data:
     ##
     ################################################################
 
+    # Kubermatic switched the default GC to G1GC.
+
     ## GC configuration
-    -XX:+UseConcMarkSweepGC
-    -XX:CMSInitiatingOccupancyFraction=75
-    -XX:+UseCMSInitiatingOccupancyOnly
+    # -XX:+UseConcMarkSweepGC
+    # -XX:CMSInitiatingOccupancyFraction=75
+    # -XX:+UseCMSInitiatingOccupancyOnly
 
     ## G1GC Configuration
     # NOTE: G1GC is only supported on JDK version 10 or later.
     # To use G1GC uncomment the lines below.
-    # 10-:-XX:-UseConcMarkSweepGC
-    # 10-:-XX:-UseCMSInitiatingOccupancyOnly
-    # 10-:-XX:+UseG1GC
-    # 10-:-XX:InitiatingHeapOccupancyPercent=75
+    10-:-XX:-UseConcMarkSweepGC
+    10-:-XX:-UseCMSInitiatingOccupancyOnly
+    10-:-XX:+UseG1GC
+    10-:-XX:InitiatingHeapOccupancyPercent=75
 
     ## DNS cache policy
     # cache ttl in seconds for positive DNS lookups noting that this overrides the

--- a/config/logging/elasticsearch/templates/es-data-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-data-stateful.yaml
@@ -127,9 +127,12 @@ spec:
         - name: config
           mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
-        - mountPath: /usr/share/elasticsearch/config/log4j2.properties
-          name: config
+        - name: config
+          mountPath: /usr/share/elasticsearch/config/log4j2.properties
           subPath: log4j2.properties
+        - name: config
+          mountPath: /usr/share/elasticsearch/config/jvm.options
+          subPath: jvm.options
         - name: config
           mountPath: /post-start-hook.sh
           subPath: post-start-hook.sh

--- a/config/logging/elasticsearch/templates/es-master-stateful.yaml
+++ b/config/logging/elasticsearch/templates/es-master-stateful.yaml
@@ -128,9 +128,12 @@ spec:
         - name: config
           mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           subPath: elasticsearch.yml
-        - mountPath: /usr/share/elasticsearch/config/log4j2.properties
-          name: config
+        - name: config
+          mountPath: /usr/share/elasticsearch/config/log4j2.properties
           subPath: log4j2.properties
+        - name: config
+          mountPath: /usr/share/elasticsearch/config/jvm.options
+          subPath: jvm.options
         - name: config
           mountPath: /post-start-hook.sh
           subPath: post-start-hook.sh

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -6,7 +6,9 @@ logging:
       pullPolicy: IfNotPresent
 
     cluster:
-      additionalJavaOpts: "-XX:MaxRAMPercentage=80"
+      # make sure to always configure the JVM to have min=max heap size, or else
+      # Elasticsearch will refuse to start up.
+      additionalJavaOpts: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=80"
       config: {}
       env:
         # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -8,7 +8,7 @@ logging:
     cluster:
       # make sure to always configure the JVM to have min=max heap size, or else
       # Elasticsearch will refuse to start up.
-      additionalJavaOpts: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=80"
+      additionalJavaOpts: "-XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=70"
       config: {}
 
       # environment variables used on all data and master nodes;
@@ -21,10 +21,10 @@ logging:
       # additionalJavaOpts: ""
       resources:
         requests:
-          cpu: 75m
+          cpu: 200m
           memory: 512Mi
         limits:
-          cpu: 200m
+          cpu: 1
           memory: 1536Mi
       nodeSelector: {}
       affinity:
@@ -48,7 +48,7 @@ logging:
           cpu: 200m
           memory: 2560Mi
         limits:
-          cpu: 200m
+          cpu: 1
           memory: 4Gi
       nodeSelector: {}
       affinity:

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -16,6 +16,15 @@ logging:
       # to be set here
       env: {}
 
+    # When the sum of master and data nodes is 1, the chart will deploy a cluster
+    # with single-node mode enabled. In this mode there is no discovery and no
+    # separation between masters and data nodes anymore. You also lose any redundancy
+    # and should not use this for production workloads.
+    # Note that you should set data=1 and master=0 if you need a single-node cluster.
+    # Scaling the StatefulSets via kubectl will *not change the mode*, so to scale
+    # up you need to re-deploy the chart with updated replica counts. Once the
+    # regular cluster mode is enabled, using kubectl to scale up and down is fine.
+
     master:
       replicas: 3
       # additionalJavaOpts: ""
@@ -41,7 +50,7 @@ logging:
       storageSize: 5Gi
 
     data:
-      replicas: 5
+      replicas: 3
       # additionalJavaOpts: ""
       resources:
         requests:

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -10,11 +10,11 @@ logging:
       # Elasticsearch will refuse to start up.
       additionalJavaOpts: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=80"
       config: {}
-      env:
-        # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes
-        # To prevent data loss, it is vital to configure the discovery.zen.minimum_master_nodes setting so that each master-eligible
-        # node knows the minimum number of master-eligible nodes that must be visible in order to form a cluster.
-        MINIMUM_MASTER_NODES: "2"
+
+      # environment variables used on all data and master nodes;
+      # note that MINIMUM_MASTER_NODES is computed automatically and does not need
+      # to be set here
+      env: {}
 
     master:
       replicas: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
After the last PR (#3670) where we moved away from setting explicit memory constraints, we noticed that they were still present due to the jvm.options file. This PR adds a customized version to our ConfigMap and mounts that one instead of the default one.

Options that are changed:

* Do not set `Xms` and `Xmx`.
* Cache DNS results for 10 instead of 60 seconds to accomodate changing pod IPs quicker (`es.networkaddress.cache.ttl`).
* Re-enable `OmitStackTraceInFastThrow` because we do not care about stack traces.
* Disable `HeapDumpOnOutOfMemoryError` because we don't need the heap dump when ES crashes.

I ran the Rally benchmarks (`esrally --pipeline=benchmark-only --target-hosts es-data.es-pr.svc.cluster.local:9200`) on the old master branch, the current master branch and a couple of variants of this PR. All variants completed the benchmarks and all basically performed identically. IMHO it's safe to transition to MaxRAMPercentage.

This PR, while we're at it, also makes it possible to run a single-node ES "cluster" by setting the sum of data and master replicas to 1. This interferes with scaling the StatefulSet, but it's clearly documented and should be fine.

This PR also switches to the new GC because ES kept warning about the old one. There were no big gains to be expected and according to the benchmark the speedup in indexing new documents was barely noticeable. But as changing the GC did not break anything, I'd wager it's safe to switch the GC.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
