### PR TITLE
AWS: set WaitForFirstConsumer in default SC, instead of hardcoding an AZ

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -26,7 +26,7 @@ metadata:
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
-  zone: {{ .Cluster.Spec.Cloud.AWS.AvailabilityZone }}
+volumeBindingMode: WaitForFirstConsumer
 {{ end }}
 
 {{ if .Cluster.Spec.Cloud.VSphere }}

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.2.17
+export TAG=v0.2.18
 
 docker build -t quay.io/kubermatic/addons:${TAG} .
 docker push quay.io/kubermatic/addons:${TAG}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -80,7 +80,7 @@ kubermatic:
         - nodelocal-dns-cache
         image:
           repository: "quay.io/kubermatic/addons"
-          tag: "v0.2.17"
+          tag: "v0.2.18"
           pullPolicy: "IfNotPresent"
       openshift:
         # list of Addons to install into every user-cluster. All need to exist in the addons image


### PR DESCRIPTION
Another step towards dealing with #3456 

```release-note
AWS: Default storage class is no longer bound to a single AZ - `WaitForFirstConsumer` configured instead
```