### PR TITLE
 AWS: pass role ARN and dummy AZ instead of subnet/zone to control plane cloudconfig

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3354,6 +3354,10 @@
           "type": "string",
           "x-go-name": "InstanceProfileName"
         },
+        "roleARN": {
+          "type": "string",
+          "x-go-name": "RoleARN"
+        },
         "roleName": {
           "type": "string",
           "x-go-name": "RoleName"

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -322,6 +322,7 @@ type AWSCloudSpec struct {
 	VPCID               string `json:"vpcId"`
 	SubnetID            string `json:"subnetId"`
 	RoleName            string `json:"roleName"`
+	RoleARN             string `json:"roleARN"`
 	RouteTableID        string `json:"routeTableId"`
 	InstanceProfileName string `json:"instanceProfileName"`
 	SecurityGroupID     string `json:"securityGroupID"`

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -100,6 +100,37 @@ func (a *AmazonEC2) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 	return nil
 }
 
+// MigrateToMultiAZ migrates an AWS cluster from the old AZ-hardcoded spec to multi-AZ spec
+func (a *AmazonEC2) MigrateToMultiAZ(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) error {
+	// If not even the role name is set, then the cluster is not fully
+	// initialized and we don't need to worry about this migration just yet.
+	if cluster.Spec.Cloud.AWS.RoleName == "" {
+		return nil
+	}
+
+	if cluster.Spec.Cloud.AWS.RoleARN == "" {
+		svcIAM, err := a.getIAMClient(cluster.Spec.Cloud)
+		if err != nil {
+			return fmt.Errorf("failed to get IAM client: %v", err)
+		}
+
+		paramsRoleGet := &iam.GetRoleInput{RoleName: aws.String(cluster.Spec.Cloud.AWS.RoleName)}
+		getRoleOut, err := svcIAM.GetRole(paramsRoleGet)
+		if err != nil {
+			return fmt.Errorf("failed to get already existing aws IAM role %s: %v", cluster.Spec.Cloud.AWS.RoleName, err)
+		}
+
+		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+			cluster.Spec.Cloud.AWS.RoleARN = *getRoleOut.Role.Arn
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // AddICMPRulesIfRequired will create security rules that allow ICMP traffic if these do not yet exist.
 // It is a part of a migration for older clusers (migrationRevision < 1) that didn't have these rules.
 func (a *AmazonEC2) AddICMPRulesIfRequired(cluster *kubermaticv1.Cluster) error {
@@ -614,6 +645,7 @@ func (a *AmazonEC2) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.AddFinalizer(cluster, instanceProfileCleanupFinalizer)
 			cluster.Spec.Cloud.AWS.RoleName = *role.RoleName
+			cluster.Spec.Cloud.AWS.RoleARN = *role.Arn
 			cluster.Spec.Cloud.AWS.InstanceProfileName = *instanceProfile.InstanceProfileName
 		})
 		if err != nil {

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -100,6 +100,8 @@ func (a *AmazonEC2) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 	return nil
 }
 
+// AddICMPRulesIfRequired will create security rules that allow ICMP traffic if these do not yet exist.
+// It is a part of a migration for older clusers (migrationRevision < 1) that didn't have these rules.
 func (a *AmazonEC2) AddICMPRulesIfRequired(cluster *kubermaticv1.Cluster) error {
 	if cluster.Spec.Cloud.AWS.SecurityGroupID == "" {
 		glog.Infof("Not adding ICMP allow rules for cluster %q as it has no securityGroupID set",

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -56,14 +56,17 @@ func CloudConfig(cluster *kubermaticv1.Cluster, dc *provider.DatacenterMeta) (cl
 	cloud := cluster.Spec.Cloud
 	if cloud.AWS != nil {
 		awsCloudConfig := &aws.CloudConfig{
+			// Dummy AZ, so that K8S can extract the region from it.
+			// https://github.com/kubernetes/kubernetes/blob/v1.15.0/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L1199
+			// https://github.com/kubernetes/kubernetes/blob/v1.15.0/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L1174
 			Global: aws.GlobalOpts{
-				Zone:                        cloud.AWS.AvailabilityZone,
+				Zone:                        dc.Spec.AWS.Region + "x",
 				VPC:                         cloud.AWS.VPCID,
 				KubernetesClusterID:         cluster.Name,
 				DisableSecurityGroupIngress: false,
-				SubnetID:                    cloud.AWS.SubnetID,
 				RouteTableID:                cloud.AWS.RouteTableID,
 				DisableStrictZoneCheck:      true,
+				RoleARN:                     cloud.AWS.RoleARN,
 			},
 		}
 		cloudConfig, err = aws.CloudConfigToString(awsCloudConfig)

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-cloud-config.yaml
@@ -1,11 +1,11 @@
 data:
   config: |
     [global]
-    Zone="aws-availability-zone"
+    Zone="us-central1x"
     VPC="aws-vpn-id"
-    SubnetID="aws-subnet-id"
+    SubnetID=""
     RouteTableID="aws-route-table-id"
-    RoleARN=""
+    RoleARN="aws-role-arn"
     KubernetesClusterID="de-test-01"
     DisableSecurityGroupIngress=false
     ElbSecurityGroup=""

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-cloud-config.yaml
@@ -1,11 +1,11 @@
 data:
   config: |
     [global]
-    Zone="aws-availability-zone"
+    Zone="us-central1x"
     VPC="aws-vpn-id"
-    SubnetID="aws-subnet-id"
+    SubnetID=""
     RouteTableID="aws-route-table-id"
-    RoleARN=""
+    RoleARN="aws-role-arn"
     KubernetesClusterID="de-test-01"
     DisableSecurityGroupIngress=false
     ElbSecurityGroup=""

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-cloud-config.yaml
@@ -1,11 +1,11 @@
 data:
   config: |
     [global]
-    Zone="aws-availability-zone"
+    Zone="us-central1x"
     VPC="aws-vpn-id"
-    SubnetID="aws-subnet-id"
+    SubnetID=""
     RouteTableID="aws-route-table-id"
-    RoleARN=""
+    RoleARN="aws-role-arn"
     KubernetesClusterID="de-test-01"
     DisableSecurityGroupIngress=false
     ElbSecurityGroup=""

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-cloud-config.yaml
@@ -1,11 +1,11 @@
 data:
   config: |
     [global]
-    Zone="aws-availability-zone"
+    Zone="us-central1x"
     VPC="aws-vpn-id"
-    SubnetID="aws-subnet-id"
+    SubnetID=""
     RouteTableID="aws-route-table-id"
-    RoleARN=""
+    RoleARN="aws-role-arn"
     KubernetesClusterID="de-test-01"
     DisableSecurityGroupIngress=false
     ElbSecurityGroup=""

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-cloud-config.yaml
@@ -1,11 +1,11 @@
 data:
   config: |
     [global]
-    Zone="aws-availability-zone"
+    Zone="us-central1x"
     VPC="aws-vpn-id"
-    SubnetID="aws-subnet-id"
+    SubnetID=""
     RouteTableID="aws-route-table-id"
-    RoleARN=""
+    RoleARN="aws-role-arn"
     KubernetesClusterID="de-test-01"
     DisableSecurityGroupIngress=false
     ElbSecurityGroup=""

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-cloud-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-cloud-config.yaml
@@ -1,11 +1,11 @@
 data:
   config: |
     [global]
-    Zone="aws-availability-zone"
+    Zone="us-central1x"
     VPC="aws-vpn-id"
-    SubnetID="aws-subnet-id"
+    SubnetID=""
     RouteTableID="aws-route-table-id"
-    RoleARN=""
+    RoleARN="aws-role-arn"
     KubernetesClusterID="de-test-01"
     DisableSecurityGroupIngress=false
     ElbSecurityGroup=""

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -141,6 +141,7 @@ func TestLoadFiles(t *testing.T) {
 				SecurityGroupID:     "aws-security-group",
 				SubnetID:            "aws-subnet-id",
 				VPCID:               "aws-vpn-id",
+				RoleARN:             "aws-role-arn",
 			},
 		},
 		"openstack": {


### PR DESCRIPTION
**What this PR does / why we need it**:
A step towards solving #3456 

**Special notes for your reviewer**:
The PR adds a cloud spec migration, but that particular migration is not fully ready. More PRs addressing #3456 will follow that will add to that particular migration.

```release-note
NONE
```
