### PR TITLE
add a method to validate spec changes by cloud providers

### DIFF
--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -770,3 +770,8 @@ func isEntityAlreadyExists(err error) bool {
 	}
 	return aerr.Code() == "EntityAlreadyExists"
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (a *AmazonEC2) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/azure/provider.go
+++ b/api/pkg/provider/cloud/azure/provider.go
@@ -884,3 +884,8 @@ func icmpAllowAllRule() network.SecurityRule {
 		},
 	}
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (a *Azure) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/bringyourown/provider.go
+++ b/api/pkg/provider/cloud/bringyourown/provider.go
@@ -27,3 +27,8 @@ func (b *bringyourown) InitializeCloudProvider(cluster *kubermaticv1.Cluster, up
 func (b *bringyourown) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (b *bringyourown) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/digitalocean/provider.go
+++ b/api/pkg/provider/cloud/digitalocean/provider.go
@@ -39,3 +39,8 @@ func (do *digitalocean) InitializeCloudProvider(cluster *kubermaticv1.Cluster, u
 func (do *digitalocean) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (do *digitalocean) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/fake/provider.go
+++ b/api/pkg/provider/cloud/fake/provider.go
@@ -32,3 +32,8 @@ func (p *fakeCloudProvider) InitializeCloudProvider(cluster *kubermaticv1.Cluste
 func (p *fakeCloudProvider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (p *fakeCloudProvider) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/gcp/provider.go
+++ b/api/pkg/provider/cloud/gcp/provider.go
@@ -234,3 +234,8 @@ func ensureFirewallRules(cluster *kubermaticv1.Cluster, update provider.ClusterU
 
 	return err
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (g *gcp) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/hetzner/provider.go
+++ b/api/pkg/provider/cloud/hetzner/provider.go
@@ -40,3 +40,8 @@ func (h *hetzner) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update 
 func (h *hetzner) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (h *hetzner) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -541,3 +541,8 @@ func addICMPRulesToSecurityGroupIfNecesary(cluster *kubermaticv1.Cluster, secGro
 
 	return nil
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (os *Provider) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/packet/provider.go
+++ b/api/pkg/provider/cloud/packet/provider.go
@@ -67,3 +67,8 @@ func (p *packet) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update p
 func (p *packet) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (p *packet) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -283,3 +283,8 @@ func logout(client *govmomi.Client) {
 		kruntime.HandleError(fmt.Errorf("Failed to logout from vsphere: %v", err))
 	}
 }
+
+// ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted
+func (v *Provider) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
+	return nil
+}

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -45,6 +45,7 @@ type CloudProvider interface {
 	CleanUpCloudProvider(*kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
 	DefaultCloudSpec(spec *kubermaticv1.CloudSpec) error
 	ValidateCloudSpec(spec kubermaticv1.CloudSpec) error
+	ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error
 }
 
 // ClusterUpdater defines a function to persist an update to a cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
It allows a cloud provider to ensure that no breaking changes to the spec are applied by the API consumers, e.g. you can still update credentials but you cannot mess with network configuration of an existing cluster.
I need it to forbid changing of the CIDR mentioned in https://github.com/kubermatic/kubermatic/issues/3024 but I'm opening as a separate PR for clarity.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @mrIncompetent 